### PR TITLE
Fixed incept and send commands to exit properly

### DIFF
--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -101,7 +101,7 @@ class InceptDoer(doing.DoDoer):
             print(f'Public key {idx+1}:\t{verfer.qb64}')
         print()
 
-        # toRemove = [self.ksDoer, self.dbDoer, self.habDoer, self.witDoer]
-        # self.remove(toRemove)
+        toRemove = [self.ksDoer, self.dbDoer, self.habDoer, self.witDoer]
+        self.remove(toRemove)
 
         return

--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -79,17 +79,66 @@ class CacheResolver:
         return jsonschema.RefResolver("", scer, handlers={"did": self.handler})
 
 
-
 jsonSchemaCache = CacheResolver(cache={
-    "EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY": (b'{"$id":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-                                                     b'"$schema":"http://json-schema.org/draft-07/schema#",'
-                                                     b'"type":"object","properties":{"id":{"type":"string"},'
-                                                     b'"lei":{"type":"string"}}}')
+    "E3gXAQwgB_wGtQ5ZVhKrggkDPCQQXPQ1FWlW3d8Csdc8": (
+        b'{"$id": "E3gXAQwgB_wGtQ5ZVhKrggkDPCQQXPQ1FWlW3d8Csdc8", "$schema": '
+        b'"http://json-schema.org/draft-07/schema#", "additionalProperties": false, "properties": {"d": {'
+        b'"additionalProperties": false, "description": "data block", "properties": {"LEI": {"type": "string"}, '
+        b'"credentialStatus": {"type": "string"}, "i": {"type": "string"}, "issuanceDate": {"format": "date-time", '
+        b'"type": "string"}, "type": {"type": "array"}}, "required": ["i", "LEI", "credentialStatus", "issuanceDate", '
+        b'"type"], "type": "object"}, "i": {"type": "string"}, "ti": {"type": "string"}, "x": {"description": "schema '
+        b'block", "type": "string"}}, "required": ["i", "d"], "type": "object"}'),
+    "EDN2qAfVB0coKA26AkutgHXEAbnzDI3O-bL7rZOl6YAw": (
+        b'{"$id": "EDN2qAfVB0coKA26AkutgHXEAbnzDI3O-bL7rZOl6YAw", "$schema": '
+        b'"http://json-schema.org/draft-07/schema#", "additionalProperties": false, "properties": {"d": {'
+        b'"additionalProperties": false, "description": "data block", "properties": {"LEI": {"type": "string"}, '
+        b'"credentialStatus": {"type": "string"}, "engagementContextRole": {"type": "string"}, "i": {"type": '
+        b'"string"}, "issuanceDate": {"format": "date-time", "type": "string"}, "personLegalName": {"type": '
+        b'"string"}, "type": {"type": "array"}}, "required": ["i", "LEI", "credentialStatus", "issuanceDate", "type", '
+        b'"personLegalName", "engagementContextRole"], "type": "object"}, "i": {"type": "string"}, "s": {"contains": '
+        b'{"type": "object"}, "description": "source block", "items": {"additionalProperties": false, "properties": {'
+        b'"qualifiedvLEIIssuervLEICredential": {"type": "string"}}, "required": ['
+        b'"qualifiedvLEIIssuervLEICredential"], "type": "object"}, "maxItems": 1, "minItems": 1, "type": "array"}, '
+        b'"ti": {"type": "string"}, "x": {"description": "schema block", "type": "string"}}, "required": ["i", "s", '
+        b'"d"], "type": "object"}'),
+    "Ehp1Pnyhw0BMY_0pdtTUUZh3f2PxTFVHWddZaF7KT2_g": (
+        b'{"$id": "Ehp1Pnyhw0BMY_0pdtTUUZh3f2PxTFVHWddZaF7KT2_g", "$schema": '
+        b'"http://json-schema.org/draft-07/schema#", "additionalProperties": false, "properties": {"d": {'
+        b'"additionalProperties": false, "description": "data block", "properties": {"LEI": {"type": "string"}, '
+        b'"credentialStatus": {"type": "string"}, "i": {"type": "string"}, "issuanceDate": {"format": "date-time", '
+        b'"type": "string"}, "officialRole": {"type": "string"}, "personLegalName": {"type": "string"}, '
+        b'"type": {"type": "array"}}, "required": ["i", "LEI", "credentialStatus", "issuanceDate", "type", '
+        b'"personLegalName", "officialRole"], "type": "object"}, "i": {"type": "string"}, "s": {"contains": {"type": '
+        b'"object"}, "description": "source block", "items": {"additionalProperties": false, "properties": {'
+        b'"qualifiedvLEIIssuervLEICredential": {"type": "string"}}, "required": ['
+        b'"qualifiedvLEIIssuervLEICredential"], "type": "object"}, "maxItems": 1, "minItems": 1, "type": "array"}, '
+        b'"ti": {"type": "string"}, "x": {"description": "schema block", "type": "string"}}, "required": ["i", "s", '
+        b'"d"], "type": "object"}'),
+    "EfFdEfsloa6q0zNZdvwThrtEQ-jJuPu8_LFXDRDFpvmo": (
+        b'{"$id": "EfFdEfsloa6q0zNZdvwThrtEQ-jJuPu8_LFXDRDFpvmo", "$schema": '
+        b'"http://json-schema.org/draft-07/schema#", "additionalProperties": false, "properties": {"d": {'
+        b'"additionalProperties": false, "description": "data block", "properties": {"LEI": {"type": "string"}, '
+        b'"credentialStatus": {"type": "string"}, "i": {"type": "string"}, "issuanceDate": {"format": "date-time", '
+        b'"type": "string"}, "type": {"type": "array"}}, "required": ["i", "LEI", "credentialStatus", "issuanceDate", '
+        b'"type"], "type": "object"}, "i": {"type": "string"}, "s": {"contains": {"type": "object"}, "description": '
+        b'"source block", "items": {"additionalProperties": false, "properties": {'
+        b'"qualifiedvLEIIssuervLEICredential": {"type": "string"}}, "required": ['
+        b'"qualifiedvLEIIssuervLEICredential"], "type": "object"}, "maxItems": 1, "minItems": 1, "type": "array"}, '
+        b'"ti": {"type": "string"}, "x": {"description": "schema block", "type": "string"}}, "required": ["i", "s", '
+        b'"d"], "type": "object"}'),
+    "ELqz2NN3YhEfzonGT-aOLeA1bOY6hWkxl8YR-Lo4C3Og": (
+        b'{"$id": "ELqz2NN3YhEfzonGT-aOLeA1bOY6hWkxl8YR-Lo4C3Og", "$schema": '
+        b'"http://json-schema.org/draft-07/schema#", "additionalProperties": false, "properties": {"d": {'
+        b'"additionalProperties": false, "description": "data block", "properties": {"LEI": {"type": "string"}, '
+        b'"credentialStatus": {"type": "string"}, "gracePeriod": {"default": 90, "type": "integer"}, "i": {"type": '
+        b'"string"}, "issuanceDate": {"format": "date-time", "type": "string"}, "type": {"type": "array"}}, '
+        b'"required": ["i", "LEI", "credentialStatus", "issuanceDate", "type"], "type": "object"}, "i": {"type": '
+        b'"string"}, "ti": {"type": "string"}, "x": {"description": "schema block", "type": "string"}}, "required": ['
+        b'"i", "d"], "type": "object"}'),
 })
 
 
 class JSONSchema:
-
     id = Ids.dollar
 
     def __init__(self, resolver=CacheResolver()):
@@ -104,24 +153,23 @@ class JSONSchema:
                 sed = json.loads(raw.decode("utf-8"))
             except Exception as ex:
                 raise DeserializationError("Error deserializing JSON: {}"
-                      "".format(raw.decode("utf-8")))
+                                           "".format(raw.decode("utf-8")))
 
         elif kind == Serials.mgpk:
             try:
                 sed = msgpack.loads(raw)
             except Exception as ex:
                 raise DeserializationError("Error deserializing MGPK: {}"
-                      "".format(raw))
+                                           "".format(raw))
 
         elif kind == Serials.cbor:
             try:
                 sed = cbor.loads(raw)
             except Exception as ex:
                 raise DeserializationError("Error deserializing CBOR: {}"
-                      "".format(raw))
+                                           "".format(raw))
         else:
             raise ValueError("Invalid serialization kind = {}".format(kind))
-
 
         if self.id in sed:
             saider = Saider(qb64=sed[self.id], idder=self.id)
@@ -140,7 +188,6 @@ class JSONSchema:
         raw = coring.dumps(sed, kind)
         return raw
 
-
     @staticmethod
     def detect(raw=b''):
         """
@@ -154,7 +201,6 @@ class JSONSchema:
             return False
 
         return True
-
 
     @staticmethod
     def verify_schema(schema):
@@ -171,7 +217,6 @@ class JSONSchema:
             return False
 
         return True
-
 
     def verify_json(self, schema=b'', raw=b''):
         """
@@ -195,8 +240,6 @@ class JSONSchema:
             return False
 
         return True
-
-
 
 
 class Schemer:
@@ -257,7 +300,6 @@ class Schemer:
             raise ValidationError("invalid kind {} for schema {}"
                                   "".format(self.kind, self.sed))
 
-
     def _inhale(self, raw):
         """
         Loads type specific Schema ked and verifies the self-addressing identifier
@@ -271,7 +313,6 @@ class Schemer:
         sed, kind, saider = self.typ.load(raw=raw)
 
         return sed, kind, saider
-
 
     def _exhale(self, sed, kind=None):
         """
@@ -289,12 +330,10 @@ class Schemer:
 
         return raw, sed, kind, saider
 
-
     @property
     def raw(self):
         """ raw property getter """
         return self._raw
-
 
     @raw.setter
     def raw(self, raw):
@@ -305,12 +344,10 @@ class Schemer:
         self._kind = kind
         self._saider = saider
 
-
     @property
     def sed(self):
         """ ked property getter"""
         return self._sed
-
 
     @sed.setter
     def sed(self, sed):
@@ -321,12 +358,10 @@ class Schemer:
         self._sed = sed
         self._saider = saider
 
-
     @property
     def kind(self):
         """ kind property getter """
         return self._kind
-
 
     @kind.setter
     def kind(self, kind):
@@ -337,18 +372,15 @@ class Schemer:
         self._kind = kind
         self._saider = Saider(raw=self._raw, code=self._code)
 
-
     @property
     def saider(self):
         """ saider property getter """
         return self._saider
 
-
     @property
     def said(self):
         """ said property getter, relies on saider """
         return self.saider.qb64
-
 
     def verify(self, raw=b''):
         """
@@ -395,7 +427,6 @@ class Saider(Matter):
             sed (dict): optional deserialized JSON for which to create the self addressing
         """
 
-
         self.idder = idder
         self._kind = kind
         try:
@@ -432,7 +463,6 @@ class Saider(Matter):
             raw, code = self._derive(sed=sed)
             super(Saider, self).__init__(raw=raw, code=code, **kwa)
 
-
         if self.code == MtrDex.Blake3_256:
             self._verify = self._verify_blake3_256
         elif self.code == MtrDex.Blake2b_256:
@@ -462,7 +492,6 @@ class Saider(Matter):
 
         return self._derive(sed=sed)
 
-
     def verify(self, sed, prefixed=False):
         """
         Returns True if derivation from ked for .code matches .qb64 and
@@ -488,7 +517,6 @@ class Saider(Matter):
 
         return True
 
-
     def rawify(self, sed):
         if 'v' in sed:
             kind, _, _ = coring.Deversify(sed['v'])
@@ -497,7 +525,6 @@ class Saider(Matter):
 
         raw = coring.dumps(sed, kind)
         return raw
-
 
     def _derive_blake3_256(self, sed):
         """
@@ -508,13 +535,12 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.Blake3_256].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.Blake3_256].fs)
 
         raw = self.rawify(sed)
 
         dig = blake3.blake3(raw).digest()
         return dig, MtrDex.Blake3_256
-
 
     def _verify_blake3_256(self, sed):
         """
@@ -526,7 +552,6 @@ class Saider(Matter):
         raw, code = self._derive_blake3_256(sed=sed)
         return Matter(raw=raw, code=MtrDex.Blake3_256)
 
-
     def _derive_sha3_256(self, sed):
         """
         Returns tuple (raw, code) of basic SHA3 digest (qb64)
@@ -536,12 +561,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.SHA3_256].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.SHA3_256].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.sha3_256(raw).digest()
         return dig, MtrDex.SHA3_256
-
 
     def _verify_sha3_256(self, sed):
         """
@@ -553,7 +577,6 @@ class Saider(Matter):
         raw, code = self._derive_sha3_256(sed=sed)
         return Matter(raw=raw, code=MtrDex.SHA3_256)
 
-
     def _derive_sha3_512(self, sed):
         """
         Returns tuple (raw, code) of basic SHA3 digest (qb64)
@@ -563,12 +586,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.SHA3_512].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.SHA3_512].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.sha3_512(raw).digest()
         return dig, MtrDex.SHA3_512
-
 
     def _verify_sha3_512(self, sed):
         """
@@ -580,7 +602,6 @@ class Saider(Matter):
         raw, code = self._derive_sha3_512(sed=sed)
         return Matter(raw=raw, code=MtrDex.SHA3_512)
 
-
     def _derive_sha2_256(self, sed):
         """
         Returns tuple (raw, code) of basic SHA2 digest (qb64)
@@ -590,12 +611,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.SHA2_256].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.SHA2_256].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.sha256(raw).digest()
         return dig, MtrDex.SHA2_256
-
 
     def _verify_sha2_256(self, sed):
         """
@@ -607,7 +627,6 @@ class Saider(Matter):
         raw, code = self._derive_sha2_256(sed=sed)
         return Matter(raw=raw, code=MtrDex.SHA2_256)
 
-
     def _derive_sha2_512(self, sed):
         """
         Returns tuple (raw, code) of basic SHA2 digest (qb64)
@@ -617,12 +636,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.SHA2_512].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.SHA2_512].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.sha512(raw).digest()
         return dig, MtrDex.SHA2_512
-
 
     def _verify_sha2_512(self, sed):
         """
@@ -635,7 +653,6 @@ class Saider(Matter):
         raw, code = self._derive_sha2_512(sed=sed)
         return Matter(raw=raw, code=MtrDex.SHA2_512)
 
-
     def _derive_blake2b_256(self, sed):
         """
         Returns tuple (raw, code) of basic BLAKE2B digest (qb64)
@@ -645,12 +662,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.Blake2b_256].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.Blake2b_256].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.blake2b(raw).digest()
         return dig, MtrDex.Blake2b_256
-
 
     def _verify_blake2b_256(self, sed):
         """
@@ -662,7 +678,6 @@ class Saider(Matter):
         raw, code = self._derive_blake2b_256(sed=sed)
         return Matter(raw=raw, code=MtrDex.Blake2b_256)
 
-
     def _derive_blake2s_256(self, sed):
         """
         Returns tuple (raw, code) of basic BLAKE2S digest (qb64)
@@ -672,12 +687,11 @@ class Saider(Matter):
 
         idf = self.idder
         # put in dummy pre to get size correct
-        sed[idf] = "{}".format(self.Dummy*Matter.Codes[MtrDex.Blake2s_256].fs)
+        sed[idf] = "{}".format(self.Dummy * Matter.Codes[MtrDex.Blake2s_256].fs)
         raw = self.rawify(sed)
 
         dig = hashlib.blake2s(raw).digest()
         return dig, MtrDex.Blake2s_256
-
 
     def _verify_blake2s_256(self, sed):
         """

--- a/src/keri/demo/demo_vic.py
+++ b/src/keri/demo/demo_vic.py
@@ -21,6 +21,7 @@ from keri.demo.demoing import VicDirector
 from keri.peer import exchanging
 from keri.vc import handling
 from keri.vdr import verifying
+from keri.help import decking, helping
 
 logger = help.ogler.getLogger()
 
@@ -86,7 +87,9 @@ def setupController(secrets, witnessPort=5621, peerPort=5629, indirect=False):
     peerClientDoer = clienting.ClientDoer(client=peerClient)
 
     jsonSchema = scheming.JSONSchema(resolver=scheming.jsonSchemaCache)
-    proofHandler = handling.ProofHandler(typ=jsonSchema, callback=print)
+
+    proofs = decking.Deck()
+    proofHandler = handling.ProofHandler(typ=jsonSchema, proofs=proofs)
 
     excDoer = exchanging.Exchanger(hab=hab, handlers=[proofHandler])
     director = VicDirector(hab=hab,
@@ -95,6 +98,7 @@ def setupController(secrets, witnessPort=5621, peerPort=5629, indirect=False):
                            peerClient=peerClient,
                            exchanger=excDoer,
                            jsonSchema=jsonSchema,
+                           proofs=proofs,
                            tock=0.125)
 
 

--- a/src/keri/demo/demoing.py
+++ b/src/keri/demo/demoing.py
@@ -609,7 +609,7 @@ class VicDirector(directing.Director):
        ._tock is hidden attribute for .tock property
     """
 
-    def __init__(self, hab, witnessClient, peerClient, verifier, exchanger, jsonSchema, **kwa):
+    def __init__(self, hab, witnessClient, peerClient, verifier, exchanger, jsonSchema, proofs, **kwa):
         """
 
             verifier is Verifier instance of local controller's TEL context
@@ -619,9 +619,10 @@ class VicDirector(directing.Director):
         self.verifier = verifier
         self.exchanger = exchanger
         self.jsonSchema = jsonSchema
-        self.presentations = []
+        self.proofs = proofs
         if self.tymth:
             self.peerClient.wind(self.tymth)
+
 
     def do(self, tymth=None, tock=0.0, **opts):
         """
@@ -672,12 +673,12 @@ class VicDirector(directing.Director):
             self.peerClient.tx(excMsg)
             tyme = (yield self.tock)
 
-            while not self.presentations:
+            while not self.proofs:
                 logger.info("%s:\n waiting for proof presentation from %s.\n\n",
                             self.hab.pre, self.peerClient.ha)
                 tyme = (yield self.tock)
 
-            presentation = self.presentations.pop()
+            _, presentation = self.proofs.pop()
 
             vc = presentation["vc"]
             body = vc["d"]
@@ -733,56 +734,6 @@ class VicDirector(directing.Director):
 
         return True  # return value of yield from, or yield ex.value of StopIteration
 
-    def verifiyCredential(self, issuer, presentation):
-        logger.info("%s: \n received presentation from %s\n\n", self.hab.pre, issuer.qb64)
-
-        self.presentations.append(presentation)
-
-        #
-        #
-        # # extract proof from VC
-        # proof = vc.pop("proof")
-        # vcdata = json.dumps(vc).encode("utf-8")
-        # vcsig = proof["jws"]
-        # method = proof["verificationMethod"]
-        # url = parse.urlsplit(method)
-        #
-        # if url.scheme != "did":
-        #     logger.error("%s:\n Invalid verification method scheme %s.\n\n",
-        #                  self.hab.pre, url.scheme)
-        #
-        # (pre, regk) = url.path.removeprefix("keri:").split("/")
-        #
-        # msg = self.verifier.query(regk,
-        #                           vcid,
-        #                           res="tels")
-        # self.client.tx(msg)  # send to connected remote
-        # logger.info("%s sent event:\n%s\n\n", self.hab.pre, bytes(msg))
-        # tyme = (yield (self.tock))
-        #
-        # while regk not in self.verifier.tevers:
-        #     logger.info("%s:\n waiting for retrieval of TEL %s.\n\n",
-        #                 self.hab.pre, regk)
-        #     tyme = (yield (self.tock))
-        #
-        # tyme = (yield (self.tock))
-        # sidx = int(url.fragment)
-        #
-        # valid = self.verifier.verify(pre=pre,
-        #                              sidx=sidx,
-        #                              regk=regk,
-        #                              vcid=vcid,
-        #                              vcdata=vcdata,
-        #                              vcsig=vcsig)
-        #
-        # if valid is True:
-        #     sub = vc["credentialSubject"]
-        #     logger.info("%s:\n\n\n Valid vLEI credential for LEI: %s.\n\n",
-        #                 self.hab.pre, sub["lei"])
-        # else:
-        #     logger.error("%s:\n\n\n Invalid vLEI credential.\n\n",
-        #                  self.hab.pre)
-        #
 
 
 class CamDirector(directing.Director):

--- a/src/keri/vc/handling.py
+++ b/src/keri/vc/handling.py
@@ -391,12 +391,12 @@ class ProofHandler(doing.Doer):
     resource = "/presentation/proof"
 
 
-    def __init__(self, callback, typ=JSONSchema(), cues=None, **kwa):
+    def __init__(self, typ=JSONSchema(), cues=None, proofs=None, **kwa):
         self.msgs = decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
+        self.proofs = proofs if proofs is not None else decking.Deck()
 
         self.typ = typ
-        self.callback = callback
 
         super(ProofHandler, self).__init__(**kwa)
 
@@ -438,8 +438,7 @@ class ProofHandler(doing.Doer):
                 for idx, descriptor in enumerate(dm):
                     # TODO:  Find verifiable credential in vcs based on `path`
                     vc = vcs[idx]
-                    self.callback(pre, vc)
-
+                    self.proofs.append((pre, vc))
 
                 yield
 

--- a/src/keri/vc/proving.py
+++ b/src/keri/vc/proving.py
@@ -49,19 +49,18 @@ def credential(schema,
         v=vs,
         i="",
         x=schema,
-        issuer=issuer,
-        issuance=iss,
-        d=subject
+        ti=issuer,
     )
 
+    subject["issuanceDate"] = issuance
+
     if expiry is not None:
-        vc["expiry"] = expiry
+        subject["expiry"] = expiry
 
     if regk is not None:
-        vc["status"] = dict(
-            id=regk,
-            type=KERI_REGISTRY_TYPE
-        )
+        subject["credentialStatus"] = regk
+
+    vc["d"] = subject
 
     return Credentialer(crd=vc, typ=typ)
 
@@ -262,7 +261,7 @@ class Credentialer:
     @property
     def issuer(self):
         """ issuer property getter"""
-        return self.crd["issuer"]
+        return self.crd["ti"]
 
     @property
     def schema(self):
@@ -277,7 +276,7 @@ class Credentialer:
     @property
     def status(self):
         """ status property getter"""
-        return self.crd["status"]
+        return self.subject["credentialStatus"]
 
     def pretty(self):
         """

--- a/tests/vc/test_handling.py
+++ b/tests/vc/test_handling.py
@@ -75,17 +75,16 @@ def test_issuing():
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=jsonSchema)
 
-        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
+        assert creder.said == "EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM"
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
-            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
-            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
+            b'{"v":"KERI10JSON000136_","i":"EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","ti":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36",'
+            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
+            b'-AABAA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA')
 
         # Create the issue credential payload
         pl = dict(
@@ -102,13 +101,12 @@ def test_issuing():
         assert doist.tyme == limit
 
         ser = (
-            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
-            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36"}}'
-        )
+            b'{"v":"KERI10JSON000136_","i":"EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","ti":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36",'
+            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}')
         sig0 = (
-            b'AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg'
+            b'AA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA'
         )
 
         # verify we can load serialized VC by SAID
@@ -196,7 +194,7 @@ def test_proving():
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=JSONSchema(resolver=cache))
 
-        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
+        assert creder.said == "EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM"
 
         msg = sidHab.endorse(serder=creder)
         hanWallet = Wallet(hab=hanHab, db=hanPDB)
@@ -249,7 +247,7 @@ def test_proving():
 
         proof = (
             "-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw"
-            "-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg")
+            "-AxDNI7_ZmaI-AABAA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA")
         assert vcs[0]["proof"] == proof
 
 

--- a/tests/vc/test_proving.py
+++ b/tests/vc/test_proving.py
@@ -53,13 +53,12 @@ def test_proving():
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
-            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
-            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
+            b'{"v":"KERI10JSON000136_","i":"EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","ti":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36",'
+            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
+            b'-AABAA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA')
 
         creder = Credentialer(raw=msg, typ=JSONSchema(resolver=cache))
         proof = msg[creder.size:]
@@ -101,26 +100,26 @@ def test_proving():
 def test_credentialer():
     with pytest.raises(ValueError):
         Credentialer()
-    sub = dict(a=123, b="abc")
+    sub = dict(a=123, b="abc", issuanceDate="2021-06-27T21:26:21.233257+00:00")
     d = dict(
         v=Vstrings.json,
         i="",
         x="abc",
-        issuer="i",
-        issuance="2021-06-27T21:26:21.233257+00:00",
+        ti="i",
         d=sub
     )
 
     creder = Credentialer(crd=d)
-    assert creder.said == "EASVjcsdqrobngAG0RfGEkeOjdOO0zotPmc7O3Oi8ZWk"
+    assert creder.said == "EeFdv935UXIkVl3QGMLTMz5OQHHW650WsOHE0cF3q9f4"
     assert creder.kind == Serials.json
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.crd == d
     assert creder.size == 169
-    assert creder.raw == b'{"v":"KERI10JSON0000a9_","i":"EASVjcsdqrobngAG0RfGEkeOjdOO0zotPmc7O3Oi8ZWk","x":"abc",' \
-                         b'"issuer":"i","issuance":"2021-06-27T21:26:21.233257+00:00","d":{"a":123,"b":"abc"}}'
+    assert creder.raw == (
+        b'{"v":"KERI10JSON0000a9_","i":"EeFdv935UXIkVl3QGMLTMz5OQHHW650WsOHE0cF3q9f4","x":"abc","ti":"i",'
+        b'"d":{"a":123,"b":"abc","issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}')
 
     raw1, knd1, ked1, ver1, saider = creder._exhale(crd=d)
     assert raw1 == creder.raw
@@ -138,19 +137,19 @@ def test_credentialer():
     d2 = dict(d)
     d2["v"] = Vstrings.cbor
     creder = Credentialer(crd=d2)
-    assert creder.said == "EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6c"
+    assert creder.said == "EUoO89lNIr0K-W6-3rtyYgucAc1Jx0gKNryqYtd1aJMg"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.size == 140
     assert creder.crd == d2
-    assert creder.raw == b'\xa6avqKERI10CBOR00008c_aix,' \
-                         b'EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6caxcabcfissueraihissuancex ' \
-                         b'2021-06-27T21:26:21.233257+00:00ad\xa2aa\x18{abcabc'
+    assert creder.raw == (
+        b'\xa5avqKERI10CBOR00008c_aix,EUoO89lNIr0K-W6-3rtyYgucAc1Jx0gKNryqYtd1aJMgaxcabcbtiaiad\xa3aa\x18{'
+        b'abcabclissuanceDatex 2021-06-27T21:26:21.233257+00:00')
 
     raw2 = bytes(creder.raw)
     creder = Credentialer(raw=raw2)
-    assert creder.said == "EsxmFcwFuAoBiOOSc2LHDqWpSHdSbDoBB1NMFpAScY6c"
+    assert creder.said == "EUoO89lNIr0K-W6-3rtyYgucAc1Jx0gKNryqYtd1aJMg"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
@@ -161,19 +160,20 @@ def test_credentialer():
     d3["v"] = Vstrings.mgpk
     creder = Credentialer(crd=d3)
 
-    assert creder.said == "EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM"
+    assert creder.said == "Ef7Mu7jak-tFu2FJhzF4JAyWkymBokHkv6SFh84Wuxok"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.size == 139
     assert creder.crd == d3
-    assert creder.raw == b'\x86\xa1v\xb1KERI10MGPK00008b_\xa1i\xd9,' \
-                         b'EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM\xa1x\xa3abc\xa6issuer\xa1i\xa8issuance\xd9 ' \
-                         b'2021-06-27T21:26:21.233257+00:00\xa1d\x82\xa1a{\xa1b\xa3abc'
+    assert creder.raw == (
+        b'\x85\xa1v\xb1KERI10MGPK00008b_\xa1i\xd9,'
+        b'Ef7Mu7jak-tFu2FJhzF4JAyWkymBokHkv6SFh84Wuxok\xa1x\xa3abc\xa2ti\xa1i\xa1d\x83\xa1a{'
+        b'\xa1b\xa3abc\xacissuanceDate\xd9 2021-06-27T21:26:21.233257+00:00')
 
     raw3 = bytes(creder.raw)
     creder = Credentialer(raw=raw3)
-    assert creder.said == "EYQei3JduKN6aSbmcodvf_VOK0xttPKDewm1OKzSBrUM"
+    assert creder.said == "Ef7Mu7jak-tFu2FJhzF4JAyWkymBokHkv6SFh84Wuxok"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub

--- a/tests/vc/test_walleting.py
+++ b/tests/vc/test_walleting.py
@@ -52,30 +52,27 @@ def test_wallet():
                             subject=credSubject,
                             issuance="2021-06-27T21:26:21.233257+00:00",
                             typ=JSONSchema(resolver=cache))
-        assert creder.said == "Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY"
+        assert creder.said == "EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM"
 
         msg = sidHab.endorse(serder=creder)
         assert msg == (
-            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
-            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI-AABAAVgLJOmUNlMZpSGV0hr'
-            b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
-
+            b'{"v":"KERI10JSON000136_","i":"EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","ti":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36",'
+            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
+            b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
+            b'-AABAA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA')
         ser = (
-            b'{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-            b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E","issuance":"2021-06-27T21:26:21.233257+00:00",'
-            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-            b'"lei":"254900OPPU84GM83MG36"}}')
+            b'{"v":"KERI10JSON000136_","i":"EgaaYOPdG7vootT99cmClvwOoM-hjUIpv5Xl6hFuTcyM",'
+            b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","ti":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
+            b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v","lei":"254900OPPU84GM83MG36",'
+            b'"issuanceDate":"2021-06-27T21:26:21.233257+00:00"}}')
         seal = (
             b'E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw'
             b'-AxDNI7_ZmaI')
 
         sig0 = (
-            b'AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg'
+            b'AA0pXbQllgzXr88IczAnsPrdhgFKs9wNQvfSfzyrtcvbTwq-U1DmBluAklntCqH1AbBL6TWLZIDGi83BHLWJ82CA'
         )
 
         sidWallet = Wallet(hab=sidHab, db=sidPDB)
@@ -187,18 +184,17 @@ def test_build_proof():
         sigers = sigHab.mgr.sign(ser=creder.raw, verfers=sigHab.kever.verfers, indexed=True)
 
         proof = buildProof(prefixer, seqner, diger, sigers)
-        assert proof == (b'-FABEiRjCnZfca8gUZqecerjGpjkiY8dIkGudP6GfapWi5MU0AAAAAAAAAAAAAAAAAAAAABAECc96yX1sYswnD6LXE'
-                         b'coNuJ0ehi8gkFMEGedqURhXMBU-AADAAarmUESbxAsy42qOTYN_ChWWgHT7HlM6_qTunFZeuTf9ozrGmvJ-RSjh2r4'
-                         b'cbaID5eKe7mU3PTziJ2YjNlDB1DwAByOIg2T3S2bb8KnI40e0P5Ucllxt-5ZvxX2_2XfrCp6s8DjodXvVhZqqsQVyN'
-                         b'jOvg9MM_fh5s02NKYJ4s9UXgDgACC3_hfvm_H77YuE4IndBvm2DdB2p_wgN9K-VOefzv11e4SLX4W8_Ns4hiaMm3ul'
-                         b'm8f4RAaoJEICDax-xomO1mCA')
+        assert proof == (
+            b'-FABEiRjCnZfca8gUZqecerjGpjkiY8dIkGudP6GfapWi5MU0AAAAAAAAAAAAAAAAAAAAABAECc96yX1sYswnD6LXEcoNuJ0e'
+            b'hi8gkFMEGedqURhXMBU-AADAAGcSUhma16SY3MiKU7n6mK3JzWS2oAiBRB-jeycIDrQ2Z-36QHrMorzRAO9Iw7FvIKrneaLZP'
+            b'whz6DFFiXM4oBgAB1g2CudOfOFd9BqesyAIlCDRAkxAQynrED4_ot1MkhKwjmK71XUx1Xer25iWtHMa9sny07AsTO-KE3vu9e'
+            b'qTPDQAClDQMXWg3I8qeVEjA6JA9xBW2uESMtMzNVQ8lH31UCizqYVjXort--QEJTsfIt_b0Qq1JOCtaj7Y6U-DWHoulBA')
 
         prefixer, seqner, diger, isigers = parseProof(proof)
         assert prefixer.qb64 == sigHab.pre
         assert diger.qb64 == sigHab.kever.lastEst.d
         assert seqner.sn == 4
         assert len(isigers) == 3
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes:

* Fixed incept and send commands to exit properly by removing all Doers and returning from processing.

* Updated ProofHandler to output presentations on a buffer for consumption downstream.  Updated Vic to process that buffer

* Added vLEI AC/DC credential schema to temporary in memory schema cache.

* Updated Credentialer to return AC/DC complaint credentials by default.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>