### PR TITLE
Changed format of VC plus bug fixes and test coverage

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -652,7 +652,7 @@ def delcept(keys,
 
     if not prefixer.digestive:
         raise ValueError("Invalid derivation code ={} for delegation. Must be"
-                         " digestive".formate(prefixer.code))
+                         " digestive".format(prefixer.code))
 
     ked["i"] = prefixer.qb64  # update pre element in ked with pre qb64
 

--- a/src/keri/vc/walleting.py
+++ b/src/keri/vc/walleting.py
@@ -37,7 +37,6 @@ def parseCredential(ims=b'', wallet=None, typ=JSONSchema()):
         raise e
     else:
         del ims[:creder.size]
-
     cold = Parser.sniff(ims)
     if cold is Colds.msg:
         raise ColdStartError("unable to parse VC, attachments expected")

--- a/tests/core/test_scheming.py
+++ b/tests/core/test_scheming.py
@@ -15,11 +15,11 @@ from keri.kering import ValidationError
 def test_saider():
     # Initialize from JSON Schema JSON
     scer = (
-        b'{"$id": "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY", "$schema": '
+        b'{"$id": "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA", "$schema": '
         b'"http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"a": {"type": "string"}, '
         b'"b": {"type": "number"}, "c": {"type": "string", "format": "date-time"}}}')
 
-    sad = Saider(qb64="EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY")
+    sad = Saider(qb64="ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA")
     assert sad.code == MtrDex.Blake3_256
 
     sed = json.loads(scer)
@@ -49,7 +49,7 @@ def test_saider():
 
     # Initialize from dict
     sad = Saider(sed=sed, code=MtrDex.Blake3_256)
-    assert sad.qb64 == "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY"
+    assert sad.qb64 == "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA"
     assert sad.verify(sed, prefixed=False) is True
 
     sed = json.loads(scer)
@@ -58,7 +58,7 @@ def test_saider():
 
 def test_json_schema():
     scer = (
-        b'{"$id": "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY", "$schema": '
+        b'{"$id": "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA", "$schema": '
         b'"http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"a": {"type": "string"}, '
         b'"b": {"type": "number"}, "c": {"type": "string", "format": "date-time"}}}')
     payload = b'{"a": "test", "b": 123, "c": "2018-11-13T20:20:39+00:00"}'
@@ -66,7 +66,7 @@ def test_json_schema():
     badjson = b'{"a": "test" "b": 123 "c": "2018-11-13T20:20:39+00:00"}'
 
     sce = Schemer(raw=scer)
-    assert sce.said == "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY"
+    assert sce.said == "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA"
     assert sce.verify(raw=payload) is True
     assert sce.verify(raw=mismatch) is False
     assert sce.verify(raw=badjson) is False
@@ -119,8 +119,8 @@ def test_json_schema_dict():
     badjson = b'{"a": "test" "b": 123 "c": "2018-11-13T20:20:39+00:00"}'
 
     sce = Schemer(sed=sed, typ=JSONSchema(), code=MtrDex.Blake3_256)
-    assert sce.said == "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY"
-    assert sce.sed["$id"] == "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY"
+    assert sce.said == "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA"
+    assert sce.sed["$id"] == "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA"
     assert sce.verify(raw=payload) is True
     assert sce.verify(raw=mismatch) is False
     assert sce.verify(raw=badjson) is False
@@ -128,7 +128,7 @@ def test_json_schema_dict():
     raw = json.dumps(sce.sed).encode("utf-8")
 
     sce = Schemer(raw=raw)
-    assert sce.said == "EQtF_DhWj-uCPTsq4BONO0yR0PWLpUITkSqHoW0JjndY"
+    assert sce.said == "ExG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA"
 
     # Invalid JSON Schema
     sed = dict()
@@ -176,28 +176,28 @@ def test_json_schema_dict():
     ))
 
     sce = Schemer(sed=sed, code=MtrDex.Blake3_256)
-    assert sce.said == "E85XpgsvzBLPVHiy0EzFmNCTN13DUK4eITMoY2kmVD8o"
+    assert sce.said == "E1AqXevVnoeItc4P7TnRpW8rOIJYm1daDe9jYVZQZLEY"
     payload = b'{"a": {"b": 123, "c": "2018-11-13T20:20:39+00:00"}}'
     assert sce.verify(payload)
 
     # Additional hash types
     sce = Schemer(sed=sed, code=MtrDex.Blake2b_256)
-    assert sce.said == "FtDGHM1-15UdUiIki8mtKgfpC9CLxuq16wr55nw3htZs"
+    assert sce.said == "FWOS-OuKCWnux0Oka2G5rlQY2I68XBJmZsXDLHbHKu_I"
     sce = Schemer(sed=sed, code=MtrDex.Blake2s_256)
-    assert sce.said == "Ga063NUEvWf4ZNm7qgbAUVhcBMEL8vddQhEauTk2HuKo"
+    assert sce.said == "GRidELCmdk-47s0OI6EAVk1PBolvS1HetzVbxbwBNIbI"
     sce = Schemer(sed=sed, code=MtrDex.SHA3_256)
-    assert sce.said == "HUhsiL9Hl9c6DVZ9YioCKiyLIuJmnEd0ALKNge3bMMn0"
+    assert sce.said == "HmDms9gN0b0Zjmu7HyT2HEDkdnaOYm-1KgxIIhNTQPaI"
     sce = Schemer(sed=sed, code=MtrDex.SHA3_512)
-    assert sce.said == "0FaBVrb4jLlfgSqNaAGf3gFpRJJvZUiyPg-2W240y3IO1SCv2kD3rkowQ9i9yOVYT_K3BZ54eBN1zpqvkoEMk7YQ"
+    assert sce.said == "0FAYWj9GFRxh-YrppcR5lpVM1rm-sez1K6DDTKGfTljfbYPcdpeatBl46G8IXsQUG8ww0AbqDZRzeFuWWar2wAyA"
     sce = Schemer(sed=sed, code=MtrDex.SHA2_256)
-    assert sce.said == "IRgVJumn8RaXh0WJV1QT3zS3rUwhuCJDDhzgFRE-Fdn4"
+    assert sce.said == "IvT1u5jtwcVQl6GlOGyfNeoyJoSmKXnOwJyIZuB2Vsh4"
     sce = Schemer(sed=sed, code=MtrDex.SHA2_512)
-    assert sce.said == "0GiFhrQdu9N7xDkB7IDLVdj13zGydat-oJyYK0pFXaW695YeZZh-KPJJ-8ku47W-XmRqI8TpwV0NVyr0LC6ogGMg"
+    assert sce.said == "0GkKvqMZLvSfsGhYfl8wTZAq7Gv4khAs8v7JmUNBzZ-WOuL21RkJpxaiTXMk4_S8w_y73AnfjQZK06Vr0KMYdxww"
 
 
 def test_resolution():
     ref = (b'{'
-           b'   "$id": "EMZXD1QYBN3PtDq4M2Y_BWiswd3bdraXGoFj_ALcOPjI", '
+           b'   "$id": "Evcu66xr3s_x1k4IjwoQ3ZKEbfkdVLxLr7PW-67nYX4I", '
            b'   "$schema": "http://json-schema.org/draft-07/schema#", '
            b'   "type": "object", '
            b'   "properties": {'
@@ -207,7 +207,7 @@ def test_resolution():
 
     scer = (
         b'{'
-        b'   "$id": "ETZr8wWfVcUm7HdXwNjJaQJpcdlMeY6kR3eA9i9ZItxo", '
+        b'   "$id": "Er21QX8KuraJO-3KYXpcyBN7TFSgrasvJiTbgNLIMbbI", '
         b'   "$schema": "http://json-schema.org/draft-07/schema#", '
         b'   "type": "object", '
         b'   "properties": {'

--- a/tests/vc/test_handling.py
+++ b/tests/vc/test_handling.py
@@ -52,7 +52,7 @@ def test_issuing():
         ))
 
         schemer = scheming.Schemer(sed=sed, code=coring.MtrDex.Blake3_256)
-        assert schemer.said == "Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"
+        assert schemer.said == "EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY"
 
         cache = scheming.CacheResolver()
         cache.add(schemer.said, schemer.raw)
@@ -77,19 +77,17 @@ def test_issuing():
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=jsonSchema)
 
-        assert creder.said == "EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ"
+        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000189_","x":"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o",'
-            b'"d":{"id":"EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ","type":['
-            b'"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"],'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{'
-            b'"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAsPhz4tfZGgoV'
-            b'-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA')
+            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
+            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
+            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
 
         # Create the issue credential payload
         pl = dict(
@@ -106,15 +104,13 @@ def test_issuing():
         assert doist.tyme == limit
 
         ser = (
-            b'{"v":"KERI10JSON000189_","x":"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o",'
-            b'"d":{"id":"EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ","type":['
-            b'"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"],'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{'
-            b'"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}}')
+            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36"}}'
+        )
         sig0 = (
-            b'AAsPhz4tfZGgoV-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA'
+            b'AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg'
         )
 
         # verify we can load serialized VC by SAID
@@ -202,7 +198,7 @@ def test_proving():
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=JSONSchema(resolver=cache))
 
-        assert creder.said == "EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ"
+        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
 
         msg = sidHab.endorse(serder=creder)
         hanWallet = Wallet(hab=hanHab, db=hanPDB)
@@ -255,9 +251,9 @@ def test_proving():
         vcs = data["verifiableCredential"]
         assert len(vcs) == 1
 
-        proof = "-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE" \
-                "-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAsPhz4tfZGgoV" \
-                "-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA"
+        proof = (
+            "-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw"
+            "-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg")
         assert vcs[0]["proof"] == proof
 
 

--- a/tests/vc/test_proving.py
+++ b/tests/vc/test_proving.py
@@ -53,15 +53,13 @@ def test_proving():
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000189_","x":"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o",'
-            b'"d":{"id":"EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ","type":['
-            b'"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"],'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{'
-            b'"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAsPhz4tfZGgoV'
-            b'-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA')
+            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
+            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
+            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
 
         creder = Credentialer(raw=msg, typ=JSONSchema(resolver=cache))
         proof = msg[creder.size:]
@@ -106,62 +104,83 @@ def test_credentialer():
     sub = dict(a=123, b="abc")
     d = dict(
         v=Vstrings.json,
+        i="",
         x="abc",
-        d=dict(
-            id="",
-            type=["abc"],
-            issuer="i",
-            issuanceDate="2021-06-27T21:26:21.233257+00:00",
-            credentialSubject=sub,
-        )
+        issuer="i",
+        issuance="2021-06-27T21:26:21.233257+00:00",
+        d=sub
     )
 
     creder = Credentialer(crd=d)
-    assert creder.said == "E8TbHTnyuBV3YCoFrjFNi9Ob9kVR6l-iRHfvPcNRijyU"
+    assert creder.said == "EASVjcsdqrobngAG0RfGEkeOjdOO0zotPmc7O3Oi8ZWk"
     assert creder.kind == Serials.json
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.crd == d
-    assert creder.size == 167
-    assert creder.raw == b'{"v":"KERI10JSON0000a7_","x":"abc","d":{"id":"","type":["abc"],"issuer":"i",' \
-                         b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{"a":123,"b":"abc"}}}'
+    assert creder.size == 169
+    assert creder.raw == b'{"v":"KERI10JSON0000a9_","i":"EASVjcsdqrobngAG0RfGEkeOjdOO0zotPmc7O3Oi8ZWk","x":"abc",' \
+                         b'"issuer":"i","issuance":"2021-06-27T21:26:21.233257+00:00","d":{"a":123,"b":"abc"}}'
 
-    raw1, knd1, ked1, ver1 = creder._exhale(crd=d)
+    raw1, knd1, ked1, ver1, saider = creder._exhale(crd=d)
     assert raw1 == creder.raw
     assert knd1 == Serials.json
     assert ked1 == d
     assert ver1 == Versionage(major=1, minor=0)
+    assert saider.qb64 == creder.said
 
     creder = Credentialer(raw=raw1)
     assert creder.kind == Serials.json
     assert creder.issuer == "i"
     assert creder.crd == d
-    assert creder.size == 167
-
+    assert creder.size == 169
 
     d2 = dict(d)
     d2["v"] = Vstrings.cbor
     creder = Credentialer(crd=d2)
-    assert creder.said == "E8TbHTnyuBV3YCoFrjFNi9Ob9kVR6l-iRHfvPcNRijyU"
+    assert creder.said == "EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6c"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
-    assert creder.size == 129
+    assert creder.size == 140
     assert creder.crd == d2
-    assert creder.raw == b'\xa3avqKERI10CBOR000081_axcabcad\xa5bid`dtype\x81cabcfissuerailissuanceDatex ' \
-                         b'2021-06-27T21:26:21.233257+00:00qcredentialSubject\xa2aa\x18{abcabc'
+    assert creder.raw == b'\xa6avqKERI10CBOR00008c_aix,' \
+                         b'EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6caxcabcfissueraihissuancex ' \
+                         b'2021-06-27T21:26:21.233257+00:00ad\xa2aa\x18{abcabc'
 
     raw2 = bytes(creder.raw)
     creder = Credentialer(raw=raw2)
-    assert creder.said == "E8TbHTnyuBV3YCoFrjFNi9Ob9kVR6l-iRHfvPcNRijyU"
+    assert creder.said == "EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6c"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
-    assert creder.size == 129
+    assert creder.size == 140
     assert creder.crd == d2
 
+    d3 = dict(d)
+    d3["v"] = Vstrings.mgpk
+    creder = Credentialer(crd=d3)
+
+    assert creder.said == "EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM"
+    assert creder.issuer == "i"
+    assert creder.schema == "abc"
+    assert creder.subject == sub
+    assert creder.size == 139
+    assert creder.crd == d3
+    assert creder.raw == b'\x86\xa1v\xb1KERI10MGPK00008b_\xa1i\xd9,' \
+                         b'EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM\xa1x\xa3abc\xa6issuer\xa1i\xa8issuance\xd9 ' \
+                         b'2021-06-27T21:26:21.233257+00:00\xa1d\x82\xa1a{\xa1b\xa3abc'
+
+    raw3 = bytes(creder.raw)
+    creder = Credentialer(raw=raw3)
+    assert creder.said == "EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM"
+    assert creder.issuer == "i"
+    assert creder.schema == "abc"
+    assert creder.subject == sub
+    assert creder.size == 139
+    assert creder.crd == d3
 
 
 if __name__ == '__main__':
+    test_proving()
     test_credentialer()

--- a/tests/vc/test_walleting.py
+++ b/tests/vc/test_walleting.py
@@ -3,13 +3,15 @@
 tests.vc.walleting module
 
 """
+import pytest
 
 from keri.app import keeping, habbing
 from keri.core import coring, scheming
 from keri.core.scheming import CacheResolver, JSONSchema
 from keri.db import basing
+from keri.kering import ExtractionError, ColdStartError
 from keri.vc.proving import credential
-from keri.vc.walleting import Wallet, parseCredential, openPocket
+from keri.vc.walleting import Wallet, parseCredential, openPocket, parseProof, buildProof
 
 
 def test_wallet():
@@ -20,6 +22,7 @@ def test_wallet():
             openPocket(name="sid") as sidPDB:
         sidHab = habbing.Habitat(ks=sidKS, db=sidDB, salt=sidSalt, temp=True)
         assert sidHab.pre == "E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E"
+
         sed = dict()
         sed["$id"] = ""
         sed["$schema"] = "http://json-schema.org/draft-07/schema#"
@@ -49,36 +52,30 @@ def test_wallet():
                             subject=credSubject,
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=JSONSchema(resolver=cache))
-
-        assert creder.said == "EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ"
+        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000189_","x":"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o",'
-            b'"d":{"id":"EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ","type":['
-            b'"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"],'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{'
-            b'"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAsPhz4tfZGgoV'
-            b'-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA')
+            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
+            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
+            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
 
         ser = (
-            b'{"v":"KERI10JSON000189_","x":"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o",'
-            b'"d":{"id":"EvK-hjgQCltc-jk_FZPOj4f3S6yEuNRpQcrVTfk1UsCQ","type":['
-            b'"Et75h-slZaxkez1YDNpOxM6AF2YFMgcFL4C1ziAeFe3o"],'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00","credentialSubject":{'
-            b'"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}}')
+            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
+            b'"lei":"254900OPPU84GM83MG36"}}')
         seal = (
             b'E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw'
-            b'-AxDNI7_ZmaI'
-        )
+            b'-AxDNI7_ZmaI')
 
         sig0 = (
-            b'AAsPhz4tfZGgoV-1gYtvI1QfzSxwItp5JvguLhKnZE27px5q9fcKGPC0GkMlMBaRyfC47Db4zEWG6ceQ98g6dWDA'
+            b'AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg'
         )
 
         sidWallet = Wallet(hab=sidHab, db=sidPDB)
@@ -104,5 +101,107 @@ def test_wallet():
         assert schema[0] == key
 
 
+def test_parse_proof():
+    proof = bytearray(b'-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+                      b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
+                      b'-AABAAVgLJOmUNlMZpSGV0hr'
+                      b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
+
+    prefixer, seqner, diger, isigers = parseProof(proof)
+    assert prefixer.code == coring.MtrDex.Blake3_256
+    assert prefixer.qb64 == "E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E"
+
+    assert seqner.sn == 0
+    assert diger.qb64 == "ElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI"
+
+    assert len(isigers) == 1
+    assert isigers[0].qb64 == "AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg"
+
+    #  Invalid attachment start
+    proof = bytearray(b'-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+                      b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
+                      b'-AABAAVgLJOmUNlMZpSGV0hr'
+                      b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
+
+    with pytest.raises(ExtractionError):
+        parseProof(proof)
+
+    # Invalid, can't process a message
+    proof = bytearray(b'{{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
+                      b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
+                      b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+                      b'"issuance":"2021-06-27T21:26:21.233257+00:00",'
+                      b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
+                      b'"lei":"254900OPPU84GM83MG36"}}')
+
+    with pytest.raises(ColdStartError):
+        parseProof(proof)
+
+
+def test_build_proof():
+    sidSalt = coring.Salter(raw=b'0123456789abcdef').qb64
+
+    with basing.openDB(name="sid") as sigDB, \
+            keeping.openKS(name="sid") as sigKS:
+        sigHab = habbing.Habitat(ks=sigKS, db=sigDB, salt=sidSalt, icount=3, ncount=3, temp=True)
+
+        sed = dict()
+        sed["$id"] = ""
+        sed["$schema"] = "http://json-schema.org/draft-07/schema#"
+        sed.update(dict(
+            type="object",
+            properties=dict(
+                id=dict(
+                    type="string"
+                ),
+                lei=dict(
+                    type="string"
+                )
+            )
+        ))
+
+        schemer = scheming.Schemer(sed=sed, typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256)
+        credSubject = dict(
+            id="did:keri:Efaavv0oadfghasdfn443fhbyyr4v",  # this needs to be generated from a KEL
+            lei="254900OPPU84GM83MG36"
+        )
+
+        cache = CacheResolver()
+        cache.add(schemer.said, schemer.raw)
+
+        creder = credential(issuer=sigHab.pre,
+                            schema=schemer.said,
+                            subject=credSubject,
+                            issuance="2021-06-27T21:26:21.233257+00:00",
+                            typ=JSONSchema(resolver=cache))
+
+        sigHab.rotate()
+        sigHab.rotate()
+        sigHab.rotate()
+        sigHab.rotate()
+
+        prefixer = coring.Prefixer(qb64=sigHab.kever.prefixer.qb64)
+        seqner = coring.Seqner(sn=sigHab.kever.lastEst.s)
+        diger = coring.Diger(qb64=sigHab.kever.lastEst.d)
+
+        sigers = sigHab.mgr.sign(ser=creder.raw, verfers=sigHab.kever.verfers, indexed=True)
+
+        proof = buildProof(prefixer, seqner, diger, sigers)
+        assert proof == (b'-FABEiRjCnZfca8gUZqecerjGpjkiY8dIkGudP6GfapWi5MU0AAAAAAAAAAAAAAAAAAAAABAECc96yX1sYswnD6LXE'
+                         b'coNuJ0ehi8gkFMEGedqURhXMBU-AADAAarmUESbxAsy42qOTYN_ChWWgHT7HlM6_qTunFZeuTf9ozrGmvJ-RSjh2r4'
+                         b'cbaID5eKe7mU3PTziJ2YjNlDB1DwAByOIg2T3S2bb8KnI40e0P5Ucllxt-5ZvxX2_2XfrCp6s8DjodXvVhZqqsQVyN'
+                         b'jOvg9MM_fh5s02NKYJ4s9UXgDgACC3_hfvm_H77YuE4IndBvm2DdB2p_wgN9K-VOefzv11e4SLX4W8_Ns4hiaMm3ul'
+                         b'm8f4RAaoJEICDax-xomO1mCA')
+
+        prefixer, seqner, diger, isigers = parseProof(proof)
+        assert prefixer.qb64 == sigHab.pre
+        assert diger.qb64 == sigHab.kever.lastEst.d
+        assert seqner.sn == 4
+        assert len(isigers) == 3
+
+
+
 if __name__ == '__main__':
     test_wallet()
+    test_build_proof()
+    test_parse_proof()


### PR DESCRIPTION
This PR includes:

* Changed format of VC to get closer to AC/DC and farther from W3C.
* Fixed bug in Credentialer for SAID generation.
* Fixed Saider to take serialization type into account for SAID generation.
* Added test coverage for Credentialer serialization  formats.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>