### PR TITLE
Hardening witnesses to be launched with existing identities plus other CLI features

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -6,6 +6,7 @@ keri.app.agenting module
 """
 from hio.base import doing
 from hio.core.tcp import clienting
+from keri.core import coring
 
 from ..app import obtaining
 from ..core import eventing, parsing, scheming
@@ -19,42 +20,118 @@ from .. import help
 logger = help.ogler.getLogger()
 
 
-class AgentController:
-    """
-
-    """
-
-    def __init__(self, hab, issuer, **kwa):
-        """
-
-        Parameters:
-            hab (Habitat):
-            issuer (Issuer):
-
-        """
-        self.hab = hab
-        self.issuer = issuer
-
-
-
 class WitnessReceiptor(doing.DoDoer):
+    """
+    Sends messages to all current witnesses of given identifier (from hab) and waits
+    for receipts from each of those witnesses and propogates those receipts to each
+    of the other witnesses after receiving the complete set.
 
-    def __init__(self, hab, doers=None, **kwa):
+    Removes all Doers and exits as Done once all witnesses have been sent the entire
+    receipt set.  Could be enhanced to have a `once` method that runs once and cleans up
+    and an `all` method that runs and waits for more messages to receipt.
+
+    """
+
+    def __init__(self, hab, msg=None, **kwa):
         """
         For the current event, gather the current set of witnesses, send the event,
         gather all receipts and send them to all other witnesses
 
         Parameters:
             hab: Habitat of the identifier to populate witnesses
+            msg: is the message to send to all witnesses.
+                 Defaults to sending the latest KEL event if msg is None
 
         """
         self.hab = hab
+        self.msg = msg
         super(WitnessReceiptor, self).__init__(doers=[self.receiptDo], **kwa)
-
 
     @doing.doize()
     def receiptDo(self, tymth=None, tock=0.0, **opts):
-        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        ser = self.hab.kever.serder
+        sn = self.hab.kever.sn
+        wits = self.hab.kever.wits
+
+        if len(wits) == 0:
+            return True
+
+        msg = self.msg if self.msg is not None else self.hab.makeOwnEvent(sn=sn)
+
+        witers = []
+        for wit in wits:
+            witer = Witnesser(hab=self.hab, wit=wit)
+            witers.append(witer)
+            witer.msgs.append(msg)
+            self.extend([witer])
+
+            _ = (yield self.tock)
+
+        while True:
+            dgkey = dbing.dgKey(ser.preb, ser.digb)
+
+            wigs = self.hab.db.getWigs(dgkey)
+            if len(wigs) == len(wits):
+                break
+            _ = yield self.tock
+
+        # generate all rct msgs to send to all witnesses
+        wigers = [coring.Siger(qb64b=bytes(wig)) for wig in wigs]
+        rserder = eventing.receipt(pre=ser.pre,
+                                   sn=sn,
+                                   dig=ser.dig)
+        rctMsg = eventing.messagize(serder=rserder, wigers=wigers)
+
+        # this is a little brute forcey and can be improved by gathering receipts
+        # along the way and passing them out as we go and only sending the
+        # required ones here
+        for witer in witers:
+            witer.msgs.append(rctMsg)
+            _ = (yield self.tock)
+
+        total = len(witers) * 2
+        count = 0
+        while count < total:
+            for witer in witers:
+                count += len(witer.sent)
+            _ = (yield self.tock)
+
+        self.remove(witers)
+        return True
+
+
+class WitnessSender(doing.DoDoer):
+    """
+    Sends messages to all current witnesses of given identifier (from hab) and exits.
+
+    Removes all Doers and exits as Done once all witnesses have been sent the message.
+    Could be enhanced to have a `once` method that runs once and cleans up
+    and an `all` method that runs and waits for more messages to receipt.
+
+    """
+
+    def __init__(self, hab, msg, **kwa):
+        """
+        For the current event, gather the current set of witnesses, send the event,
+        gather all receipts and send them to all other witnesses
+
+        Parameters:
+            hab: Habitat of the identifier to populate witnesses
+            msg: is the message to send to all witnesses.
+                 Defaults to sending the latest KEL event if msg is None
+
+        """
+        self.hab = hab
+        self.msg = msg
+        super(WitnessSender, self).__init__(doers=[self.sendDo], **kwa)
+
+
+    @doing.doize()
+    def sendDo(self, tymth=None, tock=0.0, **opts):
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -62,16 +139,31 @@ class WitnessReceiptor(doing.DoDoer):
         sn = self.hab.kever.sn
         wits = self.hab.kever.wits
 
-        msg = self.hab.makeOwnEvent(sn=sn)
+        if len(wits) == 0:
+            return True
 
+        witers = []
         for wit in wits:
-            witer = Witnesser(hab=self.hab, wit=wit, msg=msg)
+            witer = Witnesser(hab=self.hab, wit=wit)
+            witers.append(witer)
+            witer.msgs.append(self.msg)
             self.extend([witer])
+
             _ = (yield self.tock)
+
+        total = len(witers)
+        count = 0
+        while count < total:
+            for witer in witers:
+                count += len(witer.sent)
+            _ = (yield self.tock)
+
+        self.remove(witers)
+        return True
 
 
 class Witnesser(doing.DoDoer):
-    def __init__(self, hab, wit, msg, doers=None, **kwa):
+    def __init__(self, hab, wit, msgs=None, sent=None, doers=None, **kwa):
         """
         For the current event, gather the current set of witnesses, send the event,
         gather all receipts and send them to all other witnesses
@@ -82,7 +174,8 @@ class Witnesser(doing.DoDoer):
         """
         self.hab = hab
         self.wit = wit
-        self.msg = msg
+        self.msgs = msgs if msgs is not None else decking.Deck()
+        self.sent = sent if sent is not None else decking.Deck()
         self.parser = None
         doers = doers if doers is not None else []
         doers.extend([self.receiptDo])
@@ -93,25 +186,35 @@ class Witnesser(doing.DoDoer):
 
         super(Witnesser, self).__init__(doers=doers, **kwa)
 
-
     @doing.doize()
     def receiptDo(self, tymth=None, tock=0.0, **opts):
-        # enter context
+
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
 
-        loc = obtaining.getwitnessbyprefix(self.wit)
-        client = clienting.Client(host=loc.ip4, port=loc.tcp)
-        self.parser = parsing.Parser(ims=client.rxbs,
-                                     framed=True,
-                                     kvy=self.kevery)
+        while True:
+            while not self.msgs:
+                yield self.tock
 
-        clientDoer = clienting.ClientDoer(client=client)
-        self.extend([clientDoer, self.msgDo])
+            msg = self.msgs.popleft()
 
-        client.tx(self.msg)   # send to connected remote
+            loc = obtaining.getwitnessbyprefix(self.wit)
+            client = clienting.Client(host=loc.ip4, port=loc.tcp)
+            self.parser = parsing.Parser(ims=client.rxbs,
+                                         framed=True,
+                                         kvy=self.kevery)
 
+            clientDoer = clienting.ClientDoer(client=client)
+            self.extend([clientDoer, self.msgDo])
+
+            client.tx(msg)  # send to connected remote
+
+            while client.txbs:
+                yield self.tock
+
+            self.sent.append(msg)
+            yield self.tock
 
     @doing.doize()
     def msgDo(self, tymth=None, tock=0.0, **opts):
@@ -161,11 +264,9 @@ class RotateHandler(doing.DoDoer):
         self.msgs = decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
 
-
         doers = [self.msgDo]
 
         super(RotateHandler, self).__init__(doers=doers, **kwa)
-
 
     @doing.doize()
     def msgDo(self, tymth=None, tock=0.0, **opts):
@@ -218,13 +319,12 @@ class RotateHandler(doing.DoDoer):
 
                 logger.info('Prefix\t\t{%s}', self.hab.pre)
                 for idx, verfer in enumerate(self.hab.kever.verfers):
-                    logger.info('Public key %d:\t%s', idx+1, verfer.qb64)
+                    logger.info('Public key %d:\t%s', idx + 1, verfer.qb64)
                 logger.info("")
 
                 yield
 
             yield
-
 
 
 class IssueCredentialHandler(doing.DoDoer):
@@ -257,7 +357,6 @@ class IssueCredentialHandler(doing.DoDoer):
 
         super(IssueCredentialHandler, self).__init__(doers=doers, **kwa)
 
-
     @doing.doize()
     def msgDo(self, tymth=None, tock=0.0, **opts):
         """
@@ -285,8 +384,6 @@ class IssueCredentialHandler(doing.DoDoer):
 
                 self.extend([rcptClientDoer])
 
-                now = helping.nowIso8601()
-
                 ref = scheming.jsonSchemaCache.resolve(schema)
                 schemer = scheming.Schemer(raw=ref)
                 jsonSchema = scheming.JSONSchema(resolver=scheming.jsonSchemaCache)
@@ -295,20 +392,17 @@ class IssueCredentialHandler(doing.DoDoer):
                 creder = proving.credential(issuer=self.hab.pre,
                                             schema=schemer.said,
                                             subject=credSubject,
-                                            issuance=now,
-                                            regk=self.issuer.regk,
                                             typ=jsonSchema)
 
                 msg = self.hab.endorse(serder=creder)
 
                 tevt, kevt = self.issuer.issue(vcdig=creder.said)
 
-                # # TODO: figure out how to send these to my witnesses
-                # self.client.tx(kevt)  # send to connected remote
-                # tyme = (yield self.tock)
-                #
-                # self.client.tx(tevt)  # send to connected remote
-                # tyme = (yield self.tock)
+                witDoer = WitnessReceiptor(hab=self.hab, msg=kevt)
+                self.extend([witDoer])
+
+                witSender = WitnessSender(hab=self.hab, msg=tevt)
+                self.extend([witSender])
 
                 pl = dict(
                     vc=[handling.envelope(msg, typ=jsonSchema)]

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -67,9 +67,10 @@ class InceptDoer(doing.DoDoer):
         db = basing.Baser(name=name, temp=False)  # not opened by default, doer opens
         self.dbDoer = basing.BaserDoer(baser=db)  # doer do reopens if not opened and closes
 
+        salt = coring.Salter(raw=opts.salt.encode("utf-8")).qb64
         hab = habbing.Habitat(name=name, ks=ks, db=db, temp=False, transferable=opts.transferable,
                               isith=opts.isith, icount=opts.icount, nsith=opts.nsith, ncount=opts.ncount,
-                              wits=opts.witnesses)
+                              wits=opts.witnesses, salt=salt)
         self.habDoer = habbing.HabitatDoer(habitat=hab)  # setup doer
         self.witDoer = agenting.WitnessReceiptor(hab=hab)
 
@@ -85,16 +86,9 @@ class InceptDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        ser = self.hab.kever.serder
-        wits = self.hab.kever.wits
-
-        while True:
-            dgkey = dbing.dgKey(ser.preb, ser.digb)
-
-            rcts = self.hab.db.getWigs(dgkey)
-            if len(rcts) == len(wits):
-                break
+        while not self.witDoer.done:
             _ = yield self.tock
+
 
         print(f'Prefix\t\t{self.hab.pre}')
         for idx, verfer in enumerate(self.hab.kever.verfers):

--- a/src/keri/app/cli/commands/query.py
+++ b/src/keri/app/cli/commands/query.py
@@ -1,0 +1,118 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+from hio.core.tcp import clienting
+
+from keri.app import habbing, keeping, directing, obtaining
+from keri.core import eventing, parsing
+from keri.db import basing, dbing
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Request KEL from Witness')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='Human readable reference', required=True)
+parser.add_argument('--witness', '-w', help='QB64 identifier of witness to query', default="", required=True)
+parser.add_argument('--prefix', '-p', help='QB64 identifier to query', default="", required=True)
+
+
+def handler(args):
+    name = args.name
+
+    qryDoer = QueryDoer(name=name, wit=args.witness, pre=args.prefix)
+    directing.runController(doers=[qryDoer], expire=0.0)
+
+
+class QueryDoer(doing.DoDoer):
+
+    def __init__(self, name, wit, pre, **kwa):
+        ks = keeping.Keeper(name=name, temp=False)  # not opened by default, doer opens
+        self.ksDoer = keeping.KeeperDoer(keeper=ks)  # doer do reopens if not opened and closes
+        db = basing.Baser(name=name, temp=False, reload=True)  # not opened by default, doer opens
+        self.dbDoer = basing.BaserDoer(baser=db)  # doer do reopens if not opened and closes
+
+        self.hab = habbing.Habitat(name=name, ks=ks, db=db, temp=False, create=False)
+        self.habDoer = habbing.HabitatDoer(habitat=self.hab)  # setup doer
+
+        self.wit = wit
+        self.pre = pre
+
+        doers = [self.ksDoer, self.dbDoer, self.habDoer, self.queryDo]
+        super(QueryDoer, self).__init__(doers=doers, **kwa)
+
+    @doing.doize()
+    def queryDo(self, tymth, tock=0.0, **opts):
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        loc = obtaining.getwitnessbyprefix(self.wit)
+        client = clienting.Client(host=loc.ip4, port=loc.tcp)
+        clientDoer = clienting.ClientDoer(client=client)
+
+        kevery = eventing.Kevery(db=self.hab.db,
+                                 lax=False,
+                                 local=False)
+
+        self.parser = parsing.Parser(ims=client.rxbs,
+                                     framed=True,
+                                     kvy=kevery)
+
+        self.extend([clientDoer, self.msgDo])
+
+        msg = self.hab.query(self.pre, res="logs")  # Query for remote pre Event
+        client.tx(msg)  # send to connected remote
+
+        while self.pre not in kevery.kevers:
+            yield self.tock
+
+        kev = kevery.kevers[self.pre]
+        ser = kev.serder
+        dgkey = dbing.dgKey(ser.preb, ser.digb)
+        wigs = self.hab.db.getWigs(dgkey)
+
+        print("Prefix:\t{}".format(self.pre))
+        print("Seq No:\t{}".format(kev.sn))
+        print("\nWitnesses:")
+        print("Count:\t\t{}".format(len(wigs)))
+        print("Receipts:\t{}".format(len(kev.wits)))
+        print("Threshold:\t{}".format(kev.toad))
+        print("\nPublic Keys:\t")
+        for idx, verfer in enumerate(kev.verfers):
+            print(f'\t{idx+1}. {verfer.qb64}')
+
+        self.remove([self.ksDoer, self.dbDoer, self.habDoer, self.msgDo, clientDoer])
+
+        return
+
+    @doing.doize()
+    def msgDo(self, tymth=None, tock=0.0, **opts):
+        """
+        Returns Doist compatibile generator method (doer dog) to process
+            incoming message stream of .kevery
+
+        Doist Injected Attributes:
+            g.tock = tock  # default tock attributes
+            g.done = None  # default done state
+            g.opts
+
+        Parameters:
+            tymth is injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock is injected initial tock value
+            opts is dict of injected optional additional parameters
+
+
+        Usage:
+            add to doers list
+        """
+        done = yield from self.parser.parsator()  # process messages continuously
+        return done  # should nover get here except forced close

--- a/src/keri/app/cli/commands/send.py
+++ b/src/keri/app/cli/commands/send.py
@@ -14,7 +14,7 @@ from keri.db import basing
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Initialize a prefix')
+parser = argparse.ArgumentParser(description='Send KEL to a target tcp endpoint')
 parser.set_defaults(handler=lambda args: handler(args),
                     transferable=True)
 parser.add_argument('--name', '-n', help='Human readable reference', required=True)

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -13,7 +13,7 @@ from keri import help
 from keri.app import directing, indirecting
 
 d = "Runs KERI witness controller.\n"
-d += "Example:\nwitness -l 5621 --e 10.0\n"
+d += "Example:\nwitness -l 5631 --e 10.0\n"
 parser = argparse.ArgumentParser(description=d)
 parser.set_defaults(handler=lambda args: launch(args))
 parser.add_argument('-V', '--version',
@@ -23,7 +23,7 @@ parser.add_argument('-V', '--version',
 parser.add_argument('-l', '--local',
                     action='store',
                     default=5631,
-                    help="Local port number the server listens on. Default is 5620.")
+                    help="Local port number the server listens on. Default is 5631.")
 parser.add_argument('-e', '--expire',
                     action='store',
                     default=0.0,
@@ -31,7 +31,7 @@ parser.add_argument('-e', '--expire',
 parser.add_argument('-n', '--name',
                     action='store',
                     default="witness",
-                    help="Name of controller. Default is eve. Choices are bob, sam, or eve.")
+                    help="Name of controller. Default is witness.")
 
 
 def launch(args):
@@ -44,7 +44,7 @@ def launch(args):
                 ".******\n\n", args.name, args.local)
 
     runWitness(name=args.name,
-               local=args.local,
+               local=int(args.local),
                expire=args.expire)
 
     logger.info("\n******* Ended Witness for %s listening on %s"

--- a/src/keri/app/obtaining.py
+++ b/src/keri/app/obtaining.py
@@ -10,6 +10,9 @@ class Location:
 
 witnesses = {
     "B8NkPDTGELcUDH-TBCEjo4dpCvUnO_DnOSNEaNlL--4M": Location(ip4="127.0.0.1", tcp=5631),
+    "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo": Location(ip4="127.0.0.1", tcp=5632),  # wan
+    "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw": Location(ip4="127.0.0.1", tcp=5633),  # wil
+    "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c": Location(ip4="127.0.0.1", tcp=5634),  # wes
 }
 
 

--- a/src/keri/demo/demoing.py
+++ b/src/keri/demo/demoing.py
@@ -426,8 +426,6 @@ class IanDirector(directing.Director):
             creder = proving.credential(issuer=self.hab.pre,
                                         schema=schemer.said,
                                         subject=credSubject,
-                                        issuance=now,
-                                        regk=self.issuer.regk,
                                         typ=jsonSchema)
 
             msg = self.hab.endorse(serder=creder)

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -6,14 +6,12 @@ keri.vdr.verifying module
 VC verifier support
 """
 
+from .. import help
 from ..core import parsing, coring
-from ..core import eventing as ceventing
-from ..core.coring import Verfer, Cigar
+from ..core.coring import Cigar
 from ..vdr import eventing
 from ..vdr.eventing import VcStates
 from ..vdr.viring import Registry
-
-from .. import help
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -8,11 +8,9 @@ Provides public simple Verifiable Credential Issuance/Revocation Registry
 A special purpose Verifiable Data Registry (VDR)
 """
 
-import traceback
-
 from .. import kering
-from ..db import dbing
 from ..core import coring
+from ..db import dbing
 
 
 def openReg(name="test", **kwa):

--- a/tests/app/cli/gleif-sample.json
+++ b/tests/app/cli/gleif-sample.json
@@ -1,7 +1,11 @@
 {
   "salt": "0123456789abcdef",
   "transferable": true,
-  "witnesses": ["B8NkPDTGELcUDH-TBCEjo4dpCvUnO_DnOSNEaNlL--4M"],
+  "witnesses": [
+    "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
+    "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
+    "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
+  ],
   "icount": 3,
   "ncount": 5,
   "isith": 1,

--- a/tests/app/cli/wan-witness-sample.json
+++ b/tests/app/cli/wan-witness-sample.json
@@ -1,6 +1,6 @@
 {
-  "salt": "controller-kel00",
-  "transferable": true,
+  "salt": "wann-the-witness",
+  "transferable": false,
   "witnesses": [],
   "icount": 1,
   "ncount": 1,

--- a/tests/app/cli/wes-witness-sample.json
+++ b/tests/app/cli/wes-witness-sample.json
@@ -1,6 +1,6 @@
 {
-  "salt": "controller-kel00",
-  "transferable": true,
+  "salt": "wess-the-witness",
+  "transferable": false,
   "witnesses": [],
   "icount": 1,
   "ncount": 1,

--- a/tests/app/cli/wil-witness-sample.json
+++ b/tests/app/cli/wil-witness-sample.json
@@ -1,6 +1,6 @@
 {
-  "salt": "controller-kel00",
-  "transferable": true,
+  "salt": "will-the-witness",
+  "transferable": false,
   "witnesses": [],
   "icount": 1,
   "ncount": 1,

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -1,0 +1,86 @@
+from contextlib import contextmanager
+
+from hio.base import doing
+from keri.app import keeping, habbing, indirecting, agenting
+from keri.core import coring
+from keri.core.eventing import SealSource
+from keri.db import basing, dbing
+from keri.vdr import eventing, viring, issuing
+
+
+def test_withness_receiptor(mockGetWitnessByPrefix):
+
+    with openHab(name="wan", salt=b'wann-the-witness', transferable=False) as wanHab, \
+            openHab(name="wil", salt=b'will-the-witness', transferable=False) as wilHab, \
+            openHab(name="wes", salt=b'wess-the-witness', transferable=False) as wesHab, \
+            openHab(name="pal", salt=b'0123456789abcdef', transferable=True,
+                    wits=[wanHab.pre, wilHab.pre, wesHab.pre]) as palHab:
+
+        wanDoers = indirecting.setupWitness(name="wan", hab=wanHab, temp=True, localPort=5632)
+        wilDoers = indirecting.setupWitness(name="wil", hab=wilHab, temp=True, localPort=5633)
+        wesDoers = indirecting.setupWitness(name="wes", hab=wesHab, temp=True, localPort=5634)
+
+        witDoer = agenting.WitnessReceiptor(hab=palHab)
+
+        limit = 1.0
+        tock = 0.03125
+        doist = doing.Doist(limit=limit, tock=tock)
+        doers = wanDoers + wilDoers + wesDoers + [witDoer]
+        doist.do(doers=doers)
+
+        kev = palHab.kever
+        ser = kev.serder
+        dgkey = dbing.dgKey(ser.preb, ser.digb)
+
+        wigs = wanHab.db.getWigs(dgkey)
+        assert len(wigs) == 3
+        wigs = wilHab.db.getWigs(dgkey)
+        assert len(wigs) == 3
+        wigs = wesHab.db.getWigs(dgkey)
+        assert len(wigs) == 3
+
+
+def test_witness_sender(mockGetWitnessByPrefix):
+    with openHab(name="wan", salt=b'wann-the-witness', transferable=False) as wanHab, \
+            openHab(name="wil", salt=b'will-the-witness', transferable=False) as wilHab, \
+            openHab(name="wes", salt=b'wess-the-witness', transferable=False) as wesHab, \
+            openHab(name="pal", salt=b'0123456789abcdef', transferable=True,
+                    wits=[wanHab.pre, wilHab.pre, wesHab.pre]) as palHab:
+
+        wanDoers = indirecting.setupWitness(name="wan", hab=wanHab, temp=True, localPort=5632)
+        wilDoers = indirecting.setupWitness(name="wil", hab=wilHab, temp=True, localPort=5633)
+        wesDoers = indirecting.setupWitness(name="wes", hab=wesHab, temp=True, localPort=5634)
+
+        serder = eventing.issue(vcdig="Ekb-iNmnXnOYIAlZ9vzK6RV9slYiKQSyQvAO-k0HMOI8",
+                                regk="EbA1o_bItVC9i6YB3hr2C3I_Gtqvz02vCmavJNoBA3Jg")
+        seal = SealSource(s=palHab.kever.sn, d=palHab.kever.serder.dig)
+        msg = issuing.Issuer.messagize(serder=serder, seal=seal)
+
+        witDoer = agenting.WitnessSender(hab=palHab, msg=msg)
+
+        limit = 1.0
+        tock = 0.03125
+        doist = doing.Doist(limit=limit, tock=tock)
+        doers = wanDoers + wilDoers + wesDoers + [witDoer]
+        doist.do(doers=doers)
+
+        assert witDoer.done is True
+
+        for name in ["wes", "wil", "wan"]:
+            reger = viring.Registry(name=name)
+            raw = reger.getTvt(dbing.dgKey(serder.preb, serder.digb))
+            found = coring.Serder(raw=bytes(raw))
+            assert serder.pre == found.pre
+
+
+@contextmanager
+def openHab(name="test", salt=b'0123456789abcdef', **kwa):
+    with basing.openDB(name=name, temp=True) as db, \
+            keeping.openKS(name=name, temp=True) as ks:
+
+        salt = coring.Salter(raw=salt).qb64
+        hab = habbing.Habitat(name=name, ks=ks, db=db, temp=True, salt=salt,
+                              icount=1, isith=1, ncount=1, nsith=1, **kwa)
+
+        yield hab
+

--- a/tests/app/test_obtaining.py
+++ b/tests/app/test_obtaining.py
@@ -1,0 +1,34 @@
+from keri.app import obtaining
+
+
+def test_getwitness():
+
+    loc = obtaining.getwitnessbyprefix("B8NkPDTGELcUDH-TBCEjo4dpCvUnO_DnOSNEaNlL--4M")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5631
+    loc = obtaining.getwitnessbyprefix("BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5632
+    loc = obtaining.getwitnessbyprefix("BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5633
+    loc = obtaining.getwitnessbyprefix("Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5634
+
+
+def test_getendpointbyprefix():
+
+    loc = obtaining.getendpointbyprefix("EhYpYZSUAtiEurF7XngDB2mII2khY9ktlfqKHd1NHfNY")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5629
+    assert loc.http == 0
+    loc = obtaining.getendpointbyprefix("ExwBAYqvPpaPpGmBCixIiC_xpcDto8YUxLoNJgE2FOKo")
+    assert loc.ip4 == "127.0.0.1"
+    assert loc.tcp == 5621
+    assert loc.http == 5620
+
+
+
+if __name__ == '__main__':
+    test_getwitness()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ https://docs.pytest.org/en/latest/pythonpath.html
 """
 import pytest
 
+from keri.app import obtaining
 from keri.help import helping
 
 
@@ -24,3 +25,26 @@ def mockHelpingNowUTC(monkeypatch):
         return helping.fromIso8601("2021-01-01T00:00:00.000000+00:00")
 
     monkeypatch.setattr(helping, "nowUTC", mockNowUTC)
+
+
+@pytest.fixture()
+def mockGetWitnessByPrefix(monkeypatch):
+    """
+    Replace getwitnessbyprefix universally with fixed cache for testing
+    """
+    # override the in memory cache for this demo, should probably use a mock
+    witnesses = {
+        "B6KBd3GmnWvjcmE775zNRPCsJfOhasjBbyLjUpYOWvyw": obtaining.Location(ip4="127.0.0.1", tcp=5632),  # wan
+        "B7L80wOpOxsItVk1p4tYiK6vNjVVLExvhB5yGEuk864U": obtaining.Location(ip4="127.0.0.1", tcp=5633),  # wil
+        "B3y3efWXFxXRJYYkggXjp-lJSoDsyqt7kok03edvHeas": obtaining.Location(ip4="127.0.0.1", tcp=5634),  # wes
+    }
+
+
+    def getwitnessbyprefix(qb64):
+        """
+        Use predetermined value for now (current time)
+        '2021-01-01T00:00:00.000000+00:00'
+        """
+        return witnesses[qb64]
+
+    monkeypatch.setattr(obtaining, "getwitnessbyprefix", getwitnessbyprefix)

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -3,6 +3,7 @@
 tests.peer.test_exchanging module
 
 """
+
 from hio.base import doing
 
 from keri.app import keeping, habbing
@@ -14,7 +15,6 @@ from keri.peer import exchanging
 
 def test_exchanger():
     sidSalt = coring.Salter(raw=b'0123456789abcdef').qb64
-    redSalt = coring.Salter(raw=b'abcdef0123456789').qb64
 
     with basing.openDB(name="sid") as sidDB, \
             keeping.openKS(name="sid") as sidKS, \

--- a/tests/peer/test_httping.py
+++ b/tests/peer/test_httping.py
@@ -1,0 +1,59 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.peer.httping module
+
+"""
+
+import falcon
+import pytest
+from falcon.testing import helpers
+from keri.peer import httping
+
+
+def test_parse_cesr_request():
+    req = helpers.create_req()
+    with pytest.raises(falcon.HTTPError):
+        httping.parseCesrHttpRequest(req=req)
+
+    req = helpers.create_req(headers=dict(
+        Content_Type=httping.CESR_CONTENT_TYPE,
+    ))
+    with pytest.raises(falcon.HTTPError):
+        httping.parseCesrHttpRequest(req=req)
+
+    req = helpers.create_req(headers=dict(
+        Content_Type=httping.CESR_CONTENT_TYPE,
+        CESR_DATE_HEADER="2021-06-27T21:26:21.233257+00:00",
+    ))
+    with pytest.raises(falcon.HTTPError):
+        httping.parseCesrHttpRequest(req=req)
+
+    req = helpers.create_req(
+        headers=dict(
+            Content_Type=httping.CESR_CONTENT_TYPE,
+            CESR_DATE="2021-06-27T21:26:21.233257+00:00",
+        ),
+        body='{}',
+    )
+    with pytest.raises(falcon.HTTPError):
+        httping.parseCesrHttpRequest(req=req)
+
+    req = helpers.create_req(
+        path="/credential/issue",
+        headers=dict(
+            Content_Type=httping.CESR_CONTENT_TYPE,
+            CESR_DATE="2021-06-27T21:26:21.233257+00:00",
+            CESR_ATTACHMENT="-H000000000"
+        ),
+        body='{"i": 1234}',
+    )
+
+    resource, dt, q, attachment = httping.parseCesrHttpRequest(req=req)
+    assert resource == "/credential/issue"
+    assert dt == "2021-06-27T21:26:21.233257+00:00"
+    assert q == dict(i=1234)
+    assert attachment == "-H000000000"
+
+
+if __name__ == '__main__':
+    test_parse_cesr_request()


### PR DESCRIPTION
This PR includes:

* Hardening witnesses to be launched with existing identities

* Fixing incept command line to use salt option

* Added query command line for requesting information from a witness about a KEL

* Tests for peer module.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>