### PR TITLE
TSN as reply support in Tevery.

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -194,7 +194,7 @@ class WitnessInquisitor(doing.DoDoer):
         msg = self.hab.query(pre, route=r, query=dict(), **kwa)  # Query for remote pre Event
         self.msgs.append(bytes(msg))  # bytes not bytearray so set membership compare works
 
-    def telquery(self, ri, i, r="tels", **kwa):
+    def telquery(self, ri, i=None, r="tels", **kwa):
         msg = self.hab.query(i, route=r, query=dict(ri=ri), **kwa)  # Query for remote pre Event
         self.msgs.append(bytes(msg))  # bytes not bytearray so set membership compare works
 
@@ -202,7 +202,7 @@ class WitnessInquisitor(doing.DoDoer):
         backoff = BackoffWitnessQuery(hab=self.hab, pre=pre, sn=sn, anc=anc)
         self.extend([backoff])
 
-    def backoffTelQuery(self, ri, i):
+    def backoffTelQuery(self, ri=None, i=None):
         backoff = BackoffWitnessTelQuery(hab=self.hab, reger=self.reger, ri=ri, i=i, wits=self.hab.kever.wits)
         self.extend([backoff])
 
@@ -405,7 +405,6 @@ class HttpWitnesser(doing.DoDoer):
                 yield self.tock
 
             msg = self.msgs.popleft()
-
             httping.createCESRRequest(msg, self.client)
             while self.client.requests:
                 yield self.tock
@@ -557,7 +556,7 @@ class BackoffWitnessTelQuery(doing.DoDoer):
 
             if self.ri in self.reger.tevers:
                 tever = self.reger.tevers[self.ri]
-                if tever.vcState(self.i) is not None:
+                if self.i is None or tever.vcState(self.i) is not None:
                     break
 
             wit = random.choice(self.wits)

--- a/src/keri/app/cli/commands/vc/issue.py
+++ b/src/keri/app/cli/commands/vc/issue.py
@@ -82,7 +82,7 @@ class CredentialIssuer(doing.DoDoer):
         )
 
 
-        reger = viring.Registry(name=registryName)
+        reger = viring.Registry(name=registryName, db=self.hab.db)
         issuer = issuing.Issuer(hab=self.hab, name=registryName, reger=reger)
         self.verifier = verifying.Verifier(hab=self.hab, name=registryName, reger=reger, tevers=issuer.tevers)
         meh = grouping.MultisigEventHandler(hab=self.hab, verifier=self.verifier)
@@ -106,14 +106,28 @@ class CredentialIssuer(doing.DoDoer):
 
         self.issr.msgs.append(self.msg)
 
-        done = False
-        while not done:
-            while self.verifier.cues:
-                cue = self.verifier.cues.popleft()
+        creder = None
+        published = False
+        witnessed = False
+        finished = False
+        while not ((published and witnessed) or finished):
+            while self.issr.cues:
+                cue = self.issr.cues.popleft()
                 if cue["kin"] == "saved":
-                    done = True
+                    creder = cue["creder"]
+
+                if cue["kin"] == "finished":
+                    finished = True
+
+                elif cue["kin"] == "published":
+                    published = True
+
+                elif cue["kin"] == "witnessed":
+                    witnessed = True
 
                 yield self.tock
             yield
 
+
+        print(f"{creder.said} has been issued.")
         self.remove(self.toRemove)

--- a/src/keri/app/cli/commands/vc/query.py
+++ b/src/keri/app/cli/commands/vc/query.py
@@ -1,0 +1,125 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+from keri.app import directing, agenting, indirecting
+from keri.app.cli.common import displaying
+from keri.app.cli.common import existing
+from keri.core import coring
+from keri.vdr import eventing, viring, verifying
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Request Transaction State from Witness or Backer')
+parser.set_defaults(handler=lambda args: query(args))
+parser.add_argument('--name', '-n', help='Human readable reference', required=True)
+parser.add_argument('--witness', '-w', help='QB64 identifier of witness to query', default="", required=True)
+parser.add_argument('--registry', '-r', help='QB64 identifier or registry to query', default="", required=True)
+parser.add_argument('--vc', '-i', help='QB64 identifier or credential to query', default="", required=False)
+
+
+def query(args):
+    name = args.name
+
+    qryDoer = QueryDoer(name=name, wit=args.witness, ri=args.registry, i=args.vc)
+    directing.runController(doers=[qryDoer], expire=0.0)
+
+
+class QueryDoer(doing.DoDoer):
+
+    def __init__(self, name, wit, ri, i, **kwa):
+        hab, doers = existing.openHabitat(name=name)
+        self.hab = hab
+
+        self.wit = wit
+        self.ri = ri
+        self.i = i
+        self.cues = help.decking.Deck()
+
+        reger = viring.Registry(name=self.hab.name)
+        self.verifier = verifying.Verifier(hab=self.hab, reger=reger)
+        self.mbd = indirecting.MailboxDirector(hab=self.hab, topics=["/replay", "/receipt"], verifier=self.verifier)
+        self.witq = agenting.WitnessInquisitor(hab=self.hab, reger=reger)
+        doers.extend([self.mbd, self.witq, doing.doify(self.cueDo)])
+
+        self.toRemove = list(doers)
+        doers.extend([doing.doify(self.queryDo)])
+        super(QueryDoer, self).__init__(doers=doers, **kwa)
+
+    def queryDo(self, tymth, tock=0.0, **opts):
+        """
+        Returns:  doifiable Doist compatible generator method
+        Usage:
+            add result of doify on this method to doers list
+        """
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        self.witq.telquery(r="tsn", ri=self.ri, i=self.i)
+
+        rserder = None
+        vcser = None
+        while True:
+            yield self.tock
+            if self.cues:
+                cue = self.cues.popleft()
+                serder = cue["serder"]
+                if serder.pre == self.ri:
+                    rserder = serder
+                elif serder.pre == self.i:
+                    vcser = serder
+
+                if rserder is not None and (self.i == "" or vcser is not None):
+                    break
+
+        print("Registry:\t", rserder.pre)
+        print("Issuer: \t", rserder.ked["ii"])
+        print("Sequence No.:\t", rserder.ked["s"])
+        print("Last Event:\t", rserder.ked["et"])
+
+        if vcser is not None:
+            print()
+            print("Credential:\t", vcser.pre)
+            print("Sequence No.:\t", vcser.ked["s"])
+            print("Last Event:\t", vcser.ked["et"])
+
+        self.remove(self.toRemove)
+
+        return
+
+
+    def cueDo(self, tymth, tock=0.0, **opts):
+        """
+
+        Handle cues coming out of our external Mailbox listener and forward to controller
+        mailbox if appropriate
+
+        """
+        self.wind(tymth)
+        self.tock = tock
+        yield self.tock
+
+        while True:
+            while self.mbd.kvy.cues:
+                cue = self.mbd.kvy.cues.popleft()
+                cueKin = cue["kin"]  # type or kind of cue
+                if cueKin == "query":
+                    qargs = cue["q"]
+                    self.witq.query(**qargs)
+                if cueKin == "telquery":
+                    qargs = cue["q"]
+                    self.witq.telquery(**qargs)
+
+                elif cueKin == "txnStateSaved":
+                    self.cues.append(cue)
+
+                yield self.tock
+            yield self.tock
+

--- a/src/keri/app/cli/commands/vc/revoke.py
+++ b/src/keri/app/cli/commands/vc/revoke.py
@@ -6,29 +6,133 @@ keri.kli.commands module
 import argparse
 
 from hio.base import doing
+from hio.help import decking
 
-from keri.app import habbing
+from keri.app import directing, indirecting, agenting
+from keri.app.cli.common import existing
+from keri.vdr import viring
 from keri.vdr.issuing import Issuer
 
 parser = argparse.ArgumentParser(description='Revoke a verifiable credential')
-parser.set_defaults(handler=lambda args: RevokeDoer(vcdig=args.vcdig, hab=args.hab))
-parser.add_argument('--vcdig', help='vcdig is hash digest of vc content qb64')
+parser.set_defaults(handler=lambda args: revokeCredential(args))
+parser.add_argument('--name', '-n', help='Human readable reference', required=True)
+parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
+                    default=None)
+parser.add_argument('--said', help='is SAID vc content qb64')
 
 
-class RevokeDoer(doing.Doer):
+def revokeCredential(args):
+    name = args.name
 
-    def __init__(self, vcdig, tock=0.0, hab: habbing.Habitat = None, **kwa):
-        self.hab = hab
-        self.vcdig = vcdig
-        super(RevokeDoer, self).__init__(**kwa)
+    revokeDoer = RevokeDoer(name=name, said=args.said, registryName=args.registry_name)
 
-    def do(self, tymth, tock=0.0, **opts):
-        iss = Issuer(hab=self.hab, name=self.hab.name)
+    doers = [revokeDoer]
+    directing.runController(doers=doers, expire=0.0)
 
-        iss.revoke(vcdig=self.vcdig)
 
-        print(f"Rotated keys for {self.hab.name}")
-        print(f"New public key {self.hab.kever.verfers[0].qb64}")
+class RevokeDoer(doing.DoDoer):
 
-        return super().do(tymth, tock, **opts)
+    def __init__(self, name, said, registryName, **kwa):
+        self.cues = decking.Deck()
+        self.registryName = registryName
+        self.hab, doers = existing.openHabitat(name=name)
+        self.said = said
+
+        reger = viring.Registry(name=self.registryName, db=self.hab.db)
+        self.issuer = Issuer(hab=self.hab, name=self.hab.name, reger=reger)
+
+        mbx = indirecting.MailboxDirector(hab=self.hab, topics=["/receipt", "/multisig"])
+        doers.extend([mbx, doing.doify(self.issuerDo)])
+
+        self.toRemove = list(doers)
+        doers.extend([doing.doify(self.revokeDo)])
+        super(RevokeDoer, self).__init__(doers=doers, **kwa)
+
+    def revokeDo(self, tymth, tock=0.0, **opts):
+        """
+
+        Parameters:
+            tymth:
+            tock:
+            **opts:
+
+        Returns:
+
+        """
+        yield self.tock
+
+        creder = self.issuer.reger.creds.get(keys=self.said)
+        if creder is None:
+            print(f"Invalid credential SAID {self.said}")
+            return
+
+        self.issuer.revoke(creder=creder)
+
+        published = False
+        witnessed = False
+        while not (published and witnessed):
+            while self.cues:
+                cue = self.cues.popleft()
+                if cue["kin"] == "witnessed":
+                    witnessed = True
+
+                elif cue["kin"] == "published":
+                    published = True
+
+                yield self.tock
+            yield
+
+        print(f"Revoked credential {creder.said}")
+
+        self.remove(self.toRemove)
+
+    def enter(self, **kwargs):
+        if not self.issuer.inited:
+            self.issuer.setup(**self.issuer._inits)
+        return super(RevokeDoer, self).enter(**kwargs)
+
+    def issuerDo(self, tymth, tock=0.0, **opts):
+        """
+        Process cues from credential issue coroutine
+
+        Parameters:
+            tymth is injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock is injected initial tock value
+            opts is dict of injected optional additional parameters
+        """
+        self.wind(tymth)
+        self.tock = tock
+        yield self.tock
+
+        while True:
+            while self.issuer.cues:
+                cue = self.issuer.cues.popleft()
+
+                cueKin = cue['kin']
+                if cueKin == "send":
+                    tevt = cue["msg"]
+                    witSender = agenting.WitnessPublisher(hab=self.hab, msg=tevt)
+                    self.extend([witSender])
+
+                    while not witSender.done:
+                        _ = yield self.tock
+
+                    self.remove([witSender])
+                    self.cues.append(dict(kin="published", regk=self.issuer.regk))
+                elif cueKin == "kevt":
+                    kevt = cue["msg"]
+                    witDoer = agenting.WitnessReceiptor(hab=self.hab, msg=kevt)
+                    self.extend([witDoer])
+
+                    while not witDoer.done:
+                        yield self.tock
+
+                    self.remove([witDoer])
+                    self.cues.append(dict(kin="witnessed", regk=self.issuer.regk))
+
+                yield self.tock
+
+            yield self.tock
+
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -15,7 +15,7 @@ from hio.help import hicting
 from .. import help
 from .. import kering
 from ..kering import ValidationError, MissingDelegationError, MissingSignatureError
-from ..core import coring, eventing, parsing
+from ..core import coring, eventing, parsing, routing
 from ..core.coring import Serder
 from ..db import dbing, basing
 from ..db.dbing import snKey, dgKey
@@ -161,8 +161,11 @@ class Habitat:
                                                                temp=self.temp,
                                                                reopen=True)
         self.ridx = 0  # rotation index of latest establishment event
-        self.kvy = eventing.Kevery(db=self.db, lax=False, local=True)
-        self.psr = parsing.Parser(framed=True, kvy=self.kvy)
+        self.rtr = routing.Router()
+        self.rvy = routing.Revery(db=self.db, rtr=self.rtr)
+        self.kvy = eventing.Kevery(db=self.db, lax=False, local=True, rvy=self.rvy)
+        self.kvy.registerReplyRoutes(router=self.rtr)
+        self.psr = parsing.Parser(framed=True, kvy=self.kvy, rvy=self.rvy)
         self.mgr = None  # wait to setup until after ks is known to be opened
         self.pre = None  # wait to setup until after db is known to be opened
         self.delpre = None

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -90,7 +90,7 @@ class Parser:
 
     """
 
-    def __init__(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None):
+    def __init__(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Initialize instance:
 
@@ -103,6 +103,7 @@ class Parser:
             kvy (Kevery): route KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger): route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
         """
         self.ims = ims if ims is not None else bytearray()
         self.framed = True if framed else False  # extract until end-of-stream
@@ -110,6 +111,7 @@ class Parser:
         self.kvy = kvy
         self.tvy = tvy
         self.exc = exc
+        self.rvy = rvy
 
     @staticmethod
     def sniff(ims):
@@ -195,7 +197,7 @@ class Parser:
                 yield
 
 
-    def parse(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None):
+    def parse(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Processes all messages from incoming message stream, ims,
         when provided. Otherwise process messages from .ims
@@ -216,6 +218,7 @@ class Parser:
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -226,7 +229,8 @@ class Parser:
                                     pipeline=pipeline,
                                     kvy=kvy,
                                     tvy=tvy,
-                                    exc=exc)
+                                    exc=exc,
+                                    rvy=rvy)
 
         while True:
             try:
@@ -235,7 +239,7 @@ class Parser:
                 break
 
 
-    def parseOne(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None):
+    def parseOne(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Processes one messages from incoming message stream, ims,
         when provided. Otherwise process message from .ims
@@ -256,6 +260,7 @@ class Parser:
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -266,7 +271,8 @@ class Parser:
                                      pipeline=pipeline,
                                      kvy=kvy,
                                      tvy=tvy,
-                                     exc=exc)
+                                     exc=exc,
+                                     rvy=rvy)
         while True:
             try:
                 next(parsator)
@@ -274,7 +280,7 @@ class Parser:
                 break
 
 
-    def allParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None):
+    def allParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Returns generator to parse all messages from incoming message stream,
         ims until ims is exhausted (empty) then returns.
@@ -311,6 +317,7 @@ class Parser:
         kvy = kvy if kvy is not None else self.kvy
         tvy = tvy if tvy is not None else self.tvy
         exc = exc if exc is not None else self.exc
+        rvy = rvy if rvy is not None else self.rvy
 
         while ims:  # only process until ims empty
             try:
@@ -319,7 +326,8 @@ class Parser:
                                                    pipeline=pipeline,
                                                    kvy=kvy,
                                                    tvy=tvy,
-                                                   exc=exc)
+                                                   exc=exc,
+                                                   rvy=rvy)
 
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -347,7 +355,7 @@ class Parser:
         return True
 
 
-    def onceParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None):
+    def onceParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Returns generator to parse one message from incoming message stream, ims.
         If ims not provided parse messages from .ims
@@ -366,6 +374,7 @@ class Parser:
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -382,6 +391,7 @@ class Parser:
         kvy = kvy if kvy is not None else self.kvy
         tvy = tvy if tvy is not None else self.tvy
         exc = exc if exc is not None else self.exc
+        rvy = rvy if rvy is not None else self.rvy
 
         done = False
         while not done:
@@ -391,7 +401,8 @@ class Parser:
                                                    pipeline=pipeline,
                                                    kvy=kvy,
                                                    tvy=tvy,
-                                                   exc=exc)
+                                                   exc=exc,
+                                                   rvy=rvy)
 
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -420,7 +431,7 @@ class Parser:
         return done
 
 
-    def parsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None):
+    def parsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Returns generator to continually parse messages from incoming message
         stream, ims. Empty yields when ims is emply.
@@ -443,6 +454,7 @@ class Parser:
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -459,6 +471,7 @@ class Parser:
         kvy = kvy if kvy is not None else self.kvy
         tvy = tvy if tvy is not None else self.tvy
         exc = exc if exc is not None else self.exc
+        rvy = rvy if rvy is not None else self.rvy
 
 
         while True:  # continuous stream processing never stop
@@ -468,7 +481,8 @@ class Parser:
                                                    pipeline=pipeline,
                                                    kvy=kvy,
                                                    tvy=tvy,
-                                                   exc=exc)
+                                                   exc=exc,
+                                                   rvy=rvy)
 
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -496,7 +510,7 @@ class Parser:
         return True  # should never return
 
 
-    def msgParsator(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None):
+    def msgParsator(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None):
         """
         Returns generator that upon each iteration extracts and parses msg
         with attached crypto material (signature etc) from incoming message
@@ -521,6 +535,7 @@ class Parser:
             kvy (Kevery) route KERI KEL message types to this instance
             tvy (Tevery) route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
 
         Logic:
             Currently only support couters on attachments not on combined or
@@ -843,10 +858,10 @@ class Parser:
 
             try:
                 if cigars:  # process separately so do not clash on errors
-                    kvy.processReply(serder, cigars=cigars)  # nontrans
+                    rvy.processReply(serder, cigars=cigars)  # nontrans
 
                 if tsgs:  # process separately so do not clash on errors
-                    kvy.processReply(serder, tsgs=tsgs)  #  trans
+                    rvy.processReply(serder, tsgs=tsgs)  #  trans
 
             except AttributeError as e:
                 raise kering.ValidationError("No kevery to process so dropped msg"

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -1,0 +1,531 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.core.routing module
+
+"""
+import datetime
+import logging
+
+from falcon.routing import util
+from hio.help import decking
+
+from . import eventing, coring
+from .. import help, kering
+from ..db import dbing
+from ..help import helping
+
+logger = help.ogler.getLogger()
+
+
+class Router:
+    """
+    Reply message router that accepts registration of route `r` handlers and dispatches
+    reply messages to the appropriate handler.
+
+    """
+
+    defaultResourceFunc = "processReply"
+
+
+    def __init__(self):
+        self.routes = list()
+
+
+    def addRoute(self, routeTemplate, resource, suffix=None):
+        """ Add a route between a route template and a resource
+
+
+        Parameters:
+            routeTemplate (str): a route template to use for the resource
+            resource (object): the resource instance to associate with the route template
+            suffix(str, optional): Optional responder name suffix for this route. If a suffix is provided,
+              Router will map reply routes to processReply{suffix}().  In this way, multiple closely-related routes
+              can be mapped to the same resource.
+
+        """
+
+        fields, regex = util.compile_uri_template(routeTemplate)
+        self.routes.append(Route(regex=regex, fields=fields, resource=resource, suffix=suffix))
+
+
+    def dispatch(self, serder, saider, cigars, tsgs):
+        """
+
+        Parameters:
+            serder:
+            saider:
+            cigars:
+            tsgs:
+
+        Returns:
+
+        """
+        ked = serder.ked
+        # Dispatch based on route
+        r = ked["r"]
+        route, match = self._find(route=r)
+        if route is None:
+            raise kering.ValidationError(f"No resource is registered to handle route {r}")
+
+        fname = self.defaultResourceFunc
+        if route.suffix is not None:
+            fname += route.suffix
+
+        kwargs = match.groupdict()
+        for name in route.fields:
+            if name not in kwargs:
+                raise kering.ValidationError(f"parameter {name} not found in route {r}")
+
+
+        fn = getattr(route.resource, fname, self.processRouteNotFound)
+        fn(serder=serder, saider=saider, route=r, cigars=cigars, tsgs=tsgs, **kwargs)
+
+
+    def _find(self, route):
+        """ Linear seach thru added routes, returning the first one that matchs
+
+        Searches through the registered routes until a regex in one of the routes matches
+        the provided route and returns the Route object along with the re.Match object.
+
+        Parameters:
+            route (str): the route from the `r` of the reply message
+
+        Returns:
+            Route: the Route object with the resource that is registered to process this rpy message
+            re.Match:  the regular expression match that contains the grouping of matched parameters.
+
+        """
+        for r in self.routes:
+            if res := r.regex.search(route):
+                return r, res
+
+        return None, None
+
+
+    def processRouteNotFound(self, *, serder, saider, route,
+                             cigars=None, tsgs=None, **kwargs):
+        
+        raise kering.ConfigurationError(f"Resource registered for route {route} in {coring.Ilks.rpy}"
+                                        f"does not contain the correct processReply method")
+
+
+class Revery:
+    """
+
+    """
+
+    TimeoutRPE = 3600  # seconds to timeout reply message escrows
+
+    def __init__(self, db, rtr, cues=None, lax=True, local=False):
+        """
+
+        Parameters:
+            db:
+            cues:
+            lax:
+            local:
+        """
+        self.db = db
+        self.rtr = rtr
+        self.cues = cues if cues is not None else decking.Deck()
+        self.lax = True if lax else False  # promiscuous mode
+        self.local = True if local else False  # local vs nonlocal restrictions
+
+
+    @property
+    def prefixes(self):
+        """
+        Returns .db.prefixes
+        """
+        return self.db.prefixes
+
+
+    def processReply(self, serder, cigars=None, tsgs=None):
+        """
+         Process one reply message with either attached nontrans signing couples
+         in cigars or attached trans indexed sig groups in tsgs. Process logic
+         is route dependent and dispatched by route.
+
+         Parameters:
+             serder (Serder): instance of reply message
+             cigars (list): of Cigar instances that contain nontrans signing couple
+                           signature in .raw and public key in .verfer
+             tsgs (list): tuples (quadruples) of form
+                 (prefixer, seqner, diger, [sigers]) where:
+                 prefixer is pre of trans endorser
+                 seqner is sequence number of trans endorser's est evt for keys for sigs
+                 diger is digest of trans endorser's est evt for keys for sigs
+                 [sigers] is list of indexed sigs from trans endorser's keys from est evt
+
+         BADA (Best Available Data Acceptance) model for each reply message.
+         Latest-Seen-Signed Pairwise comparison of new update reply compared to
+         old already accepted reply from same source for same route (same data).
+         Accept new reply (update) if new reply is later than old reply where:
+             1) Later means date-time-stamp of new is greater than old
+         If non-trans signer then also (AND)
+             2) Later means sn (sequence number) of last (if forked) Est evt that
+                provides keys for signature(s) of new is greater than or equal to
+                sn of last Est evt that provides keys for signature(s) of new.
+
+         If nontrans and last Est Evt is not yet accepted then escrow.
+         If nontrans and partially signed then escrow.
+
+         Escrow process logic is route dependent and is dispatched by route,
+         i.e. route is address of buffer with route specific handler of escrow.
+        """
+        for k in eventing.RPY_LABELS:
+            if k not in serder.ked:
+                raise kering.ValidationError(f"Missing element={k} from {coring.Ilks.rpy}"
+                                             f" msg={serder.ked}.")
+        # fetch from serder to process
+        ked = serder.ked
+
+        # verify said of reply
+        saider = coring.Saider(qb64=ked["d"])
+        if not saider.verify(sad=ked, prefixed=True):
+            raise kering.ValidationError(f"Invalid said = {saider.qb64} for reply "
+                                         f"msg={ked}.")
+
+        self.rtr.dispatch(serder=serder, saider=saider, cigars=cigars, tsgs=tsgs)
+
+
+
+    def acceptReply(self, serder, saider, route, aid, osaider=None,
+                    cigars=None, tsgs=None):
+        """
+        Applies Best Available Data Acceptance policy to reply and signatures
+
+        Returns:
+            accepted (bool): True is successfully accepted. False otherwise
+
+        Parameters:
+            saider (Saider): instance of saider for reply
+
+
+            serder (Serder): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            osaider (Saider): instance of saider for previous reply if any
+            route (str): reply route
+            aid (str): identifier prefix qb64 of authorizing attributable ID
+            cigars (list): of Cigar instances that contain nontrans signing couple
+                          signature in .raw and public key in .verfer
+            tsgs (list): tuples (quadruples) of form
+                (prefixer, seqner, diger, [sigers]) where:
+                prefixer is pre of trans endorser
+                seqner is sequence number of trans endorser's est evt for keys for sigs
+                diger is digest of trans endorser's est evt for keys for sigs
+                [sigers] is list of indexed sigs from trans endorser's keys from est evt
+
+        BADA (Best Available Data Acceptance) model for each reply message.
+        Latest-Seen-Signed Pairwise comparison of new update reply compared to
+        old already accepted reply from same source for same route (same data).
+        Accept new reply (update) if new reply is later than old reply where:
+            1) If transferable: Later is True
+                 A) If sn (sequence number) of last (if forked) Est evt that provides
+                 keys for signature(s) of new is greater than sn of last Est evt
+                 that provides keys for signature(s) of old.
+
+                 Or
+
+                 B) If sn of new equals sn of old And date-time-stamp of new is
+                    greater than old
+
+            2) Else If non-transferable: Later it True
+                 If date-time-stamp of new is greater than old
+
+            4) Else Later is False
+
+
+        If nontrans and last Est Evt is not yet accepted then escrow.
+        If nontrans and partially signed then escrow.
+
+        Escrow process logic is route dependent and is dispatched by route,
+        i.e. route is address of buffer with route specific handler of escrow.
+
+        """
+        # BADA logic.
+        accepted = False  # flag to raise UnverifiedReplyError not accepted
+        cigars = cigars if cigars is not None else []
+        tsgs = tsgs if tsgs is not None else []
+
+        # Is new later than old if old?
+        # get date-time raises error if empty or invalid format
+        dater = coring.Dater(dts=serder.ked["dt"])
+        odater = None
+        if osaider:
+            odater = self.db.sdts.get(keys=osaider.qb64b)
+
+        for cigar in cigars:  # process each couple to verify sig and write to db
+            if cigar.verfer.transferable:  # ignore invalid transferable verfers
+                continue  # skip invalid transferable
+
+            if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own cig
+                if not self.local:  # own cig when not local so ignore
+                    logger.info("Kevery process: skipped own attachment"
+                                " on nonlocal reply msg=\n%s\n", serder.pretty())
+                    continue  # skip own cig attachment on non-local reply msg
+
+            if aid != cigar.verfer.qb64:  # cig not by aid
+                logger.info("Kevery process: skipped cig not from aid="
+                            "%s on reply msg=\n%s\n", aid, serder.pretty())
+                continue  # skip invalid cig's verfer is not aid
+
+            if odater:  # get old compare datetimes to see if later
+                if dater.datetime <= odater.datetime:
+                    logger.info("Kevery process: skipped stale update from "
+                                "%s of reply msg=\n%s\n", aid, serder.pretty())
+                    continue  # skip if not later
+                    # raise ValidationError(f"Stale update of {route} from {aid} "
+                    # f"via {Ilks.rpy}={serder.ked}.")
+
+            if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
+                logger.info("Kevery process: skipped nonverifying cig from "
+                            "%s on reply msg=\n%s\n", cigar.verfer.qb64, serder.pretty())
+                continue  # skip if cig not verify
+
+            # All constraints satisfied so update
+            self.updateReply(serder=serder, saider=saider, dater=dater, cigar=cigar)
+            self.removeReply(saider=osaider)  # remove obsoleted reply artifacts
+            accepted = True
+            break  # first valid cigar sufficient ignore any duplicates in cigars
+
+        for prefixer, seqner, diger, sigers in tsgs:  # iterate over each tsg
+            if not self.lax and prefixer.qb64 in self.prefixes:  # own sig
+                if not self.local:  # own sig when not local so ignore
+                    logger.info("Kevery process: skipped own attachment"
+                                " on nonlocal reply msg=\n%s\n", serder.pretty())
+                    continue  # skip own sig attachment on non-local reply msg
+
+            spre = prefixer.qb64
+            if aid != spre:  # sig not by aid
+                logger.info("Kevery process: skipped signature not from aid="
+                            "%s on reply msg=\n%s\n", aid, serder.pretty())
+                continue  # skip invalid signature is not from aid
+
+            if osaider:  # check if later logic  sn > or sn == and dt >
+                if otsgs := eventing.fetchTsgs(db=self.db.ssgs, saider=osaider):
+                    _, osqr, _, _ = otsgs[0]  # zeroth should be authoritative
+
+                    if seqner.sn < osqr.sn:  # sn earlier
+                        logger.info("Kevery process: skipped stale key state sig"
+                                    "from %s sn=%s<%s on reply msg=\n%s\n",
+                                    aid, seqner.sn, osqr.sn, serder.pretty())
+                        continue  # skip if sn earlier
+
+                    if seqner.sn == osqr.sn:  # sn same so check datetime
+                        if odater:
+                            if dater.datetime <= odater.datetime:
+                                logger.info("Kevery process: skipped stale key"
+                                            "state sig datetime from %s on reply msg=\n%s\n",
+                                            aid, serder.pretty())
+                                continue  # skip if not later
+
+            # retrieve sdig of last event at sn of signer.
+            sdig = self.db.getKeLast(key=dbing.snKey(pre=spre, sn=seqner.sn))
+            if sdig is None:
+                # create cue here to request key state for sprefixer signer
+                # signer's est event not yet in signer's KEL
+                self.escrowReply(serder=serder, saider=saider, dater=dater,
+                                 route=route, prefixer=prefixer, seqner=seqner,
+                                 diger=diger, sigers=sigers)
+                self.cues.append(dict(kin="query", q=dict(pre=spre)))
+                continue
+
+            # retrieve last event itself of signer given sdig
+            sraw = self.db.getEvt(key=dbing.dgKey(pre=spre, dig=bytes(sdig)))
+            # assumes db ensures that sraw must not be none because sdig was in KE
+            sserder = coring.Serder(raw=bytes(sraw))
+            if not sserder.compare(diger=diger):  # signer's dig not match est evt
+                raise kering.ValidationError(f"Bad trans indexed sig group at sn = "
+                                             f"{seqner.sn} for reply = {serder.ked}.")
+            # verify sigs
+            if not (sverfers := sserder.verfers):
+                raise kering.ValidationError(f"Invalid reply from signer={spre}, no "
+                                             f"keys at signer's est. event sn={seqner.sn}.")
+
+            # fetch any escrowed sigs, extract just the siger from each quad
+            # want sn in numerical order so use hex
+            quadkeys = (saider.qb64, prefixer.qb64, f"{seqner.sn:032x}", diger.qb64)
+            esigers = self.db.ssgs.get(keys=quadkeys)
+            sigers.extend(esigers)
+            sigers, valid = eventing.validateSigs(serder=serder,
+                                                  sigers=sigers,
+                                                  verfers=sverfers,
+                                                  tholder=sserder.tholder)
+            # no error so at least one verified siger
+
+            if valid:  # meet threshold so save
+                # All constraints satisfied so update
+                self.updateReply(serder=serder, saider=saider, dater=dater,
+                                 prefixer=prefixer, seqner=seqner, diger=diger,
+                                 sigers=sigers)
+                self.removeReply(saider=osaider)  # remove obsoleted reply artifacts
+                # remove stale signatures .ssgs for this saider
+                # this ensures that zeroth tsg is authoritative
+                for prr, snr, dgr, _ in eventing.fetchTsgs(db=self.db.ssgs, saider=saider, snh=seqner.snh):
+                    if ((snr.sn < seqner.sn) or
+                            (snr.sn == seqner.sn and dgr.qb64 != diger.qb64)):
+                        self.db.ssgs.trim(keys=(prr.qb64, f"{snr.sn:032h}", dgr.qb64, ""))
+
+                accepted = True
+
+            else:  # not meet threshold so escrow
+                self.escrowReply(serder=serder, saider=saider, dater=dater,
+                                 route=route, prefixer=prefixer, seqner=seqner,
+                                 diger=diger, sigers=sigers)
+
+        return accepted
+
+    def updateReply(self, *, serder, saider, dater, cigar=None, prefixer=None,
+                    seqner=None, diger=None, sigers=None):
+        """
+        Update Reply SAD in database given by by serder and associated databases
+        for attached cig couple or sig quadruple.
+        Overwrites val at key if already exists.
+
+        Parameters:
+            serder (Serder): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            dater (Dater): instance from date-time in serder (SAD)
+            cigar (Cigar): instance that contain nontrans signing couple
+                          signature in .raw and public key in .verfer
+            prefixer (Prefixer): is pre of trans endorser
+            seqner (Seqner): is sequence number of trans endorser's est evt for keys for sigs
+            diger (Diger): is digest of trans endorser's est evt for keys for sigs
+            sigers (list): of indexed sigs from trans endorser's key from est evt
+        """
+        # if sigers is None:
+        # sigers = []
+        keys = (saider.qb64,)
+        self.db.sdts.put(keys=keys, val=dater)  # first one idempotent
+        self.db.rpys.put(keys=keys, val=serder)  # first one idempotent
+        if cigar:
+            self.db.scgs.put(keys=keys, vals=[(cigar.verfer, cigar)])
+        if sigers:  # want sn in numerical order so use hex
+            quadkeys = (saider.qb64, prefixer.qb64, f"{seqner.sn:032x}", diger.qb64)
+            self.db.ssgs.put(keys=quadkeys, vals=sigers)
+
+    def removeReply(self, saider):
+        """
+        Remove Reply SAD artifacts given by saider.
+
+        Parameters:
+            saider (Saider): instance from said in serder (SAD)
+
+        """
+        if saider:
+            keys = (saider.qb64,)
+
+            self.db.ssgs.trim(keys=(saider.qb64, ""))  # remove whole branch
+            self.db.scgs.rem(keys=keys)
+            self.db.rpys.rem(keys=keys)
+            self.db.sdts.rem(keys=keys)
+
+    def escrowReply(self, *, serder, saider, dater, route, prefixer, seqner,
+                    diger, sigers):
+        """
+        Escrow reply by route
+
+        Parameters:
+            serder (Serder): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            dater (Dater): instance from date-time in serder (SAD)
+            route (str): reply route
+
+            prefixer (Prefixer): is pre of trans endorser
+            seqner (Seqner): is sequence number of trans endorser's est evt for keys for sigs
+            diger (Diger) is digest of trans endorser's est evt for keys for sigs
+            sigers (list): is indexed sigs from trans endorser's key from est evt
+        """
+        if not sigers:
+            return  # nothing to escrow
+        keys = (saider.qb64,)
+        self.db.sdts.put(keys=keys, val=dater)  # first one idempotent
+        self.db.rpys.put(keys=keys, val=serder)  # first one idempotent
+        quadkeys = (saider.qb64, prefixer.qb64, f"{seqner.sn:032x}", diger.qb64)
+        self.db.ssgs.put(keys=quadkeys, vals=sigers)
+        self.db.rpes.put(keys=(route,), vals=[saider])
+
+
+    def processEscrowReply(self):
+        """
+        Process escrows for reply messages. Escrows are keyed by reply route
+        and val is reply said
+
+        triple (prefixer, seqner, diger)
+        quadruple (prefixer, seqner, diger, siger)
+
+        """
+        for (route, ion), saider in self.db.rpes.getIoItemIter():
+            try:
+                tsgs = eventing.fetchTsgs(db=self.db.ssgs, saider=saider)
+
+                keys = (saider.qb64,)
+                dater = self.db.sdts.get(keys=keys)
+                serder = self.db.rpys.get(keys=keys)
+                try:
+                    if not (dater and serder and tsgs):
+                        raise ValueError(f"Missing escrow artifacts at said={saider.qb64}"
+                                         f"for route={route}.")
+
+                    # do date math for stale escrow
+                    if ((helping.nowUTC() - dater.datetime) >
+                            datetime.timedelta(seconds=self.TimeoutRPE)):
+                        # escrow stale so raise ValidationError which unescrows below
+                        logger.info("Kevery unescrow error: Stale reply escrow "
+                                    " at route = %s\n", route)
+
+                        raise kering.ValidationError(f"Stale reply escrow at route = {route}.")
+
+                    self.processReply(serder=serder, tsgs=tsgs)
+
+                except kering.UnverifiedReplyError as ex:
+                    # still waiting on missing prior event to validate
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Kevery unescrow attempt failed: %s\n", ex.args[0])
+                    else:
+                        logger.error("Kevery unescrow attempt failed: %s\n", ex.args[0])
+
+                except Exception as ex:  # other error so remove from reply escrow
+                    self.db.rpes.remIokey(iokeys=(route, ion))  # remove escrow
+                    self.removeReply(saider)  # remove escrow reply artifacts
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                    else:
+                        logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+
+                else:  # unescrow succeded
+                    self.db.rpes.remIokey(iokeys=(route, ion))  # remove escrow only
+                    logger.info("Kevery unescrow succeeded for reply=\n%s\n",
+                                serder.pretty())
+
+            except Exception as ex:  # log diagnostics errors etc
+                self.db.rpes.remIokey(iokeys=(route, ion))  # remove escrow
+                self.removeReply(saider)  # remove escrow reply artifacts
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                else:
+                    logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+
+
+
+class Route:
+    """
+
+    """
+
+    def __init__(self, regex, fields, resource, suffix=None):
+        """
+
+
+        Parameters:
+            regex(re):
+            fields(set):
+            resource(object):
+            suffix(str, optional):
+
+        """
+        self.regex = regex
+        self.fields = fields
+        self.resource = resource
+        self.suffix = suffix

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -760,12 +760,12 @@ class Baser(dbing.LMDBer):
 
         # all key state escrows indices of partially signed ksn messages. Maps
         # route in reply to single (Saider,)  of escrowed ksn.
-        # Routes such as ???
+        # Routes such as /ksn/{aid}
         self.knes = subing.CesrIoSetSuber(db=self, subkey='knes', klas=coring.Saider)
 
 
-        # auth AuthN/AuthZ by controller at cid of endpoint provider at eid
-        # maps key=cid.role.eid to val=said of end reply
+        # key state SAID database for successfully saved key state notices
+        # maps key=(prefix, aid) to val=said of key state
         self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Saider)
 
         return self.env

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -1,0 +1,196 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.core.escrowing module
+
+"""
+import datetime
+import logging
+from typing import Type
+
+from keri.core import coring
+from keri import help
+from keri import kering
+from keri.core import eventing
+from keri.db import subing
+from keri.help import helping
+
+logger = help.ogler.getLogger()
+
+
+class Broker:
+
+    def __init__(self, db, subkey, timeout=3600):
+        self.db = db
+        self.timeout = timeout
+
+        # State support datetime stamps and signatures indexed and not-indexed
+        # all ksn  kdts (key state datetime serializations) maps said to date-time
+        self.daterdb = subing.CesrSuber(db=self.db, subkey=subkey + '-dts.', klas=coring.Dater)
+
+        # all key state messages. Maps key state said to serialization. ksns are
+        # versioned sads ( with version string) so use Serder to deserialize and
+        # use  .kdts, .ksgs, and .kcgs for datetimes and signatures
+        self.serderdb = subing.SerderSuber(db=self.db, subkey=subkey + '-sns.')
+
+        # all key state ksgs (ksn indexed signature serializations) maps ksn quadkeys
+        # given by quadruple (saider.qb64, subkeyer.qb64, seqner.q64, diger.qb64)
+        #  of reply and trans signer's key state est evt to val Siger for each
+        # signature.
+        self.tigerdb = subing.CesrIoSetSuber(db=self.db, subkey=subkey + '-sgs.', klas=coring.Siger)
+
+        # all key state kcgs  (ksn non-indexed signature serializations) maps ksn SAID
+        # to couple (Verfer, Cigar) of nontrans signer of signature in Cigar
+        # nontrans qb64 of subkeyer is same as Verfer
+        self.cigardb = subing.CatCesrIoSetSuber(db=self.db, subkey=subkey + '-cgs.',
+                                                klas=(coring.Verfer, coring.Cigar))
+
+        # all key state escrows indices of partially signed ksn messages. Maps
+        # route in reply to single (Saider,)  of escrowed ksn.
+        # Routes such as /ksn/{aid} or /tsn/registry/{aid}
+        self.escrowdb = subing.CesrIoSetSuber(db=self.db, subkey=subkey + '-nes', klas=coring.Saider)
+
+        # transaction state SAID database for successfully saved transaction state notices
+        # maps key=(prefix, aid) to val=said of transaction state
+        self.saiderdb = subing.CesrSuber(db=self.db, subkey=subkey + '-nas.', klas=coring.Saider)
+
+    def current(self, keys):
+        return self.saiderdb.get(keys=keys)
+
+
+    def processEscrowState(self, typ, processReply, extype: Type[Exception]):
+        """ Process escrows for reply messages
+
+        Process escrows for reply messages. Escrows are keyed by reply pre
+        and val is reply said
+
+        triple (prefixer, seqner, diger)
+        quadruple (prefixer, seqner, diger, siger)
+
+        Parameters:
+            typ (str): escrow type
+            processReply (func): function to call to process each message taken out of escrow
+            extype (Type[Exception]): the expected exception type if the message should remain in escrow
+
+        """
+        for (typ, pre, aid, ion), saider in self.escrowdb.getIoItemIter(keys=(typ,)):
+            try:
+                tsgs = eventing.fetchTsgs(db=self.tigerdb, saider=saider)
+
+                keys = (saider.qb64,)
+                dater = self.daterdb.get(keys=keys)
+                serder = self.serderdb.get(keys=keys)
+                vcigars = self.cigardb.get(keys=keys)
+
+                try:
+                    if not (dater and serder and (tsgs or vcigars)):
+                        raise ValueError(f"Missing escrow artifacts at said={saider.qb64}"
+                                         f"for pre={pre}.")
+
+                    cigars = []
+                    if vcigars:
+                        for (verfer, cigar) in vcigars:
+                            cigar.verfer = verfer
+                            cigars.append(cigar)
+
+                    # do date math for stale escrow
+                    if ((helping.nowUTC() - dater.datetime) >
+                            datetime.timedelta(seconds=self.timeout)):
+                        # escrow stale so raise ValidationError which unescrows below
+                        logger.info("Kevery unescrow error: Stale txn state escrow "
+                                    " at pre = %s\n", pre)
+
+                        raise kering.ValidationError(f"Stale txn state escrow at pre = {pre}.")
+
+                    processReply(serder=serder, saider=saider, route=serder.ked["r"],
+                                 cigars=cigars, tsgs=tsgs, aid=aid)
+
+                except extype as ex:
+                    # still waiting on missing prior event to validate
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Kevery unescrow attempt failed: %s\n", ex.args[0])
+                    else:
+                        logger.error("Kevery unescrow attempt failed: %s\n", ex.args[0])
+
+                except Exception as ex:  # other error so remove from reply escrow
+                    self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                    else:
+                        logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+
+                else:  # unescrow succeded
+                    self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow only
+                    logger.info("Kevery unescrow succeeded for txn state=\n%s\n",
+                                serder.pretty())
+
+            except Exception as ex:  # log diagnostics errors etc
+                self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow
+                self.removeState(saider)
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                else:
+                    logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+
+    def escrowStateNotice(self, *, typ, pre, aid, serder, saider, dater, cigars=None, tsgs=None):
+        """
+        Escrow reply by route
+
+        Parameters:
+            typ (str): escrow type
+            pre (str): identifier of key state
+            aid (str): identifier of authorizer of key state
+            serder (Serder): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            dater (Dater): instance from date-time in serder (SAD)
+            cigars (list): of Cigar instances that contain nontrans signing couple
+                          signature in .raw and public key in .verfer
+
+            tsgs (Iterable): of quadruples of form (prefixer, seqner, diger, siger) where:
+                prefixer is pre of trans endorser
+                seqner is sequence number of trans endorser's est evt for keys for sigs
+                diger is digest of trans endorser's est evt for keys for sigs
+                siger is indexed sig from trans endorser's key from est evt
+        """
+        cigars = cigars if cigars is not None else []
+        tsgs = tsgs if tsgs is not None else []
+
+        keys = (saider.qb64,)
+        self.daterdb.put(keys=keys, val=dater)  # first one idempotent
+        self.serderdb.put(keys=keys, val=serder)  # first one idempotent
+
+        for prefixer, seqner, diger, sigers in tsgs:  # iterate over each tsg
+            quadkeys = (saider.qb64, prefixer.qb64, f"{seqner.sn:032x}", diger.qb64)
+            self.tigerdb.put(keys=quadkeys, vals=sigers)
+        for cigar in cigars:  # process each couple to verify sig and write to db
+            self.cigardb.put(keys=keys, vals=[(cigar.verfer, cigar)])
+
+        return self.escrowdb.put(keys=(typ, pre, aid), vals=[saider])  # overwrite
+
+    def updateState(self, aid, serder, saider, dater):
+        """
+        Update Reply SAD in database given by by serder and associated databases
+        for attached cig couple or sig quadruple.
+        Overwrites val at key if already exists.
+
+        Parameters:
+            aid (str): identifier of key state
+            serder (Serder): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            dater (Dater): instance from date-time in serder (SAD)
+        """
+        keys = (saider.qb64,)
+
+        # Add source of ksn to the key for DATEs too...  (source AID, ksn AID)
+        self.daterdb.put(keys=keys, val=dater)  # first one idempotent
+        self.serderdb.pin(keys=keys, val=serder)  # first one idempotent
+        # Add source of ksn to the key...  (source AID, ksn AID)
+        self.saiderdb.pin(keys=(serder.pre, aid), val=saider)  # overwrite
+
+    def removeState(self, saider):
+        if saider:
+            keys = (saider.qb64,)
+
+            self.tigerdb.trim(keys=(saider.qb64, ""))  # remove whole branch
+            self.cigardb.rem(keys=keys)
+            self.serderdb.rem(keys=keys)
+            self.daterdb.rem(keys=keys)

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -447,7 +447,7 @@ class FailedSchemaValidationError(KeriError):
 
 class OutOfOrderKeyStateError(ValidationError):
     """
-    Error referenced event missing from log so can't verify this ket state event
+    Error referenced event missing from log so can't verify this key state event
     Usage:
         raise OutOfOrderKeyStateError("error message")
     """
@@ -459,3 +459,12 @@ class UntrustedKeyStateSource(KeriError):
     Usage:
         raise UntrustedKeyStateSource("error message")
     """
+
+
+class OutOfOrderTxnStateError(ValidationError):
+    """
+    Error referenced event missing from log so can't verify this txn state event
+    Usage:
+        raise OutOfOrderTxnStateError("error message")
+    """
+

--- a/src/keri/vdr/registering.py
+++ b/src/keri/vdr/registering.py
@@ -40,7 +40,7 @@ class RegistryInceptDoer(doing.DoDoer):
                 msg = self.msgs.popleft()
                 name = msg["name"]
 
-                reger = viring.Registry(name=self.hab.name, temp=False)
+                reger = viring.Registry(name=self.hab.name, temp=False, db=self.hab.db)
                 self.issuer = issuing.Issuer(hab=self.hab, name=name, reger=reger, noBackers=True, **kwa)
                 self.extend([doing.doify(self.escrowDo), doing.doify(self.issuerDo)])
                 yield self.tock

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -5,6 +5,8 @@ tests.app.agenting module
 """
 
 from hio.base import doing
+
+from keri.core import coring
 from keri.help import nowIso8601
 from keri.app import habbing, indirecting, agenting
 from keri.core.eventing import SealSource
@@ -70,9 +72,8 @@ def test_witness_sender(mockGetWitnessByPrefix):
         for name in ["wes", "wil", "wan"]:
             reger = viring.Registry(name=name)
             raw = reger.getTvt(dbing.dgKey(serder.preb, serder.digb))
-            assert raw is None
-            # found = coring.Serder(raw=bytes(raw))
-            # assert serder.pre == found.pre
+            found = coring.Serder(raw=bytes(raw))
+            assert serder.pre == found.pre
 
 
 def test_witness_inquisitor(mockGetWitnessByPrefix, mockHelpingNowUTC):

--- a/tests/db/test_escrowing.py
+++ b/tests/db/test_escrowing.py
@@ -1,0 +1,145 @@
+from keri import kering
+from keri.app import keeping, habbing
+from keri.core import coring, eventing
+from keri.db import escrowing, dbing, subing, basing
+from keri.help import helping
+
+
+def test_broker():
+    with dbing.openLMDB() as db:
+        bork = escrowing.Broker(db=db, subkey="test")
+
+        assert isinstance(bork.escrowdb, subing.CesrIoSetSuber)
+        assert isinstance(bork.daterdb, subing.CesrSuber)
+        assert isinstance(bork.serderdb, subing.SerderSuber)
+        assert isinstance(bork.tigerdb, subing.CesrIoSetSuber)
+        assert isinstance(bork.cigardb, subing.CatCesrIoSetSuber)
+        assert isinstance(bork.escrowdb, subing.CesrIoSetSuber)
+        assert isinstance(bork.saiderdb, subing.CesrSuber)
+
+
+def test_broker_nontrans():
+    raw = b'\x05\xaa\x8f-S\x9a\xe9\xfaU\x9c\x02\x9c\x9b\x08Hu'
+    salter = coring.Salter(raw=raw)
+    salt = salter.qb64
+    assert salt == '0ABaqPLVOa6fpVnAKcmwhIdQ'
+
+    with dbing.openLMDB() as db, \
+            basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS:
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        bork = escrowing.Broker(db=db, subkey="test")
+
+        dts = helping.nowIso8601()
+        typ = "test"
+        ked = {'v': 'KERI10JSON0001fb_', 't': 'rpy', 'd': 'E--rpyw2A5OATjluDezNIcgeMvLTSYALvMqVKnop-lJo',
+               'dt': dts,
+               'r': '/tsn/credential/Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI',
+               'a': {'v': 'KERI10JSON000135_', 'i': 'EZc4FuRsgMJ3nagRMmz7kSCsh2VCHj9yI0fpaUOZf3Zs', 's': '0',
+                     'd': 'EG6VAER9fTbirNC313PrMVdlJeaFjia4xBxYvhfmTQIw',
+                     'ri': 'ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc', 'ra': {},
+                     'a': {'s': 2, 'd': 'ElcdRh_66cR79tYDs7Q2OjjOjiAf_SZp6lWERgG1aSs8'},
+                     'dt': dts, 'et': 'iss'}}
+        pre = "EZc4FuRsgMJ3nagRMmz7kSCsh2VCHj9yI0fpaUOZf3Zs"
+        aid = "EwWY7LU2xwp0d4IhCvz1etbuv2iwcgBEigKJWnd-0Whs"
+        serder = coring.Serder(ked=ked)
+        tserder = coring.Serder(ked=ked["a"])
+        saider, _ = coring.Saider.saidify(sad=ked, kind=coring.Serials.json, label=coring.Ids.d)
+        dater = coring.Dater(dts=dts)
+
+        cigars = wesHab.mgr.sign(ser=serder.raw,
+                                 verfers=wesHab.kever.verfers,
+                                 indexed=False)
+
+        bork.escrowStateNotice(typ=typ,
+                               pre=saider.qb64,
+                               aid=aid,
+                               serder=serder,
+                               saider=saider,
+                               dater=dater,
+                               cigars=cigars
+                               )
+
+        assert [s.qb64 for s in bork.escrowdb.get(keys=("test", saider.qb64, aid))] == [saider.qb64]
+        assert [c.qb64 for (v, c) in bork.cigardb.get(keys=(saider.qb64,))] == [c.qb64 for c in cigars]
+        assert bork.daterdb.get(keys=(saider.qb64,)).raw == dater.raw
+        assert bork.serderdb.get(keys=(saider.qb64,)).raw == serder.raw
+
+        def process(**kwargs):
+            assert kwargs["route"] == ked["r"]
+            assert [c.qb64 for c in kwargs["cigars"]] == [c.qb64 for c in cigars]
+            assert kwargs["tsgs"] == []
+            assert kwargs["aid"] == aid
+            tser = coring.Serder(ked=kwargs["serder"].ked["a"])
+            bork.updateState(aid=aid, serder=tser, saider=kwargs["saider"], dater=dater)
+
+        bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
+
+        assert bork.escrowdb.get(keys=("test", saider.qb64, aid)) == []
+        assert bork.serderdb.get(keys=(saider.qb64,)).raw == tserder.raw
+        assert bork.saiderdb.get(keys=(pre, aid)).qb64 == saider.qb64
+
+
+def test_broker_trans():
+    with dbing.openLMDB() as db, \
+            basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS:
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[], temp=True)
+
+        bork = escrowing.Broker(db=db, subkey="test")
+        dts = helping.nowIso8601()
+        typ = "test"
+        ked = {'v': 'KERI10JSON0001fb_', 't': 'rpy', 'd': 'E--rpyw2A5OATjluDezNIcgeMvLTSYALvMqVKnop-lJo',
+               'dt': dts,
+               'r': '/tsn/credential/Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI',
+               'a': {'v': 'KERI10JSON000135_', 'i': 'EZc4FuRsgMJ3nagRMmz7kSCsh2VCHj9yI0fpaUOZf3Zs', 's': '0',
+                     'd': 'EG6VAER9fTbirNC313PrMVdlJeaFjia4xBxYvhfmTQIw',
+                     'ri': 'ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc', 'ra': {},
+                     'a': {'s': 2, 'd': 'ElcdRh_66cR79tYDs7Q2OjjOjiAf_SZp6lWERgG1aSs8'},
+                     'dt': dts, 'et': 'iss'}}
+        pre = "EZc4FuRsgMJ3nagRMmz7kSCsh2VCHj9yI0fpaUOZf3Zs"
+        aid = "EwWY7LU2xwp0d4IhCvz1etbuv2iwcgBEigKJWnd-0Whs"
+        serder = coring.Serder(ked=ked)
+        tserder = coring.Serder(ked=ked["a"])
+        saider, _ = coring.Saider.saidify(sad=ked, kind=coring.Serials.json, label=coring.Ids.d)
+        dater = coring.Dater(dts=dts)
+
+        sigers = bobHab.mgr.sign(ser=serder.raw,
+                                 verfers=bobHab.kever.verfers,
+                                 indexed=True,
+                                 indices=None)
+
+        tsgs = [(bobHab.kever.prefixer, coring.Seqner(sn=bobHab.kever.lastEst.s),
+                coring.Diger(qb64=bobHab.kever.lastEst.d), sigers)]
+        bork.escrowStateNotice(typ=typ,
+                               pre=saider.qb64,
+                               aid=aid,
+                               serder=serder,
+                               saider=saider,
+                               dater=dater,
+                               tsgs=tsgs
+                               )
+
+        assert [s.qb64 for s in bork.escrowdb.get(keys=("test", saider.qb64, aid))] == [saider.qb64]
+        quadkeys = (saider.qb64, bobHab.kever.prefixer.qb64, f"{bobHab.kever.lastEst.s:032x}", bobHab.kever.lastEst.d)
+        assert [s.qb64 for s in bork.tigerdb.get(keys=quadkeys)] == [s.qb64 for s in sigers]
+        assert bork.daterdb.get(keys=(saider.qb64,)).raw == dater.raw
+        assert bork.serderdb.get(keys=(saider.qb64,)).raw == serder.raw
+
+        def process(**kwargs):
+            assert kwargs["route"] == ked["r"]
+            assert len(kwargs["tsgs"]) == 1
+            (prefixer, seqner, diger, sigs) = kwargs["tsgs"][0]
+            assert [s.qb64 for s in sigs] == [s.qb64 for s in sigers]
+            assert kwargs["cigars"] == []
+            assert kwargs["aid"] == aid
+            tser = coring.Serder(ked=kwargs["serder"].ked["a"])
+            bork.updateState(aid=aid, serder=tser, saider=kwargs["saider"], dater=dater)
+
+        bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
+
+        assert bork.escrowdb.get(keys=("test", saider.qb64, aid)) == []
+        assert bork.serderdb.get(keys=(saider.qb64,)).raw == tserder.raw
+        assert bork.saiderdb.get(keys=(pre, aid)).qb64 == saider.qb64

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -14,7 +14,7 @@ from keri.db.dbing import snKey, dgKey
 from keri.kering import Version, EmptyMaterialError, DerivationError, MissingAnchorError, ValidationError, \
     MissingWitnessSignatureError, LikelyDuplicitousError
 from keri.vdr import eventing, viring
-from keri.vdr.eventing import rotate, issue, revoke, backerIssue, backerRevoke, Tever, Tevery, VcStates
+from keri.vdr.eventing import rotate, issue, revoke, backerIssue, backerRevoke, Tever, Tevery
 from keri.vdr.viring import nsKey
 
 
@@ -694,10 +694,9 @@ def test_tevery():
         diger = rotser.diger
 
         tvy.processEvent(serder=iss, seqner=seqner, diger=diger)
-        status, lastSeen = tev.vcState(vcdig)
-        assert status == VcStates.issued
-        assert lastSeen is not None
-        assert tev.vcSn(vcdig) == 0
+        status = tev.vcState(vcdig.decode("utf-8"))
+        assert status.ked['et'] == Ilks.iss
+        assert status.sn == 0
 
         # revoke the vc
         rev = eventing.revoke(vcdig=vcdig.decode("utf-8"), regk=regk, dig=iss.dig)
@@ -710,10 +709,9 @@ def test_tevery():
         diger = rotser.diger
 
         tvy.processEvent(serder=rev, seqner=seqner, diger=diger)
-        status, lastSeen = tev.vcState(vcdig)
-        assert status == VcStates.revoked
-        assert lastSeen is not None
-        assert tev.vcSn(vcdig) == 1
+        status = tev.vcState(vcdig.decode("utf-8"))
+        assert status.ked["et"] == Ilks.rev
+        assert status.sn == 1
 
 
 def test_tevery_process_escrow():

--- a/tests/vdr/test_issuing.py
+++ b/tests/vdr/test_issuing.py
@@ -37,6 +37,7 @@ def test_issuer(mockHelpingNowUTC):
         assert ser.diger.qb64 == 'EvpB-_BWD7tOhLI0cDyEQbziBt6IMyQnkrh0booR4vhg'
 
         res = issuer.rotate(adds=["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU"])
+        tsn = issuer.tevers[issuer.regk].state()
         assert res is True
         kevt, tevt = events(issuer)
         assert kevt == (
@@ -70,6 +71,8 @@ def test_issuer(mockHelpingNowUTC):
                         b'ZY_6m5mL9DkqKYnUvnyLufx-iLQMZhgfnAQ')
         ser = Serder(raw=tevt)
         assert ser.diger.qb64 == 'ENNTabgWbaNqOKLqEZdQCjxbafwwSoXNzAsE1Enq-kdk'
+
+        tsn = issuer.tevers[issuer.regk].vcState(vcpre=ser.pre)
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -1,0 +1,456 @@
+from keri.app import habbing, keeping
+from keri.core import routing, parsing, coring
+from keri.core.eventing import Kevery
+
+from keri.db import basing
+from keri.vc import proving
+from keri.vdr import viring, issuing, eventing
+
+
+def test_tsn_message_out_of_order(mockHelpingNowUTC):
+    # Bob is the controller
+    # Bam is verifying the key state for Bob with a stale key state in the way
+    with basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+            basing.openDB(name="bam") as bamDB:
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[], temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        reger = viring.Registry(name=bobHab.name, temp=True)
+        issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
+
+        assert issuer.regk == "ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc"
+
+        # Gather up Bob's key event log
+        msgs = bytearray()
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        # pass key event log to Bam
+        bamRtr = routing.Router()
+        bamRvy = routing.Revery(db=bamDB, rtr=bamRtr)
+        bamKvy = Kevery(db=bamDB, lax=False, local=False, rvy=bamRvy)
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
+
+        tever = issuer.tevers[issuer.regk]
+        tsn = tever.state()
+
+        assert tsn.raw == ((b'{"v":"KERI10JSON000158_","i":"ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc",'
+                            b'"s":"0","d":"EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M","ii":"Eta8KLf1zrE'
+                            b'5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI","dt":"2021-01-01T00:00:00.000000+00:00","'
+                            b'et":"vcp","a":{"s":1,"d":"EbFIqGFsIJnlkf6h9AT_AU_Uyiqtko__BEkxP_n2IvXk"},"bt'
+                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}'))
+
+        rpy = bobHab.reply(route="/tsn/registry/" + bobHab.pre, data=tsn.ked)
+
+        bamReger = viring.Registry(name="bam", temp=True)
+        bamTvy = eventing.Tevery(reger=bamReger, db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamTvy.registerReplyRoutes(router=bamRtr)
+        parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
+
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "telquery"
+        assert cue['q']['ri'] == issuer.regk
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, bobHab.pre))
+        assert saider[0].qb64b == b'ENRhplnqsNRO94MRu3mYM3VthB7kmuZGoS5tLvRy-uFI'
+
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        parsing.Parser().parse(ims=tmsgs, tvy=bamTvy, rvy=bamRvy)
+        assert issuer.regk in bamReger.tevers
+
+        bamTvy.processEscrows()
+        # check to make sure the tsn escrow state is clear
+        assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, bobHab.pre)) == []
+        # check to make sure the tsn has been saved
+        saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, bobHab.pre))
+        assert saider.qb64b == b'EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M'
+
+
+def test_tsn_message_missing_anchor(mockHelpingNowUTC):
+    # Bob is the controller
+    # Bam is verifying the key state for Bob with a stale key state in the way
+    with basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+            basing.openDB(name="bam") as bamDB:
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[], temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        reger = viring.Registry(name=bobHab.name, temp=True)
+        issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
+
+        assert issuer.regk == "ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc"
+
+        # pass key event log to Bam
+        bamRtr = routing.Router()
+        bamRvy = routing.Revery(db=bamDB, rtr=bamRtr)
+        bamKvy = Kevery(db=bamDB, lax=False, local=False, rvy=bamRvy)
+
+        tever = issuer.tevers[issuer.regk]
+        tsn = tever.state()
+
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc",'
+                           b'"s":"0","d":"EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M","ii":"Eta8KLf1zrE'
+                           b'5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EbFIqGFsIJnlkf6h9AT_AU_Uyiqtko__BEkxP_n2IvXk"},"bt'
+                           b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
+
+        rpy = bobHab.reply(route="/tsn/registry/" + bobHab.pre, data=tsn.ked)
+
+        bamReger = viring.Registry(name="bam", temp=True)
+        bamTvy = eventing.Tevery(reger=bamReger, db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamTvy.registerReplyRoutes(router=bamRtr)
+        parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("registry-mae", issuer.regk, bobHab.pre))
+        assert saider[0].qb64b == b'ENRhplnqsNRO94MRu3mYM3VthB7kmuZGoS5tLvRy-uFI'
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "query"
+        assert cue['q']['pre'] == bobHab.pre
+
+        # Gather up Bob's key event log
+        msgs = bytearray()
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
+
+        bamTvy.processEscrows()
+
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "telquery"
+        assert cue['q']['ri'] == issuer.regk
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, bobHab.pre))
+        assert saider[0].qb64b == b'ENRhplnqsNRO94MRu3mYM3VthB7kmuZGoS5tLvRy-uFI'
+
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        parsing.Parser().parse(ims=tmsgs, tvy=bamTvy, rvy=bamRvy)
+        assert issuer.regk in bamReger.tevers
+
+        bamTvy.processEscrows()
+
+        # check to make sure the tsn escrow state is clear
+        assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, bobHab.pre)) == []
+        # check to make sure the tsn has been saved
+        saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, bobHab.pre))
+        assert saider.qb64b == b'EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M'
+
+
+def test_tsn_from_witness(mockHelpingNowUTC):
+    # Bob is the controller
+    # Wes is his witness
+    # Bam is verifying the key state for Bob from Wes
+    raw = b'\x05\xaa\x8f-S\x9a\xe9\xfaU\x9c\x02\x9c\x9b\x08Hu'
+    salter = coring.Salter(raw=raw)
+    salt = salter.qb64
+    assert salt == '0ABaqPLVOa6fpVnAKcmwhIdQ'
+
+    with basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS, \
+            basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+            basing.openDB(name="bam") as bamDB:
+
+        # setup Wes's habitat nontrans
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[wesHab.pre], temp=True)
+        assert bobHab.pre == "E4BsxCYUtUx3d6UkDVIQ9Ke3CLQfqWBfICSmjIzkS1u4"
+
+        reger = viring.Registry(name=bobHab.name, temp=True)
+        issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
+
+        assert issuer.regk == "EBBbecdi5jrcJR-R0bgwhHCtcj-WBbqvaXyKJbZaeKsY"
+
+        # Create Bob's icp, pass to Wes.
+        wesKvy = Kevery(db=wesDB, lax=False, local=False)
+
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)
+            iserder = coring.Serder(raw=bytearray(msg))
+            wesHab.receipt(serder=iserder)
+
+        assert bobHab.pre in wesHab.kevers
+
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        wesReger = viring.Registry(name="wes", temp=True)
+        wesRtr = routing.Router()
+        wesRvy = routing.Revery(db=bamDB, rtr=wesRtr)
+        wesTvy = eventing.Tevery(reger=wesReger, db=wesDB, lax=False, local=False, rvy=wesRvy)
+        wesTvy.registerReplyRoutes(router=wesRtr)
+        parsing.Parser().parse(ims=bytearray(tmsgs), tvy=wesTvy, rvy=wesRvy)
+
+        assert issuer.regk in wesReger.tevers
+
+        tever = wesReger.tevers[issuer.regk]
+        tsn = tever.state()
+
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"EBBbecdi5jrcJR-R0bgwhHCtcj-WBbqvaXyKJbZaeKsY",'
+                           b'"s":"0","d":"EKpzPCVpoHZQliTIvZhLaJKn5-6fbN0wJ_y7jKfsJ2ac","ii":"E4BsxCYUtUx'
+                           b'3d6UkDVIQ9Ke3CLQfqWBfICSmjIzkS1u4","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"Eo4BSkczfAJtaVXOde_n0OtRfEJn6llRMW2GONnafkvM"},"bt'
+                           b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
+
+        rpy = wesHab.reply(route="/tsn/registry/" + wesHab.pre, data=tsn.ked)
+
+        bamRtr = routing.Router()
+        bamRvy = routing.Revery(db=bamDB, rtr=bamRtr)
+        bamKvy = Kevery(db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamReger = viring.Registry(name="bam", temp=True)
+        bamTvy = eventing.Tevery(reger=bamReger, db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamTvy.registerReplyRoutes(router=bamRtr)
+        parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("registry-mae", issuer.regk, wesHab.pre))
+        assert saider[0].qb64b == b'Ehcsr9i4WlTUy1mp-HU_Fqrrkyj61MYR2UfyZI0c6syI'
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "query"
+        assert cue['q']['pre'] == bobHab.pre
+
+        wesIcp = wesHab.makeOwnEvent(sn=0)
+        parsing.Parser().parse(ims=bytearray(wesIcp), kvy=bamKvy)
+        assert wesHab.pre in bamDB.kevers
+
+        msgs = bytearray()
+        for msg in wesDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
+        assert bobHab.pre in bamDB.kevers
+
+        bamTvy.processEscrows()
+
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "telquery"
+        assert cue['q']['ri'] == issuer.regk
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, wesHab.pre))
+        assert saider[0].qb64b == b'Ehcsr9i4WlTUy1mp-HU_Fqrrkyj61MYR2UfyZI0c6syI'
+
+        parsing.Parser().parse(ims=bytearray(tmsgs), tvy=bamTvy, rvy=bamRvy)
+
+        assert issuer.regk in bamReger.tevers
+
+        bamTvy.processEscrows()
+
+        # check to make sure the tsn escrow state is clear
+        assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, wesHab.pre)) == []
+        # check to make sure the tsn has been saved
+        saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, wesHab.pre))
+        assert saider.qb64b == b'EKpzPCVpoHZQliTIvZhLaJKn5-6fbN0wJ_y7jKfsJ2ac'
+
+
+def test_tsn_from_no_one(mockHelpingNowUTC):
+    # Bob is the controller
+    # Bam is verifying the key state for Bob from Wes
+    # Wes is no one
+    raw = b'\x05\xaa\x8f-S\x9a\xe9\xfaU\x9c\x02\x9c\x9b\x08Hu'
+    salter = coring.Salter(raw=raw)
+    salt = salter.qb64
+    assert salt == '0ABaqPLVOa6fpVnAKcmwhIdQ'
+
+    with basing.openDB(name="wes") as wesDB, keeping.openKS(name="wes") as wesKS, \
+            basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+            basing.openDB(name="bam") as bamDB:
+
+        # setup Wes's habitat nontrans
+        wesHab = habbing.Habitat(name='wes', ks=wesKS, db=wesDB,
+                                 isith=1, icount=1,
+                                 salt=salt, transferable=False, temp=True)
+
+        assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[], temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        reger = viring.Registry(name=bobHab.name, temp=True)
+        issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
+
+        assert issuer.regk == "ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc"
+
+        # Create Bob's icp, pass to Wes.
+        wesKvy = Kevery(db=wesDB, lax=False, local=False)
+
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)
+
+        assert bobHab.pre in wesHab.kevers
+
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        wesReger = viring.Registry(name="wes", temp=True)
+        wesRtr = routing.Router()
+        wesRvy = routing.Revery(db=bamDB, rtr=wesRtr)
+        wesTvy = eventing.Tevery(reger=wesReger, db=wesDB, lax=False, local=False, rvy=wesRvy)
+        wesTvy.registerReplyRoutes(router=wesRtr)
+        parsing.Parser().parse(ims=bytearray(tmsgs), tvy=wesTvy, rvy=wesRvy)
+
+        assert issuer.regk in wesReger.tevers
+
+        tever = wesReger.tevers[issuer.regk]
+        tsn = tever.state()
+
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc",'
+                           b'"s":"0","d":"EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M","ii":"Eta8KLf1zrE'
+                           b'5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EbFIqGFsIJnlkf6h9AT_AU_Uyiqtko__BEkxP_n2IvXk"},"bt'
+                           b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
+
+        rpy = wesHab.reply(route="/tsn/registry/" + wesHab.pre, data=tsn.ked)
+
+        bamRtr = routing.Router()
+        bamRvy = routing.Revery(db=bamDB, rtr=bamRtr)
+        bamKvy = Kevery(db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamReger = viring.Registry(name="bam", temp=True)
+        bamTvy = eventing.Tevery(reger=bamReger, db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamTvy.registerReplyRoutes(router=bamRtr)
+
+        msgs = bytearray()
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
+        assert bobHab.pre in bamDB.kevers
+
+        # Parse TSN from someone who is not authorized to provide it
+        parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
+
+        # Assert that the TSN did not end up in escrow or the database
+        assert bamReger.txnsb.escrowdb.get(keys=("registry-mae", issuer.regk, wesHab.pre)) == []
+        assert bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, wesHab.pre)) == []
+        assert bamReger.txnsb.saiderdb.get(keys=(issuer.regk, wesHab.pre)) is None
+
+        assert len(bamTvy.cues) == 0
+
+
+def test_credential_tsn_message(mockHelpingNowUTC):
+    # Bob is the controller
+    # Bam is verifying the key state for Bob with a stale key state in the way
+    with basing.openDB(name="bob") as bobDB, keeping.openKS(name="bob") as bobKS, \
+            basing.openDB(name="bam") as bamDB:
+
+        bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1, transferable=True,
+                                 wits=[], temp=True)
+        assert bobHab.pre == "Eta8KLf1zrE5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI"
+
+        reger = viring.Registry(name=bobHab.name, temp=True)
+        issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
+
+        assert issuer.regk == "ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc"
+        assert len(issuer.cues) == 2
+
+        # pass key event log to Bam
+        bamRtr = routing.Router()
+        bamRvy = routing.Revery(db=bamDB, rtr=bamRtr)
+        bamKvy = Kevery(db=bamDB, lax=False, local=False, rvy=bamRvy)
+
+        credSubject = dict(
+            d="",
+            i="EJJR2nmwyYAfSVPzhzS6b5CMZAoTNZH3ULvaU6Z-i0d8",
+            LEI="254900OPPU84GM83MG36",
+        )
+
+        creder = proving.credential(issuer=bobHab.pre,
+                                    schema="E7brwlefuH-F_KU_FPWAZR78A3pmSVDlnfJUqnm8Lhr4",
+                                    subject=credSubject,
+                                    status=issuer.regk)
+        issuer.issue(creder=creder)
+        assert len(issuer.cues) == 4
+
+        tever = issuer.tevers[issuer.regk]
+        tsn = tever.state()
+
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc",'
+                           b'"s":"0","d":"EE5c5Cr5u4xU8lfTWLwYtd5R_8kcB64uoMqG5F_jND6M","ii":"Eta8KLf1zrE'
+                           b'5n-HZpgRAnDmxLASZdXEiU9u6aahqR8TI","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EbFIqGFsIJnlkf6h9AT_AU_Uyiqtko__BEkxP_n2IvXk"},"bt'
+                           b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
+
+        ctsn = tever.vcState(vcpre=creder.said)
+        assert ctsn.raw == (
+            b'{"v":"KERI10JSON000135_","i":"EZc4FuRsgMJ3nagRMmz7kSCsh2VCHj9yI0fpaUOZf3Zs","s":"0",'
+            b'"d":"EG6VAER9fTbirNC313PrMVdlJeaFjia4xBxYvhfmTQIw","ri":"ECWWojIv_2OqlFL7BSwkyd69_vWKYaTUU5jUhxhXvjmc",'
+            b'"ra":{},"a":{"s":2,"d":"ElcdRh_66cR79tYDs7Q2OjjOjiAf_SZp6lWERgG1aSs8"},'
+            b'"dt":"2021-01-01T00:00:00.000000+00:00","et":"iss"}')
+
+        rpy = bobHab.reply(route="/tsn/credential/" + bobHab.pre, data=ctsn.ked)
+
+        bamReger = viring.Registry(name="bam", temp=True)
+        bamTvy = eventing.Tevery(reger=bamReger, db=bamDB, lax=False, local=False, rvy=bamRvy)
+        bamTvy.registerReplyRoutes(router=bamRtr)
+        parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("credential-mre", creder.said, bobHab.pre))
+        assert saider[0].qb64b == b'E--rpyw2A5OATjluDezNIcgeMvLTSYALvMqVKnop-lJo'
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "telquery"
+        assert cue['q']['ri'] == issuer.regk
+
+        # Gather up Bob's key event log
+        msgs = bytearray()
+        for msg in bobDB.clonePreIter(pre=bobHab.pre, fn=0):
+            msgs.extend(msg)
+
+        parsing.Parser().parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
+
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        parsing.Parser().parse(ims=tmsgs, tvy=bamTvy, rvy=bamRvy)
+        assert issuer.regk in bamReger.tevers
+
+        bamTvy.processEscrows()
+
+        assert len(bamTvy.cues) == 1
+        cue = bamTvy.cues.popleft()
+        assert cue["kin"] == "telquery"
+        assert cue['q']['ri'] == issuer.regk
+
+        saider = bamReger.txnsb.escrowdb.get(keys=("credential-ooo", creder.said, bobHab.pre))
+        assert saider[0].qb64b == b'E--rpyw2A5OATjluDezNIcgeMvLTSYALvMqVKnop-lJo'
+
+        vci = viring.nsKey([issuer.regk, creder.said])
+        tmsgs = bytearray()
+        cloner = reger.clonePreIter(pre=vci, fn=0)  # create iterator at 0
+        for msg in cloner:
+            tmsgs.extend(msg)
+
+        parsing.Parser().parse(ims=tmsgs, tvy=bamTvy, rvy=bamRvy)
+
+        bamTvy.processEscrows()
+
+        # check to make sure the tsn escrow state is clear
+        assert bamReger.txnsb.escrowdb.get(keys=(creder.said, bobHab.pre)) == []
+        # check to make sure the tsn has been saved
+        saider = bamReger.txnsb.saiderdb.get(keys=(creder.said, bobHab.pre))
+        assert saider.qb64b == b'EG6VAER9fTbirNC313PrMVdlJeaFjia4xBxYvhfmTQIw'

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -262,9 +262,8 @@ def test_verifier_multisig():
         assert kever.sn == 2
 
         issuer.processEscrows()
-        status, lastSeen = issuer.tvy.tevers[issuer.regk].vcState(creder.said)
-        assert status == eventing.VcStates.issued
-        assert lastSeen is not None
+        status = issuer.tvy.tevers[issuer.regk].vcState(creder.said)
+        assert status.ked["et"] == coring.Ilks.iss
 
         gkev = hab1.kevers[gid]
         sigers = []


### PR DESCRIPTION
Included in this PR: 

* TSN as reply support in Tevery.

* Revery for processing reply messages that uses a Router for routing to other handlers for the specific content of the data block.

* Broker class to maintain escrows and release from escrows when appropriate conditions are met.

* Added kli vc commands for query and revoke credential and fixed the vc issue command.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>