### PR TITLE
Key state notification as a reply message.

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -411,7 +411,6 @@ class Habitat:
                     msgs.extend(self.makeLocScheme(url=url,
                                                  scheme=scheme,
                                                  stamp=help.toIso8601(dt=dt)))
-
             self.psr.parse(ims=msgs)
 
             if "iurls" in conf:  # process OOBI URLs
@@ -1184,6 +1183,12 @@ class Habitat:
             elif cueKin in ("replay",):
                 msgs = cue["msgs"]
                 yield msgs
+
+            elif cueKin in ("reply", ):
+                data = cue["data"]
+                route = cue["route"]
+                msg = self.reply(data=data, route=route)
+                yield msg
 
 
 class HabitatDoer(doing.Doer):

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -353,7 +353,15 @@ class Respondant(doing.DoDoer):
                 elif cueKin in ("replay",):
                     dest = cue["dest"]
                     msgs = cue["msgs"]
+
                     self.mbx.storeMsg(topic=dest+'/replay', msg=msgs)
+                elif cueKin in ("reply", ):
+                    data = cue["data"]
+                    route = cue["route"]
+                    dest = cue["dest"]
+
+                    msg = self.hab.reply(data=data, route=route+"/"+self.hab.pre)
+                    self.mbx.storeMsg(topic=dest+"/replay", msg=msg)
 
                 yield self.tock
 

--- a/src/keri/core/__init__.py
+++ b/src/keri/core/__init__.py
@@ -4,3 +4,4 @@ KERI
 keri.core Package
 """
 
+__all__ = ["coring", "eventing", "parsing", "scheming"]

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -814,9 +814,9 @@ class Parser:
                 if trqs:
                     kvy.processReceiptQuadruples(serder, trqs, firner=firner)
 
-            except AttributeError:
+            except AttributeError as e:
                 raise kering.ValidationError("No kevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty))
+                                      "= {}.".format(serder.pretty()))
 
         elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
             if not (cigars or wigers or tsgs):
@@ -836,24 +836,6 @@ class Parser:
                 raise kering.ValidationError("No kevery to process so dropped msg"
                                       "= {}.".format(serder.pretty()))
 
-        elif ilk in (Ilks.ksn,):  # key state notification msg
-            if not (cigars or tsgs):
-                raise kering.ValidationError("Missing attached endorser signature(s) "
-                       "to key state notification msg = {}.".format(serder.pretty()))
-
-            try:
-                if cigars:  # process separately so do not clash on errors
-                    # may want two different functions One for processKeyStateNoticeNonTrans
-                    # and one for processKeyStateNoticeTrans
-                    kvy.processKeyStateNotice(serder, cigars=cigars)  # nontrans
-
-                if tsgs:  # process separately so do not clash on errors
-                    kvy.processKeyStateNotice(serder, tsgs=tsgs)  #  trans
-
-            except AttributeError:
-                raise kering.ValidationError("No kevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty()))
-
         elif ilk in (Ilks.rpy, ):  # reply message
             if not (cigars or tsgs):
                 raise kering.ValidationError("Missing attached endorser signature(s) "
@@ -866,7 +848,7 @@ class Parser:
                 if tsgs:  # process separately so do not clash on errors
                     kvy.processReply(serder, tsgs=tsgs)  #  trans
 
-            except AttributeError:
+            except AttributeError as e:
                 raise kering.ValidationError("No kevery to process so dropped msg"
                                       "= {}.".format(serder.pretty()))
 
@@ -886,14 +868,14 @@ class Parser:
                                              "to key log query msg = {}.".format(serder.pretty()))
 
             route = serder.ked["r"]
-            if route in ["logs"]:
+            if route in ["logs", "ksn"]:
                 try:
                     kvy.processQuery(**args)
                 except AttributeError:
                     raise kering.ValidationError("No kevery to process so dropped msg"
                                                  "= {}.".format(serder.pretty()))
 
-            elif route in ["tels"]:
+            elif route in ["tels", "tsn"]:
                 try:
                     tvy.processQuery(**args)
                 except AttributeError as e:

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -736,6 +736,38 @@ class Baser(dbing.LMDBer):
         # exchange source prefix
         self.esrc = subing.CesrSuber(db=self, subkey='esrc.', klas=coring.Prefixer)
 
+
+        # KSN support datetime stamps and signatures indexed and not-indexed
+        # all ksn  kdts (key state datetime serializations) maps said to date-time
+        self.kdts = subing.CesrSuber(db=self, subkey='kdts.', klas=coring.Dater)
+
+        # all key state messages. Maps key state said to serialization. ksns are
+        # versioned sads ( with version string) so use Serder to deserialize and
+        # use  .kdts, .ksgs, and .kcgs for datetimes and signatures
+        self.ksns = subing.SerderSuber(db=self, subkey='ksns.')
+
+        # all key state ksgs (ksn indexed signature serializations) maps ksn quadkeys
+        # given by quadruple (saider.qb64, prefixer.qb64, seqner.q64, diger.qb64)
+        #  of reply and trans signer's key state est evt to val Siger for each
+        # signature.
+        self.ksgs = subing.CesrIoSetSuber(db=self, subkey='ksgs.', klas=coring.Siger)
+
+        # all key state kcgs  (ksn non-indexed signature serializations) maps ksn SAID
+        # to couple (Verfer, Cigar) of nontrans signer of signature in Cigar
+        # nontrans qb64 of Prefixer is same as Verfer
+        self.kcgs = subing.CatCesrIoSetSuber(db=self, subkey='kcgs.',
+                                             klas=(coring.Verfer, coring.Cigar))
+
+        # all key state escrows indices of partially signed ksn messages. Maps
+        # route in reply to single (Saider,)  of escrowed ksn.
+        # Routes such as ???
+        self.knes = subing.CesrIoSetSuber(db=self, subkey='knes', klas=coring.Saider)
+
+
+        # auth AuthN/AuthZ by controller at cid of endpoint provider at eid
+        # maps key=cid.role.eid to val=said of end reply
+        self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Saider)
+
         return self.env
 
     def reload(self):

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -443,3 +443,19 @@ class FailedSchemaValidationError(KeriError):
     Usage:
         raise FailedSchemaValidationError("error message")
     """
+
+
+class OutOfOrderKeyStateError(ValidationError):
+    """
+    Error referenced event missing from log so can't verify this ket state event
+    Usage:
+        raise OutOfOrderKeyStateError("error message")
+    """
+
+
+class UntrustedKeyStateSource(KeriError):
+    """
+    Error untrusted source of key state, not aid, aid's witness or our watcher
+    Usage:
+        raise UntrustedKeyStateSource("error message")
+    """

--- a/src/keri/vc/__init__.py
+++ b/src/keri/vc/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.vc Package
+"""
+

--- a/src/keri/vdr/__init__.py
+++ b/src/keri/vdr/__init__.py
@@ -4,3 +4,4 @@ KERI
 keri.vdr Package
 """
 
+__all__ = ["issuing", "eventing", "registering", "viring", "verifying"]

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -91,7 +91,7 @@ def incept(
     if len(oset(baks)) != len(baks):
         raise ValueError("Invalid baks = {}, has duplicates.".format(baks))
 
-    if isinstance(toad, int):
+    if isinstance(toad, str):
         toad = "{:x}".format(toad)
     elif toad is None:
         if not baks:
@@ -194,7 +194,7 @@ def rotate(
         raise ValueError("Invalid member combination among baks = {}, cuts ={}, "
                          "and adds = {}.".format(baks, cuts, adds))
 
-    if isinstance(toad, int):
+    if isinstance(toad, str):
         toad = "{:x}".format(toad)
     elif toad is None:
         if not newbakset:
@@ -449,7 +449,6 @@ def state(pre,
         "v": "KERI10JSON00011c_",
         "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
         "s": "2":,
-        "t": "ksn",
         "p": "EYAfSVPzhzZ-i0d8JZS6b5CMAoTNZH3ULvaU6JR2nmwy",
         "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
         "ri": "EYAfSVPzhzZ-i0d8JZS6b5CMAoTNZH3ULvaU6JR2nmwy",
@@ -468,7 +467,6 @@ def state(pre,
 
     """
     vs = Versify(version=version, kind=kind, size=0)
-    ilk = Ilks.ksn
 
     if sn < 0:
         raise ValueError("Negative sn = {} in key state.".format(sn))
@@ -513,7 +511,6 @@ def state(pre,
                i=pre,  # qb64 prefix
                s="{:x}".format(sn),  # lowercase hex string no leading zeros
                d=dig,
-               t=ilk,
                ri=ri,
                dt=dts,
                et=eilk,

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -8,28 +8,25 @@ VC TEL  support
 
 import json
 import logging
-from collections import deque, namedtuple
+from collections import namedtuple
 
 from hio.help import decking
 from math import ceil
-
-import pysodium
-from keri import kering
-
-from keri.core import coring
 from orderedset import OrderedSet as oset
 
+from keri import kering
+from keri.core import coring
+from .. import core
+from .. import help
 from ..core.coring import (MtrDex, Serder, Serials, Versify, Prefixer,
                            Ilks, Seqner, Verfer)
 from ..core.eventing import SealEvent, ample, TraitDex, verifySigs, validateSN
-from .. import core
 from ..db import basing
 from ..db.dbing import dgKey, snKey
 from ..help import helping
 from ..kering import (MissingWitnessSignatureError, Version,
                       MissingAnchorError, ValidationError, OutOfOrderError, LikelyDuplicitousError)
 from ..vdr.viring import Registry, nsKey
-from .. import help
 
 logger = help.ogler.getLogger()
 
@@ -58,20 +55,26 @@ def incept(
         kind=Serials.json,
         code=None,
 ):
-    """
+    """ Returns serder of credential registry inception (vcp) message event
 
     Returns serder of vcp message event
     Utility function to create a Registry inception event
 
     Parameters:
-         pre is issuer identifier prefix qb64
-         cnfg is list of strings TraitDex of configuration traits
-         toad is int, or str hex of backer threshold
-         baks is the initial list of backers prefixes for VCs in the Registry
+         pre (str): issuer identifier prefix qb64
+         toad (int): int or str hex of backer threshold
+         baks (list): the initial list of backers prefixes for VCs in the Registry
+         cnfg (list): is list of strings TraitDex of configuration traits
 
-         version is the API version
-         kind is the event type
-         code is default code for Prefixer
+         version (Versionage): the API version
+         kind (str): the event type
+         code (str): default code for Prefixer
+
+    Returns:
+        Serder: Event message Serder
+
+    Todo:
+        Apply nonce to registry inception event to guarantee uniquiness of identifier
 
     """
 
@@ -88,7 +91,7 @@ def incept(
     if len(oset(baks)) != len(baks):
         raise ValueError("Invalid baks = {}, has duplicates.".format(baks))
 
-    if isinstance(toad, str):
+    if isinstance(toad, int):
         toad = "{:x}".format(toad)
     elif toad is None:
         if not baks:
@@ -103,8 +106,8 @@ def incept(
         if toad != 0:  # invalid toad
             raise ValueError("Invalid toad = {} for baks = {}".format(toad, baks))
 
-    preseed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
-    seedqb64 = coring.Matter(raw=preseed, code=MtrDex.Ed25519_Seed).qb64
+    # preseed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
+    # seedqb64 = coring.Matter(raw=preseed, code=MtrDex.Ed25519_Seed).qb64
 
     ked = dict(v=vs,  # version string
                i="",  # qb64 prefix
@@ -134,19 +137,24 @@ def rotate(
         version=Version,
         kind=Serials.json,
 ):
-    """
+    """ Returns serder of registry rotation (brt) message event
 
     Returns serder of vrt message event
     Utility function to create a Registry rotation event
 
     Parameters:
-        pre is identifier prefix qb64
-        regk is regsitry identifier prefix qb64
-        sn is int sequence number
-        toad is int or str hex of witness threshold
-        baks is list of prior backers prefixes qb64
-        cuts is list of witness prefixes to cut qb64
-        adds is list of witness prefixes to add qb64
+        regk (str): identifier prefix qb64
+        dig (str): qb64 digest or prior event
+        sn (int): sequence number
+        toad (int): int or str hex of witness threshold
+        baks (list): prior backers prefixes qb64
+        cuts (list): witness prefixes to cut qb64
+        adds (list): witness prefixes to add qb64
+        version (Versionage): the API version
+        kind (str): the event type
+
+    Returns:
+        Serder: event message Serder
 
     """
 
@@ -186,7 +194,7 @@ def rotate(
         raise ValueError("Invalid member combination among baks = {}, cuts ={}, "
                          "and adds = {}.".format(baks, cuts, adds))
 
-    if isinstance(toad, str):
+    if isinstance(toad, int):
         toad = "{:x}".format(toad)
     elif toad is None:
         if not newbakset:
@@ -223,14 +231,20 @@ def issue(
         kind=Serials.json,
         dt=None
 ):
-    """
+    """ Returns serder of issuance (iss) message event
 
     Returns serder of iss message event
     Utility function to create a VC issuance event
 
     Parameters:
-        vcdig is hash digest of vc content qb64
-        regk is regsitry identifier prefix qb64
+        vcdig (str): qb64 SAID of credential
+        regk (str): qb64 AID of credential registry
+        version (Versionage): the API version
+        kind (str): the event type
+        dt (str): ISO 8601 formatted date string of issuance date
+
+    Returns:
+        Serder: event message Serder
 
     """
 
@@ -257,15 +271,21 @@ def revoke(
         kind=Serials.json,
         dt=None
 ):
-    """
+    """ Returns serder of backerless credential revocation (rev) message event
 
     Returns serder of rev message event
     Utility function to create a VC revocation vent
 
     Parameters:
-        vcdig is hash digest of vc content qb64
-        regk is regsitry identifier prefix qb64
-        dig is digest of previous event qb64
+        vcdig (str): qb64 SAID of credential
+        regk (str): qb64 AID of credential registry
+        dig (str): digest of previous event qb64
+        version (Versionage): the API version
+        kind (str): the event type
+        dt (str): ISO 8601 formatted date string of revocation date
+
+    Returns:
+        Serder: event message Serder
 
     """
 
@@ -297,16 +317,22 @@ def backerIssue(
         kind=Serials.json,
         dt=None,
 ):
-    """
+    """ Returns serder of backer issuance (bis) message event
 
     Returns serder of bis message event
     Utility function to create a VC issuance event
 
     Parameters:
-        vcdig is hash digest of vc content qb64
-        regk is registry identifier prefix qb64
-        regsn is int sequence number of anchoring registry TEL event
-        regd is digest qb64 of anchoring registry TEL event
+        vcdig (str): qb64 SAID of credential
+        regk (str): qb64 AID of credential registry
+        regsn (int): sequence number of anchoring registry TEL event
+        regd (str): digest qb64 of anchoring registry TEL event
+        version (Versionage): the API version
+        kind (str): the event type
+        dt (str): ISO 8601 formatted date string of issuance date
+
+    Returns:
+        Serder: event message Serder
 
     """
 
@@ -341,17 +367,23 @@ def backerRevoke(
         kind=Serials.json,
         dt=None
 ):
-    """
+    """ Returns serder of backer credential revocation (brv) message event
 
     Returns serder of brv message event
     Utility function to create a VC revocation event
 
     Parameters:
-        vcdig is hash digest of vc content qb64
-        regk is regsitry identifier prefix qb64
-        regsn is int sequence number of anchoring registry TEL event
-        regd is digest qb64 of anchoring registry TEL event
-        dig is digest of previous event qb64
+        vcdig (str): qb64 SAID of credential
+        regk (str): qb64 AID of credential registry
+        regsn (int): sequence number of anchoring registry TEL event
+        regd (str): digest qb64 of anchoring registry TEL event
+        dig (str) digest of previous event qb64
+        version (Versionage): the API version
+        kind (str): the event type
+        dt (str): ISO 8601 formatted date string of issuance date
+
+    Returns:
+        Serder: event message Serder
 
     """
 
@@ -381,7 +413,6 @@ def state(pre,
           sn,
           ri,
           eilk,
-          es,
           br,
           ba,
           dts=None,  # default current datetime
@@ -396,18 +427,22 @@ def state(pre,
     Utility function to automate creation of rotation events.
 
     Parameters:
-        pre is identifier prefix qb64
-        sn is int sequence number of latest event
-        dig is digest of latest event
-        eilk is message type (ilk) oflatest event
-        keys is list of qb64 signing keys
-        br = witness remove list (cuts)
-        ba = witness add list (adds)
-        toad is int of witness threshold
-        wits is list of witness prefixes qb64
-        cnfg is list of strings TraitDex of configuration traits
-        version is Version instance
-        kind is serialization kind
+        pre (str): identifier prefix qb64
+        sn (int): int sequence number of latest event
+        dig (str): digest of latest event
+        ri (str): qb64 AID of credential registry
+        eilk (str): message type (ilk) oflatest event
+        br (list): witness remove list (cuts)
+        ba (list): witness add list (adds)
+        dts (str) ISO 8601 formated current datetime
+        toad (int): int of witness threshold
+        wits (str): list of witness prefixes qb64
+        cnfg (list): list of strings TraitDex of configuration traits
+        version (str): Version instance
+        kind (str): serialization kind
+
+    Returns:
+        Serder: Event message Serder
 
     Key State Dict
     {
@@ -481,7 +516,6 @@ def state(pre,
                t=ilk,
                ri=ri,
                dt=dts,
-               es=es,
                et=eilk,
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                br=br,
@@ -502,36 +536,45 @@ def query(regk,
           dtb=None,
           stamp=None,
           version=Version,
-          kind=Serials.json):
-    """
+          kind=Serials.json
+          ):
+    """ Returns serder of credentialquery (qry) event message.
+
     Returns serder of query event message.
     Utility function to automate creation of interaction events.
 
      Parameters:
-        pre is identifier prefix qb64
-        dig is digest of previous event qb64
-        sn is int sequence number
-        data is list of dicts of comitted data such as seals
-        version is Version instance
-        kind is serialization kind
-    """
-    vs = Versify(version=version, kind=kind, size=0)
-    ilk = Ilks.qry
+         regk (str): qb64 AID of credential registry
+         vcid (str): qb64 SAID of credential
+         route (str): namesapaced path, '/' delimited, that indicates data flow
+                      handler (behavior) to processs the query
+         replyRoute (str): namesapaced path, '/' delimited, that indicates data flow
+                      handler (behavior) to processs reply message to query if any.
+         dt (str): ISO 8601 formatted datetime query
+         dta (str): ISO 8601 formatted datetime after query
+         dtb (str): ISO 8601 formatted datetime before query
+         stamp (str): ISO 8601 formatted current datetime of query message
+         version (Versionage): the API version
+         kind (str): the event type
 
-    query = dict(i=vcid, ri=regk)
+     Returns:
+         Serder: query event message Serder
+
+    """
+    qry = dict(i=vcid, ri=regk)
 
     if dt is not None:
-        query["dt"] = dt
+        qry["dt"] = dt
 
     if dta is not None:
-        query["dta"] = dt
+        qry["dta"] = dt
 
     if dtb is not None:
-        query["dtb"] = dt
+        qry["dtb"] = dt
 
     return core.eventing.query(route=route,
                                replyRoute=replyRoute,
-                               query=query,
+                               query=qry,
                                stamp=stamp,
                                version=version,
                                kind=kind)
@@ -557,7 +600,7 @@ class Tever:
             True means only process msgs for own events if .regk
             False means only process msgs for not own events if .regk
         .version is version of current event state
-        .prefixer is prefixer instance for current event state
+        .prefixer is prefixer instance fParemtersor current event state
         .sn is sequence number int
         .serder is Serder instance of current event with .serder.diger for digest
         .toad is int threshold of accountable duplicity
@@ -566,30 +609,34 @@ class Tever:
         .adds is list of qualified qb64 aids for backers added to prev wits list
         .noBackers is boolean trait True means do not allow backers
 
-
-
     """
     NoBackers = False
 
     def __init__(self, cues=None, state=None, serder=None, seqner=None, diger=None, bigers=None, db=None,
                  reger=None, noBackers=None, regk=None, local=False):
-        """
+        """ Create incepting tever and state from registry inception serder
+
         Create incepting tever and state from registry inception serder
 
         Parameters:
-            serder is Serder instance of registry inception event
+            serder (Serder): instance of registry inception event
+            state (Serder): transaction state notice state message Serder
             seqner (Seqner): issuing event sequence number from controlling KEL.
             diger (Diger): issuing event digest from controlling KEL.
-            bigers is list of Siger instances of indexed backer signatures of
+            bigers (list): list of Siger instances of indexed backer signatures of
                 event. Index is offset into baks list of latest est event
-            db is Baser instance of lmdb database
-            reger is Registry instance of VC lmdb database
-            noBackers is boolean True means do not allow backer configuration
-            regk is identifier prefix of own or local registry. May not be the
+            db (Baser): instance of baser lmdb database
+            reger (Registry): instance of VC lmdb database
+            noBackers (bool): True means do not allow backer configuration
+            regk (str): identifier prefix of own or local registry. May not be the
                 prefix of this Tever's event. Some restrictions if present
-            local is Boolean, True means only process msgs for own controller's
+            local (bool): True means only process msgs for own controller's
                 events if .regk. False means only process msgs for not own events
                 if .regk
+
+        Returns:
+            Tever:  instance representing credential Registry
+
         """
 
         if not (state or serder):
@@ -641,48 +688,56 @@ class Tever:
         self.regk = self.prefixer.qb64
         self.reger.states.pin(keys=self.regk, val=self.state())
 
-    def reload(self, state):
-        """
+
+    def reload(self, ksn):
+        """ Reload Tever attributes (aka its state) from state serder
+
         Reload Tever attributes (aka its state) from state serder
 
         Parameters:
-            state (Serder): instance of key stat notice 'ksn' message body
+            ksn (Serder): instance of key stat notice 'ksn' message body
 
         """
 
         for k in TSN_LABELS:
-            if k not in state.ked:
+            if k not in ksn.ked:
                 raise ValidationError("Missing element = {} from {} event."
                                       " evt = {}.".format(k, Ilks.ksn,
-                                                          state.pretty()))
+                                                          ksn.pretty()))
 
-        self.version = state.version
-        self.pre = state.pre
-        self.regk = state.ked["ri"]
+        self.version = ksn.version
+        self.pre = ksn.pre
+        self.regk = ksn.ked["ri"]
         self.prefixer = Prefixer(qb64=self.regk)
-        self.sn = state.sn
-        self.ilk = state.ked["et"]
-        self.toad = int(state.ked["bt"], 16)
-        self.baks = state.ked["b"]
-        self.cuts = state.ked["br"]
-        self.adds = state.ked["ba"]
+        self.sn = ksn.sn
+        self.ilk = ksn.ked["et"]
+        self.toad = int(ksn.ked["bt"], 16)
+        self.baks = ksn.ked["b"]
+        self.cuts = ksn.ked["br"]
+        self.adds = ksn.ked["ba"]
 
-        self.noBackers = True if TraitDex.NoBackers in state.ked["c"] else False
+        self.noBackers = True if TraitDex.NoBackers in ksn.ked["c"] else False
 
         if (raw := self.reger.getTvt(key=dgKey(pre=self.prefixer.qb64,
-                                               dig=state.ked['d']))) is None:
+                                               dig=ksn.ked['d']))) is None:
             raise kering.MissingEntryError("Corresponding event for state={} not found."
-                                           "".format(state.pretty()))
+                                           "".format(ksn.pretty()))
         self.serder = Serder(raw=bytes(raw))
 
+
     def state(self, kind=Serials.json):
-        """
-        Returns Serder instance of current key state notification message
+        """ Returns Serder instance of current transaction state notification message
+
+        Returns Serder instance of current transaction state notification message of this
+        credential registry.
 
         Parameters:
-            kind is serialization kind for message json, cbor, mgpk
+            kind (str): serialization kind for message json, cbor, mgpk
+
+        Returns:
+            Serder:  event message Serder instance
+
         """
-        es = self.sn
         br = self.cuts
         ba = self.adds
 
@@ -696,7 +751,6 @@ class Tever:
                       ri=self.regk,
                       dts=None,
                       eilk=self.ilk,
-                      es=es,
                       br=br,
                       ba=ba,
                       toad=self.toad,
@@ -707,6 +761,15 @@ class Tever:
                 )
 
     def incept(self, serder):
+        """  Validate registry inception event and initialize local attributes
+
+        Parse and validate registry inception event for this Tever.  Update all
+        local attributes with initial values.
+
+        Parameters:
+            serder (Serder): registry inception event (vcp)
+
+        """
 
         ked = serder.ked
         self.pre = ked["ii"]
@@ -739,8 +802,17 @@ class Tever:
         self.serder = serder
 
     def config(self, serder, noBackers=None):
-        """
-        Process cnfg field for configuration traits
+        """ Process cnfg field for configuration traits
+
+        Parse and validate the configuration options for registry inception from
+        the `c` field of the provided inception event.
+
+        Parameters:
+            serder (Serder): credential registry inception event `vcp`
+            noBackers (bool): override flag for specifying a registry with no additional backers
+                              beyond the controlling KEL's witnesses
+
+
         """
         # assign traits
         self.noBackers = (True if (noBackers if noBackers is not None
@@ -752,8 +824,19 @@ class Tever:
             self.noBackers = True
 
     def update(self, serder, seqner=None, diger=None, bigers=None):
-        """
-        Process registry non-inception events.
+        """ Process registry non-inception events.
+
+        Process non-inception registry and credential events and update local
+        Tever state for registry or credential
+
+        Parameters:
+            serder (Serder): instance of issuance or backer issuance event
+            seqner (Seqner): issuing event sequence number from controlling KEL.
+            diger (Diger): issuing event digest from controlling KEL.
+            bigers (list): of Siger instances of indexed witness signatures.
+                Index is offset into wits list of associated witness nontrans pre
+                from which public key may be derived.
+
         """
 
         ked = serder.ked
@@ -804,13 +887,23 @@ class Tever:
         else:  # unsupported event ilk so discard
             raise ValidationError("Unsupported ilk = {} for evt = {}.".format(ilk, ked))
 
+
     def rotate(self, serder, sn):
-        """
-        Process registry management TEL, non-inception events (vrt)
+        """ Process registry management TEL, non-inception events (vrt)
+
+        Parameters:
+            serder (Serder): registry rotation event
+            sn (int): sequence number of event
+
+        Returns:
+            int: calculated backer threshold
+            list: new list of backers after applying cuts and adds to previous list
+            list: list of backer adds processed from event
+            list: list of backer cuts processed from event
+
         """
 
         ked = serder.ked
-        pre = ked["i"]
         dig = ked["p"]
 
         if serder.pre != self.prefixer.qb64:
@@ -875,9 +968,20 @@ class Tever:
         return toad, baks, cuts, adds
 
     def issue(self, serder, seqner, diger, sn, bigers=None):
-        """
-        Process VC TEL issuance events (iss, bis)
-        Currently placeholder
+        """ Process VC TEL issuance events (iss, bis)
+
+        Validate and process credential issuance events.  If valid, event is persisted
+        in local datastore for TEL.  Will escrow event if missing anchor or backer signatures
+
+        Parameters
+            serder (Serder): instance of issuance or backer issuance event
+            seqner (Seqner): issuing event sequence number from controlling KEL.
+            diger (Diger): issuing event digest from controlling KEL.
+            sn (int): event sequence event
+            bigers (list): of Siger instances of indexed witness signatures.
+                Index is offset into wits list of associated witness nontrans pre
+                from which public key may be derived.
+
         """
 
         ked = serder.ked
@@ -933,9 +1037,20 @@ class Tever:
             raise ValidationError("Unsupported ilk = {} for evt = {}.".format(ilk, ked))
 
     def revoke(self, serder, seqner, diger, sn, bigers=None):
-        """
-        Process VC TEL revocation events (rev, brv)
-        Currently placeholder
+        """ Process VC TEL revocation events (rev, brv)
+
+        Validate and process credential revocation events.  If valid, event is persisted
+        in local datastore for TEL.  Will escrow event if missing anchor or backer signatures
+
+        Parameters
+            serder (Serder): instance of issuance or backer issuance event
+            seqner (Seqner): issuing event sequence number from controlling KEL.
+            diger (Diger): issuing event digest from controlling KEL.
+            sn (int): event sequence event
+            bigers (list): of Siger instances of indexed witness signatures.
+                Index is offset into wits list of associated witness nontrans pre
+                from which public key may be derived.
+
         """
 
         ked = serder.ked
@@ -998,12 +1113,15 @@ class Tever:
             raise ValidationError("Unsupported ilk = {} for evt = {}.".format(ilk, ked))
 
     def vcState(self, vcpre):
-        """
-        Calculate state (issued/revoked) of VC from db.
-         Returns None if never issued from this Registry
+        """ Calculate state (issued/revoked) of VC from db.
+
+        Returns None if never issued from this Registry
 
         Parameters:
-          vcpre:  the VC identifier
+          vcpre (str):  qb64 VC identifier
+
+        Returns:
+            status (str): `issued` or `revoked` or None if credential identifier is not found
         """
         vci = nsKey([self.prefixer.qb64, vcpre])
         digs = []
@@ -1020,12 +1138,15 @@ class Tever:
         return status, lastSeen
 
     def vcSn(self, vcpre):
-        """
-        Calculates the current seq no of VC from db.
-         Returns None if never issued from this Registry
+        """ Calculates the current seq no of VC from db.
+
+        Returns None if never issued from this Registry
 
         Parameters:
-          vcpre:  the VC identifier
+          vcpre (str):  qb64 VC identifier
+
+        Returns:
+            int: current TEL sequence number of credential or None if not found
 
         """
         vci = nsKey([self.prefixer.qb64, vcpre])
@@ -1034,8 +1155,8 @@ class Tever:
         return None if cnt == 0 else cnt - 1
 
     def logEvent(self, pre, sn, serder, seqner, diger, bigers=None, baks=None):
-        """
-        Update associated logs for verified event.
+        """ Update associated logs for verified event.
+
         Update is idempotent. Logs will not write dup at key if already exists.
 
         Parameters:
@@ -1043,15 +1164,13 @@ class Tever:
             sn (int): is event sequence number
             serder (Serder): is Serder instance of current event
             seqner (Seqner): issuing event sequence number from controlling KEL.
-            diger (Diger): issuing event digest from controlling KEL.
-            bigers (Siger): is optional list of Siger instance of indexed backer sigs
             seqner (Seqner): is optional Seqner instance of cloned first seen ordinal
                 If cloned mode then seqner maybe provided (not None)
                 When seqner provided then compare fn of dater and database and
                 first seen if not match then log and add cue notify problem
-            baks (qb64): is optional Dater instance of cloned replay datetime
-                If cloned mode then dater maybe provided (not None)
-                When dater provided then use dater for first seen datetime
+            diger (Diger): issuing event digest from controlling KEL.
+            bigers (list): is optional list of Siger instance of indexed backer sigs
+            baks (list): is optional list of qb64 non-trans identifiers of backers
         """
 
         dig = serder.diger.qb64b
@@ -1070,9 +1189,7 @@ class Tever:
                     pre, json.dumps(serder.ked, indent=1))
 
     def valAnchorBigs(self, serder, seqner, diger, bigers, toad, baks):
-        """
-        Returns double (bigers) where:
-        bigers is unique validated signature verified members of inputed bigers
+        """ Validate anchor and backer signatures (bigers) when provided.
 
         Validates sigers signatures by validating indexes, verifying signatures, and
             validating threshold sith.
@@ -1081,15 +1198,18 @@ class Tever:
         Backer validation is a function of .regk and .local
 
         Parameters:
-            serder is Serder instance of event
+            serder (Serder): instance of event
             seqner (Seqner): issuing event sequence number from controlling KEL.
             diger (Diger): issuing event digest from controlling KEL.
-            bigers is list of Siger instances of indexed witness signatures.
+            bigers (list)  Siger instances of indexed witness signatures.
                 Index is offset into wits list of associated witness nontrans pre
                 from which public key may be derived.
-            toad is int or  str hex of witness threshold
-            baks is list of qb64 non-transferable prefixes of backers used to
+            toad (int):  str hex of witness threshold
+            baks (list): qb64 non-transferable prefixes of backers used to
                 derive werfers for bigers
+
+        Returns:
+            list: unique validated signature verified members of inputed bigers
 
         """
 
@@ -1128,10 +1248,20 @@ class Tever:
         return bigers
 
     def verifyAnchor(self, serder, seqner, diger):
-        """
-        retrieve event from db using anchor
-        get seal from event eserder
+        """ Retrieve specified anchoring event and verify seal
+
+        Retrieve event from db using anchor, get seal from event eserder and
         verify pre, sn and dig against serder
+
+        Parameters:
+            serder (Serder): anchored TEL event
+            seqner (Seqner): sequence number of anchoring event
+            diger (Diger): digest of anchoring event
+
+        Returns:
+             bool: True is anchoring event exists in database and seal is valid against
+                   TEL event.
+
         """
 
         dig = self.db.getKeLast(key=snKey(pre=self.pre, sn=seqner.sn))
@@ -1168,12 +1298,14 @@ class Tever:
         return False
 
     def escrowPWEvent(self, serder, seqner, diger, bigers=None):
-        """
-        Update associated logs for escrow of partially witnessed event
+        """ Update associated logs for escrow of partially witnessed event
 
         Parameters:
-            serder is Serder instance of  event
-            bigers is list of Siger instance of indexed witness sigs
+            serder (Serder): instance of  event
+            seqner (Seqner): sequence number for anchor seal
+            diger (Diger): digest of anchor
+            bigers (list): Siger instance of indexed witness sigs
+
         """
         dgkey = dgKey(serder.preb, serder.digb)
         sealet = seqner.qb64b + diger.qb64b
@@ -1184,12 +1316,20 @@ class Tever:
         logger.info("Tever state: Escrowed partially witnessed "
                     "event = %s\n", serder.ked)
 
+
     def escrowALEvent(self, serder, seqner, diger, bigers=None, baks=None):
-        """
-        Update associated logs for escrow of anchorless event
+        """ Update associated logs for escrow of anchorless event
 
         Parameters:
-            serder is Serder instance of  event
+            serder (Serder): instance of  event
+            seqner (Seqner): sequence number for anchor seal
+            diger (Diger): digest of anchor
+            bigers (list): Siger instance of indexed witness sigs
+            baks (list): qb64 of new backers
+
+        Returns:
+            bool: True if escrow is successful, False otherwith (eg. already escrowed)
+
         """
         key = dgKey(serder.preb, serder.digb)
         if seqner and diger:
@@ -1205,7 +1345,17 @@ class Tever:
                     "event = %s\n", serder.ked)
         return self.reger.putTae(snKey(serder.preb, serder.sn), serder.digb)
 
+
     def getBackerState(self, ked):
+        """ Calculate and return the current list of backers for event dict
+
+        Parameters:
+            ked (dict):  event dict
+
+        Returns:
+            list:  qb64 of current list of backers for state at ked
+
+        """
         rega = ked["ra"]
         regi = rega["i"]
         regd = rega["d"]
@@ -1232,26 +1382,36 @@ class Tever:
 
 
 class Tevery:
-    """
-    Tevery (Transaction Event Message Processing Facility)
+    """ Tevery (Transaction Event Message Processing Facility)
 
-    Currently placeholder
+    Tevery processes an incoming message stream composed of KERI key event related
+    messages and attachments.  Tevery acts as a Tever (transaction event verifier)
+    factory for managing transaction state of KERI credential registries and associated
+    credentials.
 
     Attributes:
+        db (Baser):  local LMDB identifier database
+        reger (Registry): local LMDB credential database
+        regk (str): qb64 registry AID
+        local (bool): True means only process msgs for own events if .regk
+                        False means only process msgs for not own events if .regk
+        cues (Deck): notices generated from processing events
+
 
     """
 
     def __init__(self, reger=None, db=None, regk=None, local=False, cues=None):
-        """
-        Initialize instance:
+        """ Initialize instance:
 
         Parameters:
-            tevers is dict of Kever instances of key state in db
-            reger is Registry instance
-            db is Baser instance
-            regk is local or own identifier prefix. Some restriction if present
-            local is Boolean, True means only process msgs for own events if .pre
-                        False means only process msgs for not own events if .pre
+            reger (Registry): local LMDB credential database
+            db (Baser):  local LMDB identifier database
+            regk (str): local or own identifier prefix. Some restriction if present
+            local (bool): True means only process msgs for own events if .regk
+                        False means only process msgs for not own events if .regk
+            cues (Deck): notices generated from processing events
+
+
         """
         self.db = db if db is not None else basing.Baser(reopen=True)  # default name = "main"
         self.reger = reger if reger is not None else Registry()
@@ -1261,26 +1421,29 @@ class Tevery:
 
     @property
     def tevers(self):
-        """
-        Returns .reger.tevers
-        """
+        """ Returns .reger.tevers read through cache of credential registries """
+
         return self.reger.tevers
 
+
     def processEvent(self, serder, seqner, diger, wigers=None):
-        """
-        Process one event serder with attached indexd signatures sigers
+        """ Process one event serder with attached indexde signatures sigers
+
+        Validates event against current state of registry or credential, creating registry
+        on inception events and processing change in state to credential or registry for
+        other events
 
         Parameters:
             serder (Serder): event to process
             seqner (Seqner): issuing event sequence number from controlling KEL.
             diger (Diger): issuing event digest from controlling KEL.
-            wigers (Siger): is optional list of Siger instances of attached witness indexed sigs
+            wigers (list): optional list of Siger instances of attached witness indexed sigs
 
         """
         ked = serder.ked
         try:  # see if code of pre is supported and matches size of pre
             Prefixer(qb64b=serder.preb)
-        except Exception as ex:  # if unsupported code or bad size raises error
+        except Exception:  # if unsupported code or bad size raises error
             raise ValidationError("Invalid pre = {} for evt = {}."
                                   "".format(serder.pre, ked))
 
@@ -1316,7 +1479,7 @@ class Tevery:
                               db=self.db,
                               regk=self.regk,
                               local=self.local,
-                              cues = self.cues)
+                              cues=self.cues)
                 self.tevers[regk] = tever
                 if not self.regk or self.regk != regk:
                     # witness style backers will need to send receipts so lets queue them up for now
@@ -1359,29 +1522,30 @@ class Tevery:
 
 
     def processQuery(self, serder, source=None, sigers=None, cigars=None):
-        """
+        """ Process TEL query event message (qry)
+
         Process query mode replay message for collective or single element query.
-        Assume promiscuous mode for now.
+        Will cue response message with kin of "replay".  Assume promiscuous mode for now.
 
         Parameters:
-            serder (Serder) is query message serder
-            source (qb64) identifier prefix of querier
-            sigers (list) of Siger instances of attached controller indexed sigs
+            serder (Serder): is query message serder
+            source (qb64): identifier prefix of querier
+            sigers (list): Siger instances of attached controller indexed sigs
+            cigars (list): Siger instances of non-transferable signatures
 
         """
         ked = serder.ked
 
         ilk = ked["t"]
         route = ked["r"]
-        replyRoute = ked["rr"]
-        query = ked["q"]
+        qry = ked["q"]
 
         # do signature validation and replay attack prevention logic here
         # src, dt, route
 
         if route == "tels":
-            mgmt = query["ri"]
-            vcpre = query["i"]
+            mgmt = qry["ri"]
+            vcpre = qry["i"]
             vck = nsKey([mgmt, vcpre])
 
             cloner = self.reger.clonePreIter(pre=mgmt, fn=0)  # create iterator at 0
@@ -1400,6 +1564,14 @@ class Tevery:
 
     @staticmethod
     def registryKey(serder):
+        """  Utility method to extract registry key from any type of TEL serder
+
+        Parameters:
+            serder (Serder): event messate
+
+        Returns:
+            str: qb64 regsitry identifier
+        """
         ilk = serder.ked["t"]
 
         if ilk in (Ilks.vcp, Ilks.vrt):
@@ -1412,7 +1584,24 @@ class Tevery:
         else:
             raise ValidationError("invalid ilk {} for tevery event = {}".format(ilk, serder.ked))
 
+
     def escrowOOEvent(self, serder, seqner, diger):
+        """ Escrow out-of-order TEL events.
+
+        Saves the serialized event, anchor and event digest in escrow for any
+        event that is received out of order.
+
+        Examples include registry rotation events, credential issuance event
+         received before the registry inception event or a credential revocation
+         event received before the issuance event.
+
+        Parameters:
+            serder (Serder): serder of event message
+            seqner (Seqner): sequence number of anchoring TEL event
+            diger (Diger) digest of anchoring TEL event
+
+
+        """
         key = dgKey(serder.preb, serder.digb)
         self.reger.putTvt(key, serder.raw)
         sealet = seqner.qb64b + diger.qb64b
@@ -1421,12 +1610,10 @@ class Tevery:
         logger.info("Tever state: Escrowed our of order TEL event "
                     "event = %s\n", serder.ked)
 
+
     def processEscrows(self):
-        """
-        Loop through escrows and process and events that may now be finalized
+        """ Loop through escrows and process and events that may now be finalized """
 
-
-        """
         try:
             self.processEscrowAnchorless()
             self.processEscrowOutOfOrders()
@@ -1438,19 +1625,35 @@ class Tevery:
                 logger.error("Tevery escrow process error: %s\n", ex.args[0])
 
     def processEscrowOutOfOrders(self):
+        """ Loop through out of order escrow:
+
+         Process out of order events in the following way:
+           1. loop over event digests saved in oots
+           2. deserialize event out of tvts
+           3. read anchor information out of .ancs
+           4. perform process event
+           5. Remove event digest from oots if processed successfully or a non-out-of-order event occurs.
+
+        """
         for (pre, snb, digb) in self.reger.getOotItemIter():
             print("oot-tel-event", pre)
 
 
     def processEscrowAnchorless(self):
-        """
-        Process escrow of TEL events received before the anchoring KEL
-        event.
+        """ Process escrow of TEL events received before the anchoring KEL event.
+
+        Process anchorless events in the following way:
+           1. loop over event digests saved in taes
+           2. deserialize event out of tvts
+           3. load backer signatures out of tibs
+           4. read anchor information out of ancs
+           5. perform process event
+           6. Remove event digest from oots if processed successfully or a non-anchorless event occurs.
 
         """
         for (pre, snb, digb) in self.reger.getTaeItemIter():
+            sn = int(snb, 16)
             try:
-                sn = int(snb, 16)
                 dgkey = dgKey(pre, digb)
                 traw = self.reger.getTvt(dgkey)
                 if traw is None:

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -395,6 +395,7 @@ class Verifier:
 
         return creder, prefixer, seqner, diger, sigers
 
+
     def query(self, regk, vcid, *, dt=None, dta=None, dtb=None, **kwa):
         """
         Returns query message for querying registry

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -5,44 +5,33 @@ tests.core.test_eventing module
 """
 import os
 
+import blake3
+import pysodium
 import pytest
 
-import pysodium
-import blake3
-from math import ceil
-
-from keri import kering
-from keri.kering import Version
-from keri.kering import (ValidationError, EmptyMaterialError, DerivationError,
-                         ShortageError)
-
+from keri import help
+from keri.app import habbing, keeping
+from keri.app.keeping import openKS, Manager
 from keri.core import coring, eventing, parsing
-from keri.core.coring import MtrDex, Matter, IdrDex, Indexer, CtrDex, Counter
-from keri.core.coring import Seqner, Verfer, Signer, Diger, Nexter, Prefixer
-from keri.core.coring import Salter, Serder, Siger, Cigar
 from keri.core.coring import Ilks
-
-from keri.core.eventing import (TraitDex, LastEstLoc, Serials, Versify,
-                                simple,  ample)
-from keri.core.eventing import (deWitnessCouple, deReceiptCouple, deSourceCouple,
-                                deReceiptTriple,
-                                deTransReceiptQuadruple, deTransReceiptQuintuple)
+from keri.core.coring import MtrDex, Matter, IdrDex, Indexer, CtrDex, Counter
+from keri.core.coring import Salter, Serder, Siger, Cigar
+from keri.core.coring import Seqner, Verfer, Signer, Nexter, Prefixer
+from keri.core.eventing import Kever, Kevery
 from keri.core.eventing import (SealDigest, SealRoot, SealBacker,
                                 SealEvent, SealLast, SealLocation,
                                 StateEvent, StateEstEvent)
+from keri.core.eventing import (TraitDex, LastEstLoc, Serials, Versify,
+                                simple, ample)
+from keri.core.eventing import (deWitnessCouple, deReceiptCouple, deSourceCouple,
+                                deReceiptTriple,
+                                deTransReceiptQuadruple, deTransReceiptQuintuple)
 from keri.core.eventing import (incept, rotate, interact, receipt, query,
                                 delcept, deltate, state, messagize)
-from keri.core.eventing import Kever, Kevery
-
 from keri.db import dbing, basing
-from keri.db.dbing import dgKey, snKey
 from keri.db.basing import openDB
-
-from keri.app import habbing, keeping
-from keri.app.keeping import openKS, Manager
-
-
-from keri import help
+from keri.db.dbing import dgKey, snKey
+from keri.kering import (ValidationError, DerivationError)
 
 logger = help.ogler.getLogger()
 
@@ -143,7 +132,6 @@ def test_ample():
     assert ample(13, weak=False) == 9
     assert ample(13, f=4) == 9
     assert ample(13, f=4, weak=False) == 9
-
 
 
 def test_dewitnesscouple():
@@ -297,7 +285,6 @@ def test_desourcecouple():
     snub = b'0AAAAAAAAAAAAAAAAAAAAABQ'
     digb = b'E62X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ'
 
-
     # str
     couple = snu + dig
     assert len(couple) == 68
@@ -417,14 +404,14 @@ def test_dereceipttriple():
     assert len(triple) == 176
     with pytest.raises(TypeError):
         diger, prefixer, cigar = deReceiptTriple(triple, strip=True)
-    assert len(triple) == 176   # immutable so no strip delete
+    assert len(triple) == 176  # immutable so no strip delete
 
     # memoryview converts to bytes
     triple = memoryview(triple)
     assert len(triple) == 176
     with pytest.raises(TypeError):
         diger, prefixer, cigar = deReceiptTriple(triple, strip=True)
-    assert len(triple) == 176   # immutable so no strip delete
+    assert len(triple) == 176  # immutable so no strip delete
 
     # bytearray
     triple = bytearray(triple)
@@ -433,9 +420,10 @@ def test_dereceipttriple():
     assert diger.qb64b == digb
     assert prefixer.qb64b == preb
     assert cigar.qb64b == cigb
-    assert len(triple) == 0   # mutable so strip delete
+    assert len(triple) == 0  # mutable so strip delete
 
     """end test"""
+
 
 def test_dequadruple():
     """
@@ -451,7 +439,7 @@ def test_dequadruple():
     sdigb = b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
     sigb = b'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
 
-    #str
+    # str
     quadruple = spre + ssnu + sdig + sig
     sprefixer, sseqner, sdiger, siger = deTransReceiptQuadruple(quadruple)
     assert sprefixer.qb64 == spre
@@ -538,7 +526,7 @@ def test_dequintuple():
     sdigb = b'EsLkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
     sigb = b'AFmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
 
-    #str
+    # str
     sealet = spre + ssnu + sdig
     quintuple = edig + sealet + sig
     ediger, sprefixer, sseqner, sdiger, siger = deTransReceiptQuintuple(quintuple)
@@ -600,7 +588,7 @@ def test_dequintuple():
     assert len(quintuple) == 244
     with pytest.raises(TypeError):
         ediger, sprefixer, sseqner, sdiger, siger = deTransReceiptQuintuple(quintuple, strip=True)
-    assert len(quintuple) == 244 # immutable so no strip delete
+    assert len(quintuple) == 244  # immutable so no strip delete
 
     # bytearray
     quintuple = bytearray(quintuple)
@@ -631,6 +619,7 @@ def test_lastestloc():
 
     """End Test """
 
+
 def test_seals_states():
     """
     Test seal and state namedtuples
@@ -641,14 +630,14 @@ def test_seals_states():
     assert 'E12345' in seal
     assert seal.d == 'E12345'
     assert seal._asdict() == dict(d='E12345')
-    assert seal._fields == ('d', )
+    assert seal._fields == ('d',)
 
     seal = SealRoot(rd='EABCDE')
     assert isinstance(seal, SealRoot)
     assert 'EABCDE' in seal
     assert seal.rd == 'EABCDE'
     assert seal._asdict() == dict(rd='EABCDE')
-    assert seal._fields == ('rd', )
+    assert seal._fields == ('rd',)
 
     seal = SealBacker(bi='B4321', d='EABCDE')
     assert isinstance(seal, SealBacker)
@@ -664,7 +653,7 @@ def test_seals_states():
     assert 'B4321' in seal
     assert seal.i == 'B4321'
     assert '1' in seal
-    assert seal.s ==  '1'
+    assert seal.s == '1'
     assert 'Eabcd' in seal
     assert seal.d == 'Eabcd'
     assert seal._asdict() == dict(i='B4321', s='1', d='Eabcd')
@@ -675,7 +664,7 @@ def test_seals_states():
     assert 'B4321' in seal
     assert seal.i == 'B4321'
     assert seal._asdict() == dict(i='B4321')
-    assert seal._fields == ('i', )
+    assert seal._fields == ('i',)
 
     seal = SealLocation(i='B4321', s='1', t='ixn', p='Eabcd')
     assert isinstance(seal, SealLocation)
@@ -716,6 +705,7 @@ def test_seals_states():
 
     """End Test """
 
+
 def test_keyeventfuncs(mockHelpingNowUTC):
     """
     Test the support functionality for key event generation functions
@@ -726,40 +716,38 @@ def test_keyeventfuncs(mockHelpingNowUTC):
             b'\xc9\xbd\x04\x9d\x85)~\x93')
 
     # Inception: Non-transferable (ephemeral) case
-    signer0 = Signer(raw=seed, transferable=False)  #  original signing keypair non transferable
+    signer0 = Signer(raw=seed, transferable=False)  # original signing keypair non transferable
     assert signer0.code == MtrDex.Ed25519_Seed
     assert signer0.verfer.code == MtrDex.Ed25519N
     keys0 = [signer0.verfer.qb64]
-    serder = incept(keys=keys0)  #  default nxt is empty so abandoned
+    serder = incept(keys=keys0)  # default nxt is empty so abandoned
     assert serder.ked["i"] == 'BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder.ked["n"] == ""
     assert serder.raw == (b'{"v":"KERI10JSON0000c1_","i":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc",'
                           b'"s":"0","t":"icp","kt":"1","k":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
                           b'c"],"n":"","bt":"0","b":[],"c":[],"a":[]}')
 
-
     with pytest.raises(DerivationError):
         # non-empty nxt wtih non-transferable code
         serder = incept(keys=keys0, code=MtrDex.Ed25519N, nxt="ABCDE")
 
     # Inception: Transferable Case but abandoned in incept so equivalent
-    signer0 = Signer(raw=seed)  #  original signing keypair transferable default
+    signer0 = Signer(raw=seed)  # original signing keypair transferable default
     assert signer0.code == MtrDex.Ed25519_Seed
     assert signer0.verfer.code == MtrDex.Ed25519
     keys0 = [signer0.verfer.qb64]
-    serder = incept(keys=keys0)  #  default nxt is empty so abandoned
+    serder = incept(keys=keys0)  # default nxt is empty so abandoned
     assert serder.ked["i"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder.ked["n"] == ""
     assert serder.raw == (b'{"v":"KERI10JSON0000c1_","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc",'
                           b'"s":"0","t":"icp","kt":"1","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhc'
                           b'c"],"n":"","bt":"0","b":[],"c":[],"a":[]}')
 
-
     # Inception: Transferable not abandoned i.e. next not empty
     # seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     seed1 = (b'\x83B~\x04\x94\xe3\xceUQy\x11f\x0c\x93]\x1e\xbf\xacQ\xb5\xd6Y^\xa2E\xfa\x015'
-            b'\x98Y\xdd\xe8')
-    signer1 = Signer(raw=seed1)  #  next signing keypair transferable is default
+             b'\x98Y\xdd\xe8')
+    signer1 = Signer(raw=seed1)  # next signing keypair transferable is default
     assert signer1.code == MtrDex.Ed25519_Seed
     assert signer1.verfer.code == MtrDex.Ed25519
     keys1 = [signer1.verfer.qb64]
@@ -783,8 +771,8 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     # Rotation: Transferable not abandoned i.e. next not empty
     # seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     seed2 = (b'\xbe\x96\x02\xa9\x88\xce\xf9O\x1e\x0fo\xc0\xff\x98\xb6\xfa\x1e\xa2y\xf2'
-            b'e\xf9AL\x1aeK\xafj\xa1pB')
-    signer2 = Signer(raw=seed2)  #  next signing keypair transferable is default
+             b'e\xf9AL\x1aeK\xafj\xa1pB')
+    signer2 = Signer(raw=seed2)  # next signing keypair transferable is default
     assert signer2.code == MtrDex.Ed25519_Seed
     assert signer2.verfer.code == MtrDex.Ed25519
     keys2 = [signer2.verfer.qb64]
@@ -821,7 +809,6 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     assert serder3.raw == (b'{"v":"KERI10JSON000091_","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc",'
                            b'"s":"0","t":"rct","d":"ENjADDuGb8QwXfG2-Q6mqFCZqnze_L9dufxLAg8AGtCE"}')
 
-
     # Receipt  transferable identifier
     serderA = incept(keys=keys0, nxt=nxt1, code=MtrDex.Blake3_256)
     seal = SealEvent(i=serderA.ked["i"], s=serderA.ked["s"], d=serderA.dig)
@@ -846,13 +833,12 @@ def test_keyeventfuncs(mockHelpingNowUTC):
                             b'0I3i4-AABAAUMALurW2PdrOG5l_sfRdiIdKqpDZShNcPNQ-6vJb6dwG9-wahbQrj'
                             b'303CRsAVT0gOqI9Ty4EoEyiv6LAX5w9Cw')
 
-
     # Delegated Inception:
     # Transferable not abandoned i.e. next not empty
     # seed = pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)
     seedD = (b'\x83B~\x04\x94\xe3\xceUQy\x11f\x0c\x93]\x1e\xbf\xacQ\xb5\xd6Y^\xa2E\xfa\x015'
-            b'\x98Y\xdd\xe8')
-    signerD = Signer(raw=seedD)  #  next signing keypair transferable is default
+             b'\x98Y\xdd\xe8')
+    signerD = Signer(raw=seedD)  # next signing keypair transferable is default
     assert signerD.code == MtrDex.Ed25519_Seed
     assert signerD.verfer.code == MtrDex.Ed25519
     keysD = [signerD.verfer.qb64]
@@ -876,8 +862,8 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     # Delegated Rotation:
     # Transferable not abandoned i.e. next not empty
     seedR = (b'\xbe\x96\x02\xa9\x88\xce\xf9O\x1e\x0fo\xc0\xff\x98\xb6\xfa\x1e\xa2y\xf2'
-            b'e\xf9AL\x1aeK\xafj\xa1pB')
-    signerR = Signer(raw=seedR)  #  next signing keypair transferable is default
+             b'e\xf9AL\x1aeK\xafj\xa1pB')
+    signerR = Signer(raw=seedR)  # next signing keypair transferable is default
     assert signerR.code == MtrDex.Ed25519_Seed
     assert signerR.verfer.code == MtrDex.Ed25519
     keysR = [signerR.verfer.qb64]
@@ -1000,12 +986,11 @@ def test_state(mockHelpingNowUTC):
     wits = [preW1, preW2, preW3]
     toad = 2
 
-    #create namedtuple of latest est event
+    # create namedtuple of latest est event
     eevt = StateEstEvent(s='3',
                          d='EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30',
                          br=[preW0],
                          ba=[preW3])
-
 
     serderK = state(pre=preC,
                     sn=4,
@@ -1021,18 +1006,18 @@ def test_state(mockHelpingNowUTC):
                     wits=wits,
                     )
 
-    assert serderK.raw == (b'{"v":"KERI10JSON0002d0_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
-                        b'"s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"Eg'
-                        b'Nkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:0'
-                        b'0.000000+00:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-                        b'WVK9ZBNZk0"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b"'
-                        b':["BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LM'
-                        b'YWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"'
-                        b'ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTks'
-                        b'tUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc'
-                        b'1CQnigIUBKrBFz_1Y"]},"di":"","r":""}')
+    assert serderK.raw == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
+                           b'"s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"EgNkcl_Qewzr'
+                           b'RSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:00.000000+0'
+                           b'0:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
+                           b'"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1yt'
+                           b'EFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYWO5lPWOrS'
+                           b'B6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"ee":{"s":"'
+                           b'3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1'
+                           b'IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBK'
+                           b'rBFz_1Y"]},"di":""}')
 
-    assert serderK.dig == 'EapwUdeEbLXzm4RgrrcottEItkl6VON_F_nCuFC1dPBY'
+    assert serderK.dig == 'EcTO0kxOr49dIY8_XLEljCIFFGxPAuswUdgbtqFZIggg'
     assert serderK.pre == preC == 'D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
     assert serderK.sn == 4
 
@@ -1046,20 +1031,20 @@ def test_state(mockHelpingNowUTC):
     cigarE = signerE.sign(ser=serderK.raw)
     assert signerE.verfer.verify(sig=cigarE.raw, ser=serderK.raw)
     msg = messagize(serderK, cigars=[cigarE])
-    assert msg == (b'{"v":"KERI10JSON0002d0_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-                    b'WVK9ZBNZk0","s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSK'
-                    b'H2p9zHQIO132Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z'
-                    b'30","f":"4","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","'
-                    b'kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n"'
-                    b':"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["B'
-                    b'aEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2G'
-                    b'U5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIU'
-                    b'BKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewzr'
-                    b'RSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS'
-                    b'2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]}'
-                    b',"di":"","r":""}-CABByvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'
-                    b'0BPxWkuJixAdYrPjWnwz1vrvKHG1U3jk8M18dnGgLssXvjf7lcWaBsal_jBEhck2'
-                    b'lMd4jNGo7y4VBesF7sseeDBg')
+    assert msg == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+                   b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
+                   b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
+                   b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
+                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
+                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
+                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
+                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
+                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
+                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":""}-'
+                   b'CABByvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0BWGCQOoDC5E_VaBs'
+                   b'xLtfB37HLMMhiPnECIW0gSrQa0etFKSX9lKfuHNy4YBLQBtkPCuDQTG4QMgpWRoa'
+                   b'WDolZCw')
 
     # create endorsed ksn with trans endorser
     # create trans key pair for endorder of KSN
@@ -1077,21 +1062,21 @@ def test_state(mockHelpingNowUTC):
     sigerE = signerE.sign(ser=serderK.raw, index=0)
     assert signerE.verfer.verify(sig=sigerE.raw, ser=serderK.raw)
     msg = messagize(serderK, sigers=[sigerE], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0002d0_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-          b'WVK9ZBNZk0","s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSK'
-          b'H2p9zHQIO132Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z'
-          b'30","f":"4","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","'
-          b'kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n"'
-          b':"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["B'
-          b'aEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2G'
-          b'U5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIU'
-          b'BKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewzr'
-          b'RSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS'
-          b'2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]}'
-          b',"di":"","r":""}-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'
-          b'0AAAAAAAAAAAAAAAAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhke'
-          b'DZ2z-AABAAPxWkuJixAdYrPjWnwz1vrvKHG1U3jk8M18dnGgLssXvjf7lcWaBsal'
-          b'_jBEhck2lMd4jNGo7y4VBesF7sseeDBg')
+    assert msg == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+                   b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
+                   b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
+                   b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
+                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
+                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
+                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
+                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
+                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
+                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":""}-'
+                   b'FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAA'
+                   b'AAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAWGCQOoD'
+                   b'C5E_VaBsxLtfB37HLMMhiPnECIW0gSrQa0etFKSX9lKfuHNy4YBLQBtkPCuDQTG4'
+                   b'QMgpWRoaWDolZCw')
 
     # State Delegated (key state notification)
     # create transferable key pair for controller of KEL
@@ -1130,7 +1115,7 @@ def test_state(mockHelpingNowUTC):
     wits = [preW1, preW2, preW3]
     toad = 2
 
-    #create namedtuple of latest est event
+    # create namedtuple of latest est event
     eevt = StateEstEvent(s='3',
                          d='EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30',
                          br=[preW0],
@@ -1158,21 +1143,18 @@ def test_state(mockHelpingNowUTC):
                     dpre=preD
                     )
 
-    assert serderK.raw == (b'{"v":"KERI10JSON0002fc_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
-                    b'"s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"Eg'
-                    b'Nkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:0'
-                    b'0.000000+00:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-                    b'WVK9ZBNZk0"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b"'
-                    b':["BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LM'
-                    b'YWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"'
-                    b'ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTks'
-                    b'tUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc'
-                    b'1CQnigIUBKrBFz_1Y"]},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U","r"'
-                    b':""}')
+    assert serderK.raw == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
+                           b'"s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"EgNkcl_Qewzr'
+                           b'RSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:00.000000+0'
+                           b'0:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
+                           b'"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1yt'
+                           b'EFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYWO5lPWOrS'
+                           b'B6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"ee":{"s":"'
+                           b'3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1'
+                           b'IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBK'
+                           b'rBFz_1Y"]},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}')
 
-
-
-    assert serderK.dig == 'Ej1enA_vBCgI9_cOS_oxcWwhl1wagBOcdEOHR5NnhUTo'
+    assert serderK.dig == 'EXuEleW4p6jz4QZTJRjtTkoupxLNNnWSsm2Irkwfpwlg'
     assert serderK.pre == preC == 'D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
     assert serderK.sn == 4
 
@@ -1187,22 +1169,20 @@ def test_state(mockHelpingNowUTC):
     cigarE = signerE.sign(ser=serderK.raw)
     assert signerE.verfer.verify(sig=cigarE.raw, ser=serderK.raw)
     msg = messagize(serderK, cigars=[cigarE])
-    assert msg == (b'{"v":"KERI10JSON0002fc_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-          b'WVK9ZBNZk0","s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSK'
-          b'H2p9zHQIO132Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z'
-          b'30","f":"4","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","'
-          b'kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n"'
-          b':"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["B'
-          b'aEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2G'
-          b'U5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIU'
-          b'BKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewzr'
-          b'RSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS'
-          b'2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]}'
-          b',"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U","r":""}-CAB'
-          b'ByvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0B1eH0MbCjEoIO0w4D_7'
-          b'wBDFMZXs691CfrTzW8q-52xjUei0s5gYq_dGYp2xMH-zRktKjCGZEgMG0mqbTu2g'
-          b'HAAQ')
-
+    assert msg == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+                   b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
+                   b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
+                   b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
+                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
+                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
+                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
+                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
+                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
+                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":"DGz'
+                   b'6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-CABByvCLRr5luWmp7keD'
+                   b'vDuLP0kIqcyBYq79b3Dho1QvrjI0B2qBC_LNRwoFyQnaBbbUdy8oSfsR3IpdHgm4'
+                   b'wsln317OJJ4b2CpYpjtSdbUbddEYOPOOtuiSOY1Hb1LxvC3zNCQ')
 
     # create endorsed ksn with trans endorser
     # create trans key pair for endorder of KSN
@@ -1220,22 +1200,21 @@ def test_state(mockHelpingNowUTC):
     sigerE = signerE.sign(ser=serderK.raw, index=0)
     assert signerE.verfer.verify(sig=sigerE.raw, ser=serderK.raw)
     msg = messagize(serderK, sigers=[sigerE], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0002fc_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
-          b'WVK9ZBNZk0","s":"4","t":"ksn","p":"EUskHI462CuIMS_gNkcl_QewzrRSK'
-          b'H2p9zHQIO132Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z'
-          b'30","f":"4","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","'
-          b'kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n"'
-          b':"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["B'
-          b'aEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2G'
-          b'U5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIU'
-          b'BKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewzr'
-          b'RSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS'
-          b'2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]}'
-          b',"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U","r":""}-FAB'
-          b'DyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAA'
-          b'AAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAA1eH0MbCjEo'
-          b'IO0w4D_7wBDFMZXs691CfrTzW8q-52xjUei0s5gYq_dGYp2xMH-zRktKjCGZEgMG'
-          b'0mqbTu2gHAAQ')
+    assert msg == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+                   b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
+                   b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
+                   b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
+                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
+                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
+                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
+                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
+                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
+                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":"DGz'
+                   b'6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-FABDyvCLRr5luWmp7keD'
+                   b'vDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAAEMuNWHss_H_kH'
+                   b'4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAA2qBC_LNRwoFyQnaBbbUdy8oSfsR'
+                   b'3IpdHgm4wsln317OJJ4b2CpYpjtSdbUbddEYOPOOtuiSOY1Hb1LxvC3zNCQ')
 
     """Done Test"""
 
@@ -1262,9 +1241,8 @@ def test_messagize():
                          b'}-AABAA0X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFantYynS'
                          b'BLWXjxYc5c_sW0052it_g6rX30kDA')
 
-
         # Test with pipelined
-        msg =  messagize(serder, sigers=sigers, pipelined=True)
+        msg = messagize(serder, sigers=sigers, pipelined=True)
         assert msg == bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
                                 b'GOM-ijM93o","s":"0","t":"icp","kt":"1","k":["D6J_jzCECalv_iTKSwx'
                                 b'zPnuycxEi5fRuo3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]'
@@ -1314,7 +1292,6 @@ def test_messagize():
                                 b'}-VAX-BABAAWha5gf4wk__OEK_ZvAyA4WYArQVKfVKevOmZWliDBpdIn7oHsWgvm'
                                 b'8T7UvEjfnKobH8lKD1ILacrT6KVIxNeCw')
 
-
         # Test with cigars
         verfers, digers, cst, nst = mgr.incept(icount=1, ncount=0, transferable=False, stem="R")
         cigars = mgr.sign(ser=serder.raw, verfers=verfers, indexed=False)
@@ -1346,7 +1323,6 @@ def test_messagize():
                                 b'nXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0JyfN6'
                                 b'CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
-
         # Test with wigers and cigars and pipelined
         msg = messagize(serder, cigars=cigars, wigers=wigers, pipelined=True)
         assert msg == bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
@@ -1356,7 +1332,6 @@ def test_messagize():
                                 b'8T7UvEjfnKobH8lKD1ILacrT6KVIxNeCw-CABBmMfUwIOywRkyc5GyQXfgDA4UOA'
                                 b'MvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0J'
                                 b'yfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
-
 
         # Test with sigers and wigers and cigars
         msg = messagize(serder, sigers=sigers, cigars=cigars, wigers=wigers)
@@ -1369,7 +1344,6 @@ def test_messagize():
                          b'fUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdT'
                          b'hIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
-
         # Test with sigers and wigers and cigars and pipelines
         msg = messagize(serder, sigers=sigers, cigars=cigars, wigers=wigers, pipelined=True)
         assert msg == bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
@@ -1381,7 +1355,6 @@ def test_messagize():
                                 b'BBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgO'
                                 b'BzdThIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnq'
                                 b'Q3aBg')
-
 
         # Test with receipt message
         ked = serder.ked
@@ -1399,7 +1372,6 @@ def test_messagize():
                          b'}-BABAAT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqq'
                          b'UYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
-
         # Test with cigars
         cigars = mgr.sign(ser=serder.raw, verfers=verfers, indexed=False)  # sign event not receipt
         msg = messagize(reserder, cigars=cigars)
@@ -1408,8 +1380,6 @@ def test_messagize():
                                 b'2hFIcmNpzEHvbm0"}-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939Ar'
                                 b'M0BT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqqUYFm'
                                 b'RhABQ-vPywggLATxBDnqQ3aBg')
-
-
 
         # Test with wigers and cigars
         msg = messagize(serder, wigers=wigers, cigars=cigars, )
@@ -1421,7 +1391,6 @@ def test_messagize():
                                 b'nXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0JyfN6'
                                 b'CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
-
         # Test with wigers and cigars and pipelined
         msg = messagize(serder, wigers=wigers, cigars=cigars, pipelined=True)
         assert msg == bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
@@ -1432,20 +1401,19 @@ def test_messagize():
                                 b'MvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0J'
                                 b'yfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
-
         # Test with sigers and seal and wigers and cigars and pipelined
         msg = messagize(serder, sigers=sigers, seal=seal, wigers=wigers,
                         cigars=cigars, pipelined=True)
-        assert msg ==   bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
-                                  b'GOM-ijM93o","s":"0","t":"icp","kt":"1","k":["D6J_jzCECalv_iTKSwx'
-                                  b'zPnuycxEi5fRuo3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]'
-                                  b'}-VBt-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAA'
-                                  b'AAAAAAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAA0'
-                                  b'X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFantYynSBLWXjxYc'
-                                  b'5c_sW0052it_g6rX30kDA-BABAAT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhym'
-                                  b'gr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg-CABBmMfUwIOywR'
-                                  b'kyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq'
-                                  b'8gMinhymgr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
+                                b'GOM-ijM93o","s":"0","t":"icp","kt":"1","k":["D6J_jzCECalv_iTKSwx'
+                                b'zPnuycxEi5fRuo3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]'
+                                b'}-VBt-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAA'
+                                b'AAAAAAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAA0'
+                                b'X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFantYynSBLWXjxYc'
+                                b'5c_sW0052it_g6rX30kDA-BABAAT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhym'
+                                b'gr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg-CABBmMfUwIOywR'
+                                b'kyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdThIQjKCbq'
+                                b'8gMinhymgr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
 
         # Test with query message
         ked = serder.ked
@@ -1453,16 +1421,14 @@ def test_messagize():
                         query=dict(i='DyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI'),
                         stamp=help.helping.DTS_BASE_0)
 
-
         # create SealEvent for endorsers est evt whose keys use to sign
         seal = SealLast(i=ked["i"])
         msg = messagize(qserder, sigers=sigers, seal=seal)
-        assert msg ==  (b'{"v":"KERI10JSON000096_","t":"qry","dt":"2021-01-01T00:00:00.000'
-                        b'000+00:00","r":"log","rr":"","q":{"i":"DyvCLRr5luWmp7keDvDuLP0kI'
-                        b'qcyBYq79b3Dho1QvrjI"}}-HABECE-_06hkl9stCfQu4IluYevW5_YlxHc6eGOM-'
-                        b'ijM93o-AABAA0X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFan'
-                        b'tYynSBLWXjxYc5c_sW0052it_g6rX30kDA')
-
+        assert msg == (b'{"v":"KERI10JSON000096_","t":"qry","dt":"2021-01-01T00:00:00.000'
+                       b'000+00:00","r":"log","rr":"","q":{"i":"DyvCLRr5luWmp7keDvDuLP0kI'
+                       b'qcyBYq79b3Dho1QvrjI"}}-HABECE-_06hkl9stCfQu4IluYevW5_YlxHc6eGOM-'
+                       b'ijM93o-AABAA0X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFan'
+                       b'tYynSBLWXjxYc5c_sW0052it_g6rX30kDA')
 
         # create SealEvent for endorsers est evt whose keys use to sign
         msg = messagize(qserder, sigers=sigers, seal=seal, pipelined=True)
@@ -1489,7 +1455,7 @@ def test_kever(mockHelpingNowUTC):
         salt = b'\x05\xaa\x8f-S\x9a\xe9\xfaU\x9c\x02\x9c\x9b\x08Hu'
         salter = Salter(raw=salt)
         # create current key
-        sith = 1  #  one signer
+        sith = 1  # one signer
         #  original signing keypair transferable default
         skp0 = salter.signer(path="A", temp=True)
         assert skp0.code == MtrDex.Ed25519_Seed
@@ -1507,22 +1473,22 @@ def test_kever(mockHelpingNowUTC):
         nxt = nexter.qb64
         assert nxt == "E_d8cX6vuQwmD5P62_b663OeaVCLbiBFsirRHJsHn9co"  # transferable so nxt is not empty
 
-        sn = 0  #  inception event so 0
+        sn = 0  # inception event so 0
         toad = 0  # no witnesses
-        nsigs = 1  #  one attached signature unspecified index
+        nsigs = 1  # one attached signature unspecified index
 
         ked0 = dict(v=Versify(kind=Serials.json, size=0),
                     i="",  # qual base 64 prefix
                     s="{:x}".format(sn),  # hex string no leading zeros lowercase
                     t=Ilks.icp,
-                    kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                    kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                     k=keys,  # list of signing keys each qual Base64
                     n=nxt,  # hash qual Base64
                     bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                     b=[],  # list of qual Base64 may be empty
                     c=[],  # list of config ordered mappings may be empty
                     a=[],  # list of seals
-                   )
+                    )
 
         # Derive AID from ked
         aid0 = Prefixer(ked=ked0, code=MtrDex.Ed25519)
@@ -1559,25 +1525,24 @@ def test_kever(mockHelpingNowUTC):
         assert serderK.sn == kever.sn
         assert ([verfer.qb64 for verfer in serderK.verfers] ==
                 [verfer.qb64 for verfer in kever.verfers])
-        assert serderK.raw == (b'{"v":"KERI10JSON0001bc_","i":"DBQOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4",'
-                            b'"s":"0","t":"ksn","p":"","d":"ErSmGekLPyCOf0VIVmYJJLHo6CVdd1K_ApeFUYsU_5WE",'
-                            b'"f":"0","dt":"2021-01-01T00:00:00.000000+00:00","et":"icp","kt":"1","k":["DB'
-                            b'QOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4"],"n":"E_d8cX6vuQwmD5P62_b663OeaV'
-                            b'CLbiBFsirRHJsHn9co","bt":"0","b":[],"c":[],"ee":{"s":"0","d":"ErSmGekLPyCOf0'
-                            b'VIVmYJJLHo6CVdd1K_ApeFUYsU_5WE","br":[],"ba":[]},"di":"","r":""}')
-
+        assert serderK.raw == (b'{"v":"KERI10JSON0001ab_","i":"DBQOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4",'
+                               b'"s":"0","p":"","d":"ErSmGekLPyCOf0VIVmYJJLHo6CVdd1K_ApeFUYsU_5WE","f":"0","d'
+                               b't":"2021-01-01T00:00:00.000000+00:00","et":"icp","kt":"1","k":["DBQOqSaf6GqV'
+                               b'AoPxb4UARrklS8kLYj3JqsR6b4AASDd4"],"n":"E_d8cX6vuQwmD5P62_b663OeaVCLbiBFsirR'
+                               b'HJsHn9co","bt":"0","b":[],"c":[],"ee":{"s":"0","d":"ErSmGekLPyCOf0VIVmYJJLHo'
+                               b'6CVdd1K_ApeFUYsU_5WE","br":[],"ba":[]},"di":""}')
 
     with openDB() as db:  # Non-Transferable case
         # Setup inception key event dict
         # create current key
-        sith = 1  #  one signer
-        skp0 = Signer(transferable=False)  #  original signing keypair non-transferable
+        sith = 1  # one signer
+        skp0 = Signer(transferable=False)  # original signing keypair non-transferable
         assert skp0.code == MtrDex.Ed25519_Seed
         assert skp0.verfer.code == MtrDex.Ed25519N
         keys = [skp0.verfer.qb64]
 
         # create next key Error case
-        skp1 = Signer()  #  next signing keypair transferable is default
+        skp1 = Signer()  # next signing keypair transferable is default
         assert skp1.code == MtrDex.Ed25519_Seed
         assert skp1.verfer.code == MtrDex.Ed25519
         nxtkeys = [skp1.verfer.qb64]
@@ -1585,23 +1550,22 @@ def test_kever(mockHelpingNowUTC):
         nexter = Nexter(keys=nxtkeys)
         nxt = nexter.qb64  # nxt is not empty so error
 
-        sn = 0  #  inception event so 0
+        sn = 0  # inception event so 0
         toad = 0  # no witnesses
-        nsigs = 1  #  one attached signature unspecified index
+        nsigs = 1  # one attached signature unspecified index
 
         ked0 = dict(v=Versify(kind=Serials.json, size=0),
                     i="",  # qual base 64 prefix
                     s="{:x}".format(sn),  # hex string no leading zeros lowercase
                     t=Ilks.icp,
-                    kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                    kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                     k=keys,  # list of signing keys each qual Base64
                     n=nxt,  # hash qual Base64
                     bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                     b=[],  # list of qual Base64 may be empty
                     c=[],  # list of config ordered mappings may be empty
                     a={},  # list of seals
-                   )
-
+                    )
 
         # Derive AID from ked
         with pytest.raises(DerivationError):
@@ -1611,7 +1575,7 @@ def test_kever(mockHelpingNowUTC):
         # assert aid0.qb64 == skp0.verfer.qb64
 
         # update ked with pre
-        ked0["i"] =skp0.verfer.qb64
+        ked0["i"] = skp0.verfer.qb64
 
         # Serialize ked0
         tser0 = Serder(ked=ked0)
@@ -1625,17 +1589,17 @@ def test_kever(mockHelpingNowUTC):
         with pytest.raises(ValidationError):
             kever = Kever(serder=tser0, sigers=[tsig0], db=db)
 
-        #retry with valid empty nxt
+        # retry with valid empty nxt
         nxt = ""  # nxt is empty so no error
-        sn = 0  #  inception event so 0
+        sn = 0  # inception event so 0
         toad = 0  # no witnesses
-        nsigs = 1  #  one attached signature unspecified index
+        nsigs = 1  # one attached signature unspecified index
 
         ked0 = dict(v=Versify(kind=Serials.json, size=0),
                     i="",  # qual base 64 prefix
                     s="{:x}".format(sn),  # hex string no leading zeros lowercase
                     t=Ilks.icp,
-                    kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                    kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                     k=keys,  # list of signing keys each qual Base64
                     n=nxt,  # hash qual Base64
                     bt="{:x}".format(toad),  # hex string no leading zeros lowercase
@@ -1643,7 +1607,6 @@ def test_kever(mockHelpingNowUTC):
                     c=[],  # list of config ordered mappings may be empty
                     a=[],  # list of seals
                     )
-
 
         # Derive AID from ked
         aid0 = Prefixer(ked=ked0, code=MtrDex.Ed25519N)
@@ -1665,7 +1628,6 @@ def test_kever(mockHelpingNowUTC):
 
         kever = Kever(serder=tser0, sigers=[tsig0], db=db)  # valid so no error
 
-
     """ Done Test """
 
 
@@ -1677,45 +1639,44 @@ def test_keyeventsequence_0():
     # manual process to generate a list of secrets
     # root = pysodium.randombytes(pysodium.crypto_pwhash_SALTBYTES)
     # root = b'g\x15\x89\x1a@\xa4\xa47\x07\xb9Q\xb8\x18\xcdJW'
-    #root = '0AZxWJGkCkpDcHuVG4GM1KVw'
-    #rooter = CryMat(qb64=root)
-    #assert rooter.qb64 == root
-    #assert rooter.code == CryTwoDex.Seed_128
-    #signers = generateSigners(root=rooter.raw, count=8, transferable=True)
-    #secrets = [signer.qb64 for signer in signers]
-    #secrets =generateSecrets(root=rooter.raw, count=8, transferable=True)
+    # root = '0AZxWJGkCkpDcHuVG4GM1KVw'
+    # rooter = CryMat(qb64=root)
+    # assert rooter.qb64 == root
+    # assert rooter.code == CryTwoDex.Seed_128
+    # signers = generateSigners(root=rooter.raw, count=8, transferable=True)
+    # secrets = [signer.qb64 for signer in signers]
+    # secrets =generateSecrets(root=rooter.raw, count=8, transferable=True)
 
     # Test sequence of events given set of secrets
     secrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create signers
     signers = [Signer(qb64=secret) for secret in secrets]  # faster
     assert [signer.qb64 for signer in signers] == secrets
 
-    pubkeys = [signer.verfer.qb64 for  signer in  signers]
+    pubkeys = [signer.verfer.qb64 for signer in signers]
     assert pubkeys == [
-                        'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
-                        'DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI',
-                        'DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8',
-                        'DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ',
-                        'D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU',
-                        'D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM',
-                        'DVjWcaNX2gCkHOjk6rkmqPBCxkRCqwIJ-3OjdYmMwxf4',
-                        'DT1nEDepd6CSAMCE7NY_jlLdG6_mKUlKS_mW-2HJY1hg'
-                     ]
+        'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
+        'DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI',
+        'DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8',
+        'DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ',
+        'D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU',
+        'D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM',
+        'DVjWcaNX2gCkHOjk6rkmqPBCxkRCqwIJ-3OjdYmMwxf4',
+        'DT1nEDepd6CSAMCE7NY_jlLdG6_mKUlKS_mW-2HJY1hg'
+    ]
 
     with openDB(name="controller") as conlgr:
-
-        event_digs = [] # list of event digs in sequence
+        event_digs = []  # list of event digs in sequence
 
         # Event 0  Inception Transferable (nxt digest not empty)
         keys0 = [signers[0].verfer.qb64]
@@ -1881,7 +1842,7 @@ def test_keyeventsequence_0():
         assert kever.serder.diger.qb64 == serder6.dig
         assert kever.ilk == Ilks.ixn
         assert [verfer.qb64 for verfer in kever.verfers] == keys3  # no change
-        assert kever.nexter.qb64 == nxt4    # no change
+        assert kever.nexter.qb64 == nxt4  # no change
 
         # Event 7 Rotation to null NonTransferable Abandon
         nxt5 = ""  # nxt digest is empty
@@ -1940,6 +1901,7 @@ def test_keyeventsequence_0():
 
     """ Done Test """
 
+
 def test_keyeventsequence_1():
     """
     Test generation of a sequence of key events
@@ -1948,35 +1910,35 @@ def test_keyeventsequence_1():
 
     # Test sequence of events given set of secrets
     secrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create signers
     signers = [Signer(qb64=secret) for secret in secrets]  # faster
     assert [signer.qb64 for signer in signers] == secrets
 
-    pubkeys = [signer.verfer.qb64 for  signer in  signers]
+    pubkeys = [signer.verfer.qb64 for signer in signers]
     assert pubkeys == [
-                        'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
-                        'DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI',
-                        'DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8',
-                        'DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ',
-                        'D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU',
-                        'D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM',
-                        'DVjWcaNX2gCkHOjk6rkmqPBCxkRCqwIJ-3OjdYmMwxf4',
-                        'DT1nEDepd6CSAMCE7NY_jlLdG6_mKUlKS_mW-2HJY1hg'
-                     ]
+        'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA',
+        'DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI',
+        'DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8',
+        'DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ',
+        'D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU',
+        'D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM',
+        'DVjWcaNX2gCkHOjk6rkmqPBCxkRCqwIJ-3OjdYmMwxf4',
+        'DT1nEDepd6CSAMCE7NY_jlLdG6_mKUlKS_mW-2HJY1hg'
+    ]
 
     # New Sequence establishment only
     with openDB(name="controller") as conlgr:
-        event_digs = [] # list of event digs in sequence
+        event_digs = []  # list of event digs in sequence
 
         # Event 0  Inception Transferable (nxt digest not empty)
         keys0 = [signers[0].verfer.qb64]
@@ -1984,7 +1946,7 @@ def test_keyeventsequence_1():
         keys1 = [signers[1].verfer.qb64]
         nexter1 = Nexter(keys=keys1)
         nxt1 = nexter1.qb64  # transferable so nxt is not empty
-        cnfg = [TraitDex.EstOnly]  #  EstOnly
+        cnfg = [TraitDex.EstOnly]  # EstOnly
         serder0 = incept(keys=keys0, nxt=nxt1, cnfg=cnfg)
         event_digs.append(serder0.dig)
         pre = serder0.ked["i"]
@@ -2053,6 +2015,7 @@ def test_keyeventsequence_1():
 
     """ Done Test """
 
+
 def test_kevery():
     """
     Test the support functionality for Kevery factory class
@@ -2062,25 +2025,24 @@ def test_kevery():
 
     # Test sequence of events given set of secrets
     secrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     with openDB(name="controller") as conlgr, openDB(name="validator") as vallgr:
-        event_digs = [] # list of event digs in sequence
+        event_digs = []  # list of event digs in sequence
 
         # create event stream
         msgs = bytearray()
         #  create signers
         signers = [Signer(qb64=secret) for secret in secrets]  # faster
         assert [signer.qb64 for signer in signers] == secrets
-
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[signers[0].verfer.qb64],
@@ -2092,7 +2054,7 @@ def test_kevery():
         siger = signers[0].sign(serder.raw, index=0)  # return siger
         # create key event verifier state
         kever = Kever(serder=serder, sigers=[siger], db=conlgr)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2117,7 +2079,7 @@ def test_kevery():
         siger = signers[1].sign(serder.raw, index=0)  # returns siger
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2135,7 +2097,7 @@ def test_kevery():
         siger = signers[2].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2151,7 +2113,7 @@ def test_kevery():
         siger = signers[2].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2167,7 +2129,7 @@ def test_kevery():
         siger = signers[2].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2185,7 +2147,7 @@ def test_kevery():
         siger = signers[3].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2201,7 +2163,7 @@ def test_kevery():
         siger = signers[3].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2209,10 +2171,10 @@ def test_kevery():
         # Event 7 Rotation to null NonTransferable Abandon
         # nxt digest is empty
         serder = rotate(pre=kever.prefixer.qb64,
-                    keys=[signers[4].verfer.qb64],
-                    dig=kever.serder.diger.qb64,
-                    nxt="",
-                    sn=7)
+                        keys=[signers[4].verfer.qb64],
+                        dig=kever.serder.diger.qb64,
+                        nxt="",
+                        sn=7)
         event_digs.append(serder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -2220,7 +2182,7 @@ def test_kevery():
         siger = signers[4].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2236,7 +2198,7 @@ def test_kevery():
         # update key event verifier state
         with pytest.raises(ValidationError):  # nulled so reject any more events
             kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2254,7 +2216,7 @@ def test_kevery():
         # update key event verifier state
         with pytest.raises(ValidationError):  # nontransferable so reject update
             kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
@@ -2284,7 +2246,6 @@ def test_kevery():
         db_digs = [bytes(val).decode("utf-8") for val in kevery.db.getKelIter(pre)]
         assert db_digs == event_digs
 
-
     assert not os.path.exists(kevery.db.path)
     assert not os.path.exists(kever.db.path)
 
@@ -2296,18 +2257,17 @@ def test_multisig_digprefix():
     Test multisig with self-addressing (digest) pre
     """
 
-
     # Test sequence of events given set of secrets
     secrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     with openDB(name="controller") as conlgr, openDB(name="validator") as vallgr:
 
@@ -2316,7 +2276,6 @@ def test_multisig_digprefix():
         #  create signers
         signers = [Signer(qb64=secret) for secret in secrets]  # faster
         assert [siger.qb64 for siger in signers] == secrets
-
 
         # Event 0  Inception Transferable (nxt digest not empty)
         #  2 0f 3 multisig
@@ -2337,7 +2296,7 @@ def test_multisig_digprefix():
         sigers = [signers[i].sign(serder.raw, index=i) for i in range(count)]
         # create key event verifier state
         kever = Kever(serder=serder, sigers=sigers, db=conlgr)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         for siger in sigers:
@@ -2368,15 +2327,14 @@ def test_multisig_digprefix():
         count = len(keys)
         counter = Counter(CtrDex.ControllerIdxSigs, count=count)  # default is count = 1
         # sign serialization
-        sigers = [signers[i].sign(serder.raw, index=i-count) for i in range(count, count+count)]
+        sigers = [signers[i].sign(serder.raw, index=i - count) for i in range(count, count + count)]
         # update key event verifier state
         kever.update(serder=serder, sigers=sigers)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         for siger in sigers:
             msgs.extend(siger.qb64b)
-
 
         # Event 2 Interaction
         serder = interact(pre=kever.prefixer.qb64,
@@ -2385,10 +2343,10 @@ def test_multisig_digprefix():
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs, count=count)  # default is count = 1
         # sign serialization
-        sigers = [signers[i].sign(serder.raw, index=i-count) for i in range(count, count+count)]
+        sigers = [signers[i].sign(serder.raw, index=i - count) for i in range(count, count + count)]
         # update key event verifier state
         kever.update(serder=serder, sigers=sigers)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         for siger in sigers:
@@ -2401,10 +2359,10 @@ def test_multisig_digprefix():
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs, count=count)  # default is count = 1
         # sign serialization
-        sigers = [signers[i].sign(serder.raw, index=i-count) for i in range(count, count+count)]
+        sigers = [signers[i].sign(serder.raw, index=i - count) for i in range(count, count + count)]
         # update key event verifier state
         kever.update(serder=serder, sigers=sigers)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         for siger in sigers:
@@ -2414,18 +2372,18 @@ def test_multisig_digprefix():
         # nxt digest is empty
         keys = nxtkeys
         serder = rotate(pre=kever.prefixer.qb64,
-                    keys=keys,
-                    sith="2",
-                    dig=kever.serder.diger.qb64,
-                    nxt="",
-                    sn=4)
+                        keys=keys,
+                        sith="2",
+                        dig=kever.serder.diger.qb64,
+                        nxt="",
+                        sn=4)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs, count=count)  # default is count = 1
         # sign serialization
-        sigers = [signers[i].sign(serder.raw, index=i-5) for i in range(5, 8)]
+        sigers = [signers[i].sign(serder.raw, index=i - 5) for i in range(5, 8)]
         # update key event verifier state
         kever.update(serder=serder, sigers=sigers)
-        #extend key event stream
+        # extend key event stream
         msgs.extend(serder.raw)
         msgs.extend(counter.qb64b)
         for siger in sigers:
@@ -2455,22 +2413,22 @@ def test_recovery():
     """
     # set of secrets
     secrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create signers
     signers = [Signer(qb64=secret) for secret in secrets]  # faster
     assert [signer.qb64 for signer in signers] == secrets
 
     with openDB(name="controller") as conlgr, openDB(name="validator") as vallgr:
-        event_digs = [] # list of event digs in sequence to verify against database
+        event_digs = []  # list of event digs in sequence to verify against database
 
         # create event stream
         kes = bytearray()
@@ -2478,7 +2436,7 @@ def test_recovery():
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[signers[esn].verfer.qb64],
-                        nxt=Nexter(keys=[signers[esn+1].verfer.qb64]).qb64)
+                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64)
 
         assert sn == int(serder.ked["s"], 16) == 0
 
@@ -2489,7 +2447,7 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)  # return siger
         # create key event verifier state
         kever = Kever(serder=serder, sigers=[siger], db=conlgr)
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2501,7 +2459,7 @@ def test_recovery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
                         dig=kever.serder.diger.qb64,
-                        nxt=Nexter(keys=[signers[esn+1].verfer.qb64]).qb64,
+                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
                         sn=sn)
 
         event_digs.append(serder.dig)
@@ -2511,18 +2469,18 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)  # returns siger
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 2
         assert esn == 1
         serder = interact(pre=kever.prefixer.qb64,
-                              dig=kever.serder.diger.qb64,
-                              sn=sn)
+                          dig=kever.serder.diger.qb64,
+                          sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -2530,7 +2488,7 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2543,7 +2501,7 @@ def test_recovery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
                         dig=kever.serder.diger.qb64,
-                        nxt=Nexter(keys=[signers[esn+1].verfer.qb64]).qb64,
+                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
                         sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
@@ -2552,13 +2510,13 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 4
         assert esn == 2
         serder = interact(pre=kever.prefixer.qb64,
@@ -2571,13 +2529,13 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 5
         assert esn == 2
         serder = interact(pre=kever.prefixer.qb64,
@@ -2590,18 +2548,18 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 6
         assert esn == 2
         serder = interact(pre=kever.prefixer.qb64,
-                              dig=kever.serder.diger.qb64,
-                              sn=sn)
+                          dig=kever.serder.diger.qb64,
+                          sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -2609,11 +2567,10 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
-
 
         # Next Event Rotation Recovery at sn = 5
         sn = 5
@@ -2623,8 +2580,8 @@ def test_recovery():
 
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
-                        dig=event_digs[sn-1],
-                        nxt=Nexter(keys=[signers[esn+1].verfer.qb64]).qb64,
+                        dig=event_digs[sn - 1],
+                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
                         sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
@@ -2633,13 +2590,13 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 6
         assert esn == 3
         serder = interact(pre=kever.prefixer.qb64,
@@ -2652,27 +2609,26 @@ def test_recovery():
         siger = signers[esn].sign(serder.raw, index=0)
         # update key event verifier state
         kever.update(serder=serder, sigers=[siger])
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
 
         assert kever.verfers[0].qb64 == signers[esn].verfer.qb64
 
-
         pre = kever.prefixer.qb64
 
         db_digs = [bytes(val).decode("utf-8") for val in kever.db.getKelIter(pre)]
         assert len(db_digs) == len(event_digs) == 9
-        assert db_digs[0:6] ==  event_digs[0:6]
+        assert db_digs[0:6] == event_digs[0:6]
         assert db_digs[-1] == event_digs[-1]
-        assert db_digs[7] ==  event_digs[6]
-        assert db_digs[6] ==  event_digs[7]
+        assert db_digs[7] == event_digs[6]
+        assert db_digs[6] == event_digs[7]
 
         db_est_digs = [bytes(val).decode("utf-8") for val in kever.db.getKelEstIter(pre)]
         assert len(db_est_digs) == 7
-        assert db_est_digs[0:5] ==  event_digs[0:5]
-        assert db_est_digs[5:7] ==  event_digs[7:9]
+        assert db_est_digs[0:5] == event_digs[0:5]
+        assert db_est_digs[5:7] == event_digs[7:9]
 
         kevery = Kevery(db=vallgr)
         parsing.Parser().parse(ims=kes, kvy=kevery)
@@ -2682,7 +2638,6 @@ def test_recovery():
         vkever = kevery.kevers[pre]
         assert vkever.sn == kever.sn
         assert vkever.verfers[0].qb64 == kever.verfers[0].qb64 == signers[esn].verfer.qb64
-
 
         y_db_digs = [bytes(val).decode("utf-8") for val in kevery.db.getKelIter(pre)]
         assert db_digs == y_db_digs
@@ -2694,6 +2649,7 @@ def test_recovery():
 
     """ Done Test """
 
+
 def test_receipt():
     """
     Test event receipt message and attached couplets
@@ -2702,20 +2658,19 @@ def test_receipt():
     # root = pysodium.randombytes(pysodium.crypto_pwhash_SALTBYTES)
     # secrets = generateSecrets(root=root, count=8)
 
-
     #  Direct Mode coe is controller, val is validator
 
     # set of secrets  (seeds for private keys)
     coeSecrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create signers
     coeSigners = [Signer(qb64=secret) for secret in coeSecrets]
@@ -2745,18 +2700,18 @@ def test_receipt():
     with openDB(name="controller") as coeLogger, openDB(name="validator") as valLogger:
         coeKevery = Kevery(db=coeLogger)
         valKevery = Kevery(db=valLogger)
-        event_digs = [] # list of event digs in sequence to verify against database
+        event_digs = []  # list of event digs in sequence to verify against database
 
         # create event stream
         kes = bytearray()
         sn = esn = 0  # sn and last establishment sn = esn
 
-        #create receipt msg stream
+        # create receipt msg stream
         res = bytearray()
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[coeSigners[esn].verfer.qb64],
-                        nxt=Nexter(keys=[coeSigners[esn+1].verfer.qb64]).qb64)
+                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64)
 
         assert sn == int(serder.ked["s"], 16) == 0
         coepre = serder.ked["i"]
@@ -2783,7 +2738,7 @@ def test_receipt():
         # valKevery.process(ims=kes)  # process by Val
         assert coepre in valKevery.kevers
         valKever = valKevery.kevers[coepre]
-        assert len(kes) ==  0
+        assert len(kes) == 0
 
         # create receipt from val to coe
         reserder = receipt(pre=coeKever.prefixer.qb64,
@@ -2791,7 +2746,8 @@ def test_receipt():
                            dig=coeKever.serder.diger.qb64)
         # sign event not receipt
         valCigar = valSigner.sign(ser=serder.raw)  # returns Cigar cause no index
-        assert valCigar.qb64 == '0Bs2d05m7zpn6C9IJhb_GspbllxJwwxdrBg9bcbCjR5B8lrXJlglmiitpq3lEusEWdmmHSY4C_fxElKfF8mySfDQ'
+        assert valCigar.qb64 == \
+               '0Bs2d05m7zpn6C9IJhb_GspbllxJwwxdrBg9bcbCjR5B8lrXJlglmiitpq3lEusEWdmmHSY4C_fxElKfF8mySfDQ'
         recnt = Counter(code=CtrDex.NonTransReceiptCouples, count=1)
         assert recnt.qb64 == '-CAB'
 
@@ -2809,10 +2765,9 @@ def test_receipt():
         # coeKevery.process(ims=res)  #  coe process the receipt from val
         #  check if in receipt database
         result = coeKevery.db.getRcts(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                    dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == valPrefixer.qb64b + valCigar.qb64b
         assert len(result) == 1
-
 
         # create invalid receipt to escrow use invalid dig and sn so not in db
         fake = reserder.dig  # some other dig
@@ -2832,15 +2787,15 @@ def test_receipt():
         # coeKevery.process(ims=res)  #  coe process the escrow receipt from val
         #  check if in escrow database
         result = coeKevery.db.getUres(key=snKey(pre=coeKever.prefixer.qb64,
-                                                        sn=2))
+                                                sn=2))
         assert bytes(result[0]) == fake.encode("utf-8") + valPrefixer.qb64b + valCigar.qb64b
 
         # create invalid receipt stale use valid sn so in database but invalid dig
         # so bad receipt
         fake = reserder.dig  # some other dig
         reserder = receipt(pre=coeKever.prefixer.qb64,
-                               sn=coeKever.sn,
-                               dig=fake)
+                           sn=coeKever.sn,
+                           dig=fake)
         # sign event not receipt
         valCigar = valSigner.sign(ser=serder.raw)  # returns Cigar cause no index
         recnt = Counter(code=CtrDex.NonTransReceiptCouples, count=1)
@@ -2858,7 +2813,7 @@ def test_receipt():
         assert len(result) == 1
         # no new receipt at invalid dig
         result = coeKevery.db.getRcts(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                    dig=fake))
+                                                dig=fake))
         assert not result
 
         # Next Event Rotation Transferable
@@ -2868,7 +2823,7 @@ def test_receipt():
         serder = rotate(pre=coeKever.prefixer.qb64,
                         keys=[coeSigners[esn].verfer.qb64],
                         dig=coeKever.serder.diger.qb64,
-                        nxt=Nexter(keys=[coeSigners[esn+1].verfer.qb64]).qb64,
+                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64,
                         sn=sn)
 
         event_digs.append(serder.dig)
@@ -2876,7 +2831,7 @@ def test_receipt():
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)  # returns siger
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2886,19 +2841,19 @@ def test_receipt():
         # valKevery.process(ims=kes)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 2
         assert esn == 1
         serder = interact(pre=coeKever.prefixer.qb64,
-                              dig=coeKever.serder.diger.qb64,
-                              sn=sn)
+                          dig=coeKever.serder.diger.qb64,
+                          sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)
 
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2915,7 +2870,7 @@ def test_receipt():
         serder = rotate(pre=coeKever.prefixer.qb64,
                         keys=[coeSigners[esn].verfer.qb64],
                         dig=coeKever.serder.diger.qb64,
-                        nxt=Nexter(keys=[coeSigners[esn+1].verfer.qb64]).qb64,
+                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64,
                         sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
@@ -2923,7 +2878,7 @@ def test_receipt():
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)
 
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2933,7 +2888,7 @@ def test_receipt():
         # valKevery.process(ims=kes)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 4
         assert esn == 2
         serder = interact(pre=coeKever.prefixer.qb64,
@@ -2945,7 +2900,7 @@ def test_receipt():
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)
 
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2955,7 +2910,7 @@ def test_receipt():
         # valKevery.process(ims=kes)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 5
         assert esn == 2
         serder = interact(pre=coeKever.prefixer.qb64,
@@ -2967,7 +2922,7 @@ def test_receipt():
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)
 
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -2977,19 +2932,19 @@ def test_receipt():
         # valKevery.process(ims=kes)
 
         # Next Event Interaction
-        sn += 1  #  do not increment esn
+        sn += 1  # do not increment esn
         assert sn == 6
         assert esn == 2
         serder = interact(pre=coeKever.prefixer.qb64,
-                              dig=coeKever.serder.diger.qb64,
-                              sn=sn)
+                          dig=coeKever.serder.diger.qb64,
+                          sn=sn)
         event_digs.append(serder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
         # sign serialization
         siger = coeSigners[esn].sign(serder.raw, index=0)
 
-        #extend key event stream
+        # extend key event stream
         kes.extend(serder.raw)
         kes.extend(counter.qb64b)
         kes.extend(siger.qb64b)
@@ -3003,7 +2958,6 @@ def test_receipt():
         db_digs = [bytes(val).decode("utf-8") for val in coeKever.db.getKelIter(coepre)]
         assert len(db_digs) == len(event_digs) == 7
 
-
         assert valKever.sn == coeKever.sn
         assert valKever.verfers[0].qb64 == coeKever.verfers[0].qb64 == coeSigners[esn].verfer.qb64
 
@@ -3011,6 +2965,7 @@ def test_receipt():
     assert not os.path.exists(coeKever.db.path)
 
     """ Done Test """
+
 
 def test_direct_mode():
     """
@@ -3021,21 +2976,20 @@ def test_direct_mode():
     # root = pysodium.randombytes(pysodium.crypto_pwhash_SALTBYTES)
     # secrets = generateSecrets(root=root, count=8)
 
-
     #  Direct Mode initiated by coe is controller, val is validator
     #  but goes both ways once initiated.
 
     # set of secrets  (seeds for private keys)
     coeSecrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create coe signers
     coeSigners = [Signer(qb64=secret) for secret in coeSecrets]
@@ -3055,14 +3009,13 @@ def test_direct_mode():
     valSigners = [Signer(qb64=secret) for secret in valSecrets]
     assert [signer.qb64 for signer in valSigners] == valSecrets
 
-
     with openDB(name="controller") as coeLogger, openDB(name="validator") as valLogger:
         #  init Keverys
         coeKevery = Kevery(db=coeLogger)
         valKevery = Kevery(db=valLogger)
 
-        coe_event_digs = [] # list of coe's own event log digs to verify against database
-        val_event_digs = [] # list of val's own event log digs to verify against database
+        coe_event_digs = []  # list of coe's own event log digs to verify against database
+        val_event_digs = []  # list of val's own event log digs to verify against database
 
         #  init sequence numbers for both coe and val
         csn = cesn = 0  # sn and last establishment sn = esn
@@ -3070,8 +3023,8 @@ def test_direct_mode():
 
         # Coe Event 0  Inception Transferable (nxt digest not empty)
         coeSerder = incept(keys=[coeSigners[cesn].verfer.qb64],
-                        nxt=Nexter(keys=[coeSigners[cesn+1].verfer.qb64]).qb64,
-                        code=MtrDex.Blake3_256)
+                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
+                           code=MtrDex.Blake3_256)
 
         assert csn == int(coeSerder.ked["s"], 16) == 0
         coepre = coeSerder.ked["i"]
@@ -3102,8 +3055,8 @@ def test_direct_mode():
 
         # Val Event 0  Inception Transferable (nxt digest not empty)
         valSerder = incept(keys=[valSigners[vesn].verfer.qb64],
-                            nxt=Nexter(keys=[valSigners[vesn+1].verfer.qb64]).qb64,
-                            code=MtrDex.Blake3_256)
+                           nxt=Nexter(keys=[valSigners[vesn + 1].verfer.qb64]).qb64,
+                           code=MtrDex.Blake3_256)
 
         assert vsn == int(valSerder.ked["s"], 16) == 0
         valpre = valSerder.ked["i"]
@@ -3145,8 +3098,8 @@ def test_direct_mode():
         coeK = valKevery.kevers[coepre]  # lookup coeKever from val's .kevers
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIcpDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3180,7 +3133,7 @@ def test_direct_mode():
         assert valpre in coeKevery.kevers
         #  check if receipt quadruple from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                    dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
@@ -3189,12 +3142,11 @@ def test_direct_mode():
                                     b'nxUgO_wfuFo6GR_vii-RNv5iGo8ibUrhe6Z0AAocy9m9ToxeeZk-FkgjFh1x839Ims4peTy2C5Md'
                                     b'awIwoa9wlIDbD-wGmiGO4QdrQ1lSntqUAUMkcGAzB0Q6SsAA')
 
-
         # create receipt to escrow use invalid dig and sn so not in coe's db
         fake = reserder.dig  # some other dig
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=10,
-                        dig=fake)
+                           sn=10,
+                           dig=fake)
         # sign event not receipt
         siger = valSigners[vesn].sign(ser=coeIcpRaw, index=0)  # return Siger if index
 
@@ -3210,13 +3162,12 @@ def test_direct_mode():
         # coeKevery.process(ims=vmsg)  #  coe process the escrow receipt from val
         #  check if receipt quadruple in escrow database
         result = coeKevery.db.getVres(key=snKey(pre=coeKever.prefixer.qb64,
-                                                   sn=10))
+                                                sn=10))
         assert bytes(result[0]) == (fake.encode("utf-8") +
                                     valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
-
 
         # Send receipt from coe to val
         # create receipt of val's inception
@@ -3227,8 +3178,8 @@ def test_direct_mode():
         valK = coeKevery.kevers[valpre]  # lookup valKever from coe's .kevers
         # create validator receipt
         reserder = receipt(pre=valK.prefixer.qb64,
-                        sn=valK.sn,
-                        dig=valK.serder.diger.qb64)
+                           sn=valK.sn,
+                           dig=valK.serder.diger.qb64)
         # sign vals's event not receipt
         # look up event to sign from coe's kever for val
         valIcpDig = bytes(coeKevery.db.getKeLast(key=snKey(pre=valpre, sn=vsn)))
@@ -3260,7 +3211,7 @@ def test_direct_mode():
 
         #  check if receipt quadruple from coe in val's receipt database
         result = valKevery.db.getVrcs(key=dgKey(pre=valKever.prefixer.qb64,
-                                                    dig=valKever.serder.diger.qb64))
+                                                dig=valKever.serder.diger.qb64))
         assert bytes(result[0]) == (coeKever.prefixer.qb64b +
                                     Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.diger.qb64b +
@@ -3276,7 +3227,7 @@ def test_direct_mode():
         coeSerder = rotate(pre=coeKever.prefixer.qb64,
                            keys=[coeSigners[cesn].verfer.qb64],
                            dig=coeKever.serder.diger.qb64,
-                           nxt=Nexter(keys=[coeSigners[cesn+1].verfer.qb64]).qb64,
+                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
                            sn=csn)
         coe_event_digs.append(coeSerder.dig)
         # create sig counter
@@ -3316,8 +3267,8 @@ def test_direct_mode():
                          d=valKever.lastEst.d)
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeRotDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3349,7 +3300,7 @@ def test_direct_mode():
 
         #  check if receipt quadruple from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                        dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
@@ -3360,12 +3311,12 @@ def test_direct_mode():
                                     b'mbsInqIN5oNSupo7S_j7AnCOdBaGf9WQMwwfHkeQpayCCyAA')
 
         # Next Event 2 Coe Interaction
-        csn += 1  #  do not increment esn
+        csn += 1  # do not increment esn
         assert csn == 2
         assert cesn == 1
         coeSerder = interact(pre=coeKever.prefixer.qb64,
-                              dig=coeKever.serder.diger.qb64,
-                              sn=csn)
+                             dig=coeKever.serder.diger.qb64,
+                             sn=csn)
         coe_event_digs.append(coeSerder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -3395,7 +3346,6 @@ def test_direct_mode():
         assert coeK.sn == csn
         assert coeK.serder.diger.qb64 == coeSerder.dig
 
-
         # create receipt of coe's interaction
         # create seal of val's last est event
         seal = SealEvent(i=valpre,
@@ -3403,8 +3353,8 @@ def test_direct_mode():
                          d=valKever.lastEst.d)
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIxnDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3433,43 +3383,40 @@ def test_direct_mode():
 
         #  check if receipt quadruple from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                        dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
                                     siger.qb64b)
 
         assert bytes(result[0]) == (b'ED9EB3sA5u2vCPOEmX3d7bEyHiSh7Xi8fjew2KMl3FQM0AAAAAAAAAAAAAAAAAAAAAAAEeGqW24E'
-                                     b'nxUgO_wfuFo6GR_vii-RNv5iGo8ibUrhe6Z0AAFyuqh4gxmfs7NcXRV5RN6iL2_OJAtYbDjBv3oL'
-                                     b'_UwFyolhS1EhBBjeLXvsCAVXOqrj7GMW9t3tpxL7Xtfsc5Bw')
-
+                                    b'nxUgO_wfuFo6GR_vii-RNv5iGo8ibUrhe6Z0AAFyuqh4gxmfs7NcXRV5RN6iL2_OJAtYbDjBv3oL'
+                                    b'_UwFyolhS1EhBBjeLXvsCAVXOqrj7GMW9t3tpxL7Xtfsc5Bw')
 
         #  verify final coe event state
         assert coeKever.verfers[0].qb64 == coeSigners[cesn].verfer.qb64
         assert coeKever.sn == coeK.sn == csn
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(coepre)]
-        assert len(db_digs) == len(coe_event_digs) == csn+1
+        assert len(db_digs) == len(coe_event_digs) == csn + 1
         assert db_digs == coe_event_digs == ['EXeKMHPw0ql8vHiBOpo72AOrOsWZ3bRDL-DKkYHo4v6w',
                                              'EQK8BvEIsvM9r3VGd1Qi10Gzzllodv0Vmnl7nl_a05eY',
                                              'EaQ7xvXmDpg7twdzEUEJGokBS6S_TXzmlY1a93ZQkx84']
 
-
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(coepre)]
-        assert len(db_digs) == len(coe_event_digs) == csn+1
+        assert len(db_digs) == len(coe_event_digs) == csn + 1
         assert db_digs == coe_event_digs
-
 
         #  verify final val event state
         assert valKever.verfers[0].qb64 == valSigners[vesn].verfer.qb64
         assert valKever.sn == valK.sn == vsn
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(valpre)]
-        assert len(db_digs) == len(val_event_digs) == vsn+1
+        assert len(db_digs) == len(val_event_digs) == vsn + 1
         assert db_digs == val_event_digs == ['EeGqW24EnxUgO_wfuFo6GR_vii-RNv5iGo8ibUrhe6Z0']
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(valpre)]
-        assert len(db_digs) == len(val_event_digs) == vsn+1
+        assert len(db_digs) == len(val_event_digs) == vsn + 1
         assert db_digs == val_event_digs
 
     assert not os.path.exists(valKevery.db.path)
@@ -3488,21 +3435,20 @@ def test_direct_mode_cbor_mgpk():
     # root = pysodium.randombytes(pysodium.crypto_pwhash_SALTBYTES)
     # secrets = generateSecrets(root=root, count=8)
 
-
     #  Direct Mode initiated by coe is controller, val is validator
     #  but goes both ways once initiated.
 
     # set of secrets  (seeds for private keys)
     coeSecrets = [
-                'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
-                'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
-                'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
-                'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
-                'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
-                'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
-                'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
-                'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
-                ]
+        'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+        'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+        'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+        'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+        'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+        'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+        'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+        'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY'
+    ]
 
     #  create coe signers
     coeSigners = [Signer(qb64=secret) for secret in coeSecrets]
@@ -3522,14 +3468,13 @@ def test_direct_mode_cbor_mgpk():
     valSigners = [Signer(qb64=secret) for secret in valSecrets]
     assert [signer.qb64 for signer in valSigners] == valSecrets
 
-
     with openDB(name="controller") as coeLogger, openDB(name="validator") as valLogger:
         #  init Keverys
         coeKevery = Kevery(db=coeLogger)
         valKevery = Kevery(db=valLogger)
 
-        coe_event_digs = [] # list of coe's own event log digs to verify against database
-        val_event_digs = [] # list of val's own event log digs to verify against database
+        coe_event_digs = []  # list of coe's own event log digs to verify against database
+        val_event_digs = []  # list of val's own event log digs to verify against database
 
         #  init sequence numbers for both coe and val
         csn = cesn = 0  # sn and last establishment sn = esn
@@ -3537,7 +3482,7 @@ def test_direct_mode_cbor_mgpk():
 
         # Coe Event 0  Inception Transferable (nxt digest not empty)
         coeSerder = incept(keys=[coeSigners[cesn].verfer.qb64],
-                           nxt=Nexter(keys=[coeSigners[cesn+1].verfer.qb64]).qb64,
+                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
                            code=MtrDex.Blake3_256,
                            kind=Serials.cbor)
 
@@ -3554,11 +3499,11 @@ def test_direct_mode_cbor_mgpk():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg ==  bytearray(b'\xabavqKERI10CBOR0000c3_aix,EVA41BuPTjEEtBXWwBSeD4yRHz_TyyzfGE1ldQT'
-                                  b'Dqe1wasa0atcicpbkta1ak\x81x,DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWT'
-                                  b'OunRAanx,EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqUbbta0ab'
-                                  b'\x80ac\x80aa\x80-AABAAEiOvc6Yv5oBR6tHMAOJvAg_YKkHR4ifXF2mIsPYmDjE'
-                                  b'q-WL3uimpNHMdGoSRVmXCotuCfDGTx3h0Gk5tz2jFBA')
+        assert cmsg == bytearray(b'\xabavqKERI10CBOR0000c3_aix,EVA41BuPTjEEtBXWwBSeD4yRHz_TyyzfGE1ldQT'
+                                 b'Dqe1wasa0atcicpbkta1ak\x81x,DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWT'
+                                 b'OunRAanx,EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqUbbta0ab'
+                                 b'\x80ac\x80aa\x80-AABAAEiOvc6Yv5oBR6tHMAOJvAg_YKkHR4ifXF2mIsPYmDjE'
+                                 b'q-WL3uimpNHMdGoSRVmXCotuCfDGTx3h0Gk5tz2jFBA')
 
         # create own Coe Kever in  Coe's Kevery
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3568,9 +3513,9 @@ def test_direct_mode_cbor_mgpk():
 
         # Val Event 0  Inception Transferable (nxt digest not empty)
         valSerder = incept(keys=[valSigners[vesn].verfer.qb64],
-                            nxt=Nexter(keys=[valSigners[vesn+1].verfer.qb64]).qb64,
-                            code=MtrDex.Blake3_256,
-                            kind=Serials.mgpk)
+                           nxt=Nexter(keys=[valSigners[vesn + 1].verfer.qb64]).qb64,
+                           code=MtrDex.Blake3_256,
+                           kind=Serials.mgpk)
 
         assert vsn == int(valSerder.ked["s"], 16) == 0
         valpre = valSerder.ked["i"]
@@ -3611,9 +3556,9 @@ def test_direct_mode_cbor_mgpk():
         coeK = valKevery.kevers[coepre]  # lookup coeKever from val's .kevers
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64,
-                        kind=Serials.mgpk)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64,
+                           kind=Serials.mgpk)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIcpDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3647,7 +3592,7 @@ def test_direct_mode_cbor_mgpk():
         assert valpre in coeKevery.kevers
         #  check if receipt quadruple from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                    dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
@@ -3659,9 +3604,9 @@ def test_direct_mode_cbor_mgpk():
         # create receipt to escrow use invalid dig so not in coe's db
         fake = reserder.dig  # some other dig
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=10,
-                        dig=fake,
-                        kind=Serials.mgpk)
+                           sn=10,
+                           dig=fake,
+                           kind=Serials.mgpk)
         # sign event not receipt
         siger = valSigners[vesn].sign(ser=coeIcpRaw, index=0)  # return Siger if index
 
@@ -3678,13 +3623,12 @@ def test_direct_mode_cbor_mgpk():
         # coeKevery.process(ims=vmsg)  #  coe process the escrow receipt from val
         #  check if in escrow database
         result = coeKevery.db.getVres(key=snKey(pre=coeKever.prefixer.qb64,
-                                                       sn=10))
+                                                sn=10))
         assert bytes(result[0]) == (fake.encode("utf-8") +
-                                        valKever.prefixer.qb64b +
-                                        Seqner(sn=valKever.sn).qb64b +
-                                        valKever.serder.diger.qb64b +
-                                        siger.qb64b)
-
+                                    valKever.prefixer.qb64b +
+                                    Seqner(sn=valKever.sn).qb64b +
+                                    valKever.serder.diger.qb64b +
+                                    siger.qb64b)
 
         # Send receipt from coe to val
         # create receipt of val's inception
@@ -3695,9 +3639,9 @@ def test_direct_mode_cbor_mgpk():
         valK = coeKevery.kevers[valpre]  # lookup valKever from coe's .kevers
         # create validator receipt
         reserder = receipt(pre=valK.prefixer.qb64,
-                        sn=valK.sn,
-                        dig=valK.serder.diger.qb64,
-                        kind=Serials.cbor)
+                           sn=valK.sn,
+                           dig=valK.serder.diger.qb64,
+                           kind=Serials.cbor)
         # sign vals's event not receipt
         # look up event to sign from coe's kever for val
         valIcpDig = bytes(coeKevery.db.getKeLast(key=snKey(pre=valpre, sn=vsn)))
@@ -3728,7 +3672,7 @@ def test_direct_mode_cbor_mgpk():
 
         #  check if receipt from coe in val's receipt database
         result = valKevery.db.getVrcs(key=dgKey(pre=valKever.prefixer.qb64,
-                                                    dig=valKever.serder.diger.qb64))
+                                                dig=valKever.serder.diger.qb64))
         assert bytes(result[0]) == (coeKever.prefixer.qb64b +
                                     Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.diger.qb64b +
@@ -3744,7 +3688,7 @@ def test_direct_mode_cbor_mgpk():
         coeSerder = rotate(pre=coeKever.prefixer.qb64,
                            keys=[coeSigners[cesn].verfer.qb64],
                            dig=coeKever.serder.diger.qb64,
-                           nxt=Nexter(keys=[coeSigners[cesn+1].verfer.qb64]).qb64,
+                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
                            sn=csn,
                            kind=Serials.cbor)
         coe_event_digs.append(coeSerder.dig)
@@ -3785,9 +3729,9 @@ def test_direct_mode_cbor_mgpk():
                          d=valKever.lastEst.d)
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64,
-                        kind=Serials.mgpk)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64,
+                           kind=Serials.mgpk)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeRotDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3808,7 +3752,6 @@ def test_direct_mode_cbor_mgpk():
                         b'-SSywAKr5PZV-0k-AABAAVRZVF2PkwQe5oFFQoDM_efMgGHCKlf1denoAa1NJZ45'
                         b'jnz1AP1VeVmfSFLsjApfJmgCBp-mYw0mP8KwrolsICQ')
 
-
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
         # valKevery.processOne(ims=bytearray(vmsg))  # make copy
@@ -3819,7 +3762,7 @@ def test_direct_mode_cbor_mgpk():
 
         #  check if receipt from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                        dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
@@ -3830,13 +3773,13 @@ def test_direct_mode_cbor_mgpk():
                                     b'NJZ45jnz1AP1VeVmfSFLsjApfJmgCBp-mYw0mP8KwrolsICQ')
 
         # Next Event Coe Interaction
-        csn += 1  #  do not increment esn
+        csn += 1  # do not increment esn
         assert csn == 2
         assert cesn == 1
         coeSerder = interact(pre=coeKever.prefixer.qb64,
-                              dig=coeKever.serder.diger.qb64,
-                              sn=csn,
-                              kind=Serials.cbor)
+                             dig=coeKever.serder.diger.qb64,
+                             sn=csn,
+                             kind=Serials.cbor)
         coe_event_digs.append(coeSerder.dig)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -3866,7 +3809,6 @@ def test_direct_mode_cbor_mgpk():
         assert coeK.sn == csn
         assert coeK.serder.diger.qb64 == coeSerder.dig
 
-
         # create receipt of coe's interaction
         # create seal of val's last est event
         seal = SealEvent(i=valpre,
@@ -3874,9 +3816,9 @@ def test_direct_mode_cbor_mgpk():
                          d=valKever.lastEst.d)
         # create validator receipt
         reserder = receipt(pre=coeK.prefixer.qb64,
-                        sn=coeK.sn,
-                        dig=coeK.serder.diger.qb64,
-                        kind=Serials.mgpk)
+                           sn=coeK.sn,
+                           dig=coeK.serder.diger.qb64,
+                           kind=Serials.mgpk)
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIxnDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
@@ -3895,7 +3837,6 @@ def test_direct_mode_cbor_mgpk():
                         b'-SSywAKr5PZV-0k-AABAAMkr7U_m3dAj9t4l6vBYp-KJaioD46oc5uUdwRzrt8bm'
                         b'yvx7qJuFeM_rv9mYvY_lHN5kP9BDjig6dD6Fheo2fDg')
 
-
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
         # valKevery.processOne(ims=bytearray(vmsg))  # make copy
@@ -3906,7 +3847,7 @@ def test_direct_mode_cbor_mgpk():
 
         #  check if receipt from val in receipt database
         result = coeKevery.db.getVrcs(key=dgKey(pre=coeKever.prefixer.qb64,
-                                                        dig=coeKever.serder.diger.qb64))
+                                                dig=coeKever.serder.diger.qb64))
         assert bytes(result[0]) == (valKever.prefixer.qb64b +
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.diger.qb64b +
@@ -3916,19 +3857,18 @@ def test_direct_mode_cbor_mgpk():
                                     b'uuxWenrs4SlX0RFV-VmcU-SSywAKr5PZV-0kAAMkr7U_m3dAj9t4l6vBYp-KJaioD46oc5uUdwRz'
                                     b'rt8bmyvx7qJuFeM_rv9mYvY_lHN5kP9BDjig6dD6Fheo2fDg')
 
-
         #  verify final coe event state
         assert coeKever.verfers[0].qb64 == coeSigners[cesn].verfer.qb64
         assert coeKever.sn == coeK.sn == csn
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(coepre)]
-        assert len(db_digs) == len(coe_event_digs) == csn+1
+        assert len(db_digs) == len(coe_event_digs) == csn + 1
         assert db_digs == coe_event_digs == ['ETtM9-qTtHK-KKnFerFmtFQAaw70dGBFOQwz7tp85w6E',
                                              'EPHvonlASEhFuMiLwzbNp9cB9t2DJrcnvVvrK_P4G4Ss',
                                              'EOMlWNCvqWStLVUUBlhwEbo3slpOD6-iVCtPBEsW9ofQ']
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(coepre)]
-        assert len(db_digs) == len(coe_event_digs) == csn+1
+        assert len(db_digs) == len(coe_event_digs) == csn + 1
         assert db_digs == coe_event_digs
 
         #  verify final val event state
@@ -3936,11 +3876,11 @@ def test_direct_mode_cbor_mgpk():
         assert valKever.sn == valK.sn == vsn
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(valpre)]
-        assert len(db_digs) == len(val_event_digs) == vsn+1
+        assert len(db_digs) == len(val_event_digs) == vsn + 1
         assert db_digs == val_event_digs == ['EER-hNqduuxWenrs4SlX0RFV-VmcU-SSywAKr5PZV-0k']
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(valpre)]
-        assert len(db_digs) == len(val_event_digs) == vsn+1
+        assert len(db_digs) == len(val_event_digs) == vsn + 1
         assert db_digs == val_event_digs
 
     assert not os.path.exists(valKevery.db.path)
@@ -3955,7 +3895,7 @@ def test_process_nontransferable():
     """
 
     # Ephemeral (Nontransferable) case
-    skp0 = Signer(transferable=False)  #  original signing keypair non transferable
+    skp0 = Signer(transferable=False)  # original signing keypair non transferable
     assert skp0.code == MtrDex.Ed25519_Seed
     assert skp0.verfer.code == MtrDex.Ed25519N
 
@@ -3965,23 +3905,23 @@ def test_process_nontransferable():
 
     # Ephemeral may be used without inception event
     # but when used with inception event must be compatible event
-    sn = 0  #  inception event so 0
-    sith = 1 #  one signer
+    sn = 0  # inception event so 0
+    sith = 1  # one signer
     nxt = ""  # non-transferable so nxt is empty
     toad = 0  # no witnesses
-    nsigs = 1  #  one attached signature unspecified index
+    nsigs = 1  # one attached signature unspecified index
 
     ked0 = dict(v=Versify(kind=Serials.json, size=0),
                 i=aid0.qb64,  # qual base 64 prefix
                 s="{:x}".format(sn),  # hex string no leading zeros lowercase
                 t=Ilks.icp,
-                kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                 k=[aid0.qb64],  # list of signing keys each qual Base64
                 n=nxt,  # hash qual Base64
                 wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                 w=[],  # list of qual Base64 may be empty
                 c=[],  # list of config ordered mappings may be empty
-               )
+                )
 
     # verify derivation of aid0 from ked0
     assert aid0.verify(ked=ked0)
@@ -4014,7 +3954,7 @@ def test_process_nontransferable():
 
     # extract attached sigs
     keys = rser0.ked["k"]
-    for i in range(nrsigs): # verify each attached signature
+    for i in range(nrsigs):  # verify each attached signature
         rsig = Indexer(qb64=msgb0)
         assert rsig.index == 0
         verfer = Verfer(qb64=keys[rsig.index])
@@ -4028,6 +3968,7 @@ def test_process_nontransferable():
     assert raid0.verify(ked=rser0.ked)
     """ Done Test """
 
+
 def test_process_transferable():
     """
     Test process of generating and validating key event messages
@@ -4035,14 +3976,14 @@ def test_process_transferable():
     # Transferable case
     # Setup inception key event dict
     # create current key
-    sith = 1  #  one signer
-    skp0 = Signer()  #  original signing keypair transferable default
+    sith = 1  # one signer
+    skp0 = Signer()  # original signing keypair transferable default
     assert skp0.code == MtrDex.Ed25519_Seed
     assert skp0.verfer.code == MtrDex.Ed25519
     keys = [skp0.verfer.qb64]
 
     # create next key
-    skp1 = Signer()  #  next signing keypair transferable is default
+    skp1 = Signer()  # next signing keypair transferable is default
     assert skp1.code == MtrDex.Ed25519_Seed
     assert skp1.verfer.code == MtrDex.Ed25519
     nxtkeys = [skp1.verfer.qb64]
@@ -4050,22 +3991,21 @@ def test_process_transferable():
     nexter = Nexter(keys=nxtkeys)
     nxt = nexter.qb64  # transferable so next is not empty
 
-    sn = 0  #  inception event so 0
+    sn = 0  # inception event so 0
     toad = 0  # no witnesses
-    nsigs = 1  #  one attached signature unspecified index
+    nsigs = 1  # one attached signature unspecified index
 
     ked0 = dict(v=Versify(kind=Serials.json, size=0),
                 i="",  # qual base 64 prefix
                 s="{:x}".format(sn),  # hex string no leading zeros lowercase
                 t=Ilks.icp,
-                kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                 k=keys,  # list of signing keys each qual Base64
                 n=nxt,  # hash qual Base64
                 wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                 w=[],  # list of qual Base64 may be empty
                 c=[],
-               )
-
+                )
 
     # Derive AID from ked
     aid0 = Prefixer(ked=ked0, code=MtrDex.Ed25519)
@@ -4103,7 +4043,7 @@ def test_process_transferable():
 
     # extract attached sigs
     keys = rser0.ked["k"]
-    for i in range(nrsigs): # verify each attached signature
+    for i in range(nrsigs):  # verify each attached signature
         rsig = Indexer(qb64=msgb0)
         assert rsig.index == 0
         verfer = Verfer(qb64=keys[rsig.index])
@@ -4116,11 +4056,10 @@ def test_process_transferable():
     raid0 = Prefixer(qb64=rser0.pre)
     assert raid0.verify(ked=rser0.ked)
 
-    #verify nxt digest from event is still valid
+    # verify nxt digest from event is still valid
     rnxt1 = Nexter(qb64=rser0.ked["n"])
     assert rnxt1.verify(keys=nxtkeys)
     """ Done Test """
-
 
 
 def test_process_manual():
@@ -4137,7 +4076,8 @@ def test_process_manual():
     # redundant, that is, sigkey = sigseed + verkey. So we can easily recreate
     # sigkey by concatenating sigseed + verkey.
     verkey, sigkey = pysodium.crypto_sign_seed_keypair(aidseed)
-    assert verkey == b'\xaf\x96\xb0p\xfb0\xa7\xd0\xa4\x18\xc9\xdc\x1d\x86\xc2:\x98\xf7?t\x1b\xde.\xcc\xcb;\x8a\xb0\xa2O\xe7K'
+    assert verkey == b'\xaf\x96\xb0p\xfb0\xa7\xd0\xa4\x18\xc9\xdc\x1d\x86\xc2:\x98\xf7?t\x1b\xde.\xcc\xcb;\x8a\xb0' \
+                     b'\xa2O\xe7K'
     assert len(verkey) == 32
 
     # create qualified pre in basic format
@@ -4161,7 +4101,7 @@ def test_process_manual():
     assert nxtkeymat.qb64 == 'D9URPQjo8zRYYm4NMpQyYWJBDGrMwT6UP4zlspt9YGDU'
 
     # create nxt digest
-    nxtsith =  "{:x}".format(1)  # lowecase hex no leading zeros
+    nxtsith = "{:x}".format(1)  # lowecase hex no leading zeros
     assert nxtsith == "1"
     nxts = []  # create list to concatenate for hashing
     nxts.append(nxtsith.encode("utf-8"))
@@ -4174,31 +4114,29 @@ def test_process_manual():
     nxtdigmat = Matter(raw=nxtdig, code=MtrDex.Blake3_256)
     assert nxtdigmat.qb64 == 'E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI'
 
-    sn =  0
+    sn = 0
     sith = 1
     toad = 0
     index = 0
 
-    #create key event dict
+    # create key event dict
     ked0 = dict(v=Versify(kind=Serials.json, size=0),
                 i=aidmat.qb64,  # qual base 64 prefix
                 s="{:x}".format(sn),  # hex string no leading zeros lowercase
                 t=Ilks.icp,
-                kt="{:x}".format(sith), # hex string no leading zeros lowercase
+                kt="{:x}".format(sith),  # hex string no leading zeros lowercase
                 k=[aidmat.qb64],  # list of signing keys each qual Base64
                 n=nxtdigmat.qb64,  # hash qual Base64
-                wt ="{:x}".format(toad),  # hex string no leading zeros lowercase
+                wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                 w=[],  # list of qual Base64 may be empty
                 c=[],  # list of config ordered mappings may be empty
-               )
-
+                )
 
     txsrdr = Serder(ked=ked0, kind=Serials.json)
     assert txsrdr.raw == (b'{"v":"KERI10JSON0000e6_","i":"Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50s",'
                           b'"s":"0","t":"icp","kt":"1","k":["Dr5awcPswp9CkGMncHYbCOpj3P3Qb3i7MyzuKsKJP50'
                           b's"],"n":"E3ld50z3LYM7pmQxG3bJDNgOnRg1T1v5tmYmsYDyqiNI","wt":"0","w":[],"c":['
                           b']}')
-
 
     assert txsrdr.size == 230
 
@@ -4208,7 +4146,7 @@ def test_process_manual():
 
     assert txsrdr.dig == txdigmat.qb64
 
-    sig0raw = pysodium.crypto_sign_detached(txsrdr.raw, aidseed + aidmat.raw)  #  sigkey = seed + verkey
+    sig0raw = pysodium.crypto_sign_detached(txsrdr.raw, aidseed + aidmat.raw)  # sigkey = seed + verkey
     assert len(sig0raw) == 64
 
     result = pysodium.crypto_sign_verify_detached(sig0raw, txsrdr.raw, aidmat.raw)
@@ -4221,7 +4159,7 @@ def test_process_manual():
 
     msgb = txsrdr.raw + txsigmat.qb64.encode("utf-8")
 
-    assert len(msgb) == 318  #  230 + 88
+    assert len(msgb) == 318  # 230 + 88
 
     #  Recieve side
     rxsrdr = Serder(raw=msgb)
@@ -4240,12 +4178,11 @@ def test_process_manual():
 
     rxverqb64 = rxsrdr.ked["k"][index]
     rxvermat = Matter(qb64=rxverqb64)
-    assert rxvermat.qb64 == rxaidmat.qb64  #  basic derivation same
+    assert rxvermat.qb64 == rxaidmat.qb64  # basic derivation same
 
     result = pysodium.crypto_sign_verify_detached(rxsigmat.raw, rxsrdr.raw, rxvermat.raw)
     assert not result  # None if verifies successfully else raises ValueError
     """ Done Test """
-
 
 
 def test_reload_kever(mockHelpingNowUTC):
@@ -4256,7 +4193,7 @@ def test_reload_kever(mockHelpingNowUTC):
     with basing.openDB(name="nat") as natDB, keeping.openKS(name="nat") as natKS:
         # setup Nat's habitat using default salt multisig already incepts
         natHab = habbing.Habitat(name='nat', ks=natKS, db=natDB,
-                                isith=2, icount=3, temp=True)
+                                 isith=2, icount=3, temp=True)
         assert natHab.name == 'nat'
         assert natHab.ks == natKS
         assert natHab.db == natDB
@@ -4280,39 +4217,38 @@ def test_reload_kever(mockHelpingNowUTC):
         assert natHab.kever.serder.dig == 'En0iLDgaeD9Dydf4Tkd0ilgOW-clbhwMdGW3_t4xHsXI'
         ldig = bytes(natHab.db.getKeLast(dbing.snKey(natHab.pre, natHab.kever.sn)))
         assert ldig == natHab.kever.serder.digb
-        serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre,ldig))))
+        serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre, ldig))))
         assert serder.dig == natHab.kever.serder.dig
         nstate = natHab.kever.state()
 
         state = natHab.db.states.get(keys=natHab.pre)  # Serder instance
         assert state.pretty() == ('{\n'
-                                    ' "v": "KERI10JSON000246_",\n'
-                                    ' "i": "E5lskf_uSh7ymhplif9nKREEsuwbBfHbHTJuMZyV6Fls",\n'
-                                    ' "s": "6",\n'
-                                    ' "t": "ksn",\n'
-                                    ' "p": "E4T5Gk5v7cv9x5oxT34zwBrTQ7K-x_Atw_kFFBNs_Mgw",\n'
-                                    ' "d": "En0iLDgaeD9Dydf4Tkd0ilgOW-clbhwMdGW3_t4xHsXI",\n'
-                                    ' "f": "6",\n'
-                                    ' "dt": "2021-01-01T00:00:00.000000+00:00",\n'
-                                    ' "et": "ixn",\n'
-                                    ' "kt": "2",\n'
-                                    ' "k": [\n'
-                                    '  "DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew",\n'
-                                    '  "D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg",\n'
-                                    '  "D36Ev0IqfpZ2wg0QbbTtPilJ2NowjFT1IqF954cLB-9M"\n'
-                                    ' ],\n'
-                                    ' "n": "EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg",\n'
-                                    ' "bt": "0",\n'
-                                    ' "b": [],\n'
-                                    ' "c": [],\n'
-                                    ' "ee": {\n'
-                                    '  "s": "2",\n'
-                                    '  "d": "EVqqrPEkZ08J82HsZss8FUWyzUrDM3mavPTPb0meWr1s",\n'
-                                    '  "br": [],\n'
-                                    '  "ba": []\n'
-                                    ' },\n'
-                                    ' "di": ""\n'
-                                    '}')
+                                  ' "v": "KERI10JSON000235_",\n'
+                                  ' "i": "E5lskf_uSh7ymhplif9nKREEsuwbBfHbHTJuMZyV6Fls",\n'
+                                  ' "s": "6",\n'
+                                  ' "p": "E4T5Gk5v7cv9x5oxT34zwBrTQ7K-x_Atw_kFFBNs_Mgw",\n'
+                                  ' "d": "En0iLDgaeD9Dydf4Tkd0ilgOW-clbhwMdGW3_t4xHsXI",\n'
+                                  ' "f": "6",\n'
+                                  ' "dt": "2021-01-01T00:00:00.000000+00:00",\n'
+                                  ' "et": "ixn",\n'
+                                  ' "kt": "2",\n'
+                                  ' "k": [\n'
+                                  '  "DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew",\n'
+                                  '  "D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg",\n'
+                                  '  "D36Ev0IqfpZ2wg0QbbTtPilJ2NowjFT1IqF954cLB-9M"\n'
+                                  ' ],\n'
+                                  ' "n": "EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg",\n'
+                                  ' "bt": "0",\n'
+                                  ' "b": [],\n'
+                                  ' "c": [],\n'
+                                  ' "ee": {\n'
+                                  '  "s": "2",\n'
+                                  '  "d": "EVqqrPEkZ08J82HsZss8FUWyzUrDM3mavPTPb0meWr1s",\n'
+                                  '  "br": [],\n'
+                                  '  "ba": []\n'
+                                  ' },\n'
+                                  ' "di": ""\n'
+                                  '}')
         assert state.sn == 6
         assert state.ked["f"] == '6'
         assert state.ked == nstate.ked
@@ -4327,34 +4263,32 @@ def test_reload_kever(mockHelpingNowUTC):
         kstate = kever.state()
         assert kstate.ked == state.ked
         assert state.pretty() == ('{\n'
-                                    ' "v": "KERI10JSON000246_",\n'
-                                    ' "i": "E5lskf_uSh7ymhplif9nKREEsuwbBfHbHTJuMZyV6Fls",\n'
-                                    ' "s": "6",\n'
-                                    ' "t": "ksn",\n'
-                                    ' "p": "E4T5Gk5v7cv9x5oxT34zwBrTQ7K-x_Atw_kFFBNs_Mgw",\n'
-                                    ' "d": "En0iLDgaeD9Dydf4Tkd0ilgOW-clbhwMdGW3_t4xHsXI",\n'
-                                    ' "f": "6",\n'
-                                    ' "dt": "2021-01-01T00:00:00.000000+00:00",\n'
-                                    ' "et": "ixn",\n'
-                                    ' "kt": "2",\n'
-                                    ' "k": [\n'
-                                    '  "DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew",\n'
-                                    '  "D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg",\n'
-                                    '  "D36Ev0IqfpZ2wg0QbbTtPilJ2NowjFT1IqF954cLB-9M"\n'
-                                    ' ],\n'
-                                    ' "n": "EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg",\n'
-                                    ' "bt": "0",\n'
-                                    ' "b": [],\n'
-                                    ' "c": [],\n'
-                                    ' "ee": {\n'
-                                    '  "s": "2",\n'
-                                    '  "d": "EVqqrPEkZ08J82HsZss8FUWyzUrDM3mavPTPb0meWr1s",\n'
-                                    '  "br": [],\n'
-                                    '  "ba": []\n'
-                                    ' },\n'
-                                    ' "di": "",\n'
-                                    ' "r": ""\n'
-                                    '}')
+                                  ' "v": "KERI10JSON000235_",\n'
+                                  ' "i": "E5lskf_uSh7ymhplif9nKREEsuwbBfHbHTJuMZyV6Fls",\n'
+                                  ' "s": "6",\n'
+                                  ' "p": "E4T5Gk5v7cv9x5oxT34zwBrTQ7K-x_Atw_kFFBNs_Mgw",\n'
+                                  ' "d": "En0iLDgaeD9Dydf4Tkd0ilgOW-clbhwMdGW3_t4xHsXI",\n'
+                                  ' "f": "6",\n'
+                                  ' "dt": "2021-01-01T00:00:00.000000+00:00",\n'
+                                  ' "et": "ixn",\n'
+                                  ' "kt": "2",\n'
+                                  ' "k": [\n'
+                                  '  "DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew",\n'
+                                  '  "D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg",\n'
+                                  '  "D36Ev0IqfpZ2wg0QbbTtPilJ2NowjFT1IqF954cLB-9M"\n'
+                                  ' ],\n'
+                                  ' "n": "EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg",\n'
+                                  ' "bt": "0",\n'
+                                  ' "b": [],\n'
+                                  ' "c": [],\n'
+                                  ' "ee": {\n'
+                                  '  "s": "2",\n'
+                                  '  "d": "EVqqrPEkZ08J82HsZss8FUWyzUrDM3mavPTPb0meWr1s",\n'
+                                  '  "br": [],\n'
+                                  '  "ba": []\n'
+                                  ' },\n'
+                                  ' "di": ""\n'
+                                  '}')
 
     assert not os.path.exists(natKS.path)
     assert not os.path.exists(natDB.path)
@@ -4362,10 +4296,6 @@ def test_reload_kever(mockHelpingNowUTC):
     """End Test"""
 
 
-
-
 if __name__ == "__main__":
     # pytest.main(['-vv', 'test_eventing.py::test_keyeventfuncs'])
     test_messagize()
-
-

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -4311,8 +4311,7 @@ def test_reload_kever(mockHelpingNowUTC):
                                     '  "br": [],\n'
                                     '  "ba": []\n'
                                     ' },\n'
-                                    ' "di": "",\n'
-                                    ' "r": ""\n'
+                                    ' "di": ""\n'
                                     '}')
         assert state.sn == 6
         assert state.ked["f"] == '6'

--- a/tests/core/test_keystate.py
+++ b/tests/core/test_keystate.py
@@ -1,0 +1,234 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.core.test_keystate module
+
+Test key state notification reply messages
+routes: /ksn
+
+"""
+from keri.app import keeping, habbing
+from keri.core import coring, eventing, parsing
+from keri.db import basing
+
+
+def test_keystate(mockHelpingNowUTC):
+    """
+        {
+          "v": "KERI10JSON000301_",
+          "t": "rpy",
+          "d": "E_9aLcmV9aEVEm7mXvEY3V_CmbyvG7Ahj6HCq-D48meM",
+          "dt": "2021-11-04T12:57:59.823350+00:00",
+          "r": "ksn",
+          "a": {
+            "v": "KERI10JSON000274_",
+            "i": "EeS834LMlGVEOGR8WU3rzZ9M6HUv_vtF32pSXQXKP7jg",
+            "s": "1",
+            "t": "ksn",
+            "p": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
+            "d": "EtgNGVxYd6W0LViISr7RSn6ul8Yn92uyj2kiWzt51mHc",
+            "f": "1",
+            "dt": "2021-11-04T12:55:14.480038+00:00",
+            "et": "ixn",
+            "kt": "1",
+            "k": [
+              "DTH0PwWwsrcO_4zGe7bUR-LJX_ZGBTRsmP-ZeJ7fVg_4"
+            ],
+            "n": "E6qpfz7HeczuU3dAd1O9gPPS6-h_dCxZGYhU8UaDY2pc",
+            "bt": "3",
+            "b": [
+              "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
+              "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
+              "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
+            ],
+            "c": [],
+            "ee": {
+              "s": "0",
+              "d": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
+              "br": [],
+              "ba": []
+            },
+            "di": ""
+          }
+        }
+
+    """
+    print()
+    raw = b'\x05\xaa\x8f-S\x9a\xe9\xfaU\x9c\x02\x9c\x9b\x08Hu'
+    salter = coring.Salter(raw=raw)
+    salt = salter.qb64
+    assert salt == '0ABaqPLVOa6fpVnAKcmwhIdQ'
+
+    # Bob is the controller
+    # Wes is his witness
+    # Bam is verifying the key state for Bob from Wes
+    with basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS, \
+         basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+         basing.openDB(name="bam") as bamDB:
+
+        # setup Wes's habitat nontrans
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[wesHab.pre], temp=True)
+        assert bobHab.pre == "E4BsxCYUtUx3d6UkDVIQ9Ke3CLQfqWBfICSmjIzkS1u4"
+
+        # Create Bob's icp, pass to Wes.
+        wesKvy = eventing.Kevery(db=wesDB, lax=False, local=False)
+        bobIcp = bobHab.makeOwnEvent(sn=0)
+        parsing.Parser().parse(ims=bytearray(bobIcp), kvy=wesKvy)
+        assert bobHab.pre in wesHab.kevers
+        iserder = coring.Serder(raw=bytearray(bobIcp))
+        wesHab.receipt(serder=iserder)
+
+        # Get ksn from Bob and verify
+        ksn = bobHab.kever.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+
+        # Get ksn from Wes and verify
+        bobKeverFromWes = wesHab.kevers[bobHab.pre]
+        ksn = bobKeverFromWes.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+        msg = wesHab.reply(route="/ksn/" + wesHab.pre, data=ksn.ked)
+
+        bamKvy = eventing.Kevery(db=bamDB, lax=False, local=False)
+        parsing.Parser().parse(ims=bytearray(msg), kvy=bamKvy)
+
+        assert len(bamKvy.cues) == 1
+        cue = bamKvy.cues.popleft()
+        assert cue["kin"] == "query"
+        assert cue["q"]["pre"] == bobHab.pre
+
+        msgs = bytearray()  # outgoing messages
+        for msg in wesDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy)
+        bamKvy.processEscrows()
+
+        keys = (bobHab.pre, wesHab.pre)
+        saider = bamDB.knas.get(keys=keys)
+        assert saider.qb64 == bobHab.kever.serder.dig
+
+    # Bob is the controller
+    # Bam is verifying the key state for Bob from Wes
+    # Wes is Bam's watcher
+    with basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS, \
+         basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+         basing.openDB(name="bam") as bamDB, keeping.openKS(name="bam") as bamKS:
+
+        # setup Wes's habitat nontrans
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True, temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        # Create Bob's icp, pass to Wes.
+        wesKvy = eventing.Kevery(db=wesDB, lax=False, local=False)
+        bobIcp = bobHab.makeOwnEvent(sn=0)
+        parsing.Parser().parse(ims=bytearray(bobIcp), kvy=wesKvy)
+        assert bobHab.pre in wesHab.kevers
+
+        # Get ksn from Bob and verify
+        ksn = bobHab.kever.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+
+        # Get ksn from Wes and verify
+        bobKeverFromWes = wesHab.kevers[bobHab.pre]
+        ksn = bobKeverFromWes.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+        msg = wesHab.reply(route="/ksn/" + wesHab.pre, data=ksn.ked)
+
+        bamHab = habbing.Habitat(name="bam", ks=bamKS, db=bamDB, isith=1, icount=1, transferable=True, temp=True)
+
+        # Set Wes has Bam's watcher
+        habr = bamHab.db.habs.get("bam")
+        habr.watchers = [wesHab.pre]
+        bamHab.db.habs.pin("bam", habr)
+
+        bamKvy = eventing.Kevery(db=bamDB, lax=False, local=False)
+        parsing.Parser().parse(ims=bytearray(msg), kvy=bamKvy)
+
+        assert len(bamKvy.cues) == 1
+        cue = bamKvy.cues.popleft()
+        assert cue["kin"] == "query"
+        assert cue["q"]["pre"] == bobHab.pre
+
+        msgs = bytearray()  # outgoing messages
+        for msg in wesDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy)
+        bamKvy.processEscrows()
+
+        keys = (bobHab.pre, wesHab.pre)
+        saider = bamDB.knas.get(keys=keys)
+        assert saider.qb64 == bobHab.kever.serder.dig
+
+
+    # Bob is the controller
+    # Bam is verifying the key state for Bob from Wes
+    # Wes is no one
+    with basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS, \
+         basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+         basing.openDB(name="bam") as bamDB, keeping.openKS(name="bam") as bamKS:
+
+        # setup Wes's habitat nontrans
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True, temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        # Create Bob's icp, pass to Wes.
+        wesKvy = eventing.Kevery(db=wesDB, lax=False, local=False)
+        bobIcp = bobHab.makeOwnEvent(sn=0)
+        parsing.Parser().parse(ims=bytearray(bobIcp), kvy=wesKvy)
+        assert bobHab.pre in wesHab.kevers
+
+        # Get ksn from Bob and verify
+        ksn = bobHab.kever.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+        # Get ksn from Wes and verify
+        bobKeverFromWes = wesHab.kevers[bobHab.pre]
+        ksn = bobKeverFromWes.state()
+        assert ksn.pre == bobHab.pre
+        assert ksn.sn == 0
+        assert ksn.ked["d"] == bobHab.kever.serder.dig
+
+        msg = wesHab.reply(route="/ksn/" + wesHab.pre, data=ksn.ked)
+
+        bamKvy = eventing.Kevery(db=bamDB, lax=False, local=False)
+        parsing.Parser().parse(ims=bytearray(msg), kvy=bamKvy)
+
+        assert len(bamKvy.cues) == 0
+        saider = bamDB.knas.get(keys=keys)
+        assert saider is None
+
+
+    """End Test"""

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -3,33 +3,23 @@
 tests.db.dbing module
 
 """
-import pytest
-
-import os
 import json
-import datetime
+import os
+
 import lmdb
-
+import pytest
 from hio.base import doing
-
-from keri.help import helping
 from keri.app import habbing, keeping
 from keri.core import coring, eventing
-
-from keri.core.coring import Signer, Nexter, Prefixer, Serder
-from keri.core.coring import MtrDex, MtrDex, MtrDex
-from keri.core.coring import Serials, Vstrings, Versify
-from keri.core.eventing import incept, rotate, interact, Kever, Kevery
-
-from keri.db import dbing
-from keri.db.dbing import clearDatabaserDir, openLMDB
-from keri.db.dbing import (dgKey, onKey, fnKey, snKey, dtKey, splitKey,
-                           splitKeyON, splitKeyFN, splitKeySN, splitKeyDT)
-from keri.db.dbing import LMDBer
+from keri.core.coring import MtrDex
+from keri.core.coring import Serials, Versify
+from keri.core.coring import Signer, Nexter
+from keri.core.eventing import incept, rotate, interact, Kever
 from keri.db import basing
+from keri.db import dbing
 from keri.db.basing import openDB, Baser
-
-
+from keri.db.dbing import (dgKey, onKey, snKey)
+from keri.db.dbing import openLMDB
 
 
 def test_baser():
@@ -1731,7 +1721,7 @@ def test_clean_baser():
         state = natHab.db.states.get(keys=natHab.pre)  # Serder instance
         assert state.sn == 6
         assert state.ked["f"] == '6'
-        assert natHab.db.env.stat()['entries'] == 37
+        assert natHab.db.env.stat()['entries'] == 43
 
         # test reopenDB with reuse  (because temp)
         with basing.reopenDB(db=natHab.db, reuse=True):
@@ -1740,7 +1730,7 @@ def test_clean_baser():
             assert ldig == natHab.kever.serder.digb
             serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre,ldig))))
             assert serder.dig == natHab.kever.serder.dig
-            assert natHab.db.env.stat()['entries'] == 37
+            assert natHab.db.env.stat()['entries'] == 43
 
             # verify name pre kom in db
             data = natHab.db.habs.get(keys=natHab.name)


### PR DESCRIPTION
This PR includes:

* Key state notification as a reply message.
* Added checks for source, accepting ksn only from my watchers, controller of aid or witnesses of aid.
* Removed route (`r`) field from key state notice.
* Docstring updates for `vdr.eventing`

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>