### PR TITLE
CESR Proof Signatures

### DIFF
--- a/scripts/demo/demo-script.sh
+++ b/scripts/demo/demo-script.sh
@@ -1,5 +1,3 @@
-start-demo.sh
-
 # GETTING STARTED
 rm -rf /usr/local/var/keri/*;
 
@@ -20,6 +18,8 @@ kli interact --name trans --data @./tests/app/cli/anchor.json
 
 kli rotate --name trans --next-count 3 --sith 2
 
+kli rotate --name trans --next-count 3 --sith 2
+
 kli sign --name trans --text @tests/app/cli/anchor.json
 
 kli verify --name trans --prefix Ep_l4FJyHxcZBc6JIP7sG3YKBfuMaLJe9dktrz1wX9x4 --text @tests/app/cli/anchor.json --signature AAr6xD1YJW4fFJkoHU7JhtnixOjE8ubouxzUdoe1Hmc4GKnu7KoeZN1s4BD9ctaQVmyxTq0QszqZSzdJAQhDBACw
@@ -28,6 +28,7 @@ kli verify --name trans --prefix Ep_l4FJyHxcZBc6JIP7sG3YKBfuMaLJe9dktrz1wX9x4 --
 
 kli verify --name trans --prefix Ep_l4FJyHxcZBc6JIP7sG3YKBfuMaLJe9dktrz1wX9x4 --text @tests/app/cli/anchor.json --signature ACSHdal6kHAAjbW_frH83sDDCoBHw_nNKFysW5Dj8PSsnwVPePCNw-kFmF6Z8H87q7D3abw_5u2i4jmzdnWFsRDQ
 
+kli verify --name trans --prefix Ep_l4FJyHxcZBc6JIP7sG3YKBfuMaLJe9dktrz1wX9x4 --text @tests/app/cli/anchor.json --signature ACSHdal6kHAAjbW_frH83sDDCoBHw_nNKFysW5Dj8PSsnwVPePCNw-kFmF6Z8H87q7D3abw_5u2i4jmzdnWFsRDz
 
 # ESTABLISHMENT ONLY
 kli incept --name est-only --file tests/app/cli/estonly-sample.json
@@ -36,6 +37,8 @@ kli interact --name est-only --data @./tests/app/cli/anchor.json
 
 kli rotate --name est-only
 
+kli rotate --name est-only --data @./tests/app/cli/anchor.json
+
 # WITNESSES
 kli witness start --name non-trans --http 5631 --tcp 5632
 
@@ -43,7 +46,9 @@ kli witness demo
 
 kli incept --name trans-wits --file ./tests/app/cli/trans-wits-sample.json
 
-kli query --name trans --prefix Ezgv-1LmULy9ghlCP5Wt9mrQY-jJ-tQHcZZ9SteV7Hqo --witness BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw
+kli incept --name inquisitor --file ./tests/app/cli/inquisitor-sample.json
+
+kli query --name inquisitor --prefix Ezgv-1LmULy9ghlCP5Wt9mrQY-jJ-tQHcZZ9SteV7Hqo --witness BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw
 
 kli rotate --name trans-wits --witness-cut Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c
 
@@ -54,13 +59,19 @@ kli incept --name reg --file ./tests/app/cli/holder-sample.json
 
 kli vc registry incept --name reg --registry-name reg
 
+kli vc issue --name reg --registry-name reg --schema ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo --recipient Ezgv-1LmULy9ghlCP5Wt9mrQY-jJ-tQHcZZ9SteV7Hqo --data @../../test/gleif-vc.json
+
+kli vc query --name inquisitor --witness BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo --registry=E_kLIm0UdZUYFWKDEiSxP1Yvt3A3TUoo6TMaijR3voz0 --vc EoRRdOHzYDU0_fYE07MTYF3dPKMH00BJHYJUuKFhLRa0
+
+kli vc revoke --name reg --registry-name reg --said EoRRdOHzYDU0_fYE07MTYF3dPKMH00BJHYJUuKFhLRa0
+
 # DELEGATION
 
 scripts/demo/start-agent.sh
 
 kli delegate incept --name del --file tests/app/cli/commands/delegate/incept-sample.json
 
-kli rotate --name del
+kli delegate rotate --name del
 
 #MULTISIG
 

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -13,7 +13,7 @@ from hio.base import doing
 from hio.core import http
 from hio.core.tcp import clienting
 from hio.help import decking
-from keri.app import forwarding
+from keri.app import forwarding, signing
 from keri.vdr import viring
 from orderedset import OrderedSet as oset
 
@@ -676,7 +676,7 @@ class KiwiServer(doing.DoDoer):
 
                 if cueKin == "saved":
                     creder = cue["creder"]
-                    proof = cue["proof"]
+                    craw = cue["msg"]
 
                     print("Credential: {}, Schema: {},  Saved".format(creder.said, creder.schema))
                     print(creder.pretty())
@@ -699,7 +699,6 @@ class KiwiServer(doing.DoDoer):
                             msgs.extend(msg)
 
 
-                        craw = viring.messagize(creder, proof)
                         vcs = [handling.envelope(msg=craw)]
 
                         sources = self.verifier.reger.sources(self.hab.db, creder)
@@ -713,6 +712,7 @@ class KiwiServer(doing.DoDoer):
 
                         self.postman.send(recipient=recpt, topic="credential", msg=msgs)
                         exn = exchanging.exchange(route="/credential/issue", payload=pl)
+                        #  TODO:  Respondant must accept transposable signatures to add to the endorsed message
                         self.rep.reps.append(dict(dest=recpt, rep=exn, topic="credential"))
 
                 elif cueKin == "query":
@@ -888,8 +888,10 @@ class KiwiServer(doing.DoDoer):
         except kering.MissingAnchorError:
             logger.info("Missing anchor from credential issuance due to multisig identifier")
 
-        craw = self.hab.endorse(creder)
-        proving.parseCredential(ims=craw, verifier=self.verifier)
+        print()
+        print(creder.raw)
+        craw = signing.ratify(hab=self.hab, serder=creder)
+        parsing.Parser().parse(ims=craw, vry=self.verifier)
 
         if notify and group:
             for aid in group.aids:
@@ -1173,7 +1175,7 @@ class KiwiServer(doing.DoDoer):
             pre = group.gid
 
         saids = issuer.reger.issus.get(keys=pre)
-        creds = self.verifier.reger.get_credentials(saids)
+        creds = self.verifier.reger.cloneCreds(saids)
 
         rep.status = falcon.HTTP_200
         rep.content_type = "application/json"
@@ -1197,7 +1199,7 @@ class KiwiServer(doing.DoDoer):
             pre = group.gid
 
         saids = self.verifier.reger.subjs.get(keys=pre)
-        creds = self.verifier.reger.get_credentials(saids)
+        creds = self.verifier.reger.cloneCreds(saids)
 
         rep.status = falcon.HTTP_200
         rep.content_type = "application/json"

--- a/src/keri/app/cli/commands/agent/start.py
+++ b/src/keri/app/cli/commands/agent/start.py
@@ -19,6 +19,7 @@ from keri import help
 from keri import kering
 from keri.app import directing, agenting, indirecting, storing, grouping, forwarding
 from keri.app.cli.common import existing
+from keri.core import parsing
 from keri.help import helping
 from keri.peer import exchanging
 from keri.vc import walleting, handling, proving
@@ -204,14 +205,14 @@ class AdminProofHandler(doing.DoDoer):
                 self.ims.extend(msgs)
                 yield
 
-                creder = proving.Credentialer(crd=vc)
+                creder = proving.Credentialer(ked=vc)
 
                 # Remove credential from database so we revalidate it fully
                 self.verifier.reger.saved.rem(creder.said)
 
                 msg = bytearray(creder.raw)
                 msg.extend(vcproof)
-                proving.parseCredential(ims=msg, verifier=self.verifier)
+                parsing.Parser().parse(ims=msg, vry=self.verifier)
 
                 c = self.verifier.reger.saved.get(creder.said)
                 while c is None:
@@ -247,7 +248,7 @@ class AdminProofHandler(doing.DoDoer):
                     self.parsed.append((creder, vcproof))
 
                 else:
-                    creders = self.verifier.reger.get_credentials([creder.saider])
+                    creders = self.verifier.reger.cloneCreds([creder.saider])
                     cred = creders[0]
 
                     ser = exchanging.exchange(route="/cmd/presentation/proof", payload=cred)

--- a/src/keri/app/cli/commands/delegate/rotate.py
+++ b/src/keri/app/cli/commands/delegate/rotate.py
@@ -115,7 +115,7 @@ class DelegateRotateDoer(doing.DoDoer):
         delPre = self.data[0]["i"]
         delK = self.hab.kevers[delPre]
 
-        verfers, digers, cst, nst = self.hab.interact(pre=delK.prefixer.qb64, temp=False)
+        verfers, digers, cst, nst = self.hab.mgr.rotate(pre=delK.prefixer.qb64, temp=False)
         rotSrdr = eventing.deltate(pre=delK.prefixer.qb64,
                                    keys=[verfer.qb64 for verfer in verfers],
                                    dig=delK.serder.saider.qb64,

--- a/src/keri/app/cli/commands/query.py
+++ b/src/keri/app/cli/commands/query.py
@@ -39,7 +39,7 @@ class QueryDoer(doing.DoDoer):
         self.cues = help.decking.Deck()
 
         self.mbd = indirecting.MailboxDirector(hab=self.hab, topics=["/replay", "/receipt"])
-        self.witq = agenting.WitnessInquisitor(hab=self.hab)
+        self.witq = agenting.WitnessInquisitor(hab=self.hab, wits=[self.wit])
         doers.extend([self.mbd, self.witq, doing.doify(self.cueDo)])
 
         self.toRemove = list(doers)

--- a/src/keri/app/cli/commands/vc/issue.py
+++ b/src/keri/app/cli/commands/vc/issue.py
@@ -20,8 +20,6 @@ parser.add_argument('--registry-name', '-r', help='Human readable name for regis
                     default=None)
 parser.add_argument('--schema', '-s', help='qb64 SAID of Schema to issue',
                     default=None, required=True)
-parser.add_argument('--type', '-t', help='Human readable type name of credential to issue',
-                    default=None, required=True)
 parser.add_argument('--source', '-c', help='AC/DC Source links',
                     default=None)
 parser.add_argument('--recipient', '-R', help='qb64 identifier prefix of the recipient of the credential',
@@ -45,7 +43,7 @@ def issueCredential(args):
 
 
     issueDoer = CredentialIssuer(name=name, registryName=args.registry_name, schema=args.schema, source=args.source,
-                                 recipient=args.recipient, typ=args.type, data=data)
+                                 recipient=args.recipient, data=data)
 
     doers = [issueDoer]
     directing.runController(doers=doers, expire=0.0)
@@ -57,7 +55,7 @@ class CredentialIssuer(doing.DoDoer):
 
     """
 
-    def __init__(self, name, registryName, schema, source, recipient, typ, data):
+    def __init__(self, name, registryName, schema, source, recipient, data):
         """
 
         Parameters:
@@ -66,7 +64,6 @@ class CredentialIssuer(doing.DoDoer):
              schema:
              source:
              recipient:
-             typ: (str) human readable credential type name
              data: (dict) credential data dict
         """
         self.name = name
@@ -77,7 +74,6 @@ class CredentialIssuer(doing.DoDoer):
             schema=schema,
             source=source,
             recipient=recipient,
-            typ=typ,
             data=data
         )
 

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -782,7 +782,7 @@ class MultisigEventHandler(doing.Doer):
                 parsing.Parser().parse(bytearray(evt), kvy=self.kvy)
                 if reason is not None:
                     craw = reason.encode("utf-8")
-                    proving.parseCredential(ims=craw, verifier=self.verifier)
+                    parsing.Parser().parse(ims=craw, vry=self.verifier)
 
                 yield
 

--- a/src/keri/app/signing.py
+++ b/src/keri/app/signing.py
@@ -1,0 +1,123 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.app.signing module
+
+"""
+from keri.core import coring, eventing
+
+
+
+def ratify(hab, serder, paths=None, pipelined=False):
+    """ Sign the SAD or SAIDs with the keys from the Habitat.
+
+    Sign the SADs or SAIDs of the SADs as identified by the paths.  If paths is
+    None, default to signing the root SAD only.
+
+    Parameters:
+        hab (Habitat): environment used to sign the SAD
+        serder (Union[Serder,Credentialer]): the self addressing data (SAD)
+        paths (list): list of paths specified as arrays of path components
+        pipelined (bool): True means prepend pipelining count code to attachemnts
+            False means to not prepend pipelining count code
+
+    Returns:
+        str: serialized SAD with qb64 CESR Proof Signature attachments
+
+    """
+    paths = [[]] if paths is None else paths
+    sadsigers, sadcigars = signPaths(hab=hab, serder=serder, paths=paths)
+    return provision(serder, sadsigers=sadsigers, sadcigars=sadcigars, pipelined=pipelined)
+
+
+def provision(serder, *, sadsigers=None, sadcigars=None, pipelined=False):
+    """
+    Attaches indexed signatures from sigers and/or cigars and/or wigers to
+    KERI message data from serder
+    Parameters:
+        serder (Union[Serder,Credentialer]): instance containing the event
+        sadsigers (list): of Siger instances (optional) to create indexed signatures
+        sadcigars (list): optional list of Cigars instances of non-transferable non indexed
+            signatures from  which to form receipt couples.
+            Each cigar.vefer.qb64 is pre of receiptor and cigar.qb64 is signature
+        pipelined (bool): True means prepend pipelining count code to attachemnts
+            False means to not prepend pipelining count code
+
+    Returns: bytearray SAD with CESR Proof Signature
+
+    """
+    msg = bytearray(serder.raw)  # make copy into new bytearray so can be deleted
+    if not (sadsigers or sadcigars):
+        raise ValueError("Missing attached signatures on message = {}."
+                         "".format(serder.ked))
+
+    msg.extend(eventing.proofize(sadsigers=sadsigers, sadcigars=sadcigars, pipelined=pipelined))
+    return msg
+
+
+def signPaths(hab, serder, paths):
+    """ Sign the SAD or SAIDs with the keys from the Habitat.
+
+    Sign the SADs or SAIDs of the SADs as identified by the paths.
+
+    Parameters:
+        hab (Habitat): environment used to sign the SAD
+        serder (Union[Serder,Credentialer]): the self addressing data (SAD)
+        paths (list): list of paths specified as arrays of path components
+
+    Returns:
+        str: qb64 signature attachment
+
+    """
+
+    sadsigers = []
+    sadcigars = []
+
+    if hab.kever.prefixer.transferable:
+        prefixer, seqner, saider, indices = transSeal(hab)
+        for path in paths:
+            pather = coring.Pather(path=path)
+            data = pather.rawify(serder=serder)
+
+            sigers = hab.mgr.sign(ser=data,
+                                  verfers=hab.kever.verfers,
+                                  indexed=True,
+                                  indices=indices)
+            sadsigers.append((pather, prefixer, seqner, saider, sigers))
+
+    else:
+        for path in paths:
+            pather = coring.Pather(path=path)
+            data = pather.rawify(serder=serder)
+            cigars = hab.mgr.sign(ser=data,
+                                  verfers=hab.kever.verfers,
+                                  indexed=False)
+            sadcigars.append((pather, cigars))
+
+    return sadsigers, sadcigars
+
+
+def transSeal(hab):
+    """ Returns seal components and signing indices as appropriate for current state of Habitat
+
+    Args:
+        hab (Habitat): environment that contains the information for the idenfitier prefix
+
+    Returns:
+       tuple:  seal components with signing indices
+    """
+    # create SealEvent or SealLast for endorser's est evt whose keys are
+    # used to sign
+    group = hab.db.gids.get(hab.pre)  # is it a group ID
+    if group is None:  # not a group use own kever
+        kever = hab.kever
+        indices = None  # use default order
+    else:  # group so use gid kever
+        kever = hab.kevers[group.gid]
+        indices = [group.aids.index(group.lid)]  # use group order*
+
+    prefixer = kever.prefixer
+    seqner = coring.Seqner(sn=kever.lastEst.s)
+    saider = coring.Saider(qb64=kever.lastEst.d)
+
+    return prefixer, seqner, saider, indices

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass, astuple
 from .. import kering
 from .. import help
 from .coring import (Ilks, CtrDex, Counter, Seqner, Siger, Cigar, Dater, Verfer,
-                     Diger, Prefixer, Serder, Saider, )
-
+                     Prefixer, Serder, Saider, Pather, sniff, Idents, Sadder)
+from ..vc.proving import Credentialer
 
 logger = help.ogler.getLogger()
 
@@ -90,7 +90,7 @@ class Parser:
 
     """
 
-    def __init__(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None):
+    def __init__(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None, vry=None):
         """
         Initialize instance:
 
@@ -104,6 +104,7 @@ class Parser:
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger): route EXN message types to this instance
             rvy (Revery): reply (RPY) message handler
+            vry (Verfifier): credential verifier with wallet storage
         """
         self.ims = ims if ims is not None else bytearray()
         self.framed = True if framed else False  # extract until end-of-stream
@@ -112,6 +113,7 @@ class Parser:
         self.tvy = tvy
         self.exc = exc
         self.rvy = rvy
+        self.vry = vry
 
     @staticmethod
     def sniff(ims):
@@ -181,7 +183,7 @@ class Parser:
 
         Usage:
 
-        instance = self._extractGen
+        instance = self._extractor
         """
         while True:
             try:
@@ -196,8 +198,117 @@ class Parser:
                     raise  # bad pipelined frame so abort by raising error
                 yield
 
+    def _sadPathSigGroup(self, ctr, ims, root=None, cold=Colds.txt, pipelined=False):
+        """
 
-    def parse(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
+        Args:
+            ctr:
+            ims:
+            root:
+            cold:
+            pipelined:
+
+        Returns:
+
+        """
+        if ctr.code != CtrDex.SadPathSig:
+            raise kering.UnexpectedCountCodeError("Wrong "
+                                                  "count code={}.Expected code={}."
+                                                  "".format(ctr.code, CtrDex.ControllerIdxSigs))
+
+        subpath = yield from self._extractor(ims,
+                                             klas=Pather,
+                                             cold=cold,
+                                             abort=pipelined)
+        if root is not None:
+            subpath = subpath.root(root=root)
+
+        sctr = yield from self._extractor(ims=ims,
+                                          klas=Counter,
+                                          cold=cold,
+                                          abort=pipelined)
+        if sctr.code == CtrDex.TransIdxSigGroups:
+            for prefixer, seqner, saider, isigers in self._transIdxSigGroups(sctr, ims, cold=cold, pipelined=pipelined):
+                yield sctr.code, (subpath, prefixer, seqner, saider, isigers)
+        elif sctr.code == CtrDex.NonTransReceiptCouples:
+            for cigar in self._nonTransReceiptCouples(ctr=sctr, ims=ims, cold=cold, pipelined=pipelined):
+                yield sctr.code, (subpath, cigar)
+        else:
+            raise kering.UnexpectedCountCodeError("Wrong "
+                                                  "count code={}.Expected code={}."
+                                                  "".format(ctr.code, CtrDex.ControllerIdxSigs))
+
+
+
+    def _transIdxSigGroups(self, ctr, ims, cold=Colds.txt, pipelined=False):
+        """
+
+        Parameters:
+            ctr:
+            ims:
+            cold:
+            pipelined:
+
+        Yields:
+
+        """
+        for i in range(ctr.count):  # extract each attached groups
+            prefixer = yield from self._extractor(ims,
+                                                  klas=Prefixer,
+                                                  cold=cold,
+                                                  abort=pipelined)
+            seqner = yield from self._extractor(ims,
+                                                klas=Seqner,
+                                                cold=cold,
+                                                abort=pipelined)
+            saider = yield from self._extractor(ims,
+                                                klas=Saider,
+                                                cold=cold,
+                                                abort=pipelined)
+            ictr = ctr = yield from self._extractor(ims=ims,
+                                                    klas=Counter,
+                                                    cold=cold,
+                                                    abort=pipelined)
+            if ctr.code != CtrDex.ControllerIdxSigs:
+                raise kering.UnexpectedCountCodeError("Wrong "
+                                                      "count code={}.Expected code={}."
+                                                      "".format(ictr.code, CtrDex.ControllerIdxSigs))
+            isigers = []
+            for i in range(ictr.count): # extract each attached signature
+                isiger = yield from self._extractor(ims=ims,
+                                                    klas=Siger,
+                                                    cold=cold,
+                                                    abort=pipelined)
+                isigers.append(isiger)
+
+            yield prefixer, seqner, saider, isigers
+
+    def _nonTransReceiptCouples(self, ctr, ims, cold=Colds.txt, pipelined=False):
+        """
+
+        Parameters:
+            ctr:
+            ims:
+            cold:
+            pipelined:
+
+        Yields:
+
+        """
+        for i in range(ctr.count):  # extract each attached couple
+            verfer = yield from self._extractor(ims=ims,
+                                                klas=Verfer,
+                                                cold=cold,
+                                                abort=pipelined)
+            cigar = yield from self._extractor(ims=ims,
+                                               klas=Cigar,
+                                               cold=cold,
+                                               abort=pipelined)
+            cigar.verfer = verfer
+
+            yield cigar
+
+    def parse(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None, vry=None):
         """
         Processes all messages from incoming message stream, ims,
         when provided. Otherwise process messages from .ims
@@ -213,12 +324,13 @@ class Parser:
                 counted attachments instead of stream with multiple messages
 
             pipeline is Boolean, True means use pipeline processor to process
-                ims msgs when stream includes pipelined count codes.
+                ims msgs when stream incpyludes pipelined count codes.
 
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
             rvy (Revery): reply (RPY) message handler
+            vry (Verfifier): credential verifier with wallet storage
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -230,7 +342,8 @@ class Parser:
                                     kvy=kvy,
                                     tvy=tvy,
                                     exc=exc,
-                                    rvy=rvy)
+                                    rvy=rvy,
+                                    vry=vry)
 
         while True:
             try:
@@ -280,7 +393,7 @@ class Parser:
                 break
 
 
-    def allParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
+    def allParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None, vry=None):
         """
         Returns generator to parse all messages from incoming message stream,
         ims until ims is exhausted (empty) then returns.
@@ -301,6 +414,8 @@ class Parser:
             kvy (Kevery): route KERI KEL message types to this instance
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
+            rvy (Revery): reply (RPY) message handler
+            vry (Verfifier): credential verifier with wallet storage
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -327,7 +442,8 @@ class Parser:
                                                    kvy=kvy,
                                                    tvy=tvy,
                                                    exc=exc,
-                                                   rvy=rvy)
+                                                   rvy=rvy,
+                                                   vry=vry)
 
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -355,7 +471,7 @@ class Parser:
         return True
 
 
-    def onceParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None):
+    def onceParsator(self, ims=None, framed=None, pipeline=None, kvy=None, tvy=None, exc=None, rvy=None, vry=None):
         """
         Returns generator to parse one message from incoming message stream, ims.
         If ims not provided parse messages from .ims
@@ -375,6 +491,7 @@ class Parser:
             tvy (Tevery): route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
             rvy (Revery): reply (RPY) message handler
+            vry (Verfifier): credential verifier with wallet storage
 
         New Logic:
             Attachments must all have counters so know if txt or bny format for
@@ -392,6 +509,7 @@ class Parser:
         tvy = tvy if tvy is not None else self.tvy
         exc = exc if exc is not None else self.exc
         rvy = rvy if rvy is not None else self.rvy
+        vry = vry if vry is not None else self.vry
 
         done = False
         while not done:
@@ -402,7 +520,8 @@ class Parser:
                                                    kvy=kvy,
                                                    tvy=tvy,
                                                    exc=exc,
-                                                   rvy=rvy)
+                                                   rvy=rvy,
+                                                   vry=vry)
 
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -510,7 +629,7 @@ class Parser:
         return True  # should never return
 
 
-    def msgParsator(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None):
+    def msgParsator(self, ims=None, framed=True, pipeline=False, kvy=None, tvy=None, exc=None, rvy=None, vry=None):
         """
         Returns generator that upon each iteration extracts and parses msg
         with attached crypto material (signature etc) from incoming message
@@ -536,6 +655,7 @@ class Parser:
             tvy (Tevery) route TEL message types to this instance
             exc (Exchanger) route EXN message types to this instance
             rvy (Revery): reply (RPY) message handler
+            vry (Verifier) ACDC credential processor
 
         Logic:
             Currently only support couters on attachments not on combined or
@@ -566,13 +686,13 @@ class Parser:
             raise kering.ColdStartError("Expecting message counter tritet={}"
                                         "".format(cold))
         # Otherwise its a message cold start
-        while True:# extract and deserialize message from ims
+        while True:  # extract and deserialize message from ims
             try:
-                serder = Serder(raw=ims)
+                sadder = Sadder(raw=ims)
             except kering.ShortageError as ex:  # need more bytes
                 yield
             else:  # extracted successfully
-                del ims[:serder.size]  # strip off event from front of ims
+                del ims[:sadder.size]  # strip off event from front of ims
                 break
 
         sigers = []  # list of Siger instances of attached indexed controller signatures
@@ -588,6 +708,8 @@ class Parser:
         frcs = []  # each converted couple is (seqner, dater)
         # List of tuples from extracted source seal couples (delegator or issuer)
         sscs = []  # each converted couple is (seqner, diger) for delegating/issuing event
+        sadsigs = []  # TODO: add comment
+        sadcigs = []  # TODO: add comment
         pipelined = False  # all attachments in one big pipeline counted group
         # extract and deserialize attachments
         try:  # catch errors here to flush only counted part of stream
@@ -609,7 +731,7 @@ class Parser:
                     ims = pims  # now just process substream as one counted frame
 
                     if pipeline:
-                        pass  #  pass extracted ims to pipeline processor
+                        pass  # pass extracted ims to pipeline processor
                         return
 
                     ctr = yield from self._extractor(ims=ims,
@@ -639,17 +761,7 @@ class Parser:
                         # extract attached rct couplets into list of sigvers
                         # verfer property of cigar is the identifier prefix
                         # cigar itself has the attached signature
-
-                        for i in range(ctr.count): # extract each attached couple
-                            verfer = yield from self._extractor(ims=ims,
-                                                                klas=Verfer,
-                                                                cold=cold,
-                                                                abort=pipelined)
-                            cigar = yield from self._extractor(ims=ims,
-                                                               klas=Cigar,
-                                                               cold=cold,
-                                                               abort=pipelined)
-                            cigar.verfer = verfer
+                        for cigar in self._nonTransReceiptCouples(ctr=ctr, ims=ims, cold=cold, pipelined=pipelined):
                             cigars.append(cigar)
 
                     elif ctr.code == CtrDex.TransReceiptQuadruples:
@@ -686,34 +798,8 @@ class Parser:
                         # dig is dig of signer's est event when signed
                         # followed by counter for ControllerIdxSigs with attached
                         # indexed sigs from trans signer (endorser).
-                        for i in range(ctr.count):  # extract each attached groups
-                            prefixer = yield from self._extractor(ims,
-                                                                  klas=Prefixer,
-                                                                  cold=cold,
-                                                                  abort=pipelined)
-                            seqner = yield from self._extractor(ims,
-                                                                klas=Seqner,
-                                                                cold=cold,
-                                                                abort=pipelined)
-                            saider = yield from self._extractor(ims,
-                                                                klas=Saider,
-                                                                cold=cold,
-                                                                abort=pipelined)
-                            ictr = ctr = yield from self._extractor(ims=ims,
-                                                                    klas=Counter,
-                                                                    cold=cold,
-                                                                    abort=pipelined)
-                            if ctr.code != CtrDex.ControllerIdxSigs:
-                                raise kering.UnexpectedCountCodeError("Wrong "
-                                    "count code={}.Expected code={}."
-                                    "".format(ictr.code, CtrDex.ControllerIdxSigs))
-                            isigers = []
-                            for i in range(ictr.count): # extract each attached signature
-                                isiger = yield from self._extractor(ims=ims,
-                                                                    klas=Siger,
-                                                                    cold=cold,
-                                                                    abort=pipelined)
-                                isigers.append(isiger)
+                        for (prefixer, seqner, saider, isigers) in self._transIdxSigGroups(ctr, ims, cold=cold,
+                                                                                           pipelined=pipelined):
                             tsgs.append((prefixer, seqner, saider, isigers))
 
                     elif ctr.code == CtrDex.TransLastIdxSigGroups:
@@ -765,20 +851,50 @@ class Parser:
                         # snu+dig
                         # snu is sequence number  of event
                         # dig is digest of event
-                        for i in range(ctr.count): # extract each attached quadruple
-                            seqner = yield from  self._extractor(ims,
-                                                                 klas=Seqner,
-                                                                 cold=cold,
-                                                                 abort=pipelined)
-                            saider = yield from  self._extractor(ims,
-                                                                 klas=Saider,
-                                                                 cold=cold,
-                                                                 abort=pipelined)
+                        for i in range(ctr.count):  # extract each attached quadruple
+                            seqner = yield from self._extractor(ims,
+                                                                klas=Seqner,
+                                                                cold=cold,
+                                                                abort=pipelined)
+                            saider = yield from self._extractor(ims,
+                                                                klas=Saider,
+                                                                cold=cold,
+                                                                abort=pipelined)
                             sscs.append((seqner, saider))
+
+                    elif ctr.code == CtrDex.SadPathSigGroup:
+                        path = yield from self._extractor(ims,
+                                                          klas=Pather,
+                                                          cold=cold,
+                                                          abort=pipelined)
+                        for i in range(ctr.count):
+                            ictr = yield from self._extractor(ims=ims,
+                                                              klas=Counter,
+                                                              cold=cold,
+                                                              abort=pipelined)
+                            for code, sigs in self._sadPathSigGroup(ctr=ictr,
+                                                                    ims=ims,
+                                                                    root=path,
+                                                                    cold=cold,
+                                                                    pipelined=pipelined):
+                                if code == CtrDex.TransIdxSigGroups:
+                                    sadsigs.append(sigs)
+                                else:
+                                    sadcigs.append(sigs)
+
+                    elif ctr.code == CtrDex.SadPathSig:
+                        for code, sigs in self._sadPathSigGroup(ctr=ctr,
+                                                                ims=ims,
+                                                                cold=cold,
+                                                                pipelined=pipelined):
+                            if code == CtrDex.TransIdxSigGroups:
+                                sadsigs.append(sigs)
+                            else:
+                                sadcigs.append(sigs)
 
                     else:
                         raise kering.UnexpectedCountCodeError("Unsupported count"
-                                                    " code={}.".format(ctr.code))
+                                                              " code={}.".format(ctr.code))
 
                     if pipelined:  # process to end of stream (group)
                         if not ims:  # end of pipelined group frame
@@ -802,139 +918,169 @@ class Parser:
 
                     ctr = yield from self._extractor(ims=ims, klas=Counter, cold=cold)
 
-        except kering.ExtractionError as ex:
+        except kering.ExtractionError:
             if pipelined:  # extracted pipelined group is preflushed
                 raise kering.SizedGroupError("Error processing pipelined size"
-                                "attachment group of size={}.".format(pags))
+                                             "attachment group of size={}.".format(pags))
             raise  # no pipeline group so can't preflush, must flush stream
 
-        ilk = serder.ked["t"]  # dispatch abased on ilk
-        if ilk in [Ilks.icp, Ilks.rot, Ilks.ixn, Ilks.dip, Ilks.drt]:  # event msg
-            firner, dater = frcs[-1] if frcs else (None, None)  # use last one if more than one
-            seqner, saider = sscs[-1] if sscs else (None, None)  # use last one if more than one
-            if not sigers:
-                raise kering.ValidationError("Missing attached signature(s) for evt "
-                                      "= {}.".format(serder.ked))
-            try:
-                kvy.processEvent(serder=serder,
-                                 sigers=sigers,
-                                 wigers=wigers,
-                                 seqner=seqner,
-                                 saider=saider,
-                                 firner=firner,
-                                 dater=dater)
+        if sadder.ident == Idents.keri:
+            serder = Serder(sad=sadder)
 
-                if cigars:
-                    kvy.processReceiptCouples(serder, cigars, firner=firner)
-                if trqs:
-                    kvy.processReceiptQuadruples(serder, trqs, firner=firner)
+            ilk = serder.ked["t"]  # dispatch abased on ilk
 
-            except AttributeError as e:
-                raise kering.ValidationError("No kevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty()))
-
-        elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
-            if not (cigars or wigers or tsgs):
-                raise kering.ValidationError("Missing attached signatures on receipt"
-                                      "msg = {}.".format(serder.ked))
-            try:
-                if cigars:
-                    kvy.processReceipt(serder=serder, cigars=cigars)
-
-                if wigers:
-                    kvy.processReceiptWitness(serder=serder, wigers=wigers)
-
-                if tsgs:
-                    kvy.processReceiptTrans(serder=serder, tsgs=tsgs)
-
-            except AttributeError:
-                raise kering.ValidationError("No kevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty()))
-
-        elif ilk in (Ilks.rpy, ):  # reply message
-            if not (cigars or tsgs):
-                raise kering.ValidationError("Missing attached endorser signature(s) "
-                       "to reply msg = {}.".format(serder.pretty()))
-
-            try:
-                if cigars:  # process separately so do not clash on errors
-                    rvy.processReply(serder, cigars=cigars)  # nontrans
-
-                if tsgs:  # process separately so do not clash on errors
-                    rvy.processReply(serder, tsgs=tsgs)  #  trans
-
-            except AttributeError as e:
-                raise kering.ValidationError("No kevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty()))
-
-
-        elif ilk in (Ilks.qry, ):  # query message
-            args = dict(serder=serder)
-            if ssgs:
-                pre, sigers = ssgs[-1] if ssgs else (None, None)  # use last one if more than one
-                args["source"] = pre.qb64
-                args["sigers"] = sigers
-
-            elif cigars:
-                args["cigars"] = cigars
-
-            else:
-                raise kering.ValidationError("Missing attached requester signature(s) "
-                                             "to key log query msg = {}.".format(serder.pretty()))
-
-            route = serder.ked["r"]
-            if route in ["logs", "ksn"]:
+            if ilk in [Ilks.icp, Ilks.rot, Ilks.ixn, Ilks.dip, Ilks.drt]:  # event msg
+                firner, dater = frcs[-1] if frcs else (None, None)  # use last one if more than one
+                seqner, saider = sscs[-1] if sscs else (None, None)  # use last one if more than one
+                if not sigers:
+                    raise kering.ValidationError("Missing attached signature(s) for evt "
+                                                 "= {}.".format(serder.ked))
                 try:
-                    kvy.processQuery(**args)
+                    kvy.processEvent(serder=serder,
+                                     sigers=sigers,
+                                     wigers=wigers,
+                                     seqner=seqner,
+                                     saider=saider,
+                                     firner=firner,
+                                     dater=dater)
+
+                    if cigars:
+                        kvy.processReceiptCouples(serder, cigars, firner=firner)
+                    if trqs:
+                        kvy.processReceiptQuadruples(serder, trqs, firner=firner)
+
+                except AttributeError as e:
+                    raise kering.ValidationError("No kevery to process so dropped msg"
+                                          "= {}.".format(serder.pretty()))
+
+            elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
+                if not (cigars or wigers or tsgs):
+                    raise kering.ValidationError("Missing attached signatures on receipt"
+                                          "msg = {}.".format(serder.ked))
+                try:
+                    if cigars:
+                        kvy.processReceipt(serder=serder, cigars=cigars)
+
+                    if wigers:
+                        kvy.processReceiptWitness(serder=serder, wigers=wigers)
+
+                    if tsgs:
+                        kvy.processReceiptTrans(serder=serder, tsgs=tsgs)
+
                 except AttributeError:
                     raise kering.ValidationError("No kevery to process so dropped msg"
+                                          "= {}.".format(serder.pretty()))
+
+            elif ilk in (Ilks.rpy, ):  # reply message
+                if not (cigars or tsgs):
+                    raise kering.ValidationError("Missing attached endorser signature(s) "
+                           "to reply msg = {}.".format(serder.pretty()))
+
+                try:
+                    if cigars:  # process separately so do not clash on errors
+                        rvy.processReply(serder, cigars=cigars)  # nontrans
+
+                    if tsgs:  # process separately so do not clash on errors
+                        rvy.processReply(serder, tsgs=tsgs)  #  trans
+
+                except AttributeError as e:
+                    raise kering.ValidationError("No kevery to process so dropped msg"
+                                          "= {}.".format(serder.pretty()))
+
+
+            elif ilk in (Ilks.qry, ):  # query message
+                args = dict(serder=serder)
+                if ssgs:
+                    pre, sigers = ssgs[-1] if ssgs else (None, None)  # use last one if more than one
+                    args["source"] = pre.qb64
+                    args["sigers"] = sigers
+
+                elif cigars:
+                    args["cigars"] = cigars
+
+                else:
+                    raise kering.ValidationError("Missing attached requester signature(s) "
+                                                 "to key log query msg = {}.".format(serder.pretty()))
+
+                route = serder.ked["r"]
+                if route in ["logs", "ksn"]:
+                    try:
+                        kvy.processQuery(**args)
+                    except AttributeError:
+                        raise kering.ValidationError("No kevery to process so dropped msg"
+                                                     "= {}.".format(serder.pretty()))
+
+                elif route in ["tels", "tsn"]:
+                    try:
+                        tvy.processQuery(**args)
+                    except AttributeError as e:
+                        raise kering.ValidationError("No tevery to process so dropped msg"
+                                                     "= {} from {}.".format(serder.pretty(), e))
+
+                else:
+                    raise kering.ValidationError("Invalid resource type {} so dropped msg"
+                                                 "= {}.".format(route, serder.pretty()))
+
+            elif ilk in (Ilks.exn, ):
+                args = dict(serder=serder)
+                if ssgs:
+                    pre, sigers = ssgs[-1] if ssgs else (None, None)  # use last one if more than one
+                    args["source"] = pre
+                    args["sigers"] = sigers
+
+                elif cigars:
+                    args["cigars"] = cigars
+
+                else:
+                    raise kering.ValidationError("Missing attached exchanger signature(s) "
+                                                 "to peer exchange msg = {}.".format(serder.pretty()))
+                if sadsigs:
+                    args["sadsigs"] = sadsigs
+
+                if sadcigs:
+                    args["sadcigs"] = sadcigs
+
+                try:
+                    exc.processEvent(**args)
+
+                except AttributeError as e:
+                    raise kering.ValidationError("No Exchange to process so dropped msg"
                                                  "= {}.".format(serder.pretty()))
 
-            elif route in ["tels", "tsn"]:
+
+            elif ilk in (Ilks.vcp, Ilks.vrt, Ilks.iss, Ilks.rev, Ilks.bis, Ilks.brv):
+                # TEL msg
+                seqner, saider = sscs[-1] if sscs else (None, None)  # use last one if more than one
                 try:
-                    tvy.processQuery(**args)
-                except AttributeError as e:
+                    tvy.processEvent(serder=serder, seqner=seqner, saider=saider, wigers=wigers)
+
+                except AttributeError:
                     raise kering.ValidationError("No tevery to process so dropped msg"
-                                                 "= {} from {}.".format(serder.pretty(), e))
-
+                                                 "= {}.".format(serder.pretty()))
             else:
-                raise kering.ValidationError("Invalid resource type {} so dropped msg"
-                                             "= {}.".format(route, serder.pretty()))
+                raise kering.ValidationError("Unexpected message ilk = {} for evt ="
+                                             " {}.".format(ilk, serder.pretty()))
 
-        elif ilk in (Ilks.exn, ):
-            args = dict(serder=serder)
-            if ssgs:
-                pre, sigers = ssgs[-1] if ssgs else (None, None)  # use last one if more than one
-                args["source"] = pre
-                args["sigers"] = sigers
+        elif sadder.ident == Idents.acdc:
+            creder = Credentialer(sad=sadder)
+            args = dict(creder=creder)
 
-            elif cigars:
-                args["cigars"] = cigars
+            if sadsigs:
+                args["sadsigers"] = sadsigs
 
-            else:
-                raise kering.ValidationError("Missing attached exchanger signature(s) "
-                                             "to peer exchange msg = {}.".format(serder.pretty()))
+            if sadcigs:
+                args["sadcigars"] = sadcigs
+
 
             try:
-                exc.processEvent(**args)
-
-            except AttributeError as e:
-                raise kering.ValidationError("No Exchange to process so dropped msg"
-                                             "= {}.".format(serder.pretty()))
-
-
-        elif ilk in (Ilks.vcp, Ilks.vrt, Ilks.iss, Ilks.rev, Ilks.bis, Ilks.brv):
-            # TEL msg
-            seqner, saider = sscs[-1] if sscs else (None, None)  # use last one if more than one
-            try:
-                tvy.processEvent(serder=serder, seqner=seqner, saider=saider, wigers=wigers)
-
-            except AttributeError:
-                raise kering.ValidationError("No tevery to process so dropped msg"
-                                      "= {}.".format(serder.pretty()))
+                vry.processCredential(**args)
+            except Exception as e:
+                print(e)
+                raise kering.ValidationError("No verifier to process so dropped credential"
+                                             "= {}.".format(creder.pretty()))
 
         else:
-            raise kering.ValidationError("Unexpected message ilk = {} for evt ="
-                                  " {}.".format(ilk, serder.pretty()))
+            raise kering.ValidationError("Unexpected message ident = {} for evt ="
+                                         " {}.".format(serder.ident, serder.pretty()))
 
         return True  # done state

--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -86,7 +86,29 @@ jsonSchemaCache = CacheResolver(cache={
                                                     b'Credential","description":"A vLEI Role Credential issued by a '
                                                     b'Qualified vLEI issuer to official representatives of a Legal '
                                                     b'Entity",'
-                                                    b'"credentialType":"LegalEntityOfficialOrganizationalRolevLEICredential","properties":{"v":{"type":"string"},"d":{"type":"string"},"i":{"type":"string"},"s":{"description":"schema SAID","type":"string"},"a":{"description":"data block","properties":{"d":{"type":"string"},"i":{"type":"string"},"dt":{"description":"issuance date time","format":"date-time","type":"string"},"ri":{"description":"credential status registry","type":"string"},"LEI":{"type":"string"},"personLegalName":{"type":"string"},"officialRole":{"type":"string"}},"additionalProperties":false,"required":["i","dt","ri","LEI","personLegalName","officialRole"],"type":"object"},"p":{"contains":{"type":"object"},"description":"source block","items":{"properties":{"legalEntityvLEICredential":{"description":"chain to issuer credential","properties":{"d":{"type":"string"},"i":{"type":"string"}},"additionalProperties":false,"type":"object"}},"additionalProperties":false,"required":["legalEntityvLEICredential"],"type":"object"},"maxItems":1,"minItems":1,"type":"array"},"r":{"contains":{"type":"object"},"description":"rules block","type":"array"}},"additionalProperties":false,"required":["i","s","d","r"],"type":"object"}',
+                                                    b'"credentialType":"LegalEntityOfficialOrganizationalRolevLEICreden'
+                                                    b'tial","properties":{"v":{"type":"string"},'
+                                                    b'"d":{"type":"string"},"i":{"type":"string"},'
+                                                    b'"s":{"description":"schema SAID","type":"string"},'
+                                                    b'"a":{"description":"data block","properties":{"d":{'
+                                                    b'"type":"string"},"i":{"type":"string"},'
+                                                    b'"dt":{"description":"issuance date time","format":"date-time",'
+                                                    b'"type":"string"},"ri":{"description":"credential status '
+                                                    b'registry","type":"string"},"LEI":{"type":"string"},'
+                                                    b'"personLegalName":{"type":"string"},"officialRole":{'
+                                                    b'"type":"string"}},"additionalProperties":false,"required":["i",'
+                                                    b'"dt","ri","LEI","personLegalName","officialRole"],'
+                                                    b'"type":"object"},"p":{"contains":{"type":"object"},'
+                                                    b'"description":"source block","items":{"properties":{'
+                                                    b'"legalEntityvLEICredential":{"description":"chain to issuer '
+                                                    b'credential","properties":{"d":{"type":"string"},'
+                                                    b'"i":{"type":"string"}},"additionalProperties":false,'
+                                                    b'"type":"object"}},"additionalProperties":false,"required":['
+                                                    b'"legalEntityvLEICredential"],"type":"object"},"maxItems":1,'
+                                                    b'"minItems":1,"type":"array"},"r":{"contains":{"type":"object"},'
+                                                    b'"description":"rules block","type":"array"}},'
+                                                    b'"additionalProperties":false,"required":["i","s","d","r"],'
+                                                    b'"type":"object"}',
     "EYKd_PUuCGvoMfTu6X3NZrLKl1LsvFN60M-P23ZTiKQ0": b'{"$id":"EYKd_PUuCGvoMfTu6X3NZrLKl1LsvFN60M-P23ZTiKQ0",'
                                                     b'"$schema":"http://json-schema.org/draft-07/schema#",'
                                                     b'"title":"Legal Entity vLEI Credential","description":"A vLEI '
@@ -117,7 +139,29 @@ jsonSchemaCache = CacheResolver(cache={
                                                     b'"description":"A vLEI Role Credential issued to representatives '
                                                     b'of a Legal Entity in other than official roles but in '
                                                     b'functional or other context of engagement",'
-                                                    b'"credentialType":"LegalEntityEngagementContextRolevLEICredential","properties":{"v":{"type":"string"},"d":{"type":"string"},"i":{"type":"string"},"s":{"description":"schema SAID","type":"string"},"n":{"description":"one time use nonce","type":"string"},"a":{"description":"data block","properties":{"d":{"type":"string"},"i":{"type":"string"},"dt":{"description":"issuance date time","format":"date-time","type":"string"},"ri":{"description":"credential status registry","type":"string"},"LEI":{"type":"string"},"personLegalName":{"type":"string"},"engagementContextRole":{"type":"string"}},"additionalProperties":false,"required":["i","dt","ri","LEI","personLegalName","engagementContextRole"],"type":"object"},"p":{"contains":{"type":"object"},"description":"source block","items":{"properties":{"legalEntityvLEICredential":{"description":"chain to issuer credential","properties":{"d":{"type":"string"},"i":{"type":"string"}},"additionalProperties":false,"type":"object"}},"additionalProperties":false,"required":["legalEntityvLEICredential"],"type":"object"},"maxItems":1,"minItems":1,"type":"array"},"r":{"contains":{"type":"object"},"description":"rules block","type":"array"}},"additionalProperties":false,"required":["v","i","s","d","r","a"],"type":"object"}',
+                                                    b'"credentialType":"LegalEntityEngagementContextRolevLEICredential",'
+                                                    b'"properties":{"v":{"type":"string"},"d":{"type":"string"},'
+                                                    b'"i":{"type":"string"},"s":{"description":"schema SAID",'
+                                                    b'"type":"string"},"n":{"description":"one time use nonce",'
+                                                    b'"type":"string"},"a":{"description":"data block","properties":{'
+                                                    b'"d":{"type":"string"},"i":{"type":"string"},'
+                                                    b'"dt":{"description":"issuance date time","format":"date-time",'
+                                                    b'"type":"string"},"ri":{"description":"credential status '
+                                                    b'registry","type":"string"},"LEI":{"type":"string"},'
+                                                    b'"personLegalName":{"type":"string"},"engagementContextRole":{'
+                                                    b'"type":"string"}},"additionalProperties":false,"required":["i",'
+                                                    b'"dt","ri","LEI","personLegalName","engagementContextRole"],'
+                                                    b'"type":"object"},"p":{"contains":{"type":"object"},'
+                                                    b'"description":"source block","items":{"properties":{'
+                                                    b'"legalEntityvLEICredential":{"description":"chain to issuer '
+                                                    b'credential","properties":{"d":{"type":"string"},'
+                                                    b'"i":{"type":"string"}},"additionalProperties":false,'
+                                                    b'"type":"object"}},"additionalProperties":false,"required":['
+                                                    b'"legalEntityvLEICredential"],"type":"object"},"maxItems":1,'
+                                                    b'"minItems":1,"type":"array"},"r":{"contains":{"type":"object"},'
+                                                    b'"description":"rules block","type":"array"}},'
+                                                    b'"additionalProperties":false,"required":["v","i","s","d","r",'
+                                                    b'"a"],"type":"object"}',
     "EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg": b'{"$id":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg",'
                                                     b'"$schema":"http://json-schema.org/draft-07/schema#",'
                                                     b'"title":"GLEIF vLEI Credential","description":"The vLEI '
@@ -255,12 +299,15 @@ class JSONSchema:
             d = json.loads(raw)
             jsonschema.validate(instance=d, schema=schema, resolver=self.resolver.resolver(scer=raw))
         except jsonschema.exceptions.ValidationError as ex:
+            print(ex)
             logger.error(f'jsonschema.exceptions.ValidationError {ex}')
             return False
         except jsonschema.exceptions.SchemaError as ex:
+            print(ex)
             logger.error(f'jsonschema.exceptions.SchemaError {ex}')
             return False
         except json.decoder.JSONDecodeError as ex:
+            print(ex)
             logger.error(f'json.decoder.JSONDecodeError {ex}')
             return False
         except Exception:

--- a/src/keri/vc/handling.py
+++ b/src/keri/vc/handling.py
@@ -13,8 +13,8 @@ from keri.vdr import issuing, viring
 
 from . import proving
 from .. import help
-from ..app import agenting
-from ..core import scheming
+from ..app import agenting, signing
+from ..core import scheming, parsing
 from ..core.coring import dumps, Deversify
 from ..core.scheming import JSONSchema
 from ..kering import ShortageError
@@ -218,7 +218,7 @@ class ApplyHandler(doing.DoDoer):
                     logger.info("Missing anchor from credential issuance due to multisig identifier")
 
                 craw = self.hab.endorse(creder)
-                proving.parseCredential(ims=craw, verifier=self.verifier)
+                parsing.Parser().parse(ims=craw, vry=self.verifier)
 
                 yield self.tock
 
@@ -330,11 +330,11 @@ class IssueHandler(doing.DoDoer):
                     self.ims.extend(msgs)
                     yield
 
-                    creder = proving.Credentialer(crd=crd)
+                    creder = proving.Credentialer(ked=crd)
 
                     msg = bytearray(creder.raw)
                     msg.extend(proof.encode("utf-8"))
-                    proving.parseCredential(ims=msg, verifier=self.verifier)
+                    parsing.Parser().parse(ims=msg, vry=self.verifier)
 
                     c = self.verifier.reger.saved.get(creder.said)
                     while c is None:
@@ -414,8 +414,8 @@ class RequestHandler(doing.Doer):
 
                 matches = []
                 for descriptor in descriptors:
-                    said = descriptor["x"]
-                    credentials = self.wallet.getCredentials(said)
+                    schema = descriptor["s"]
+                    credentials = self.wallet.getCredentials(schema)
                     if len(credentials) > 0:
                         matches.append(credentials[0])
 
@@ -565,7 +565,7 @@ def presentation_exchange(db, reger, credentials):
     dm = []
     vcs = []
 
-    for idx, (creder, prefixer, seqner, diger, sigers) in enumerate(credentials):
+    for idx, (creder, sadsigers, sadcigars) in enumerate(credentials):
         said = creder.said
         regk = creder.status
         vci = viring.nsKey([regk, said])
@@ -582,13 +582,13 @@ def presentation_exchange(db, reger, credentials):
         for msg in reger.clonePreIter(pre=vci):
             msgs.extend(msg)
 
-        proof = viring.buildProof(prefixer, seqner, diger, sigers)
+        # TODO:  Package credential in presentation exchange, transposing all signatures:
         dm.append(dict(
             id=creder.schema,
             format="cesr",
             path="$.verifiableCredential[{}]".format(idx)
         ))
-        craw = viring.messagize(creder=creder, proof=proof)
+        craw = signing.provision(creder, sadsigers=sadsigers, sadcigars=sadcigars)
         vcs.append(envelope(craw, msgs))
 
         sources = reger.sources(db, creder)

--- a/src/keri/vc/proving.py
+++ b/src/keri/vc/proving.py
@@ -5,7 +5,6 @@ keri.vc.proving module
 """
 
 import json
-import logging
 from collections.abc import Iterable
 from typing import Union
 
@@ -14,11 +13,9 @@ import msgpack
 
 from .. import help, kering
 from ..core import coring
-from ..core.coring import (Serials, sniff, Versify, Deversify, Rever, Counter,
-                           CtrDex, Prefixer, Seqner, Diger, Siger, Saider, Ids)
-from ..core.parsing import Parser, Colds
+from ..core.coring import (Serials, sniff, Versify, Deversify, Rever, Saider, Ids)
 from ..db import subing
-from ..kering import Version, VersionError, ShortageError, DeserializationError, ColdStartError, ExtractionError
+from ..kering import Version, VersionError, ShortageError, DeserializationError
 
 KERI_REGISTRY_TYPE = "KERICredentialRegistry"
 
@@ -43,7 +40,7 @@ def credential(schema,
         kind is serialization kind
 
     """
-    vs = Versify(version=version, kind=kind, size=0)
+    vs = Versify(ident=coring.Idents.acdc, version=version, kind=kind, size=0)
 
     source = source if source is not None else []
 
@@ -65,191 +62,19 @@ def credential(schema,
     _, sad = coring.Saider.saidify(sad=subject, kind=kind, label=coring.Ids.d)
     vc["a"] = sad
 
-    return Credentialer(crd=vc)
+    _, vc = coring.Saider.saidify(sad=vc)
+
+    return Credentialer(ked=vc)
 
 
-def parseCredential(ims, verifier):
-    parsator = allParsator(ims=ims, verifier=verifier)
-
-    while True:
-        try:
-            next(parsator)
-        except StopIteration:
-            break
-
-
-def allParsator(ims, verifier):
-    if not isinstance(ims, bytearray):
-        ims = bytearray(ims)  # so make bytearray copy
-
-    while ims:  # only process until ims empty
-        try:
-            done = yield from credParsator(ims=ims,
-                                           verifier=verifier,
-                                           )
-
-        except kering.SizedGroupError as ex:  # error inside sized group
-            # processOneIter already flushed group so do not flush stream
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Parser msg extraction error: %s\n", ex.args[0])
-            else:
-                logger.error("Parser msg extraction error: %s\n", ex.args[0])
-
-        except (kering.ColdStartError, kering.ExtractionError) as ex:  # some extraction error
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Parser msg extraction error: %s\n", ex.args[0])
-            else:
-                logger.error("Parser msg extraction error: %s\n", ex.args[0])
-            del ims[:]  # delete rest of stream to force cold restart
-
-        except (kering.ValidationError, Exception) as ex:  # non Extraction Error
-            # Non extraction errors happen after successfully extracted from stream
-            # so we don't flush rest of stream just resume
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Parser msg non-extraction error: %s\n", ex)
-            else:
-                logger.error("Parser msg non-extraction error: %s\n", ex)
-        yield
-
-    return True
-
-
-
-def credentialParsator(ims, verifier):
-    if not isinstance(ims, bytearray):
-        ims = bytearray(ims)  # so make bytearray copy
-
-        while True:  # continuous stream processing never stop
-            try:
-                done = yield from credParsator(ims=ims,
-                                               verifier=verifier)
-
-            except kering.SizedGroupError as ex:  # error inside sized group
-                # processOneIter already flushed group so do not flush stream
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s\n", ex.args[0])
-                else:
-                    logger.error("Parser msg extraction error: %s\n", ex.args[0])
-
-            except (kering.ColdStartError, kering.ExtractionError) as ex:  # some extraction error
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s\n", ex.args[0])
-                else:
-                    logger.error("Parser msg extraction error: %s\n", ex.args[0])
-                del ims[:]  # delete rest of stream to force cold restart
-
-            except (kering.ValidationError, Exception) as ex:  # non Extraction Error
-                # Non extraction errors happen after successfully extracted from stream
-                # so we don't flush rest of stream just resume
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg non-extraction error: %s\n", ex.args[0])
-                else:
-                    logger.error("Parser msg non-extraction error: %s\n", ex.args[0])
-            yield
-
-
-
-def credParsator(ims=b'', verifier=None):
-    """
-    Parse the ims bytearray as a CESR Proof Format verifiable credential
-
-    Parameters:
-        ims (bytearray) of serialized incoming verifiable credential in CESR Proof Format.
-        verifier (verifying.Verifier) verifier and storage for the verified credential
-        typ (JSONSchema) class for resolving schema references:
-
-    """
-
-    while not ims:
-        yield
-
-    cold = Parser.sniff(ims)  # check for spurious counters at front of stream
-    if cold in (Colds.txt, Colds.bny):  # not message error out to flush stream
-        # replace with pipelining here once CESR message format supported.
-        raise kering.ColdStartError("Expecting message counter tritet={}"
-                                    "".format(cold))
-
-    while True:  # extract and deserialize message from ims
-        try:
-            creder = Credentialer(raw=ims)
-        except ShortageError as e:
-            raise e
-        else:
-            del ims[:creder.size]
-            break
-
-
-    # extract attachments must start with counter so know if txt or bny.
-    while not ims:
-        yield
-    cold = Parser.sniff(ims)
-    if cold is Colds.msg:
-        raise ColdStartError("unable to parse VC, attachments expected")
-
-    ctr = Parser.extract(ims=ims, klas=Counter, cold=cold)
-    if ctr.code != CtrDex.AttachedMaterialQuadlets:
-        raise ExtractionError("Invalid attachment to VC {}, expected {}"
-                              "".format(ctr.code, CtrDex.AttachedMaterialQuadlets))
-
-    pags = ctr.count * 4
-    if len(ims) != pags:
-        raise ShortageError("VC proof attachment invalid length {}, expected {}"
-                            "".format(len(ims), pags))
-
-    prefixer, seqner, diger, isigers = parseProof(ims=ims)
-
-    try:
-        verifier.processCredential(creder, prefixer, seqner, diger, isigers)
-    except AttributeError as ex:
-        raise kering.ValidationError("No verifier to process so dropped credential"
-                                     "= {}.".format(creder.pretty()))
-
-    return True  # done state
-
-
-def parseProof(ims=b''):
-    cold = Parser.sniff(ims)
-    if cold is Colds.msg:
-        raise ColdStartError("unable to parse VC, attachments expected")
-
-    ctr = Parser.extract(ims=ims, klas=Counter, cold=cold)
-    if ctr.code == CtrDex.AttachedMaterialQuadlets:  # check for pipelined
-        pags = ctr.count * 4
-        if len(ims) != pags:
-            raise ShortageError("VC proof attachment invalid length {}, expected {}"
-                                "".format(len(ims), pags))
-
-        ctr = Parser.extract(ims=ims, klas=Counter, cold=cold)
-
-    if ctr.code != CtrDex.TransIdxSigGroups or ctr.count != 1:
-        raise ExtractionError("Invalid attachment to VC {}, expected one {}"
-                              "".format(ctr.code, CtrDex.TransIdxSigGroups))
-
-    prefixer = Parser.extract(ims=ims, klas=Prefixer)
-    seqner = Parser.extract(ims=ims, klas=Seqner)
-    diger = Parser.extract(ims=ims, klas=Diger)
-
-    ictr = Parser.extract(ims=ims, klas=Counter)
-    if ictr.code != CtrDex.ControllerIdxSigs:
-        raise ExtractionError("Invalid attachment to VC {}, expected {}"
-                              "".format(ctr.code, CtrDex.ControllerIdxSigs))
-
-    isigers = []
-    for i in range(ictr.count):
-        isiger = Parser.extract(ims=ims, klas=Siger)
-        isigers.append(isiger)
-
-    return prefixer, seqner, diger, isigers
-
-
-class Credentialer:
+class Credentialer(coring.Sadder):
     """
     Credentialer is for creating a W3C Verifiable Credential embedded in a CESR Proof Format
     proof
 
     """
 
-    def __init__(self, raw=b'', crd=None, kind=None, code=coring.MtrDex.Blake3_256):
+    def __init__(self, raw=b'', ked=None, kind=None, sad=None, code=coring.MtrDex.Blake3_256):
         """
         Creates a serializer/deserializer for a Verifiable Credential in CESR Proof Format
 
@@ -257,185 +82,42 @@ class Credentialer:
 
         Parameters:
             raw (bytes) is raw credential
-            crd (dict) is populated credential
+            ked (dict) is populated credential
+            sad (Sadder) is clonable base class
             typ is schema type
             version is Version instance
             kind is serialization kind
 
         """
-        self._code = code  # need default code for .diger
+        super(Credentialer, self).__init__(raw=raw, ked=ked, kind=kind, sad=sad, code=code)
 
-        if raw:  # deserialize raw using property setter
-            self.raw = raw  # raw property setter does the deserialization
-        elif crd:  # serialize ked using property setter
-            self._kind = kind
-            self.crd = crd  # ked property setter does the serialization
-        else:
-            raise ValueError("Improper initialization need raw or ked.")
-
-
-    @staticmethod
-    def _inhale(raw):
-        """
-        Parse raw according to serialization type and return dict of values, kind, version and size
-
-        """
-        kind, version, size = sniff(raw)
-        if version != Version:
-            raise VersionError("Unsupported version = {}.{}, expected {}."
-                               "".format(version.major, version.minor, Version))
-        if len(raw) < size:
-            raise ShortageError("Need more bytes.")
-
-        if kind == Serials.json:
-            try:
-                crd = json.loads(raw[:size].decode("utf-8"))
-            except Exception:
-                raise DeserializationError("Error deserializing JSON: {}"
-                                           "".format(raw[:size].decode("utf-8")))
-
-        elif kind == Serials.mgpk:
-            try:
-                crd = msgpack.loads(raw[:size])
-            except Exception:
-                raise DeserializationError("Error deserializing MGPK: {}"
-                                           "".format(raw[:size]))
-
-        elif kind == Serials.cbor:
-            try:
-                crd = cbor.loads(raw[:size])
-            except Exception:
-                raise DeserializationError("Error deserializing CBOR: {}"
-                                           "".format(raw[:size]))
-
-        else:
-            raise DeserializationError("Error deserializing unsupported kind: {}"
-                                       "".format(raw[:size].decode("utf-8")))
-
-        return crd, kind, version, size
-
-    @staticmethod
-    def _exhale(crd, kind=None):
-        """
-        Create serialized format from dict of VC values.  Returns raw, kind, dict of values and version
-
-        """
-
-        knd, version, size = Deversify(crd["v"])  # extract kind and version
-        if version != Version:
-            raise ValueError("Unsupported version = {}.{}".format(version.major,
-                                                                  version.minor))
-
-        crd["d"] = Saider.Dummy * coring.Matter.Sizes[coring.MtrDex.Blake3_256].fs
-
-        if not kind:
-            kind = knd
-
-        if kind not in Serials:
-            raise ValueError("Invalid serialization kind = {}".format(kind))
-
-        raw = coring.dumps(crd, kind)
-        size = len(raw)
-
-        match = Rever.search(raw)
-        if not match or match.start() > 12:
-            raise ValueError("Invalid version string in raw = {}".format(raw))
-
-        fore, back = match.span()
-
-        # update vs with latest kind version size
-        vs = Versify(version=version, kind=kind, size=size)
-        # replace old version string in raw with new one
-        raw = b'%b%b%b' % (raw[:fore], vs.encode("utf-8"), raw[back:])
-        if size != len(raw):  # substitution messed up
-            raise ValueError("Malformed version string size = {}".format(vs))
-        crd["v"] = vs
-
-        saider = Saider(sad=crd, code=coring.MtrDex.Blake3_256, label=Ids.d)
-        crd["d"] = saider.qb64
-
-        raw = coring.dumps(crd, kind)
-
-        return raw, kind, crd, version, saider
-
-    @property
-    def kind(self):
-        """ kind property getter"""
-        return self._kind
-
-    @property
-    def raw(self):
-        """ raw gettter bytes of serialized type """
-        return self._raw
-
-    @raw.setter
-    def raw(self, raw):
-        """ raw property setter """
-        crd, kind, version, size = self._inhale(raw=raw)
-        self._raw = bytes(raw[:size])  # crypto ops require bytes not bytearray
-        self._crd = crd
-        self._kind = kind
-        self._version = version
-        self._size = size
-        self._saider = Saider(qb64=self._crd[Ids.d], code=coring.MtrDex.Blake3_256, label=Ids.d)
+        if self._ident != coring.Idents.acdc:
+            raise ValueError("Invalid ident {}, must be ACDC".format(self._ident))
 
     @property
     def crd(self):
-        """ crd dict property getter"""
-        return self._crd
-
-    @crd.setter
-    def crd(self, crd):
-        """ ked property setter  assumes ._kind """
-        raw, kind, crd, version, saider = self._exhale(crd=crd, kind=self._kind)
-        size = len(raw)
-        self._raw = raw[:size]
-        self._crd = crd
-        self._kind = kind
-        self._size = size
-        self._version = version
-        self._saider = saider
-
-    @property
-    def size(self):
-        """ size property getter"""
-        return self._size
-
-    @property
-    def saider(self):
-        """ saider property getter"""
-        return self._saider
-
-    @property
-    def said(self):
-        """ said property getter, relies on saider """
-        return self.saider.qb64
+        """ issuer property getter"""
+        return self._ked
 
     @property
     def issuer(self):
         """ issuer property getter"""
-        return self.crd["i"]
+        return self._ked["i"]
 
     @property
     def schema(self):
         """ schema property getter"""
-        return self.crd["s"]
+        return self._ked["s"]
 
     @property
     def subject(self):
         """ subject property getter"""
-        return self.crd["a"]
+        return self._ked["a"]
 
     @property
     def status(self):
         """ status property getter"""
-        return self.crd["a"]["ri"]
-
-    def pretty(self):
-        """
-        Returns str JSON of .ked with pretty formatting
-        """
-        return json.dumps(self.crd, indent=1)
+        return self._ked["a"]["ri"]
 
 
 class CrederSuber(subing.Suber):
@@ -453,7 +135,6 @@ class CrederSuber(subing.Suber):
         """
         super(CrederSuber, self).__init__(*pa, **kwa)
 
-
     def put(self, keys: Union[str, Iterable], val: Credentialer):
         """
         Puts val at key made from keys. Does not overwrite
@@ -470,7 +151,6 @@ class CrederSuber(subing.Suber):
                                key=self._tokey(keys),
                                val=val.raw))
 
-
     def pin(self, keys: Union[str, Iterable], val: Credentialer):
         """
         Pins (sets) val at key made from keys. Overwrites.
@@ -485,7 +165,6 @@ class CrederSuber(subing.Suber):
         return (self.db.setVal(db=self.sdb,
                                key=self._tokey(keys),
                                val=val.raw))
-
 
     def get(self, keys: Union[str, Iterable]):
         """
@@ -508,7 +187,6 @@ class CrederSuber(subing.Suber):
         val = self.db.getVal(db=self.sdb, key=self._tokey(keys))
         return Credentialer(raw=bytes(val)) if val is not None else None
 
-
     def rem(self, keys: Union[str, Iterable]):
         """
         Removes entry at keys
@@ -521,8 +199,7 @@ class CrederSuber(subing.Suber):
         """
         return self.db.delVal(db=self.sdb, key=self._tokey(keys))
 
-
-    def getItemIter(self, keys: Union[str, Iterable]=b""):
+    def getItemIter(self, keys: Union[str, Iterable] = b""):
         """
         Return iterator over the all the items in subdb
 
@@ -533,3 +210,11 @@ class CrederSuber(subing.Suber):
         """
         for key, val in self.db.getTopItemIter(db=self.sdb, key=self._tokey(keys)):
             yield self._tokeys(key), Credentialer(raw=bytes(val))
+
+
+def findPath(said, sad):
+    if not isinstance(sad, dict) or 'd' not in sad:
+        raise kering.ValidationError("Not valid SAD")
+
+    if said == sad:
+        return "-"

--- a/src/keri/vc/walleting.py
+++ b/src/keri/vc/walleting.py
@@ -50,18 +50,8 @@ class Wallet:
 
         creds = []
         for saider in saiders:
-            creder = self.reger.creds.get(keys=saider.qb64b)
-
-            seals = self.reger.seals.get(keys=saider.qb64b)
-            prefixer = None
-            seqner = None
-            diger = None
-            sigers = []
-            for seal in seals:
-                (prefixer, seqner, diger, siger) = seal
-                sigers.append(siger)
-
-            creds.append((creder, prefixer, seqner, diger, sigers))
+            creder, sadsigers, sadcigars = self.reger.cloneCred(said=saider.qb64)
+            creds.append((creder, sadsigers, sadcigars))
 
         return creds
 

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1513,7 +1513,7 @@ class Tevery:
         Parameters:
             reger (Registry): local LMDB credential database
             db (Baser):  local LMDB identifier database
-            regk (str): local or own identifier prefix. Some restriction if present
+            regk (Union[str,None]): local or own identifier prefix. Some restriction if present
             local (bool): True means only process msgs for own events if .regk
                         False means only process msgs for not own events if .regk
             cues (Deck): notices generated from processing events

--- a/src/keri/vdr/issuing.py
+++ b/src/keri/vdr/issuing.py
@@ -204,7 +204,7 @@ class Issuer:
         return True
 
     @staticmethod
-    def messagize(serder, seal):
+    def attachSeal(serder, seal):
         msg = bytearray(serder.raw)
         msg.extend(Counter(CtrDex.SealSourceCouples, count=1).qb64b)
         msg.extend(Seqner(sn=seal.s).qb64b)
@@ -226,7 +226,7 @@ class Issuer:
                 kevt = self.hab.interact(data=[rseal])
 
             seal = SealSource(s=self.hab.kever.sn, d=self.hab.kever.serder.said)
-            tevt = self.messagize(serder=serder, seal=seal)
+            tevt = self.attachSeal(serder=serder, seal=seal)
 
             self.psr.parseOne(ims=bytearray(tevt))  # make copy as kvr deletes
             self.cues.extend([
@@ -251,7 +251,7 @@ class Issuer:
                 self.escrow(serder)
                 raise kering.MissingAnchorError("anchor not provided for multisig")
             else:
-                tevt = self.messagize(serder=serder, seal=seal)
+                tevt = self.attachSeal(serder=serder, seal=seal)
                 self.psr.parseOne(ims=bytearray(tevt))  # make copy as kvr deletes
 
                 self.cues.append(dict(kin="logEvent", msg=tevt))
@@ -437,7 +437,7 @@ class IssuerDoer(doing.DoDoer):
                     logger.info("Missing anchor from credential issuance due to multisig identifier")
 
                 craw = self.hab.endorse(creder)
-                proving.parseCredential(ims=craw, verifier=self.verifier)
+                parsing.Parser().parse(ims=craw, vry=self.verifier)
 
                 yield self.tock
 

--- a/tests/app/cli/inquisitor-sample.json
+++ b/tests/app/cli/inquisitor-sample.json
@@ -1,0 +1,13 @@
+{
+  "salt": "inquisitor-00000",
+  "transferable": true,
+  "wits": [
+    "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
+    "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
+    "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
+  ],
+  "icount": 1,
+  "ncount": 1,
+  "isith": 1,
+  "nsith": 1
+}

--- a/tests/app/test_agent_kiwiserver.py
+++ b/tests/app/test_agent_kiwiserver.py
@@ -69,25 +69,24 @@ def test_credential_handlers(mockHelpingNowUTC):
         result = client.simulate_post(path="/credential/issue", body=b)
         assert result.status == falcon.HTTP_200
 
-        tevt = (b'{"v":"KERI10JSON0000ed_","t":"iss","d":"EfZ4XAxBDq7ByJgutFqgK_S9'
-                b'lsxQvbdRadsVCPCSqg40","i":"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_E'
-                b'pa1AKKg","s":"0","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
+        tevt = (b'{"v":"KERI10JSON0000ed_","t":"iss","d":"EkkObJoLZkhWlH5rNMAGNwXz'
+                b'u9NrJ5VymB8S8faa91ok","i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_'
+                b'b9sw8NQ","s":"0","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
                 b'yyo","dt":"2021-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAA'
-                b'AAAAAAAAgEVgkg5sqEmZvTnlCBQSSrxUAmb48q-MKI7aqK7b2mx1Y')
-        kevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EVgkg5sqEmZvTnlCBQSSrxUA'
-                b'mb48q-MKI7aqK7b2mx1Y","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
+                b'AAAAAAAAgEc-gQ4RwkHHO0AWmnDD5A2tMIzNv_F9W1rYxCrjbcG7c')
+        kevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"Ec-gQ4RwkHHO0AWmnDD5A2tM'
+                b'IzNv_F9W1rYxCrjbcG7c","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
                 b'KTlh0nc","s":"2","p":"EUEfHVjhRI0f5WmNPF6PxLJigCxQn73ijikUzO9p42'
-                b'f8","a":[{"i":"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_Epa1AKKg","s"'
-                b':"0","d":"EfZ4XAxBDq7ByJgutFqgK_S9lsxQvbdRadsVCPCSqg40"}]}-AABAA'
-                b'kD43aLawYAwhCAQUTJSveKzJaiKPO2KoKfrU4tThbKb0O78kqd_x4G-F0SwGIYID'
-                b'-axzzJzOwDu1XeEtD_m3Aw')
+                b'f8","a":[{"i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ","s"'
+                b':"0","d":"EkkObJoLZkhWlH5rNMAGNwXzu9NrJ5VymB8S8faa91ok"}]}-AABAA'
+                b'dzceG1ISVULhZWVUOA_jFwp-aC8uTJQuAaG9Fl--jXdm8pUC1KFHIDoMGjoNiCzS'
+                b'jn4PlTyX_5QKgWeQkTYmCQ')
         cred = (
-            b'{"v":"KERI10JSON00019b_","d":"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_Epa1AKKg",'
-            b'"s":"ES63gXI-FmM6yQ7ISVIH__hOEhyE6W6-Ev0cArldsxuc","i":"EPmpiN6bEM8EI0Mctny-'
-            b'6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"EX68IGyVlJbavp7mMFUqDUtZ6M0QVhAI-hZvwEoE'
-            b'ZzaM","i":"Eo-yqSHYEN7C1T7fQLiRCkB_yObnXLpMNXaqBe4-uwBc","dt":"2021-01-01T00'
-            b':00:00.000000+00:00","LEI":"1234567890abcdefg","ri":"EUmNxM911ZUMWSdndXCq8kS'
-            b'Jq6ILtWt7oZBn27iOQyyo"},"p":[]}')
+            b'{"v":"ACDC10JSON00019b_","d":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ",'
+            b'"s":"ES63gXI-FmM6yQ7ISVIH__hOEhyE6W6-Ev0cArldsxuc","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc",'
+            b'"a":{"d":"EX68IGyVlJbavp7mMFUqDUtZ6M0QVhAI-hZvwEoEZzaM",'
+            b'"i":"Eo-yqSHYEN7C1T7fQLiRCkB_yObnXLpMNXaqBe4-uwBc","dt":"2021-01-01T00:00:00.000000+00:00",'
+            b'"LEI":"1234567890abcdefg","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQyyo"},"p":[]}')
 
         assert len(issuer.cues) == 2
         cue = issuer.cues.popleft()
@@ -98,7 +97,7 @@ def test_credential_handlers(mockHelpingNowUTC):
         assert evt == tevt
 
         creder = proving.Credentialer(raw=cred)
-        assert reger.creds.get(b'EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_Epa1AKKg').raw == creder.raw
+        assert reger.creds.get(b'EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ').raw == creder.raw
 
         # Try to revoke a credential that doesn't exist and get the appropriate error
         result = client.simulate_post(path="/credential/revoke",
@@ -110,23 +109,23 @@ def test_credential_handlers(mockHelpingNowUTC):
         # Now revoke the actual credential
         result = client.simulate_post(path="/credential/revoke",
                                       body=b'{"registry": "EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQyyo", "said": '
-                                           b'"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_Epa1AKKg"}')
+                                           b'"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ"}')
         assert result.status == falcon.HTTP_202
 
-        rev = (b'{"v":"KERI10JSON000120_","t":"rev","d":"EaVOPw17fC1KO_DaEh4p1PbF'
-               b'Js9ZApQDIezlcY3SDRtk","i":"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_E'
-               b'pa1AKKg","s":"1","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
-               b'yyo","p":"EfZ4XAxBDq7ByJgutFqgK_S9lsxQvbdRadsVCPCSqg40","dt":"20'
-               b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwELsa'
-               b'CvnKHrn29YjPZhi39BJ5cc13Ll4XMdZq26ptjPBA')
-        rkevt = (
-            b'{"v":"KERI10JSON00013a_","t":"ixn","d":"ELsaCvnKHrn29YjPZhi39BJ5'
-            b'cc13Ll4XMdZq26ptjPBA","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
-            b'KTlh0nc","s":"3","p":"EVgkg5sqEmZvTnlCBQSSrxUAmb48q-MKI7aqK7b2mx'
-            b'1Y","a":[{"i":"EAGNYbo_llzaafSd3GdJsApSwBJuO-vYviS_Epa1AKKg","s"'
-            b':"1","d":"EaVOPw17fC1KO_DaEh4p1PbFJs9ZApQDIezlcY3SDRtk"}]}-AABAA'
-            b'j0A10hxN0xmyPtUnJJVppeCSXNIjTkPEwSl-jmIzG0rv7GUDfNy3jh2GOW9FgbSn'
-            b'ldpmTXF4sbltRygpx_HbCA')
+        rev = (b'{"v":"KERI10JSON000120_","t":"rev","d":"EAeIinuz-droPXota2YFXZ16'
+               b'm4-Gyq-yjo56Av0ckoMg","i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_'
+               b'b9sw8NQ","s":"1","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
+               b'yyo","p":"EkkObJoLZkhWlH5rNMAGNwXzu9NrJ5VymB8S8faa91ok","dt":"20'
+               b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwEmAa'
+               b'D4PJNioOn-jUo96EuN0rz7GalszG_pz90EKR_1qc')
+        rkevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EmAaD4PJNioOn-jUo96EuN0r'
+                 b'z7GalszG_pz90EKR_1qc","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
+                 b'KTlh0nc","s":"3","p":"Ec-gQ4RwkHHO0AWmnDD5A2tMIzNv_F9W1rYxCrjbcG'
+                 b'7c","a":[{"i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ","s"'
+                 b':"1","d":"EAeIinuz-droPXota2YFXZ16m4-Gyq-yjo56Av0ckoMg"}]}-AABAA'
+                 b'0gBlBfu1q-vKDi2nn318dJ8Cmbrzg5We80Sg4OgkkBzUvNMSb3xu7NreG5vMRJSb'
+                 b'NQMc9FB2t-efuWbg1YuTAA')
+
         assert len(issuer.cues) == 2
         cue = issuer.cues.popleft()
         evt = cue["msg"]
@@ -273,7 +272,7 @@ def test_issue_credential_full_multisig():
         result = client.simulate_post(path="/credential/issue", body=b)
         assert result.status == falcon.HTTP_200
 
-        creder = proving.Credentialer(crd=result.json, kind=coring.Serials.json)
+        creder = proving.Credentialer(ked=result.json, kind=coring.Serials.json)
 
         # The Issuer will have cue'd up a multisig request to be processed
         assert len(issuer.cues) == 1

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -57,7 +57,7 @@ def test_witness_sender(mockGetWitnessByPrefix):
         serder = eventing.issue(vcdig="Ekb-iNmnXnOYIAlZ9vzK6RV9slYiKQSyQvAO-k0HMOI8",
                                 regk="EbA1o_bItVC9i6YB3hr2C3I_Gtqvz02vCmavJNoBA3Jg")
         seal = SealSource(s=palHab.kever.sn, d=palHab.kever.serder.said)
-        msg = issuing.Issuer.messagize(serder=serder, seal=seal)
+        msg = issuing.Issuer.attachSeal(serder=serder, seal=seal)
 
         witDoer = agenting.WitnessPublisher(hab=palHab, msg=msg, klas=agenting.TCPWitnesser)
 

--- a/tests/app/test_signing.py
+++ b/tests/app/test_signing.py
@@ -1,0 +1,356 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.signing module
+
+"""
+
+from keri.app import habbing, keeping, configing
+from keri.app import signing
+from keri.core import coring, parsing, eventing
+from keri.db import basing
+from keri.peer import exchanging
+from keri.vc import proving
+from keri.vdr import verifying, issuing
+
+
+def test_sad_signature():
+    with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as sidHab, \
+            habbing.openHab(name="wan", temp=True, salt=b'0123456789abcdef', transferable=False) as wanHab:
+        personal = dict(
+            d="",
+            n="Q8rNaKITBLLA96Euh5M5v4o3fRl1Bc54xdM-bOIHUjY",
+            personLegalName="Anna Jones",
+            engagementContextRole="Project Manager",
+        )
+
+        _, sad = coring.Saider.saidify(sad=personal, label=coring.Ids.d)
+
+        d = dict(
+            d="",
+            i="EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0",
+            dt="2021-06-09T17:35:54.169967+00:00",
+            ri="EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
+            LEI="254900OPPU84GM83MG36",
+            personal=sad,
+        )
+
+        # test source chaining with labeled edge
+        s = [
+            dict(qualifiedvLEIIssuervLEICredential="EGtyThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD")
+        ]
+
+        cred = proving.credential(schema="EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q",
+                                  issuer="EYNHFK056fqNSG_MDE7d_Eqk0bazefvd4eeQLMPPNBnM",
+                                  subject=d, source=s, status="ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M")
+        paths = [[], ["a"], ["a", "personal"]]
+
+        # Sign with non-transferable identifier
+        sig0 = signing.ratify(wanHab, cred)
+        assert sig0 == (b'{"v":"ACDC10JSON0002af_","d":"E25eYAS69RFUAJSaTf_hjYNx-IZJdv--FJ'
+                        b'fNIaW7RkL0","s":"EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q","'
+                        b'i":"EYNHFK056fqNSG_MDE7d_Eqk0bazefvd4eeQLMPPNBnM","a":{"d":"Ecea'
+                        b'O4431cYvUZLLAM_ImtSS8XISjNHuyaBuwHzovd94","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","ri":"ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M","LEI":"'
+                        b'254900OPPU84GM83MG36","personal":{"d":"ExSxzzsvGlhO6W0O1_-k5Api8'
+                        b'NgD8dDHLgazBxTqi_z4","n":"Q8rNaKITBLLA96Euh5M5v4o3fRl1Bc54xdM-bO'
+                        b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
+                        b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
+                        b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-JAB6AABAAA--CABB'
+                        b'BtKPeN9p4lum6qDRa28fDfVShFk6c39FlBgHBsCq1480B-EmK-iwW0gMYKY6Yw5v'
+                        b'EjAXvxy9MvIlR0MR6XOrBWWnBoNGHCYbyK3Olxoq1T9MjCBlQNIK-q8vUbltKzEJ'
+                        b'RDQ')
+        sig1 = signing.ratify(wanHab, cred, paths=paths)
+        assert sig1 == (b'{"v":"ACDC10JSON0002af_","d":"E25eYAS69RFUAJSaTf_hjYNx-IZJdv--FJ'
+                        b'fNIaW7RkL0","s":"EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q","'
+                        b'i":"EYNHFK056fqNSG_MDE7d_Eqk0bazefvd4eeQLMPPNBnM","a":{"d":"Ecea'
+                        b'O4431cYvUZLLAM_ImtSS8XISjNHuyaBuwHzovd94","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","ri":"ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M","LEI":"'
+                        b'254900OPPU84GM83MG36","personal":{"d":"ExSxzzsvGlhO6W0O1_-k5Api8'
+                        b'NgD8dDHLgazBxTqi_z4","n":"Q8rNaKITBLLA96Euh5M5v4o3fRl1Bc54xdM-bO'
+                        b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
+                        b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
+                        b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-KAD6AABAAA--JAB6'
+                        b'AABAAA--CADBBtKPeN9p4lum6qDRa28fDfVShFk6c39FlBgHBsCq1480B-EmK-iw'
+                        b'W0gMYKY6Yw5vEjAXvxy9MvIlR0MR6XOrBWWnBoNGHCYbyK3Olxoq1T9MjCBlQNIK'
+                        b'-q8vUbltKzEJRDQ-JAB5AABAA-a-CADBBtKPeN9p4lum6qDRa28fDfVShFk6c39F'
+                        b'lBgHBsCq1480BBDoK0wCjjNsq-ozd7JETJ3Un2qR2FB83yPF5eNURQxJAUpt1QiC'
+                        b'EDkh_lXPIdCv2ElXEx856_XMpT08e8dCMCQ-JAB4AADA-a-personal-CADBBtKP'
+                        b'eN9p4lum6qDRa28fDfVShFk6c39FlBgHBsCq1480BJdTjYZ2A0kXZX7tLxKgju6Z'
+                        b'P31-21J5Pl_VUmE-QGtl1h_GJb-aUox-UQLx_rum18xWhHi9zLSqFv5lY39FfBw')
+
+        # Sign with transferable identifier
+        sig2 = signing.ratify(sidHab, cred)
+        assert sig2 == (b'{"v":"ACDC10JSON0002af_","d":"E25eYAS69RFUAJSaTf_hjYNx-IZJdv--FJ'
+                        b'fNIaW7RkL0","s":"EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q","'
+                        b'i":"EYNHFK056fqNSG_MDE7d_Eqk0bazefvd4eeQLMPPNBnM","a":{"d":"Ecea'
+                        b'O4431cYvUZLLAM_ImtSS8XISjNHuyaBuwHzovd94","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","ri":"ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M","LEI":"'
+                        b'254900OPPU84GM83MG36","personal":{"d":"ExSxzzsvGlhO6W0O1_-k5Api8'
+                        b'NgD8dDHLgazBxTqi_z4","n":"Q8rNaKITBLLA96Euh5M5v4o3fRl1Bc54xdM-bO'
+                        b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
+                        b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
+                        b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-JAB6AABAAA--FABE'
+                        b'tjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAA'
+                        b'AAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAA7iGoMHHAZf1'
+                        b'UnqzTQF_r35WgwcmtfM-U5vbJapBX3lZlLd_bZr1bSLV7CTnQ8GMXLp5ocx1boO0'
+                        b'mn81roT8XDg')
+
+        sig3 = signing.ratify(sidHab, cred, paths=paths)
+
+        assert sig3 == (b'{"v":"ACDC10JSON0002af_","d":"E25eYAS69RFUAJSaTf_hjYNx-IZJdv--FJ'
+                        b'fNIaW7RkL0","s":"EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q","'
+                        b'i":"EYNHFK056fqNSG_MDE7d_Eqk0bazefvd4eeQLMPPNBnM","a":{"d":"Ecea'
+                        b'O4431cYvUZLLAM_ImtSS8XISjNHuyaBuwHzovd94","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","ri":"ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M","LEI":"'
+                        b'254900OPPU84GM83MG36","personal":{"d":"ExSxzzsvGlhO6W0O1_-k5Api8'
+                        b'NgD8dDHLgazBxTqi_z4","n":"Q8rNaKITBLLA96Euh5M5v4o3fRl1Bc54xdM-bO'
+                        b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
+                        b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
+                        b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-KAD6AABAAA--JAB6'
+                        b'AABAAA--FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAA'
+                        b'AAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABA'
+                        b'A7iGoMHHAZf1UnqzTQF_r35WgwcmtfM-U5vbJapBX3lZlLd_bZr1bSLV7CTnQ8GM'
+                        b'XLp5ocx1boO0mn81roT8XDg-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56'
+                        b'_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28z'
+                        b'ge56_B2lzdGGLwLpuRBkZ8w-AABAAJqM8t5rLscoH7hq5LXeU8f_k3qPzvXEaZDn'
+                        b'T9hqK2KQY82-Jmt1Wwn7kuSLpBsGZNFA20IeROzQxS8EpJC_XBA-JAB4AADA-a-p'
+                        b'ersonal-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAA'
+                        b'AAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABA'
+                        b'AzwL1MASfBplH3RRW-l51-RS8H0ahSNmQMCZlb0CxX2VNrvkqePjjNv3tIocjapf'
+                        b'5pHx8Y7TNUKsQFjK6-qxACA')
+
+    # Test multisig identifier
+    with basing.openDB(name="mel", temp=True) as db, \
+            keeping.openKS(name="mel", temp=True) as ks, \
+            configing.openCF(name="mel", base="mel", temp=True) as cf:
+        salt = coring.Salter(raw=b'0123456789abcdef').qb64
+        hab = habbing.Habitat(name="mel", base="mel", ks=ks, db=db, cf=cf, temp=True,
+                              salt=salt, icount=3, isith=3, ncount=3, nsith=3)
+
+        md = dict(
+            d="",
+            i="EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0",
+            dt="2021-06-09T17:35:54.169967+00:00",
+            LEI="254900OPPU84GM83MG36"
+        )
+        verifier = verifying.Verifier(hab=hab)
+        issuer = issuing.Issuer(hab=hab, reger=verifier.reger)
+
+        cred = proving.credential(schema="ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo",
+                                  issuer=hab.pre, subject=md, source=[], status=issuer.regk)
+
+        sig1 = signing.ratify(hab=hab, serder=cred)
+        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"ElnunisdNcMdaIypzfn3_9l2E8rsLk_2Q1'
+                        b'Mrdqb8igFA","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"EsZsrhSSwVZF62GzoINWF5NveSQTwgn2tHSmMKGDNGZg","a":{"d":"EtLL'
+                        b'Edd6k46Zk5Yxni8p9bZlfOk5fPRl41UPJvz4af-0","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"EnZLgDCpgBbtLdyvrVBCoawO'
+                        b'jRfGcag-uYEqYTHqyhUs"},"p":[]}-JAB6AABAAA--FABEsZsrhSSwVZF62GzoI'
+                        b'NWF5NveSQTwgn2tHSmMKGDNGZg0AAAAAAAAAAAAAAAAAAAAAAAEsZsrhSSwVZF62'
+                        b'GzoINWF5NveSQTwgn2tHSmMKGDNGZg-AADAAR8EhWkTy6qFgyz7afoA1PPvXQQGz'
+                        b'GhJjCP7HeBEm4Z-phNiA3NSpMf0jsOJDOaM7EZ5xeUajZxlG02_P5pzNDAABh6mU'
+                        b'ZuJEo0HVmoAd6cCqqVceZeg3nfwjANlortQp2egedZ_XPXEVVjRco2pNzDz7HIGA'
+                        b'8qNSBEAiQfvEQNO_CAACY5SlzCTKzRnCMGVJFmvHdU0Szcl4nHZYiFGPrTkXBxrj'
+                        b'Ylz09FJ4yzYZwY-7f2iG1HN4_LOow6I288vuwdxfBg')
+
+        issuer.issue(creder=cred)
+        parsing.Parser().parse(ims=sig1, vry=verifier)
+
+        saider = verifier.reger.saved.get(keys=cred.said)
+        assert saider is not None
+
+    """End Test"""
+
+
+
+def test_signature_transposition():
+    d = dict(
+        d="",
+        i="EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0",
+        dt="2021-06-09T17:35:54.169967+00:00",
+        LEI="254900OPPU84GM83MG36"
+    )
+
+    with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as hab:
+        verifier = verifying.Verifier(hab=hab)
+        issuer = issuing.Issuer(hab=hab, reger=verifier.reger)
+
+        cred = proving.credential(schema="ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo",
+                                  issuer=hab.pre, subject=d, source=[], status=issuer.regk)
+
+        # Sign with non-transferable identifier
+        sig0 = signing.ratify(hab=hab, serder=cred)
+        assert sig0 == (b'{"v":"ACDC10JSON00019e_","d":"E1x9hWR5ypCrhgqMaIUlALI1Id_Y8IgDli'
+                        b'PbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w","a":{"d":"E0kF'
+                        b'tfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMGAc","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"Eg1H4eN7P5ndJAWtcymq3ZrY'
+                        b'ZwQsBRYd3-VuZ6wMAwxE"},"p":[]}-JAB6AABAAA--FABEtjehgJ3LiIcPUKIQy'
+                        b'28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPU'
+                        b'KIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZh47Wkoez4lOg'
+                        b'oG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno2eR4DQ')
+
+        issuer.issue(creder=cred)
+        parsing.Parser().parse(ims=sig0, vry=verifier)
+
+        saider = verifier.reger.saved.get(keys=cred.said)
+        assert saider is not None
+
+        scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said)
+        assert scre.raw == cred.raw
+        assert len(sadcigars) == 0
+        assert len(sadsigers) == 1
+
+        (pather, prefixer, seqner, saider, sigers) = sadsigers[0]
+        assert pather.text == "-"
+        assert prefixer.qb64 == hab.pre
+        assert seqner.sn == 0
+        assert saider.qb64 == hab.kever.lastEst.d
+        assert len(sigers) == 1
+        assert sigers[0].qb64b == (b'AADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-'
+                                   b'6mmzno2eR4DQ')
+
+        # Transpose the signature to a new root
+        scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said, root=coring.Pather(path=["a", "b", "c"]))
+        assert scre.raw == cred.raw
+        assert len(sadcigars) == 0
+        assert len(sadsigers) == 1
+
+        (pather, prefixer, seqner, saider, sigers) = sadsigers[0]
+        assert pather.text == "-a-b-c"  # new emdded location
+        assert prefixer.qb64 == hab.pre
+        assert seqner.sn == 0
+        assert saider.qb64 == hab.kever.lastEst.d
+        assert len(sigers) == 1
+        assert sigers[0].qb64b == (b'AADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-'
+                                   b'6mmzno2eR4DQ')
+
+        # embed the credential in an exn and transpose the signature
+        scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said, root=coring.Pather(path=["a"]))
+        exn = exchanging.exchange(route="/credential/issue", payload=scre.crd, date="2022-01-04T11:58:55.154502+00:00")
+        msg = hab.endorse(serder=exn)
+        msg.extend(eventing.proofize(sadsigers=sadsigers, sadcigars=sadcigars))
+
+        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"ELiFf9jptP0iYqy16cStp9W3'
+                       b'plaGIj3cqX8g8JtWKzmI","dt":"2022-01-04T11:58:55.154502+00:00","r'
+                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E1x9hWR5'
+                       b'ypCrhgqMaIUlALI1Id_Y8IgDliPbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZ'
+                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGL'
+                       b'wLpuRBkZ8w","a":{"d":"E0kFtfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMG'
+                       b'Ac","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
+                       b'1-06-09T17:35:54.169967+00:00","LEI":"254900OPPU84GM83MG36","ri"'
+                       b':"Eg1H4eN7P5ndJAWtcymq3ZrYZwQsBRYd3-VuZ6wMAwxE"},"p":[]}}-VA0-FA'
+                       b'BEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAA'
+                       b'AAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAiXFJ1sG9K'
+                       b'ZHkAKNPLoOZiz9jhzgIv2lknmmIKa2bHoDubNELBaM9Pli-8A202hbbnAg2tNGQq'
+                       b'73tT9nuCx9VDA-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLw'
+                       b'LpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzd'
+                       b'GGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o'
+                       b'7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno2eR4DQ')
+
+        issuer.issue(creder=cred)
+        parsing.Parser().parse(ims=sig0, vry=verifier)
+
+        saider = verifier.reger.saved.get(keys=cred.said)
+        assert saider is not None
+
+    # multiple path sigs
+    with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as hab:
+        verifier = verifying.Verifier(hab=hab)
+        issuer = issuing.Issuer(hab=hab, reger=verifier.reger)
+
+        cred = proving.credential(schema="ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo",
+                                  issuer=hab.pre, subject=d, source=[], status=issuer.regk)
+
+        sig1 = signing.ratify(hab=hab, serder=cred, paths=[[], ["a"], ["a", "ri"]])
+        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"E1x9hWR5ypCrhgqMaIUlALI1Id_Y8IgDli'
+                        b'PbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w","a":{"d":"E0kF'
+                        b'tfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMGAc","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"Eg1H4eN7P5ndJAWtcymq3ZrY'
+                        b'ZwQsBRYd3-VuZ6wMAwxE"},"p":[]}-KAD6AABAAA--JAB6AABAAA--FABEtjehg'
+                        b'J3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEt'
+                        b'jehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZ'
+                        b'h47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno'
+                        b'2eR4DQ-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ'
+                        b'8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpu'
+                        b'RBkZ8w-AABAA_XSmslk9G08DoUO2S-AT5v1sfASpBzr-tBmFcTpjsjFVPbQVeCfT'
+                        b'YM5qw6N9rA_06Vgmk0wSWvZrTgD3ly-XDg-JAB6AACAAA-a-ri-FABEtjehgJ3Li'
+                        b'IcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehg'
+                        b'J3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAMww_ANw37teZaMDD69pY'
+                        b'1370mw5q0JnBEadHs1n2svQeydApgrvB0ofb2XWeFXquwkzj7fitH2M2nvivNm9tBA')
+
+        issuer.issue(creder=cred)
+        parsing.Parser().parse(ims=sig1, vry=verifier)
+
+        saider = verifier.reger.saved.get(keys=cred.said)
+        assert saider is not None
+
+        scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said, root=coring.Pather(path=["a"]))
+        assert len(sadsigers) == 3
+        exn = exchanging.exchange(route="/credential/issue", payload=scre.crd, date="2022-01-04T11:58:55.154502+00:00")
+        msg = hab.endorse(serder=exn)
+        msg.extend(eventing.proofize(sadsigers=sadsigers, sadcigars=sadcigars))
+        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"ELiFf9jptP0iYqy16cStp9W3'
+                       b'plaGIj3cqX8g8JtWKzmI","dt":"2022-01-04T11:58:55.154502+00:00","r'
+                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E1x9hWR5'
+                       b'ypCrhgqMaIUlALI1Id_Y8IgDliPbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZ'
+                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGL'
+                       b'wLpuRBkZ8w","a":{"d":"E0kFtfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMG'
+                       b'Ac","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
+                       b'1-06-09T17:35:54.169967+00:00","LEI":"254900OPPU84GM83MG36","ri"'
+                       b':"Eg1H4eN7P5ndJAWtcymq3ZrYZwQsBRYd3-VuZ6wMAwxE"},"p":[]}}-VA0-FA'
+                       b'BEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAA'
+                       b'AAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAiXFJ1sG9K'
+                       b'ZHkAKNPLoOZiz9jhzgIv2lknmmIKa2bHoDubNELBaM9Pli-8A202hbbnAg2tNGQq'
+                       b'73tT9nuCx9VDA-KAD6AABAAA--JAB4AAB-a-a-FABEtjehgJ3LiIcPUKIQy28zge'
+                       b'56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy2'
+                       b'8zge56_B2lzdGGLwLpuRBkZ8w-AABAA_XSmslk9G08DoUO2S-AT5v1sfASpBzr-t'
+                       b'BmFcTpjsjFVPbQVeCfTYM5qw6N9rA_06Vgmk0wSWvZrTgD3ly-XDg-JAB5AABAA-'
+                       b'a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAA'
+                       b'AAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx'
+                       b'0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcv'
+                       b'hhvw-6mmzno2eR4DQ-JAB4AACA-a-a-ri-FABEtjehgJ3LiIcPUKIQy28zge56_B'
+                       b'2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge'
+                       b'56_B2lzdGGLwLpuRBkZ8w-AABAAMww_ANw37teZaMDD69pY1370mw5q0JnBEadHs'
+                       b'1n2svQeydApgrvB0ofb2XWeFXquwkzj7fitH2M2nvivNm9tBA')
+
+    # signing SAD with non-transferable identifier
+    with habbing.openHab(name="wan", temp=True, salt=b'0123456789abcdef', transferable=False) as hab:
+        cred = proving.credential(schema="ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo",
+                                  issuer=hab.pre, subject=d, source=[],
+                                  status="Eg1H4eN7P5ndJAWtcymq3ZrYZwQsBRYd3-VuZ6wMAwxE")
+
+        # Sign with non-transferable identifier
+        sig0 = signing.ratify(hab=hab, serder=cred)
+
+        assert sig0 == (b'{"v":"ACDC10JSON00019e_","d":"ElSJrRhwdpPb6qvLt7Zc14A3gOW6_D-cP-'
+                        b'noEdwjDWNM","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"BBtKPeN9p4lum6qDRa28fDfVShFk6c39FlBgHBsCq148","a":{"d":"E0kF'
+                        b'tfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMGAc","i":"EhwC_-ISX9helBDUS'
+                        b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"Eg1H4eN7P5ndJAWtcymq3ZrY'
+                        b'ZwQsBRYd3-VuZ6wMAwxE"},"p":[]}-JAB6AABAAA--CABBBtKPeN9p4lum6qDRa'
+                        b'28fDfVShFk6c39FlBgHBsCq1480Blo8IXKRuRnMxHwf62V7_UZEqBPQx_HwsKDVF'
+                        b'a22pnSWfwEjyYcv2pK6SKLgnGFcQCc2xqK94E8GHUTow3tHZAw')
+
+        pather = coring.Pather(path=["a", "b", "c"])
+        cigars = hab.mgr.sign(ser=cred.raw,
+                              verfers=hab.kever.verfers,
+                              indexed=False)
+        sadcigars = [(pather, cigars)]
+
+        tp = eventing.proofize(sadcigars=sadcigars, pipelined=True)
+        assert tp == (b'-VAm-JAB5AACAA-a-b-c-CABBBtKPeN9p4lum6qDRa28fDfVShFk6c39FlBgHBsC'
+                      b'q1480Blo8IXKRuRnMxHwf62V7_UZEqBPQx_HwsKDVFa22pnSWfwEjyYcv2pK6SKL'
+                      b'gnGFcQCc2xqK94E8GHUTow3tHZAw')
+
+    """End Test"""
+

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -20,14 +20,13 @@ from fractions import Fraction
 
 from keri.kering import Version, Versionage
 from keri.kering import (EmptyMaterialError, RawMaterialError, DerivationError,
-                         ValidationError, ShortageError, InvalidCodeSizeError)
+                         ShortageError, InvalidCodeSizeError)
 
 from keri.help import helping
-from keri.help.helping import sceil
 
 from keri.core import coring
-from keri.core.coring import Ilkage, Ilks, Ids
-from keri.core.coring import (Sizage, MtrDex, Matter, SmallVrzDex, LargeVrzDex,
+from keri.core.coring import Ilkage, Ilks, Ids, Idents, Sadder
+from keri.core.coring import (Sizage, MtrDex, Matter,
                               IdrDex, Indexer, CtrDex, Counter, sniff)
 from keri.core.coring import (Verfer, Cigar, Signer, Salter, Saider, DigDex,
                               Diger, Nexter, Prefixer, Cipher, Encrypter, Decrypter)
@@ -231,11 +230,11 @@ def test_b64_conversions():
     p = nabSextets(b, 1)
     assert p == b'\xf8'
 
-    assert B64_CHARS == ('A','B','C','D','E','F','G','H','I','J','K','L','M','N',
-                         'O','P','Q','R','S','T','U','V','W','X','Y','Z',
-                         'a','b','c','d','e','f','g','h','i','j','k','l','m','n',
-                         'o','p','q','r','s','t','u','v','w','x','y','z',
-                         '0','1','2','3','4','5','6','7','8','9','-','_')
+    assert B64_CHARS == ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+                         'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+                         'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_')
     assert '@' not in B64_CHARS
     assert 'A' in B64_CHARS
 
@@ -1658,6 +1657,8 @@ def test_counter():
         'Keys': '-k',
         'LocationSealQuadlets': '-l',
         'RootDigestSealQuadlets': '-r',
+        'SadPathSig': '-J',
+        'SadPathSigGroup': '-K',
         'Witnesses': '-w',
         'BigMessageDataGroups': '-0U',
         'BigAttachedMaterialQuadlets': '-0V',
@@ -1694,6 +1695,8 @@ def test_counter():
         '-G': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-H': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-I': Sizage(hs=2, ss=2, fs=4, ls=0),
+        '-J': Sizage(hs=2, ss=2, fs=4, ls=0),
+        '-K': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-U': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-V': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-W': Sizage(hs=2, ss=2, fs=4, ls=0),
@@ -2238,6 +2241,7 @@ def test_dater():
 
     """ Done Test """
 
+
 def test_texter():
     """
     Test Texter variable sized Base64 text subclass of Matter
@@ -2295,6 +2299,89 @@ def test_texter():
     assert texter.text == text
 
     """ Done Test """
+
+
+def test_pather():
+    sad = dict(a=dict(z="value", b=dict(x=1, y=2, c="test")))
+    path = []
+    pather = coring.Pather(path=path)
+    assert pather.text == "-"
+    assert pather.qb64 == "6AABAAA-"
+    assert pather.raw == b'>'
+    assert pather.resolve(sad) == sad
+    assert pather.path == path
+
+    path = ["a", "b", "c"]
+    pather = coring.Pather(path=path)
+    assert pather.text == "-a-b-c"
+    assert pather.qb64 == "5AACAA-a-b-c"
+    assert pather.raw == b'\x0f\x9a\xf9\xbf\x9c'
+    assert pather.resolve(sad) == "test"
+    assert pather.path == path
+
+    path = ["0", "1", "2"]
+    pather = coring.Pather(path=path)
+    assert pather.text == "-0-1-2"
+    assert pather.qb64 == "5AACAA-0-1-2"
+    assert pather.raw == b'\x0f\xb4\xfb_\xb6'
+    assert pather.resolve(sad) == "test"
+    assert pather.path == path
+
+    sad = dict(field0=dict(z="value", field1=dict(field2=1, field3=2, c="test")))
+    path = ["field0"]
+    pather = coring.Pather(path=path)
+    assert pather.text == "-field0"
+    assert pather.qb64 == "4AACA-field0"
+    assert pather.raw == b'\x03\xe7\xe2zWt'
+    assert pather.resolve(sad) == {'field1': {'c': 'test', 'field2': 1, 'field3': 2}, 'z': 'value'}
+    assert pather.path == path
+
+    path = ["field0", "field1", "field3"]
+    pather = coring.Pather(path=path)
+    assert pather.text == "-field0-field1-field3"
+    assert pather.qb64 == "6AAGAAA-field0-field1-field3"
+    assert pather.raw == b">~'\xa5wO\x9f\x89\xe9]\xd7\xe7\xe2zWw"
+    assert pather.resolve(sad) == 2
+    assert pather.path == path
+
+    path = ["field0", "1", "0"]
+    pather = coring.Pather(path=path)
+    assert pather.text == "-field0-1-0"
+    assert pather.qb64 == "4AADA-field0-1-0"
+    assert pather.raw == b'\x03\xe7\xe2zWt\xfb_\xb4'
+    assert pather.resolve(sad) == 1
+    assert pather.path == path
+
+    sad = dict(field0=dict(z=dict(field2=1, field3=2, c="test"), field1="value"))
+    text = "-0-z-2"
+    pather = coring.Pather(text=text)
+    assert pather.text == text
+    assert pather.qb64 == "5AACAA-0-z-2"
+    assert pather.raw == b'\x0f\xb4\xfb?\xb6'
+    assert pather.resolve(sad) == "test"
+    assert pather.path == ["0", "z", "2"]
+
+    text = "-0-a"
+    pather = coring.Pather(text=text)
+    assert pather.text == text
+    assert pather.qb64 == "4AAB-0-a"
+    assert pather.raw == b'\xfbO\x9a'
+    with pytest.raises(KeyError):
+        pather.resolve(sad)
+    assert pather.path == ["0", "a"]
+
+    text = "-0-field1-0"
+    pather = coring.Pather(text=text)
+    assert pather.text == text
+    assert pather.qb64 == "4AADA-0-field1-0"
+    assert pather.raw == b"\x03\xed>~'\xa5w_\xb4"
+    with pytest.raises(ValueError):
+        pather.resolve(sad)
+    assert pather.path == ["0", "field1", "0"]
+
+    """ Done Test """
+
+
 def test_verfer():
     """
     Test the support functionality for verifier subclass of crymat
@@ -3612,7 +3699,8 @@ def test_versify():
     vs = Versify(kind=Serials.json, size=0)
     assert vs == "KERI10JSON000000_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.json
     assert version == Version
     assert size == 0
@@ -3620,15 +3708,26 @@ def test_versify():
     vs = Versify(kind=Serials.json, size=65)
     assert vs == "KERI10JSON000041_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.json
     assert version == Version
     assert size == 65
 
+    vs = Versify(ident=Idents.acdc, kind=Serials.json, size=86)
+    assert vs == "ACDC10JSON000056_"
+    assert len(vs) == VERFULLSIZE
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.acdc
+    assert kind == Serials.json
+    assert version == Version
+    assert size == 86
+
     vs = Versify(kind=Serials.mgpk, size=0)
     assert vs == "KERI10MGPK000000_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.mgpk
     assert version == Version
     assert size == 0
@@ -3636,7 +3735,8 @@ def test_versify():
     vs = Versify(kind=Serials.mgpk, size=65)
     assert vs == "KERI10MGPK000041_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.mgpk
     assert version == Version
     assert size == 65
@@ -3644,7 +3744,8 @@ def test_versify():
     vs = Versify(kind=Serials.cbor, size=0)
     assert vs == "KERI10CBOR000000_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.cbor
     assert version == Version
     assert size == 0
@@ -3652,7 +3753,8 @@ def test_versify():
     vs = Versify(kind=Serials.cbor, size=65)
     assert vs == "KERI10CBOR000041_"
     assert len(vs) == VERFULLSIZE
-    kind, version, size = Deversify(vs)
+    ident, kind, version, size = Deversify(vs)
+    assert ident == Idents.keri
     assert kind == Serials.cbor
     assert version == Version
     assert size == 65
@@ -3704,18 +3806,21 @@ def test_serder():
 
     e1s = json.dumps(e1, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     with pytest.raises(ShortageError):  # test too short
-        kind1, vers1, size1 = sniff(e1s[:VERFULLSIZE])
+        ident1, kind1, vers1, size1 = sniff(e1s[:VERFULLSIZE])
 
-    kind1, vers1, size1 = sniff(e1s[:MINSNIFFSIZE])
+    ident1, kind1, vers1, size1 = sniff(e1s[:MINSNIFFSIZE])
+    assert ident1 == Idents.keri
     assert kind1 == Serials.json
     assert size1 == 111
 
-    kind1, vers1, size1 = sniff(e1s)
+    ident1, kind1, vers1, size1 = sniff(e1s)
+    assert ident1 == Idents.keri
     assert kind1 == Serials.json
     assert size1 == 111
     e1ss = e1s + b'extra attached at the end.'
-    ked1, knd1, vrs1, siz1 = serder._inhale(e1ss)
+    ked1, idnt1, knd1, vrs1, siz1 = serder._inhale(e1ss)
     assert ked1 == e1
+    assert idnt1 == Idents.keri
     assert knd1 == kind1
     assert vrs1 == vers1
     assert siz1 == size1
@@ -3723,8 +3828,9 @@ def test_serder():
     with pytest.raises(ShortageError):  # test too short
         ked1, knd1, vrs1, siz1 = serder._inhale(e1ss[:size1 - 1])
 
-    raw1, knd1, ked1, ver1 = serder._exhale(ked=e1)
+    raw1, idnt1, knd1, ked1, ver1 = serder._exhale(ked=e1)
     assert raw1 == e1s
+    assert idnt1 == Idents.keri
     assert knd1 == kind1
     assert ked1 == e1
     assert vrs1 == vers1
@@ -3741,18 +3847,21 @@ def test_serder():
     e2s = msgpack.dumps(e2)
 
     with pytest.raises(ShortageError):  # test too short
-        kind2, vers2, size2 = sniff(e2s[:VERFULLSIZE])
+        ident2, kind2, vers2, size2 = sniff(e2s[:VERFULLSIZE])
 
-    kind2, vers2, size2 = sniff(e2s[:MINSNIFFSIZE])
+    ident2, kind2, vers2, size2 = sniff(e2s[:MINSNIFFSIZE])
+    assert ident2 == Idents.keri
     assert kind2 == Serials.mgpk
     assert size2 == 92
 
-    kind2, vers2, size2 = sniff(e2s)
+    ident2, kind2, vers2, size2 = sniff(e2s)
+    assert ident1 == Idents.keri
     assert kind2 == Serials.mgpk
     assert size2 == 92
     e2ss = e2s + b'extra attached  at the end.'
-    ked2, knd2, vrs2, siz2 = serder._inhale(e2ss)
+    ked2, idnt2, knd2, vrs2, siz2 = serder._inhale(e2ss)
     assert ked2 == e2
+    assert idnt2 == Idents.keri
     assert knd2 == kind2
     assert vrs2 == vers2
     assert siz2 == size2
@@ -3760,8 +3869,9 @@ def test_serder():
     with pytest.raises(ShortageError):  # test too short
         ked2, knd2, vrs2, siz2 = serder._inhale(e2ss[:size2 - 1])
 
-    raw2, knd2, ked2, ver2 = serder._exhale(ked=e2)
+    raw2, idnt2, knd2, ked2, ver2 = serder._exhale(ked=e2)
     assert raw2 == e2s
+    assert idnt2 == Idents.keri
     assert knd2 == kind2
     assert ked2 == e2
     assert vrs2 == vers2
@@ -3778,18 +3888,21 @@ def test_serder():
     e3s = cbor.dumps(e3)
 
     with pytest.raises(ShortageError):  # test too short
-        kind3, vers3, size3 = sniff(e3s[:VERFULLSIZE])
+        ident3, kind3, vers3, size3 = sniff(e3s[:VERFULLSIZE])
 
-    kind3, vers3, size3 = sniff(e3s[:MINSNIFFSIZE])
+    ident3, kind3, vers3, size3 = sniff(e3s[:MINSNIFFSIZE])
+    assert ident1 == Idents.keri
     assert kind3 == Serials.cbor
     assert size3 == 92
 
-    kind3, vers3, size3 = sniff(e3s)
+    ident3, kind3, vers3, size3 = sniff(e3s)
+    assert ident3 == Idents.keri
     assert kind3 == Serials.cbor
     assert size3 == 92
     e3ss = e3s + b'extra attached  at the end.'
-    ked3, knd3, vrs3, siz3 = serder._inhale(e3ss)
+    ked3, idnt3, knd3, vrs3, siz3 = serder._inhale(e3ss)
     assert ked3 == e3
+    assert idnt3 == Idents.keri
     assert knd3 == kind3
     assert vrs3 == vers3
     assert siz3 == size3
@@ -3797,11 +3910,50 @@ def test_serder():
     with pytest.raises(ShortageError):  # test too short
         ked3, knd3, vrs3, siz3 = serder._inhale(e3ss[:size3 - 1])
 
-    raw3, knd3, ked3, ver3 = serder._exhale(ked=e3)
+    raw3, idnt3, knd3, ked3, ver3 = serder._exhale(ked=e3)
     assert raw3 == e3s
+    assert idnt3 == Idents.keri
     assert knd3 == kind3
     assert ked3 == e3
     assert vrs3 == vers3
+
+    e4 = dict(v=Versify(ident=Idents.acdc, kind=Serials.json, size=0),
+              d="",
+              i="ABCDEFG",
+              s="0001",
+              t="rot")
+    _, e4 = coring.Saider.saidify(sad=e4)
+    print()
+    print(e4)
+    e4s = json.dumps(e4, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    assert e4s == (b'{"v":"ACDC10JSON00006f_","d":"EwXDowQGbBZTbz7vArhInaRqxLNWAsqQAzuLCioknTtk",'
+                   b'"i":"ABCDEFG","s":"0001","t":"rot"}')
+    vs = Versify(ident=Idents.acdc, kind=Serials.json, size=len(e4s))  # use real length
+    assert vs == 'ACDC10JSON00006f_'
+    e4["v"] = vs  # has real length
+    serder = Sadder(ked=e4)
+    pretty = serder.pretty()
+    assert pretty == ('{\n'
+                      ' "v": "ACDC10JSON00006f_",\n'
+                      ' "d": "EwXDowQGbBZTbz7vArhInaRqxLNWAsqQAzuLCioknTtk",\n'
+                      ' "i": "ABCDEFG",\n'
+                      ' "s": "0001",\n'
+                      ' "t": "rot"\n'
+                      '}')
+
+    e4s = json.dumps(e4, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    with pytest.raises(ShortageError):  # test too short
+        ident4, kind4, vers4, size4 = sniff(e4s[:VERFULLSIZE])
+
+    ident4, kind4, vers4, size4 = sniff(e4s[:MINSNIFFSIZE])
+    assert ident4 == Idents.acdc
+    assert kind4 == Serials.json
+    assert size4 == 111
+
+    ident4, kind4, vers4, size4 = sniff(e4s)
+    assert ident4 == Idents.acdc
+    assert kind4 == Serials.json
+    assert size4 == 111
 
     evt1 = Serder(raw=e1ss)
     assert evt1.kind == kind1
@@ -3811,8 +3963,6 @@ def test_serder():
     assert evt1.raw == e1ss[:size1]
     assert evt1.version == vers1
     assert evt1.sn == 1
-    assert serder.pre == "ABCDEFG"
-    assert serder.preb == b"ABCDEFG"
 
     # test digest properties .diger and .dig
     assert evt1.saider.qb64 == evt1.said
@@ -3831,9 +3981,6 @@ def test_serder():
     assert evt1.raw == e1ss[:size1]
     assert evt1.version == vers1
     assert evt1.saider.code == MtrDex.Blake3_256
-    assert serder.sn == 1
-    assert serder.pre == "ABCDEFG"
-    assert serder.preb == b"ABCDEFG"
 
     evt2 = Serder(raw=e2ss)
     assert evt2.kind == kind2
@@ -3914,7 +4061,8 @@ def test_serder():
     assert evt2.kind == Serials.cbor
     evt2.kind = Serials.json
     assert evt2.kind == Serials.json
-    knd, version, size = Deversify(evt2.ked["v"])
+    ident, knd, version, size = Deversify(evt2.ked["v"])
+    assert ident == Idents.keri
     assert knd == Serials.json
 
     #  Test diger code

--- a/tests/vc/test_handling.py
+++ b/tests/vc/test_handling.py
@@ -5,12 +5,12 @@ tests.vc.handling module
 """
 from hio.base import doing
 
-from keri.app import keeping, habbing, indirecting
+from keri.app import keeping, habbing, indirecting, signing
 from keri.core import coring, scheming, eventing, parsing
 from keri.db import basing
 from keri.peer import exchanging
 from keri.vc.handling import IssueHandler, envelope, RequestHandler
-from keri.vc.proving import credential, parseCredential
+from keri.vc.proving import credential
 from keri.vc.walleting import Wallet
 from keri.vdr import viring, verifying, issuing
 
@@ -59,20 +59,20 @@ def test_issuing():
                             subject=d,
                             status=issuer.regk)
 
-        assert creder.said == "EO7O-BNnOmo2hAJ8Sn0mdGzgsbcBzyeu3KUhWbyavJpI"
+        assert creder.said == "EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzXn7ocm0lb9A"
 
         issuer.issue(creder=creder)
-        msg = sidHab.endorse(serder=creder)
-        assert msg == (b'{"v":"KERI10JSON00019e_","d":"EO7O-BNnOmo2hAJ8Sn0mdGzgsbcBzyeu3K'
-                       b'UhWbyavJpI","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
+        msg = signing.ratify(sidHab, serder=creder, pipelined=True)
+        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzX'
+                       b'n7ocm0lb9A","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
                        b'i":"EeBZcaNdy0ZkuquN367PMj4Plg1201MSevpLREfB3Pxs","a":{"d":"Ec6X'
                        b'brY7znoeIUhxj5Xqk6sOby9MtCcUJGHolM-a6-Vc","i":"EeBZcaNdy0ZkuquN3'
                        b'67PMj4Plg1201MSevpLREfB3Pxs","dt":"2021-06-27T21:26:21.233257+00'
                        b':00","LEI":"254900OPPU84GM83MG36","ri":"ETxWu1_j6teP1VYBjRerXG3S'
-                       b'91Xs2ESrLgtBPlXkrQfw"},"p":[]}-VA0-FABEeBZcaNdy0ZkuquN367PMj4Plg'
-                       b'1201MSevpLREfB3Pxs0AAAAAAAAAAAAAAAAAAAAAAAEeBZcaNdy0ZkuquN367PMj'
-                       b'4Plg1201MSevpLREfB3Pxs-AABAA84sX0uWFDGe5SOvjmnommgxTwnNGp76K8Qy7'
-                       b'T_khiIgqSV_9QFBLwMNwkzWZ9RkVu-V1KxIUNc64f5-4bJ_mCQ')
+                       b'91Xs2ESrLgtBPlXkrQfw"},"p":[]}-VA3-JAB6AABAAA--FABEeBZcaNdy0Zkuq'
+                       b'uN367PMj4Plg1201MSevpLREfB3Pxs0AAAAAAAAAAAAAAAAAAAAAAAEeBZcaNdy0'
+                       b'ZkuquN367PMj4Plg1201MSevpLREfB3Pxs-AABAAh8MqB8-SlX1AkYHyMIaJ54Xv'
+                       b'cUkx-daOLsnyRbbBRZ5uZdfNUP_rpidW-r4f10jEUSFccI8x1IH_DGMOl_y2Dw')
 
         # Create the issue credential payload
         pl = dict(
@@ -90,29 +90,29 @@ def test_issuing():
         doist.do(doers=doers)
         assert doist.tyme == limit
 
-        ser = (b'{"v":"KERI10JSON00019e_","d":"EO7O-BNnOmo2hAJ8Sn0mdGzgsbcBzyeu3KUhWbyavJpI",'
+        ser = (b'{"v":"ACDC10JSON00019e_","d":"EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzXn7ocm0lb9A",'
                b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"EeBZcaNdy0ZkuquN367P'
                b'Mj4Plg1201MSevpLREfB3Pxs","a":{"d":"Ec6XbrY7znoeIUhxj5Xqk6sOby9MtCcUJGHolM-a'
                b'6-Vc","i":"EeBZcaNdy0ZkuquN367PMj4Plg1201MSevpLREfB3Pxs","dt":"2021-06-27T21'
                b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"ETxWu1_j6teP1VYBjRer'
                b'XG3S91Xs2ESrLgtBPlXkrQfw"},"p":[]}')
-        sig0 = (b'AA84sX0uWFDGe5SOvjmnommgxTwnNGp76K8Qy7T_khiIgqSV_9QFBLwMNwkzWZ9RkVu-V1KxIUNc'
-                b'64f5-4bJ_mCQ')
+        sig0 = (b'AAh8MqB8-SlX1AkYHyMIaJ54XvcUkx-daOLsnyRbbBRZ5uZdfNUP_rpidW-r4f10jEUSFccI8x1I'
+                b'H_DGMOl_y2Dw')
 
         # verify we can load serialized VC by SAID
-        key = creder.said.encode("utf-8")
-        assert redPDB.creds.get(key).raw == ser
+        creder, sadsigers, sadcigars = redPDB.cloneCred(said=creder.said)
+        assert creder.raw == ser
 
         # verify the signature
-        seals = redPDB.seals.get(key)
-        sigs = [sig for (_, _, _, sig) in seals]
-        assert len(sigs) == 1
-        assert sigs[0].qb64b == sig0
+        assert len(sadsigers) == 1
+        (_, _, _, _, sigers) = sadsigers[0]
+        assert sigers[0].qb64b == sig0
+        assert len(sadcigars) == 0
 
         # verify we can look up credential by Schema SAID
         schema = redPDB.schms.get(schema)
         assert len(schema) == 1
-        assert schema[0].qb64b == key
+        assert schema[0].qb64 == creder.said
 
 
 def test_proving():
@@ -172,14 +172,13 @@ def test_proving():
                             status=issuer.regk,
                             )
 
-        assert creder.said == "E6-urcXGcMqAttS_vhTIhnDfVNyrRpD4a4H-tljMlFuc"
+        assert creder.said == "EkHBr-04I1Id_bXI4luPZsASLVJ4ZOsI3a5ChZgE0iug"
 
-        msg = sidHab.endorse(serder=creder)
+        msg = signing.ratify(sidHab, serder=creder)
         hanWallet = Wallet(reger=hanPDB)
 
         issuer.issue(creder=creder)
-        parseCredential(ims=msg,
-                        verifier=verifier)
+        parsing.Parser().parse(ims=msg, vry=verifier)
 
         # verify we can load serialized VC by SAID
         key = creder.said.encode("utf-8")
@@ -192,7 +191,7 @@ def test_proving():
         # Create the issue credential payload
         pl = dict(
             input_descriptors=[
-                dict(x=schema)
+                dict(s=schema)
             ]
         )
 
@@ -227,9 +226,9 @@ def test_proving():
         assert len(vcs) == 1
 
         proof = (
-            "-VA0-FABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0Mctny"
-            "-6AfglVOKnJje8-vqyKTlh0nc-AABAACh-lXY9RhTOTsEiX1A8PSMcACFwSeS4Ba8wg2mZtfYVg-ah6iRHBPwyDS40hQJ2w9"
-            "-NCemL_JgvG2-ohIU5zCQ")
+            "-JAB6AABAAA--FABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0Mctny"
+            "-6AfglVOKnJje8-vqyKTlh0nc-AABAA6W18DO1EXT8Qeu_kaPqEQBPIlQQE_EoLDzxJb_M71EqQEC"
+            "-lA1lsW4R9lWTkj55jSvWIuTbTkXoTJVCyzKSTBA")
 
         assert vcs[0]["proof"] == proof
 

--- a/tests/vc/test_proving.py
+++ b/tests/vc/test_proving.py
@@ -6,13 +6,12 @@ tests.vc.proving module
 import pytest
 
 from keri.app import keeping, habbing
-from keri.core import coring, scheming
+from keri.core import coring, scheming, parsing
 from keri.core.coring import Serials, Counter, CtrDex, Prefixer, Seqner, Diger, Siger, Vstrings
 from keri.core.scheming import CacheResolver
 from keri.db import basing
-from keri.kering import Versionage, ExtractionError, ColdStartError
-from keri.vc import proving
-from keri.vc.proving import Credentialer, credential, parseProof
+from keri.kering import Versionage
+from keri.vc.proving import Credentialer, credential
 from keri.vdr import verifying, issuing, viring
 
 
@@ -54,16 +53,16 @@ def test_proving():
                             subject=credSubject)
 
         msg = sidHab.endorse(serder=creder)
-        assert msg == (b'{"v":"KERI10JSON000174_","d":"EFIx30Jqj0xmCe9t46L0Go0kkNjASWEXE1'
-                       b'24SsB4U3fc","s":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","'
+        assert msg == (b'{"v":"ACDC10JSON000174_","d":"EEJi2IYzwRTtvYIBx8-PjlpIiLyRrT6GWw'
+                       b'GOwycuX7vM","s":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","'
                        b'i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"E6wI'
                        b'oXUVrUsFm4pHAFDMbLloniDNvEWizHO8BNPwcyBA","i":"EPmpiN6bEM8EI0Mct'
                        b'ny-6AfglVOKnJje8-vqyKTlh0nc","lei":"254900OPPU84GM83MG36","issua'
                        b'nceDate":"2021-06-27T21:26:21.233257+00:00"},"p":[]}-VA0-FABEPmp'
                        b'iN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAA'
-                       b'EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAApdXwNj-5ilQhG'
-                       b'HeTqnnCoXKSoSNHRb9VGp_tFFvTQBqikZrYhwmGCmiOhIs4koaH7NUOXrOlXEq3i'
-                       b'NbeoI3BQ')
+                       b'EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAC2EQIRhx8mBH6a'
+                       b'zYQIFT8sokz7IBle8dZdwz_XsYh84mY3YbrasTT0pHxQ9Y2nV9UdEiM4UiunmjzB'
+                       b'ZtTvqaCA')
 
         creder = Credentialer(raw=msg)
         proof = msg[creder.size:]
@@ -107,15 +106,16 @@ def test_credentialer():
         Credentialer()
     sub = dict(a=123, b="abc", issuanceDate="2021-06-27T21:26:21.233257+00:00")
     d = dict(
-        v=Vstrings.json,
+        v=coring.Versify(ident=coring.Idents.acdc, kind=Serials.json, size=0),
         d="",
         s="abc",
         i="i",
         a=sub
     )
+    _, d = coring.Saider.saidify(sad=d)
 
-    creder = Credentialer(crd=d)
-    assert creder.said == "EComc-6OTBmeghbNLAAiZqTpQKdMDmmLaZ3khGi0QqM8"
+    creder = Credentialer(ked=d)
+    assert creder.said == "EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI"
     assert creder.kind == Serials.json
     assert creder.issuer == "i"
     assert creder.schema == "abc"
@@ -123,17 +123,15 @@ def test_credentialer():
     assert creder.crd == d
     assert creder.size == 168
     assert creder.size == len(creder.raw)
-    assert creder.raw == (
-        b'{"v":"KERI10JSON0000a8_","d":"EComc-6OTBmeghbNLAAiZqTpQKdMDmmLaZ3khGi0QqM8",'
-        b'"s":"abc","i":"i","a":{"a":123,"b":"abc","issuanceDate":"2021-06-27T21:26:21'
-        b'.233257+00:00"}}')
+    assert creder.raw == (b'{"v":"ACDC10JSON0000a8_","d":"EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI",'
+                          b'"s":"abc","i":"i","a":{"a":123,"b":"abc","issuanceDate":"2021-06-27T21:26:21'
+                          b'.233257+00:00"}}')
 
-    raw1, knd1, ked1, ver1, saider = creder._exhale(crd=d)
+    raw1, idt1, knd1, ked1, ver1 = creder._exhale(ked=d)
     assert raw1 == creder.raw
     assert knd1 == Serials.json
     assert ked1 == d
     assert ver1 == Versionage(major=1, minor=0)
-    assert saider.qb64 == creder.said
 
     creder = Credentialer(raw=raw1)
     assert creder.kind == Serials.json
@@ -142,21 +140,21 @@ def test_credentialer():
     assert creder.size == 168
 
     d2 = dict(d)
-    d2["v"] = Vstrings.cbor
-    creder = Credentialer(crd=d2)
-    assert creder.said == "Eszz-fXDUwmYeM0GhRLYLZKl2xFA8FEqtJYk_3nlpSmc"
+    d2["v"] = coring.Versify(ident=coring.Idents.acdc, kind=Serials.cbor, size=0)
+    creder = Credentialer(ked=d2)
+    assert creder.said == "EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.size == 139
     assert creder.size == len(creder.raw)
     assert creder.crd == d2
-    assert creder.raw == (b'\xa5avqKERI10CBOR00008b_adx,Eszz-fXDUwmYeM0GhRLYLZKl2xFA8FEqtJYk_3nlpSmcasc'
+    assert creder.raw == (b'\xa5avqACDC10CBOR00008b_adx,EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aIasc'
                           b'abcaiaiaa\xa3aa\x18{abcabclissuanceDatex 2021-06-27T21:26:21.233257+00:00')
 
     raw2 = bytes(creder.raw)
     creder = Credentialer(raw=raw2)
-    assert creder.said == "Eszz-fXDUwmYeM0GhRLYLZKl2xFA8FEqtJYk_3nlpSmc"
+    assert creder.said == "EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
@@ -165,23 +163,23 @@ def test_credentialer():
     assert creder.crd == d2
 
     d3 = dict(d)
-    d3["v"] = Vstrings.mgpk
-    creder = Credentialer(crd=d3)
+    d3["v"] = coring.Versify(ident=coring.Idents.acdc, kind=Serials.mgpk, size=0)
+    creder = Credentialer(ked=d3)
 
-    assert creder.said == "E3XRqG03kBX9EM-gbPSlIY7iISe6CFdiZzN56P1WBPa8"
+    assert creder.said == "EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
     assert creder.size == 138
     assert creder.size == len(creder.raw)
     assert creder.crd == d3
-    assert creder.raw == (b'\x85\xa1v\xb1KERI10MGPK00008a_\xa1d\xd9,E3XRqG03kBX9EM-gbPSlIY7iISe6CFdiZzN'
-                          b'56P1WBPa8\xa1s\xa3abc\xa1i\xa1i\xa1a\x83\xa1a{\xa1b\xa3abc\xacissuanceDate'
+    assert creder.raw == (b'\x85\xa1v\xb1ACDC10MGPK00008a_\xa1d\xd9,EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb'
+                          b'1jIsDi5aI\xa1s\xa3abc\xa1i\xa1i\xa1a\x83\xa1a{\xa1b\xa3abc\xacissuanceDate'
                           b'\xd9 2021-06-27T21:26:21.233257+00:00')
 
     raw3 = bytes(creder.raw)
     creder = Credentialer(raw=raw3)
-    assert creder.said == "E3XRqG03kBX9EM-gbPSlIY7iISe6CFdiZzN56P1WBPa8"
+    assert creder.said == "EXqZo8z93lk3tTc1EULX7pMzuT8QoPP7wAb1jIsDi5aI"
     assert creder.issuer == "i"
     assert creder.schema == "abc"
     assert creder.subject == sub
@@ -214,7 +212,7 @@ def test_credential():
                       subject=d, source=s, status="ETQoH02zJRCTNz-Wl3nnkUD_RVSzSwcoNvmfa18AWt3M")
 
     assert cred.size == len(cred.raw)
-    assert cred.raw == (b'{"v":"KERI10JSON000286_","d":"E-68VsAk0ZruNBb5LCxQ4LBu6FLb1Wh6yCWXmHbD3JxA",'
+    assert cred.raw == (b'{"v":"ACDC10JSON000286_","d":"Eoimm87D8yLKoz64dgphbsbgsgrEpZUeyRro0YyADYYw",'
                         b'"s":"EZllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q","i":"EYNHFK056fqNSG_MDE7d'
                         b'_Eqk0bazefvd4eeQLMPPNBnM","a":{"d":"ECe-ugAvprMRxaPgx0Q9__EBBtLxvqHTLiediZjc'
                         b'TGEY","issuanceDate":"2021-06-27T21:26:21.233257+00:00","personLegalName":"J'
@@ -223,46 +221,6 @@ def test_credential():
                         b'8O65r9KllNVjY8hnmfHxruMv2VG1s2_wdnj_5-kgkI","ri":"ETQoH02zJRCTNz-Wl3nnkUD_RV'
                         b'SzSwcoNvmfa18AWt3M"},"p":[{"qualifiedvLEIIssuervLEICredential":"EGtyThM1rLBS'
                         b'MZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}')
-
-
-def test_parse_proof():
-    proof = bytearray(b'-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-                      b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
-                      b'-AABAAVgLJOmUNlMZpSGV0hr'
-                      b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
-
-    prefixer, seqner, diger, isigers = parseProof(proof)
-    assert prefixer.code == coring.MtrDex.Blake3_256
-    assert prefixer.qb64 == "E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E"
-
-    assert seqner.sn == 0
-    assert diger.qb64 == "ElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI"
-
-    assert len(isigers) == 1
-    assert isigers[0].qb64 == "AAVgLJOmUNlMZpSGV0hr-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg"
-
-    #  pipelined attachment start
-    proof = bytearray(b'-VA0-FABE4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE'
-                      b'-YfcI9E0AAAAAAAAAAAAAAAAAAAAAAAElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI'
-                      b'-AABAAVgLJOmUNlMZpSGV0hr'
-                      b'-KddJmmEByoxfDdvkW161VsZO2_gjYf5OODwjyA3oSThfXGnj5Jhk5iszNuT2ZSsTMBg')
-
-    prefixer, seqner, diger, isigers = parseProof(proof)
-    assert prefixer.qb64 == "E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E"
-    assert seqner.sn == 0
-    assert diger.qb64 == "ElHzHwX3V6itsD2Ksg_CNBbUNTBYzLYw-AxDNI7_ZmaI"
-    assert len(isigers) == 1
-
-    # Invalid, can't process a message
-    proof = bytearray(b'{{"v":"KERI10JSON000136_","i":"Eq1XfsuS1WNK2uLnAwfJ2SwGz8MhPUDnL0Mi1yNvTQnY",'
-                      b'"x":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY",'
-                      b'"issuer":"E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",'
-                      b'"issuance":"2021-06-27T21:26:21.233257+00:00",'
-                      b'"d":{"id":"did:keri:Efaavv0oadfghasdfn443fhbyyr4v",'
-                      b'"lei":"254900OPPU84GM83MG36"}}')
-
-    with pytest.raises(ColdStartError):
-        parseProof(proof)
 
 
 def test_credential_parsator():
@@ -285,7 +243,7 @@ def test_credential_parsator():
         msg = hab.endorse(serder=creder)
 
         verifier = verifying.Verifier(hab=hab, name="verifier")
-        proving.parseCredential(ims=msg, verifier=verifier)
+        parsing.Parser().parse(ims=msg, vry=verifier)
 
         assert len(verifier.cues) == 1
         cue = verifier.cues.popleft()
@@ -298,4 +256,3 @@ if __name__ == '__main__':
     test_proving()
     test_credentialer()
     test_credential()
-    test_parse_proof()

--- a/tests/vc/test_walleting.py
+++ b/tests/vc/test_walleting.py
@@ -4,10 +4,10 @@ tests.vc.walleting module
 
 """
 
-from keri.app import keeping, habbing
-from keri.core import coring, scheming
+from keri.app import keeping, habbing, signing
+from keri.core import coring, scheming, parsing
 from keri.db import basing
-from keri.vc.proving import credential, parseCredential
+from keri.vc.proving import credential
 from keri.vdr import verifying, issuing
 
 
@@ -34,51 +34,48 @@ def test_wallet():
                             schema=schema,
                             subject=credSubject,
                             status=issuer.regk)
-        assert creder.said == "EGB4nGODlCPWJ2hKNwf7OowxNkotRZMZ3XaN0GGw-aVQ"
+        assert creder.said == "EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T9UwPhRwMBE"
 
         issuer.issue(creder=creder)
 
-        msg = sidHab.endorse(serder=creder)
-        assert msg == (b'{"v":"KERI10JSON00019e_","d":"EGB4nGODlCPWJ2hKNwf7OowxNkotRZMZ3X'
-                       b'aN0GGw-aVQ","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
+        msg = signing.ratify(sidHab, serder=creder)
+        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T'
+                       b'9UwPhRwMBE","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
                        b'i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"EKEo'
                        b'g6cZnQv8kcaWJ02670LEKGVTIMzXdXYlXRc2B3Ws","i":"EPmpiN6bEM8EI0Mct'
                        b'ny-6AfglVOKnJje8-vqyKTlh0nc","dt":"2021-06-27T21:26:21.233257+00'
                        b':00","LEI":"254900OPPU84GM83MG36","ri":"ERAY2VjFALVZAAuC3GDM-36q'
-                       b'KD8ZhUaKF55MWtITBFnc"},"p":[]}-VA0-FABEPmpiN6bEM8EI0Mctny-6AfglV'
-                       b'OKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0Mctny-6A'
-                       b'fglVOKnJje8-vqyKTlh0nc-AABAAaAW_sKvkNqYRtJjTPr3CdaTULDufko1ScBEp'
-                       b'H2WO14Xu5zZisw9cgJV5ZIAaJx3JJ-zMd8sLpkKXYyrZQuB4Dg')
+                       b'KD8ZhUaKF55MWtITBFnc"},"p":[]}-JAB6AABAAA--FABEPmpiN6bEM8EI0Mctn'
+                       b'y-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0'
+                       b'Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAArws9pEH-d7eDwd847W2TzFrxCfuc'
+                       b'rVxPC0AsEKpdcT4oWg3chxmdxydMNndFDFqSPSOnvsetBSLz_qYdPkG6Ag')
 
-        ser = (b'{"v":"KERI10JSON00019e_","d":"EGB4nGODlCPWJ2hKNwf7OowxNkotRZMZ3XaN0GGw-aVQ",'
+        ser = (b'{"v":"ACDC10JSON00019e_","d":"EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T9UwPhRwMBE",'
                b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"EPmpiN6bEM8EI0Mctny-'
                b'6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"EKEog6cZnQv8kcaWJ02670LEKGVTIMzXdXYlXRc2'
                b'B3Ws","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","dt":"2021-06-27T21'
                b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"ERAY2VjFALVZAAuC3GDM'
                b'-36qKD8ZhUaKF55MWtITBFnc"},"p":[]}')
 
-        sig0 = (b'AAaAW_sKvkNqYRtJjTPr3CdaTULDufko1ScBEpH2WO14Xu5zZisw9cgJV5ZIAaJx'
-                b'3JJ-zMd8sLpkKXYyrZQuB4Dg')
+        sig0 = (b'AArws9pEH-d7eDwd847W2TzFrxCfucrVxPC0AsEKpdcT4oWg3chxmdxydMNndFDFqSPSOnvsetBS'
+                b'Lz_qYdPkG6Ag')
 
-        parseCredential(ims=msg, verifier=verifier)
+        parsing.Parser().parse(ims=msg, vry=verifier)
 
         # verify we can load serialized VC by SAID
-        key = creder.said.encode("utf-8")
-        assert verifier.reger.creds.get(key).raw == ser
+        creder, sadsigers, sadcigars = verifier.reger.cloneCred(said=creder.said)
+        assert creder.raw == ser
 
         # verify the signature
-        seals = verifier.reger.seals.get(keys=key)
-        assert len(seals) == 1
-        (prefixer, seqner, diger, siger) = seals[0]
-
-        assert bytearray(siger.qb64b) == sig0
-        # verify the seal
-        # assert sl == seal
+        assert len(sadsigers) == 1
+        (_, _, _, _, sigers) = sadsigers[0]
+        assert sigers[0].qb64b == sig0
+        assert len(sadcigars) == 0
 
         # verify we can look up credential by Schema SAID
         schema = verifier.reger.schms.get(schema)
         assert len(schema) == 1
-        assert schema[0].qb64b == key
+        assert schema[0].qb64 == creder.said
 
         if __name__ == '__main__':
             test_wallet()

--- a/tests/vdr/test_issuing.py
+++ b/tests/vdr/test_issuing.py
@@ -65,43 +65,43 @@ def test_issuer(mockHelpingNowUTC):
         creder = credential(hab=hab, regk=issuer.regk)
         issuer.issue(creder=creder)
         kevt, tevt = events(issuer)
-        assert tevt == (b'{"v":"KERI10JSON000160_","t":"bis","d":"E06RacBCSX5uWKlxEV8gNdZn'
-                        b'stY4itTHiBsHuqX3_7Vs","i":"EG5LDGAwp9rrJUwAfsyv1dOvcMG9hhO0qHVNh'
-                        b'iFLWrc8","ii":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
+        assert tevt == (b'{"v":"KERI10JSON000160_","t":"bis","d":"EnUnO5Ucu7GBYJyLOmcGxug8'
+                        b'NQ7wA247m2OkzusQwNdY","i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQ'
+                        b'rmexr2M","ii":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
                         b':"0","ra":{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s'
                         b'":1,"d":"EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U"},"dt":"20'
-                        b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwEDCs'
-                        b'gExJ5uJWUTXmJFhWfZO4V1P1AOMssALIzbRbqlYo')
-        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EDCsgExJ5uJWUTXmJFhWfZO4'
-                        b'V1P1AOMssALIzbRbqlYo","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
+                        b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwE6GX'
+                        b'FH72iGFS8Eci4prowJBTMevUJu_qzAUl9Gdl2rP4')
+        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"E6GXFH72iGFS8Eci4prowJBT'
+                        b'MevUJu_qzAUl9Gdl2rP4","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
                         b'SV_sdGw","s":"3","p":"ElQ-JFNVR4I_wumyv-S6YGv76eGuXjx2coApDSyCEI'
-                        b'nM","a":[{"i":"EG5LDGAwp9rrJUwAfsyv1dOvcMG9hhO0qHVNhiFLWrc8","s"'
-                        b':"0","d":"E06RacBCSX5uWKlxEV8gNdZnstY4itTHiBsHuqX3_7Vs"}]}-AABAA'
-                        b'jBPcdsLd_XpdZkJJZMuz7wRWBPBWrLAVLbI7VgvPA7pfV1kOStk9DJBtZu0RJ_wp'
-                        b'FPDkjm2ukCXH2NfPeegrBA')
+                        b'nM","a":[{"i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQrmexr2M","s"'
+                        b':"0","d":"EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwNdY"}]}-AABAA'
+                        b'MovKqyqvUTTZEKhP9upAlslkGFK611vyonvDT5VDns5AgBGAXLveWTEfzEj0ZwLT'
+                        b'8eIBNsSdPa4TyKgiiG9QDw')
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'E06RacBCSX5uWKlxEV8gNdZnstY4itTHiBsHuqX3_7Vs'
+        assert ser.saider.qb64 == 'EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwNdY'
 
         tsn = issuer.tevers[issuer.regk].vcState(vcpre=ser.pre)
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
-        assert tevt == (b'{"v":"KERI10JSON00015f_","t":"brv","d":"EHRzc-eDDcC1q4OOQSGiXE24'
-                        b'zuD-HyiNtYD4P5rU_GmE","i":"EG5LDGAwp9rrJUwAfsyv1dOvcMG9hhO0qHVNh'
-                        b'iFLWrc8","s":"1","p":"E06RacBCSX5uWKlxEV8gNdZnstY4itTHiBsHuqX3_7'
-                        b'Vs","ra":{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
+        assert tevt == (b'{"v":"KERI10JSON00015f_","t":"brv","d":"ENjTuCK2EuiNXWJ0PmiyQ6BL'
+                        b'z0DhYCBEcGEOue6VOyLc","i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQ'
+                        b'rmexr2M","s":"1","p":"EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwN'
+                        b'dY","ra":{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
                         b':1,"d":"EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U"},"dt":"202'
-                        b'1-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAABAExKi8'
-                        b'KGtM_0MnBZBnz-UhOl9pbXmQq7B6qSjLJzUn7Qw')
-        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"ExKi8KGtM_0MnBZBnz-UhOl9'
-                        b'pbXmQq7B6qSjLJzUn7Qw","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
-                        b'SV_sdGw","s":"4","p":"EDCsgExJ5uJWUTXmJFhWfZO4V1P1AOMssALIzbRbql'
-                        b'Yo","a":[{"i":"EG5LDGAwp9rrJUwAfsyv1dOvcMG9hhO0qHVNhiFLWrc8","s"'
-                        b':"1","d":"EHRzc-eDDcC1q4OOQSGiXE24zuD-HyiNtYD4P5rU_GmE"}]}-AABAA'
-                        b'F2gXCAriZ5P1E0zrrmkVVuz_PBnQjQ9mIiMaXFCxeq__9ryit9wwmb8_i3fu5vjB'
-                        b'foc1MmyqJl9jIEqbCJXuDw')
+                        b'1-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAABAEIILm'
+                        b'MSBDAjPtAUb7bcqI2JxNcExTE6yRQcnDRUwA5qw')
+        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EIILmMSBDAjPtAUb7bcqI2Jx'
+                        b'NcExTE6yRQcnDRUwA5qw","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
+                        b'SV_sdGw","s":"4","p":"E6GXFH72iGFS8Eci4prowJBTMevUJu_qzAUl9Gdl2r'
+                        b'P4","a":[{"i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQrmexr2M","s"'
+                        b':"1","d":"ENjTuCK2EuiNXWJ0PmiyQ6BLz0DhYCBEcGEOue6VOyLc"}]}-AABAA'
+                        b'fbkuXoKyHvwWnofgexkzaY6dUHLiLCEeoxQTSfQrMoay3kGlSK2aifFMGLgK2-sM'
+                        b'mHRX_YjZgx4Ib8DZzLy6CQ')
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'EHRzc-eDDcC1q4OOQSGiXE24zuD-HyiNtYD4P5rU_GmE'
+        assert ser.saider.qb64 == 'ENjTuCK2EuiNXWJ0PmiyQ6BLz0DhYCBEcGEOue6VOyLc'
 
         with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
             hab = buildHab(db, kpr)
@@ -137,7 +137,7 @@ def test_issuer(mockHelpingNowUTC):
             issuer.issue(creder=creder)
             kevt, tevt = events(issuer)
             ser = Serder(raw=tevt)
-            assert ser.pre == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+            assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
             assert ser.ked["ri"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
             assert ser.ked["t"] == "iss"
 
@@ -145,15 +145,15 @@ def test_issuer(mockHelpingNowUTC):
             assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
             assert ser.ked["t"] == "ixn"
             seal = ser.ked["a"][0]
-            assert seal["i"] == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+            assert seal["i"] == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
             assert seal["s"] == "0"
-            assert seal["d"] == 'EYJoiPXenloR_Au2j9pR4fSxb3XICzlepPLalDks_kjs'
+            assert seal["d"] == 'E2IiG6Bt4Z4dSLKRcp6tTpdS4kNZq0QAEWu0Au4EdnUg'
 
             issuer.revoke(creder=creder)
             kevt, tevt = events(issuer)
 
             ser = Serder(raw=tevt)
-            assert ser.pre == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+            assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
             assert ser.ked["t"] == "rev"
             assert ser.ked["ri"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
 
@@ -161,9 +161,9 @@ def test_issuer(mockHelpingNowUTC):
             assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
             assert ser.ked["t"] == "ixn"
             seal = ser.ked["a"][0]
-            assert seal["i"] == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+            assert seal["i"] == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
             assert seal["s"] == "1"
-            assert seal["d"] == 'ER_MTXfX6ROo5HPIZibWH0wVNZacBz1ztNRdhUakF5LU'
+            assert seal["d"] == 'E6wRBgyoP-Gq0_VR6s8QWos-cTKyhAbfJlkcoHkWaZDU'
 
     with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
         hab = buildHab(db, kpr)
@@ -189,7 +189,7 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert ser.ked["t"] == "bis"
         seal = ser.ked["ra"]
         assert seal["i"] == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
@@ -198,7 +198,7 @@ def test_issuer(mockHelpingNowUTC):
         assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert seal["i"] == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert seal["s"] == "0"
 
         issuer.rotate(adds=["B9DfgIp33muOuCI0L8db_TldMJXv892UmW8yfpUuKzkw",
@@ -223,7 +223,7 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert ser.ked["t"] == "brv"
         seal = ser.ked["ra"]
         # ensure the ra seal digest matches the vrt event digest
@@ -233,7 +233,7 @@ def test_issuer(mockHelpingNowUTC):
         assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert seal["i"] == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert seal["s"] == "1"
 
     with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
@@ -260,7 +260,7 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+        assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
         assert ser.ked["t"] == "iss"
 
         ser = Serder(raw=kevt)
@@ -271,7 +271,7 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EYej8jti_qR78oxlS4EEnJkS1N7EC_pBs11S7OwhJAhk"
+        assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
         assert ser.ked["t"] == "rev"
 
         ser = Serder(raw=kevt)
@@ -317,7 +317,7 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert ser.ked["t"] == "bis"
 
         ser = Serder(raw=kevt)
@@ -341,7 +341,7 @@ def test_issuer(mockHelpingNowUTC):
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
         ser = Serder(raw=tevt)
-        assert ser.pre == "EH_SXUzNXYdBVP6ulTxNslyNlOWN0ws3oF_eCdNfq5nQ"
+        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
         assert ser.ked["t"] == "brv"
 
         ser = Serder(raw=kevt)

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -394,12 +394,11 @@ def test_credential_tsn_message(mockHelpingNowUTC):
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         ctsn = tever.vcState(vcpre=creder.said)
-        assert ctsn.raw == (
-            b'{"v":"KERI10JSON000135_","i":"EVVXgwIhfMUoLs4_yrhN_fDPdkmxthgcVEIk6b3-Zk88",'
-            b'"s":"0","d":"EnqaokAOPWgId2MRy50RuZ-U7m9fT-i5X8lmoUhYgJvc","ri":"E_dyu0_yRdu'
-            b'OU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ra":{},"a":{"s":2,"d":"EznRN95JXRyGDE4R1'
-            b'cWAcC3c7ffVasG9Aqxh94_loe1s"},"dt":"2021-01-01T00:00:00.000000+00:00","et":"'
-            b'iss"}')
+        assert ctsn.raw == (b'{"v":"KERI10JSON000135_","i":"EU6Ihd0np3JU0p6HOiXkVMGpARyBjqZNeIIvKh_HYAPA",'
+                            b'"s":"0","d":"E1BchG9O1F4wCljhb62mfHVEe0VhLEw9ZH1iCyllH9zk","ri":"E_dyu0_yRdu'
+                            b'OU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ra":{},"a":{"s":2,"d":"Ea05BQyfxAffAqq5n'
+                            b'5QR_eIHnCPyetHcz7vsIQqYI1T8"},"dt":"2021-01-01T00:00:00.000000+00:00","et":"'
+                            b'iss"}')
 
         rpy = bobHab.reply(route="/tsn/credential/" + bobHab.pre, data=ctsn.ked)
 
@@ -409,7 +408,7 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
 
         saider = bamReger.txnsb.escrowdb.get(keys=("credential-mre", creder.said, bobHab.pre))
-        assert saider[0].qb64b == b'Ew8NvCinPq3n9LoZIqjMOUOmhY9Hw6YN99EWAozbtA6Q'
+        assert saider[0].qb64b == b'EGqcQtozQ2FoVNJ5ytNQ6VWaVlCLgPr7lslb_7oiz9aI'
         assert len(bamTvy.cues) == 1
         cue = bamTvy.cues.popleft()
         assert cue["kin"] == "telquery"
@@ -438,7 +437,7 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         assert cue['q']['ri'] == issuer.regk
 
         saider = bamReger.txnsb.escrowdb.get(keys=("credential-ooo", creder.said, bobHab.pre))
-        assert saider[0].qb64b == b'Ew8NvCinPq3n9LoZIqjMOUOmhY9Hw6YN99EWAozbtA6Q'
+        assert saider[0].qb64b == b'EGqcQtozQ2FoVNJ5ytNQ6VWaVlCLgPr7lslb_7oiz9aI'
 
         vci = viring.nsKey([issuer.regk, creder.said])
         tmsgs = bytearray()
@@ -454,4 +453,4 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         assert bamReger.txnsb.escrowdb.get(keys=(creder.said, bobHab.pre)) == []
         # check to make sure the tsn has been saved
         saider = bamReger.txnsb.saiderdb.get(keys=(creder.said, bobHab.pre))
-        assert saider.qb64b == b'EnqaokAOPWgId2MRy50RuZ-U7m9fT-i5X8lmoUhYgJvc'
+        assert saider.qb64b == b'E1BchG9O1F4wCljhb62mfHVEe0VhLEw9ZH1iCyllH9zk'

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -346,66 +346,6 @@ def test_clone():
             b'M9u2Edk-PLMZ1H4')
 
 
-def test_build_proof():
-    sidSalt = coring.Salter(raw=b'0123456789abcdef').qb64
-
-    with basing.openDB(name="sid") as sigDB, \
-            keeping.openKS(name="sid") as sigKS:
-        sigHab = habbing.Habitat(ks=sigKS, db=sigDB, salt=sidSalt, icount=3, ncount=3, temp=True)
-
-        sed = dict()
-        sed["$id"] = ""
-        sed["$schema"] = "http://json-schema.org/draft-07/schema#"
-        sed.update(dict(
-            type="object",
-            properties=dict(
-                id=dict(
-                    type="string"
-                ),
-                lei=dict(
-                    type="string"
-                )
-            )
-        ))
-
-        schemer = scheming.Schemer(sed=sed, typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256)
-        credSubject = dict(
-            d="",
-            i="E4YPqsEOaPNaZxVIbY-Gx2bJgP-c7AH_K7pEE-YfcI9E",  # this needs to be generated from a KEL
-            lei="254900OPPU84GM83MG36",
-            issuanceDate="2021-06-27T21:26:21.233257+00:00",
-        )
-
-        creder = proving.credential(issuer=sigHab.pre,
-                                    schema=schemer.said,
-                                    subject=credSubject)
-
-        sigHab.rotate()
-        sigHab.rotate()
-        sigHab.rotate()
-        sigHab.rotate()
-
-        prefixer = coring.Prefixer(qb64=sigHab.kever.prefixer.qb64)
-        seqner = coring.Seqner(sn=sigHab.kever.lastEst.s)
-        diger = coring.Diger(qb64=sigHab.kever.lastEst.d)
-
-        sigers = sigHab.mgr.sign(ser=creder.raw, verfers=sigHab.kever.verfers, indexed=True)
-
-        proof = viring.buildProof(prefixer, seqner, diger, sigers)
-        assert proof == (b'-FABEBQmzPGqnkRXCHrfRHDdy0eS5hIsTD9peCfhavXoxhXI0AAAAAAAAAAAAAAA'
-                         b'AAAAAABAExDuNKMkRvMZG8ITkX3gRAVfsRvImCtsMTplKcqKpvQE-AADAAI-OMaF'
-                         b'IvZVUmLSAApfmJnoRBtsyuXYX0ge9Xc_r6ckChqICYuScxvof4qJ_tWfwutNqbxM'
-                         b'9_hv5Ux12oTx9rCAABwVkDWD_jemXddSaBdgDU4QYvW_2eLiPCvG95gEBLu-alA3'
-                         b'4NfC5HJKL5y9m7FD2d5eXE13jgMoYv-eRYx5J4BgACpZv8RxdMD4N4HUyFTe0R_A'
-                         b'ot5gaGCQEvlAC6ELbkhJ5EcrM-GBmuegm7tMQyfcOFO0nZTYO4YVDc3NAHsu6iDQ')
-
-        prefixer, seqner, diger, isigers = proving.parseProof(proof)
-        assert prefixer.qb64 == sigHab.pre
-        assert diger.qb64 == sigHab.kever.lastEst.d
-        assert seqner.sn == 4
-        assert len(isigers) == 3
-
-
 if __name__ == "__main__":
     test_issuer()
     test_clone()


### PR DESCRIPTION
This PR includes:

* Partial path signatures using new codes and new class Pather based on Texter.

* Updated (De)Versify to accept an event type identifier to allow for ACDC credentials to have the correct version string.

* All credentials are now valid ACDC credentials with CESR Proof Signatures.

* Credential parsing has been moved into Parser along with CESR Proof Signature handling and transposition for embedding in `exn` messages.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>