### PR TITLE
Watcher start command for launching a Watcher capable of TCP or HTTP communication.

### DIFF
--- a/src/keri/app/cli/commands/wallet/start.py
+++ b/src/keri/app/cli/commands/wallet/start.py
@@ -8,16 +8,12 @@ Witness command line interface
 import argparse
 import logging
 
-import falcon
 from hio.base import doing
-from hio.core import http
-from hio.core.tcp import serving as tcpServing
-
 from keri import __version__, kering
 from keri import help
-from keri.app import directing, habbing, keeping, agenting, indirecting
+from keri.app import indirecting
+from keri.app.cli.common import existing
 from keri.core import scheming
-from keri.db import basing
 from keri.peer import httping, exchanging
 from keri.vc import walleting, handling
 
@@ -56,17 +52,7 @@ def runWallet(name="wallet"):
     Setup and run one wallet
     """
 
-    ks = keeping.Keeper(name=name, temp=False)  # not opened by default, doer opens
-    ksDoer = keeping.KeeperDoer(keeper=ks)  # doer do reopens if not opened and closes
-    db = basing.Baser(name=name, temp=False, reload=True)  # not opened by default, doer opens
-    dbDoer = basing.BaserDoer(baser=db)  # doer do reopens if not opened and closes
-
-    # setup habitat
-    hab = habbing.Habitat(name=name, ks=ks, db=db, temp=False, create=False)
-    habDoer = habbing.HabitatDoer(habitat=hab)  # setup doer
-
-    # setup doers
-
+    hab, doers = existing.openHabitat(name=name)
     wallet = walleting.Wallet(hab=hab, name=name)
 
     jsonSchema = scheming.JSONSchema(resolver=scheming.jsonSchemaCache)
@@ -78,7 +64,7 @@ def runWallet(name="wallet"):
     rep = httping.Respondant(hab=hab, mbx=mbx)
     mdir = indirecting.MailboxDirector(hab=hab, exc=exchanger, rep=rep)
 
-    doers = [ksDoer, dbDoer, habDoer, exchanger, mdir, rep]
+    doers.extend([exchanger, mdir, rep])
 
     try:
         tock = 0.03125

--- a/src/keri/app/cli/commands/watcher/start.py
+++ b/src/keri/app/cli/commands/watcher/start.py
@@ -4,61 +4,75 @@ keri.kli.commands.watcher module
 
 """
 import argparse
-import sys
 
-from hio.base import doing
-from hio.core.tcp import clienting
+import falcon
+from hio.core import http
+from hio.core.tcp import serving
+from keri.app import directing, indirecting
+from keri.app.cli.common import existing
+from keri.db import basing
+from keri.peer import exchanging, httping
+from keri import help
 
-from keri.app import habbing
-from keri.app.cli.commands.init import KLIRecord
-from keri.db import koming
-from keri.peer import exchanging
+logger = help.ogler.getLogger()
+
 
 parser = argparse.ArgumentParser(description='Start watcher')
-parser.set_defaults(handler=lambda args: handler())
+parser.set_defaults(handler=lambda args: startWatcher(args))
+parser.add_argument('-H', '--http',
+                    action='store',
+                    default=5651,
+                    help="Local port number the HTTP server listens on. Default is 5651.")
+parser.add_argument('-T', '--tcp',
+                    action='store',
+                    default=5652,
+                    help="Local port number the HTTP server listens on. Default is 5652.")
+parser.add_argument('-n', '--name',
+                    action='store',
+                    default="watcher",
+                    help="Name of controller. Default is watcher.")
 
 
-def handler():
-    startIst = StartIst(tock=0.03125)
-    startIst.do()
 
-    return
+def startWatcher(args):
+    name = args.name
+    tcpPort = int(args.tcp)
+    httpPort = int(args.http)
 
+    logger.info("\n******* Starting Watcher for %s listening: http/%s, tcp/%s "
+                ".******\n\n", args.name, args.http, args.tcp)
 
-class StartIst(doing.Doist):
+    doers = setupWatcher(name, tcpPort=tcpPort, httpPort=httpPort)
+    directing.runController(doers=doers, expire=0.0)
 
-    def __init__(self, real=False, limit=None, doers=None, **kwa):
-        self.hab = habbing.Habitat(name='kli', temp=False)
-        kli = koming.Komer(db=self.hab.db, schema=KLIRecord, subkey='kli.').get((self.hab.pre,))
-
-        super().__init__(real, limit, doers, **kwa)
-
-        self.client = clienting.Client(tymth=self.tymen(), host='127.0.0.1', port=5678)
-        clientDoer = clienting.ClientDoer(client=self.client)
-
-        self.extend([clientDoer, doing.doify(self.infoDoer)])
+    logger.info("\n******* Ended Watcher for %s listening: http/%s, tcp/%s"
+                ".******\n\n", args.name, args.http, args.tcp)
 
 
-    def infoDoer(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns:  doifiable Doist compatible generator method
-        Usage:
-            add result of doify on this method to doers list
-        """
-        while not self.client.connected:
-            (yield self.tock)
+def setupWatcher(name="watcher", tcpPort=5651, httpPort=5652):
+    """
+    """
 
-        print("connected")
-        payload = dict(
-            cmd='watcher',
-            args=('start',),
-        )
+    hab, doers = existing.openHabitat(name=name)
+    app = falcon.App(cors_enable=True)
 
-        srdr = exchanging.exchange(route="/cmd/", payload=payload)
-        excMsg = self.hab.sanction(srdr)
+    exchanger = exchanging.Exchanger(hab=hab, handlers=[])
 
-        self.client.tx(excMsg)
-        self.client.close()
+    mbx = exchanging.Mailboxer(name=name)
+    storeExchanger = exchanging.StoreExchanger(hab=hab, mbx=mbx, exc=exchanger)
 
-        print("watcher start command sent")
-        sys.exit(0)
+    rep = httping.Respondant(hab=hab, mbx=mbx)
+    httpHandler = indirecting.HttpMessageHandler(hab=hab, app=app, rep=rep, exchanger=storeExchanger)
+    mbxer = httping.MailboxServer(app=app, hab=hab, mbx=mbx)
+
+    server = http.Server(port=httpPort, app=app)
+    httpServerDoer = http.ServerDoer(server=server)
+
+    server = serving.Server(host="", port=tcpPort)
+    serverDoer = serving.ServerDoer(server=server)
+
+    directant = directing.Directant(hab=hab, server=server, exc=storeExchanger)
+
+    doers.extend([directant, serverDoer, mbxer, httpServerDoer, httpHandler, rep])
+
+    return doers

--- a/src/keri/app/cli/common/existing.py
+++ b/src/keri/app/cli/common/existing.py
@@ -1,0 +1,17 @@
+from keri.app import keeping, habbing
+from keri.db import basing
+
+
+def openHabitat(name="test"):
+    ks = keeping.Keeper(name=name, temp=False)  # not opened by default, doer opens
+    ksDoer = keeping.KeeperDoer(keeper=ks)  # doer do reopens if not opened and closes
+    db = basing.Baser(name=name, temp=False, reload=True)  # not opened by default, doer opens
+    dbDoer = basing.BaserDoer(baser=db)  # doer do reopens if not opened and closes
+
+    # setup habitat
+    hab = habbing.Habitat(name=name, ks=ks, db=db, temp=False, create=False)
+    habDoer = habbing.HabitatDoer(habitat=hab)  # setup doer
+
+    doers = [ksDoer, dbDoer, habDoer]
+
+    return hab, doers

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -298,6 +298,8 @@ class Reactor(doing.DoDoer):
         yield  # enter context
         while True:
             self.kevery.processEscrows()
+            if self.tvy is not None:
+                self.tvy.processEscrows()
             yield
         return False  # should never get here except forced close
 
@@ -681,6 +683,8 @@ class Reactant(doing.DoDoer):
         yield  # enter context
         while True:
             self.kevery.processEscrows()
+            if self.tevery is not None:
+                self.tevery.processEscrows()
             yield
         return False  # should never get here except forced close
 

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -48,9 +48,8 @@ def setupWitness(name="witness", hab=None, temp=False, tcpPort=5631, httpPort=56
     mbx = exchanging.Mailboxer(name=name)
     storeExchanger = exchanging.StoreExchanger(hab=hab, mbx=mbx, exc=exchanger)
 
-    repServer = httping.Respondant(hab=hab, mbx=mbx)
-    exnServer = httping.AgentExnServer(exc=storeExchanger, app=app, rep=repServer)
-    kelHandler = WitnessKelHandler(hab=hab, app=app, mbx=mbx)
+    rep = httping.Respondant(hab=hab, mbx=mbx)
+    httpHandler = HttpMessageHandler(hab=hab, app=app, rep=rep, verifier=verfer, exchanger=storeExchanger)
     mbxer = httping.MailboxServer(app=app, hab=hab, mbx=mbx)
 
     server = http.Server(port=httpPort, app=app)
@@ -64,7 +63,7 @@ def setupWitness(name="witness", hab=None, temp=False, tcpPort=5631, httpPort=56
 
     directant = directing.Directant(hab=hab, server=server, verifier=verfer, exc=storeExchanger)
 
-    doers.extend([regDoer, directant, serverDoer, mbxer, kelHandler, httpServerDoer, exnServer, repServer])
+    doers.extend([regDoer, directant, serverDoer, mbxer, httpServerDoer, httpHandler, rep])
 
     return doers
 
@@ -500,6 +499,9 @@ class MailboxDirector(doing.DoDoer):
         yield  # enter context
         while True:
             self.kevery.processEscrows()
+            if self.tevery is not None:
+                self.tevery.processEscrows()
+
             yield
 
 
@@ -621,18 +623,18 @@ class Poller(doing.DoDoer):
             yield
 
 
-class WitnessKelHandler(doing.DoDoer):
+class HttpMessageHandler(doing.DoDoer):
     """
-    Witness HTTP handler that accepts KEL events POSTed as the body of a request with all attachments to
-    the message as a CESR attachment HTTP header.  Messages are processed and added to the database of the provided
-    Habitat.
+    HTTP handler that accepts and KERI events POSTed as the body of a request with all attachments to
+    the message as a CESR attachment HTTP header.  KEL Messages are processed and added to the database
+    of the provided Habitat.
 
-    This also handles `req` messages that respond with a KEL replay.
+    This also handles `req`, `exn` and `tel` messages that respond with a KEL replay.
 
 
     """
 
-    def __init__(self, hab: habbing.Habitat, mbx=None, app=None, **kwa):
+    def __init__(self, hab: habbing.Habitat, rep, verifier=None, exchanger=None, app=None, **kwa):
         """
         Create the KEL HTTP server from the Habitat with an optional Falcon App to
         register the routes with.
@@ -643,32 +645,53 @@ class WitnessKelHandler(doing.DoDoer):
 
         """
         self.hab = hab
-        self.mbx = mbx if mbx is not None else exchanging.Mailboxer(name=hab.name)
+        self.rep = rep
+        self.verifier = verifier
+        self.exc = exchanger
+
         self.rxbs = bytearray()
 
         self.app = app if app is not None else falcon.App(cors_enable=True)
 
         self.app.add_route("/kel", self)
         self.app.add_route("/tel", self)
-        self.app.add_route("/req/logs", self)
-        self.app.add_route("/req/tels", self)
+        self.app.add_route("/req/logs", self, suffix="req")
+        self.app.add_route("/req/tels", self, suffix="req")
+        self.app.add_route("/req/ksn", self, suffix="req")
+        self.app.add_sink(prefix="/exn", sink=self.on_post_exn)
 
         self.kevery = eventing.Kevery(db=self.hab.db,
                                       lax=False,
                                       local=False)
 
+        doers = [doing.doify(self.msgDo), doing.doify(self.cueDo), doing.doify(self.exchangerDo)]
+
+        if self.verifier is not None:
+            self.tvy = Tevery(tevers=self.verifier.tevers,
+                              reger=self.verifier.reger,
+                              db=self.hab.db,
+                              regk=None, local=False)
+            doers.extend([doing.doify(self.verifierDo)])
+        else:
+            self.tvy = None
+
+        if self.exc is not None:
+            doers.extend([doing.doify(self.exchangerDo)])
+
+
         self.parser = parsing.Parser(ims=self.rxbs,
                                      framed=True,
-                                     kvy=self.kevery)
+                                     kvy=self.kevery,
+                                     tvy=self.tvy,
+                                     exc=self.exc)
 
-        doers = [doing.doify(self.msgDo), doing.doify(self.cueDo)]
 
-        super(WitnessKelHandler, self).__init__(doers=doers, **kwa)
+        super(HttpMessageHandler, self).__init__(doers=doers, **kwa)
 
 
     def on_post(self, req, rep):
         """
-        Handles POST requests
+        Handles POST for KERI event messages.
 
         Parameters:
               req (Request) Falcon HTTP request
@@ -677,6 +700,49 @@ class WitnessKelHandler(doing.DoDoer):
         """
 
         cr = httping.parseCesrHttpRequest(req=req)
+        self.handle(cr, rep)
+
+    def on_post_req(self, req, rep):
+        """
+        Handles POST for `req` messages.
+
+        Parameters:
+              req (Request) Falcon HTTP request
+              rep (Response) Falcon HTTP response
+
+        """
+
+        cr = httping.parseCesrHttpRequest(req=req, prefix="/req/")
+        self.handle(cr, rep)
+
+
+    def on_post_exn(self, req, rep):
+        """
+        Handles POST for `exn` messages
+        Parameters:
+              req (Request) Falcon HTTP request
+              rep (Response) Falcon HTTP response
+
+        """
+
+        cr = httping.parseCesrHttpRequest(req=req, prefix="/exn")
+        self.handle(cr, rep)
+
+
+    def handle(self, cr, rep):
+        """
+        Handles POST requests that conform to CESR HTTP Requests.
+
+        Converts the requests into KERI event messages and passes them on to
+        the Parser to be parsed and processed by either the Kevery, Tevery or
+        Exchanger.
+
+        Parameters:
+              req (Request) Falcon HTTP request
+              rep (Response) Falcon HTTP response
+              cr (CesrRequest) Result of converting HTTP Request to a CESR message
+
+        """
 
         serder = eventing.Serder(ked=cr.payload, kind=eventing.Serials.json)
         msg = bytearray(serder.raw)
@@ -692,18 +758,6 @@ class WitnessKelHandler(doing.DoDoer):
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
 
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
-
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
-
-
         Usage:
             add result of doify on this method to doers list
         """
@@ -715,40 +769,61 @@ class WitnessKelHandler(doing.DoDoer):
 
     def cueDo(self, tymth=None, tock=0.0, **opts):
         """
+        Returns doifiable Doist compatibile generator method (doer dog) to process
+            .kever.cues cues and pass them on to the HTTPResponant
+
+        Usage:
+            add result of doify on this method to doers list
+        """
+        while True:
+            while self.kevery.cues:  # iteratively process each cue in cues
+                cue = self.kevery.cues.popleft()
+                self.rep.cues.append(cue)
+                yield  # throttle just do one cue at a time
+            yield
+
+
+    def exchangerDo(self, tymth=None, tock=0.0, **opts):
+        """
+        Returns doifiable Doist compatibile generator method (doer dog) to process
+            .exc responses and pass them on to the HTTPRespondant
+
+        Usage:
+            add result of doify on this method to doers list
+        """
+        while True:
+            for rep in self.exc.processResponseIter():
+                self.rep.msgs.append(rep)
+                yield  # throttle just do one cue at a time
+            yield
+
+    def verifierDo(self, tymth=None, tock=0.0, **opts):
+        """
          Returns doifiable Doist compatibile generator method (doer dog) to process
-            .kevery.cues deque
+            .tevery.cues deque
 
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
+        Usage:
+            add to doers list
+        """
+        yield  # enter context
+        while True:
+            for cue in self.verifier.processCuesIter(self.tvy.cues):
+                self.rep.cues.append(cue)
+                yield  # throttle just do one cue at a time
+            yield
 
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
+    def escrowDo(self, tymth=None, tock=0.0, **opts):
+        """
+         Returns doifiable Doist compatibile generator method (doer dog) to process
+            .kevery and .tevery escrows.
 
         Usage:
             add result of doify on this method to doers list
         """
         yield  # enter context
         while True:
-            while self.kevery.cues:  # iteratively process each cue in cues
-                msg = bytearray()
-                cue = self.kevery.cues.popleft()
-                cueKin = cue["kin"]  # type or kind of cue
+            self.kevery.processEscrows()
+            if self.tvy is not None:
+                self.tvy.processEscrows()
 
-                if cueKin in ("receipt",):  # cue to receipt a received event from other pre
-                    serder = cue["serder"]  # Serder of received event for other pre
-                    msg.extend(self.hab.receipt(serder))
-
-                    self.mbx.storeMsg(dest=serder.preb, msg=msg)
-                elif cueKin in ("replay",):
-                    dest = cue["dest"]
-                    msgs = cue["msgs"]
-                    self.mbx.storeMsg(dest=dest, msg=msgs)
-
-                yield self.tock
-
-            yield self.tock
+            yield

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -8,8 +8,10 @@ VC TEL  support
 
 
 import json
+import logging
 from collections import deque, namedtuple
 
+from keri.core import coring
 from orderedset import OrderedSet as oset
 
 from ..core.coring import (MtrDex, Serder, Serials, Versify, Prefixer,
@@ -683,7 +685,7 @@ class Tever:
 
             # check if fully anchored
             if not self.verifyAnchor(serder=serder, seqner=seqner, diger=diger):
-                self.escrowALEvent(serder=serder)
+                self.escrowALEvent(serder=serder, seqner=seqner, diger=diger)
 
                 raise MissingAnchorError("Failure verify event = {} "
                                          "".format(serder.ked,
@@ -749,7 +751,7 @@ class Tever:
 
             # check if fully anchored
             if not self.verifyAnchor(serder=serder, seqner=seqner, diger=diger):
-                self.escrowALEvent(serder=serder)
+                self.escrowALEvent(serder=serder, seqner=seqner, diger=diger)
 
                 raise MissingAnchorError("Failure verify event = {} "
                                          "".format(serder.ked))
@@ -872,7 +874,7 @@ class Tever:
 
         # check if fully anchored
         if not self.verifyAnchor(serder=serder, seqner=seqner, diger=diger):
-            self.escrowALEvent(serder=serder, bigers=bigers)
+            self.escrowALEvent(serder=serder, seqner=seqner, diger=diger, bigers=bigers, baks=baks)
 
             raise MissingAnchorError("Failure verify event = {} "
                                      "".format(serder.ked))
@@ -955,7 +957,7 @@ class Tever:
         logger.info("Tever state: Escrowed partially witnessed "
                     "event = %s\n", serder.ked)
 
-    def escrowALEvent(self, serder, bigers=None):
+    def escrowALEvent(self, serder, seqner, diger, bigers=None, baks=None):
         """
         Update associated logs for escrow of anchorless event
 
@@ -963,8 +965,14 @@ class Tever:
             serder is Serder instance of  event
         """
         key = dgKey(serder.preb, serder.digb)
+        if seqner and diger:
+            sealet = seqner.qb64b + diger.qb64b
+            self.reger.putAnc(key, sealet)
         if bigers:
             self.reger.putTibs(key, [biger.qb64b for biger in bigers])
+        if baks:
+            self.reger.delBaks(key)
+            self.reger.putBaks(key, [bak.encode("utf-8") for bak in baks])
         self.reger.putTvt(key, serder.raw)
         self.reger.putTae(snKey(serder.preb, serder.sn), serder.digb)
         logger.info("Tever state: Escrowed anchorless event "
@@ -1160,11 +1168,97 @@ class Tevery:
         else:
             raise ValidationError("invalid ilk {} for tevery event = {}".format(ilk, serder.ked))
 
+
     def escrowOOEvent(self, serder, seqner, diger):
         key = dgKey(serder.preb, serder.digb)
         self.reger.putTvt(key, serder.raw)
         sealet = seqner.qb64b + diger.qb64b
         self.reger.putAnc(key, sealet)
         self.reger.putOot(snKey(serder.preb, serder.sn), serder.digb)
-        logger.info("Tever state: Escrowed anchorless event "
+        logger.info("Tever state: Escrowed our of order TEL event "
                     "event = %s\n", serder.ked)
+
+
+    def processEscrows(self):
+        """
+        Loop through escrows and process and events that may now be finalized
+
+
+        """
+        try:
+            self.processEscrowAnchorless()
+            self.processEscrowOutOfOrders()
+
+        except Exception as ex:  # log diagnostics errors etc
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.exception("Kevery escrow process error: %s\n", ex.args[0])
+            else:
+                logger.error("Kevery escrow process error: %s\n", ex.args[0])
+
+
+
+
+    def processEscrowOutOfOrders(self):
+        pass
+
+
+    def processEscrowAnchorless(self):
+        """
+        Process escrow of TEL events received before the anchoring KEL
+        event.
+
+        """
+        for (pre, sn, digb) in self.reger.getTaeItemIter():
+            try:
+                dgkey = dgKey(pre, digb)
+                traw = self.reger.getTvt(dgkey)
+                if traw is None:
+                    # no event so raise ValidationError which unescrows below
+                    logger.info("Tevery unescrow error: Missing event at."
+                                "dig = %s\n", bytes(digb))
+
+                    raise ValidationError("Missing escrowed evt at dig = {}."
+                                          "".format(bytes(digb)))
+
+                tserder = Serder(raw=bytes(traw))  # escrowed event
+
+                bigers = None
+                if tibs := self.reger.getTibs(key=dgkey):
+                    bigers = [coring.Siger(qb64b=tib) for tib in tibs]
+
+                couple = self.reger.getAnc(dgkey)
+                if couple is None:
+                    logger.info("Tevery unescrow error: Missing anchor at."
+                                "dig = %s\n", bytes(digb))
+
+                    raise ValidationError("Missing escrowed anchor at dig = {}."
+                                          "".format(bytes(digb)))
+                ancb = bytearray(couple)
+                seqner = coring.Seqner(qb64b=ancb, strip=True)
+                diger = coring.Diger(qb64b=ancb, strip=True)
+
+                self.processEvent(serder=tserder, seqner=seqner, diger=diger, wigers=bigers)
+
+            except MissingAnchorError as ex:
+                # still waiting on missing prior event to validate
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.exception("Tevery unescrow failed: %s\n", ex.args[0])
+                else:
+                    logger.error("Tevery unescrow failed: %s\n", ex.args[0])
+
+            except Exception as ex:  # log diagnostics errors etc
+                # error other than out of order so remove from OO escrow
+                self.reger.delTae(snKey(pre, sn))  # removes one escrow at key val
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.exception("Tevery unescrowed: %s\n", ex.args[0])
+                else:
+                    logger.error("Tevery unescrowed: %s\n", ex.args[0])
+
+            else:  # unescrow succeeded, remove from escrow
+                # We don't remove all escrows at pre,sn because some might be
+                # duplicitous so we process remaining escrows in spite of found
+                # valid event escrow.
+                self.db.delTae(snKey(pre, sn))  # removes from escrow
+                logger.info("Tevery unescrow succeeded in valid event: "
+                            "event=\n%s\n", json.dumps(tserder.ked, indent=1))
+

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -167,7 +167,7 @@ class Registry(dbing.LMDBer):
             couple = self.getAnc(dgkey)
             if couple is not None:
                 atc.extend(coring.Counter(code=coring.CtrDex.SealSourceCouples,
-                                      count=1 ).qb64b)
+                                          count=1).qb64b)
                 atc.extend(couple)
 
             # prepend pipelining counter to attachments
@@ -396,6 +396,13 @@ class Registry(dbing.LMDBer):
         Returns None if no entry at key
         """
         return self.getVal(self.taes, key)
+
+    def getTaeItemIter(self):
+        """
+        Return iterator of all items in .taes
+
+        """
+        return self.getAllItemIter(self.taes, split=True)
 
     def delTae(self, key):
         """

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -1,11 +1,10 @@
-from unittest import mock
-
 import pytest
 
 from keri.app import habbing, keeping
+from keri.core import coring
+from keri.core import eventing as keventing
 from keri.core.coring import Versify, Serials, Ilks, MtrDex, Prefixer, Serder, Signer, Seqner
-from keri.core.eventing import TraitDex, SealEvent
-from keri.db import dbing, basing
+from keri.db import basing
 from keri.db.dbing import snKey, dgKey
 from keri.kering import Version, EmptyMaterialError, DerivationError, MissingAnchorError, ValidationError, \
     MissingWitnessSignatureError, LikelyDuplicitousError
@@ -31,14 +30,14 @@ def test_incept():
         b'"ii":"DntNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","s":"0","t":"vcp","c":[],"bt":"0","b":[]}')
 
     # no backers allowed
-    serder = eventing.incept(pre, baks=[], cnfg=[TraitDex.NoBackers], code=MtrDex.Blake3_256)
+    serder = eventing.incept(pre, baks=[], cnfg=[keventing.TraitDex.NoBackers], code=MtrDex.Blake3_256)
     assert serder.raw == (
         b'{"v":"KERI10JSON0000ad_","i":"EjD_sFljMHXJCC3rEFL93MwHNGguKdC11mcMuQnZitcs",'
         b'"ii":"DntNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","s":"0","t":"vcp","c":["NB"],"bt":"0","b":[]}')
 
     # no backers allows, one attempted
     with pytest.raises(ValueError):
-        eventing.incept(pre, cnfg=[TraitDex.NoBackers],
+        eventing.incept(pre, cnfg=[keventing.TraitDex.NoBackers],
                         baks=[bak1])
 
     # with backer dupes
@@ -268,7 +267,6 @@ def test_simple_issue_revoke(mockHelpingNowUTC):
                           b'"s":"0","t":"iss","ri":"EE3Xv6CWwEMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","dt":"'
                           b'2021-01-01T00:00:00.000000+00:00"}')
 
-
     serder = revoke(vcdig=vcdig, regk=regk, dig=dig)
 
     assert serder.raw == (b'{"v":"KERI10JSON0000ed_","i":"DntNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM",'
@@ -288,9 +286,9 @@ def test_backer_issue_revoke(mockHelpingNowUTC):
 
     serder = backerIssue(vcdig=vcdig, regk=regk, regsn=sn, regd=regd)
     assert serder.raw == (b'{"v":"KERI10JSON00012d_","i":"DntNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM",'
-            b'"ii":"EE3Xv6CWwEMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":"0","t":"bis","ra":{'
-            b'"i":"EE3Xv6CWwEMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":3,"d":"Ezpq06UecHwzy-'
-            b'K9FpNoRxCJp2wIGM9u2Edk-PLMZ1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+                          b'"ii":"EE3Xv6CWwEMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":"0","t":"bis","ra":{'
+                          b'"i":"EE3Xv6CWwEMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":3,"d":"Ezpq06UecHwzy-'
+                          b'K9FpNoRxCJp2wIGM9u2Edk-PLMZ1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
     serder = backerRevoke(vcdig=vcdig, regk=regk, regsn=sn, regd=regd, dig=dig)
     assert serder.raw == (b'{"v":"KERI10JSON00012c_","i":"DntNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM",'
@@ -339,7 +337,7 @@ def test_prefixer():
                ii=pre,
                s="{:x}".format(0),
                t=Ilks.vcp,
-               c=[TraitDex.NoBackers],
+               c=[keventing.TraitDex.NoBackers],
                b=[]
                )
     prefixer = Prefixer(ked=ked, code=MtrDex.Blake3_256)
@@ -439,7 +437,7 @@ def test_tever_escrow():
         regk = vcp.pre
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(regk, vcp.ked["s"], vcp.diger.qb64)
+        rseal = keventing.SealEvent(regk, vcp.ked["s"], vcp.diger.qb64)
 
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
@@ -476,7 +474,7 @@ def test_tever_no_backers(mockHelpingNowUTC):
         regk = vcp.pre
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
+        rseal = keventing.SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
 
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
@@ -502,7 +500,7 @@ def test_tever_no_backers(mockHelpingNowUTC):
 
         # try to rotate a backerless registry
         vrt = eventing.rotate(regk, dig=vcp.dig)
-        rseal = SealEvent(regk, vrt.ked["s"], vrt.diger.qb64)
+        rseal = keventing.SealEvent(regk, vrt.ked["s"], vrt.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -517,7 +515,7 @@ def test_tever_no_backers(mockHelpingNowUTC):
         iss = eventing.issue(vcdig=vcdig.decode("utf-8"), regk=regk)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(iss.ked["i"], iss.ked["s"], iss.diger.qb64)
+        rseal = keventing.SealEvent(iss.ked["i"], iss.ked["s"], iss.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -527,16 +525,17 @@ def test_tever_no_backers(mockHelpingNowUTC):
 
         vci = nsKey([regk, vcdig])
         dgkey = dgKey(pre=vci, dig=iss.dig)
-        assert bytes(reg.getTvt(dgkey)) == (b'{"v":"KERI10JSON0000ba_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
-                                            b'"s":"0","t":"iss","ri":"Ezm53Qww2LTJ1yksEL06Wtt-5D23QKdJEGI0egFyLehw","dt":"'
-                                            b'2021-01-01T00:00:00.000000+00:00"}')
+        assert bytes(reg.getTvt(dgkey)) == (
+            b'{"v":"KERI10JSON0000ba_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
+            b'"s":"0","t":"iss","ri":"Ezm53Qww2LTJ1yksEL06Wtt-5D23QKdJEGI0egFyLehw","dt":"'
+            b'2021-01-01T00:00:00.000000+00:00"}')
         assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAAwEJLLpuUKPSDIcoOAOArQBzceWc8MoShm-cDL-w81liIw'
 
         # revoke vc with no backers
         rev = eventing.revoke(vcdig=vcdig.decode("utf-8"), regk=regk, dig=iss.dig)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(rev.ked["i"], rev.ked["s"], rev.diger.qb64)
+        rseal = keventing.SealEvent(rev.ked["i"], rev.ked["s"], rev.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -544,10 +543,11 @@ def test_tever_no_backers(mockHelpingNowUTC):
 
         tev.update(rev, seqner=seqner, diger=diger)
         dgkey = dgKey(pre=vci, dig=rev.dig)
-        assert bytes(reg.getTvt(dgkey)) == (b'{"v":"KERI10JSON0000ed_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
-                                            b'"s":"1","t":"rev","ri":"Ezm53Qww2LTJ1yksEL06Wtt-5D23QKdJEGI0egFyLehw","p":"E'
-                                            b'C9PffPrvyaKzsn72SWTvgyvWCJ1FbDThvJhsQ9LWo9M","dt":"2021-01-01T00:00:00.00000'
-                                            b'0+00:00"}')
+        assert bytes(reg.getTvt(dgkey)) == (
+            b'{"v":"KERI10JSON0000ed_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
+            b'"s":"1","t":"rev","ri":"Ezm53Qww2LTJ1yksEL06Wtt-5D23QKdJEGI0egFyLehw","p":"E'
+            b'C9PffPrvyaKzsn72SWTvgyvWCJ1FbDThvJhsQ9LWo9M","dt":"2021-01-01T00:00:00.00000'
+            b'0+00:00"}')
 
         # assert reg.getAnc(dgkey) == b'0AAAAAAAAAAAAAAAAAAAAABAECgc6yHeTRhsKh1M7k65feWZGCf_MG0dWoei5Q6SwgqU'
 
@@ -574,7 +574,7 @@ def test_tever_backers(mockHelpingNowUTC):
         valCigar = valSigner.sign(ser=vcp.raw, index=0)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
+        rseal = keventing.SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
 
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
@@ -608,7 +608,7 @@ def test_tever_backers(mockHelpingNowUTC):
         debCigar = debSigner.sign(ser=vrt.raw, index=1)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(regk, vrt.ked["s"], vrt.diger.qb64)
+        rseal = keventing.SealEvent(regk, vrt.ked["s"], vrt.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -626,7 +626,7 @@ def test_tever_backers(mockHelpingNowUTC):
         debCigar = debSigner.sign(ser=bis.raw, index=1)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(bis.ked["i"], bis.ked["s"], bis.diger.qb64)
+        rseal = keventing.SealEvent(bis.ked["i"], bis.ked["s"], bis.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -636,10 +636,11 @@ def test_tever_backers(mockHelpingNowUTC):
 
         vci = nsKey([regk, vcdig])
         dgkey = dgKey(pre=vci, dig=bis.dig)
-        assert bytes(reg.getTvt(dgkey)) == (b'{"v":"KERI10JSON00012d_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
-                                            b'"ii":"EBZR8LxEozgFa6UXwtSAmiXsmdChrT7Hr-jcxc9NFfrU","s":"0","t":"bis","ra":{'
-                                            b'"i":"EBZR8LxEozgFa6UXwtSAmiXsmdChrT7Hr-jcxc9NFfrU","s":1,"d":"EZH2Cfw3nvcMRg'
-                                            b'Y31Jyc2zHVh4a0LO_bVZ4EmL4V8Ol8"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+        assert bytes(reg.getTvt(dgkey)) == (
+            b'{"v":"KERI10JSON00012d_","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU",'
+            b'"ii":"EBZR8LxEozgFa6UXwtSAmiXsmdChrT7Hr-jcxc9NFfrU","s":"0","t":"bis","ra":{'
+            b'"i":"EBZR8LxEozgFa6UXwtSAmiXsmdChrT7Hr-jcxc9NFfrU","s":1,"d":"EZH2Cfw3nvcMRg'
+            b'Y31Jyc2zHVh4a0LO_bVZ4EmL4V8Ol8"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
 
 def test_tevery():
@@ -654,7 +655,7 @@ def test_tevery():
         regk = vcp.pre
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
+        rseal = keventing.SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
 
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
@@ -681,7 +682,7 @@ def test_tevery():
         iss = eventing.issue(vcdig=vcdig.decode("utf-8"), regk=regk)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(iss.ked["i"], iss.ked["s"], iss.diger.qb64)
+        rseal = keventing.SealEvent(iss.ked["i"], iss.ked["s"], iss.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -695,7 +696,7 @@ def test_tevery():
         rev = eventing.revoke(vcdig=vcdig.decode("utf-8"), regk=regk, dig=iss.dig)
 
         # successfully anchor to a rotation event
-        rseal = SealEvent(rev.ked["i"], rev.ked["s"], rev.diger.qb64)
+        rseal = keventing.SealEvent(rev.ked["i"], rev.ked["s"], rev.diger.qb64)
         rot = hab.rotate(data=[rseal._asdict()])
         rotser = Serder(raw=rot)
         seqner = Seqner(sn=int(rotser.ked["s"], 16))
@@ -706,8 +707,44 @@ def test_tevery():
         assert tev.vcSn(vcdig) == 1
 
 
-def buildHab(db, kpr):
+def test_tevery_process_escrow():
+    with basing.openDB() as db, keeping.openKS() as kpr, viring.openReg() as reg:
+        hab = buildHab(db, kpr)
 
+        vcp = eventing.incept(hab.pre,
+                              baks=[],
+                              toad=0,
+                              cnfg=["NB"],
+                              code=MtrDex.Blake3_256)
+        regk = vcp.pre
+
+        # successfully anchor to a rotation event
+        rseal = keventing.SealEvent(i=regk, s=vcp.ked["s"], d=vcp.diger.qb64)
+
+        seqner = Seqner(sn=1)
+        diger = coring.Diger(qb64b=b'E-yQ6BjCaJg-u2mNuE-ycVWVTq7IZ8TuN-Ew8soLijSA')
+
+        tvy = Tevery(reger=reg, db=db)
+
+        with pytest.raises(MissingAnchorError):  # Process before the Hab rotation event, will escrow
+            tvy.processEvent(serder=vcp, seqner=seqner, diger=diger)
+
+        assert regk not in tvy.tevers
+
+        rot = hab.rotate(data=[rseal._asdict()])  # Now rotate so the achoring KEL event gets into the database
+        rotser = coring.Serder(raw=rot)
+        assert rotser.digb == diger.qb64b
+
+        tvy.processEscrows()  # process escrows and now the Tever event is good.
+        assert regk in tvy.tevers
+        tev = tvy.tevers[regk]
+        assert tev.prefixer.qb64 == vcp.pre
+        assert tev.sn == 0
+
+
+
+
+def buildHab(db, kpr):
     secrets = [
         'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
         'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
@@ -722,17 +759,10 @@ def buildHab(db, kpr):
     for secret in secrets:  # convert secrets to secrecies
         secrecies.append([secret])
     # setup hab
-    hab = habbing.Habitat(ks=kpr, db=db,  secrecies=secrecies, temp=True)
+    hab = habbing.Habitat(ks=kpr, db=db, secrecies=secrecies, temp=True)
     return hab
 
 
 if __name__ == "__main__":
-    test_incept()
-    test_rotate()
-    test_simple_issue_revoke()
-    test_backer_issue_revoke()
-    test_prefixer()
     test_tever_escrow()
-    test_tever_no_backers()
-    test_tever_backers()
-    test_tevery()
+    test_tevery_process_escrow()


### PR DESCRIPTION
This PR includes:

* Watcher start command for launching a Watcher capable of TCP or HTTP communication.

* Refactor of HTTP endpoints for KERI messages

* Processing of "anchor-less" TEL escrow.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>