### PR TITLE
Partial rotation support for distributed multisig added with weighted thresholds.

### DIFF
--- a/ref/getting_started.md
+++ b/ref/getting_started.md
@@ -64,8 +64,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
     print(srdr.raw.decode("utf-8"))
     print()
 ```
@@ -99,8 +98,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
     print(srdr.raw.decode("utf-8"))
     print()
 
@@ -112,7 +110,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     keys = [verfers[0].qb64]
     nxtKeyDig = coring.Nexter(digs=[digers[0].qb64]).qb64
     icpDigest = srdr.saider.qb64
-    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nxt=nxtKeyDig, sn=1)
+    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nkeys=[digers[0].qb64], sn=1)
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -159,7 +157,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     mgr = keeping.Manager(keeper=kpr, salt=salt)
     verfers, digers = mgr.incept(icount=1, ncount=0, transferable=True)
 
-    srdr = eventing.incept(keys=[verfers[0].qb64], code=coring.MtrDex.Blake3_256, nxt="")  # empty nxt i.e. abandoned
+    srdr = eventing.incept(keys=[verfers[0].qb64], code=coring.MtrDex.Blake3_256)  # empty nxt i.e. abandoned
     print(srdr.raw.decode("utf-8"))
     print()
 ```
@@ -185,8 +183,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
     print(srdr.raw.decode("utf-8"))
     print()
 ```
@@ -220,8 +217,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt,
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64],
                            code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
     print(srdr.raw.decode("utf-8"))
     print()
@@ -234,7 +230,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     keys = [verfers[0].qb64]
     nxtKeyDig = coring.Nexter(digs=[digers[0].qb64]).qb64
     icpDigest = srdr.saider.qb64
-    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nxt=nxtKeyDig, sn=1)
+    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nkeys=[digers[0].qb64], sn=1)
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -293,8 +289,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfer.qb64 for verfer in verfers]
 
-    nxt = coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
+    srdr = eventing.incept(keys=keys, nkeys=[diger.qb64 for diger in digers], code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
     print(srdr.raw.decode("utf-8"))
     print()
 ```
@@ -329,8 +324,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfer.qb64 for verfer in verfers]
 
-    nxt = coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt,
+    srdr = eventing.incept(keys=keys, nkeys=[diger.qb64 for diger in digers],
                            code=coring.MtrDex.Blake3_256)  # code marks identifier as self-addressing
     print(srdr.raw.decode("utf-8"))
     print()
@@ -343,7 +337,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     keys = [verfer.qb64 for verfer in verfers]
     nxtKeyDig = coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64
     icpDigest = srdr.saider.qb64
-    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nxt=nxtKeyDig, sn=1)
+    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nkeys=[digers[0].qb64], sn=1)
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -489,8 +483,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)
     
     sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
     
@@ -522,8 +515,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)
     
     # Create Signatures
     sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
@@ -547,8 +539,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)
     
     sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
     
@@ -585,8 +576,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -599,7 +589,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     keys = [verfers[0].qb64]
     nxtKeyDig = coring.Nexter(digs=[digers[0].qb64]).qb64
     icpDigest = srdr.saider.qb64
-    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nxt=nxtKeyDig, sn=1)  # Create rotation event
+    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nkeys=[digers[0].qb64], sn=1)  # Create rotation event
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -627,8 +617,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
 
     keys = [verfers[0].qb64]
 
-    nxt = coring.Nexter(digs=[digers[0].qb64]).qb64
-    srdr = eventing.incept(keys=keys, nxt=nxt, code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
+    srdr = eventing.incept(keys=keys, nkeys=[digers[0].qb64], code=coring.MtrDex.Ed25519)  # code marks this identifier as basic
 
     print(srdr.raw.decode("utf-8"))
     print()
@@ -641,7 +630,7 @@ with dbing.openDB(name="edy") as db, keeping.openKS(name="edy") as kpr:
     identifier = srdr.pre
     keys = [verfers[0].qb64]
     icpDigest = srdr.saider.qb64
-    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, nxt="", sn=1)  # nxt is empty i.e. abandoned
+    srdr = eventing.rotate(pre=identifier, keys=keys, dig=icpDigest, sn=1)  # nxt is empty i.e. abandoned
 
     print(srdr.raw.decode("utf-8"))
     print()

--- a/scripts/demo/demo-script.sh
+++ b/scripts/demo/demo-script.sh
@@ -49,16 +49,16 @@ isSuccess
 kli sign --name test --alias trans --text @${SCRIPT_DIR}/anchor.json
 isSuccess
 
-kli verify --name test --alias trans --prefix ENwKjnx_hhhKthmJEO3JZ1maaIvV9d8ZsPK_RX1T4rb0 --text @${SCRIPT_DIR}/anchor.json --signature AA29iAmC1x_gYYI5sLv4MwAt6P0XRs0Be_JKKTb6iCVBy5amf4y5XzBL-kTRWSH0d0T3Zx1QsbgXhXW3i54EWkAQ
+kli verify --name test --alias trans --prefix EdSWKic0jXrzhG2mfCsdwWBOxIhnufSJjMT53YmCq8Pg --text @${SCRIPT_DIR}/anchor.json --signature AA29iAmC1x_gYYI5sLv4MwAt6P0XRs0Be_JKKTb6iCVBy5amf4y5XzBL-kTRWSH0d0T3Zx1QsbgXhXW3i54EWkAQ
 isSuccess
 
-kli verify --name test --alias trans --prefix ENwKjnx_hhhKthmJEO3JZ1maaIvV9d8ZsPK_RX1T4rb0 --text @${SCRIPT_DIR}/anchor.json --signature AB_whAvInYCuPXqfNQVDlDlyL0b4KsrQWsHA9IetyhDsD_AMToqJlmZzpN5Z9x_rlYlmL4pU2i2BC0so9aaxncDA
+kli verify --name test --alias trans --prefix EdSWKic0jXrzhG2mfCsdwWBOxIhnufSJjMT53YmCq8Pg --text @${SCRIPT_DIR}/anchor.json --signature AB_whAvInYCuPXqfNQVDlDlyL0b4KsrQWsHA9IetyhDsD_AMToqJlmZzpN5Z9x_rlYlmL4pU2i2BC0so9aaxncDA
 isSuccess
 
-kli verify --name test --alias trans --prefix ENwKjnx_hhhKthmJEO3JZ1maaIvV9d8ZsPK_RX1T4rb0 --text @${SCRIPT_DIR}/anchor.json --signature ACAEilCq8wGtjEEWBVODrh5o98cVnB8oZ_csTyrbgequWj5elEZERSfWFsW0SH4_B5oxtN-ta0rRZiIZNoQCFLAQ
+kli verify --name test --alias trans --prefix EdSWKic0jXrzhG2mfCsdwWBOxIhnufSJjMT53YmCq8Pg --text @${SCRIPT_DIR}/anchor.json --signature ACAEilCq8wGtjEEWBVODrh5o98cVnB8oZ_csTyrbgequWj5elEZERSfWFsW0SH4_B5oxtN-ta0rRZiIZNoQCFLAQ
 isSuccess
 
-kli verify --name test --alias trans --prefix ENwKjnx_hhhKthmJEO3JZ1maaIvV9d8ZsPK_RX1T4rb0 --text @${SCRIPT_DIR}/anchor.json --signature ACSHdal6kHAAjbW_frH83sDDCoBHw_nNKFysW5Dj8PSsnwVPePCNw-kFmF6Z8H87q7D3abw_5u2i4jmzdnWFsRDz
+kli verify --name test --alias trans --prefix EdSWKic0jXrzhG2mfCsdwWBOxIhnufSJjMT53YmCq8Pg --text @${SCRIPT_DIR}/anchor.json --signature ACSHdal6kHAAjbW_frH83sDDCoBHw_nNKFysW5Dj8PSsnwVPePCNw-kFmF6Z8H87q7D3abw_5u2i4jmzdnWFsRDz
 isSuccess
 
 # ESTABLISHMENT ONLY

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -711,8 +711,8 @@ class Reactant(doing.DoDoer):
         Sends message msg and loggers label if any
         """
         self.remoter.tx(msg)  # send to remote
-        logger.info("Server %s: sent %s:\n%s\n\n", self.hab.name,
-                    label, bytes(msg))
+        logger.info("Server %s: sent %s:\n%d\n\n", self.hab.name,
+                    label, len(msg))
 
 
 def runController(doers, expire=0.0):

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -112,7 +112,8 @@ class Groupy:
                                               sith=sith,
                                               toad=toad,
                                               wits=wits,
-                                              nxt=coring.Nexter(digs=[diger.qb64 for diger in msdigers]).qb64,
+                                              nsith=nsith,
+                                              nkeys=[diger.qb64 for diger in msdigers],
                                               code=coring.MtrDex.Blake3_256,
                                               data=data,
                                               delpre=delpre)
@@ -124,8 +125,8 @@ class Groupy:
                                              sith=sith,
                                              toad=toad,
                                              wits=wits,
-                                             nxt=coring.Nexter(sith=nsith,
-                                                               digs=[diger.qb64 for diger in msdigers]).qb64,
+                                             nsith=nsith,
+                                             nkeys=[diger.qb64 for diger in msdigers],
                                              code=coring.MtrDex.Blake3_256,
                                              data=data)
 
@@ -222,9 +223,9 @@ class Groupy:
                                          cuts=cuts,
                                          adds=adds,
                                          data=data,
-                                         nxt=coring.Nexter(sith=sith,  # the next digest previous calculated
-                                                           digs=[diger.qb64 for diger in msdigers]).qb64)
-
+                                         nsith=sith,
+                                         nkeys=[diger.qb64 for diger in msdigers],
+                                         )
                 sigers = self.signAndPropagate(hab, mssrdr, group.aids)
 
             indices = [siger.index for siger in sigers]
@@ -444,35 +445,17 @@ class Groupy:
             if len(keys) > 1:
                 raise kering.ConfigurationError("Identifier must have only one key, {} has {}"
                                                 .format(aid, len(keys)))
+            nkeys = kever.nekeys
+            if len(nkeys) > 1:
+                raise kering.ConfigurationError("Identifier must have only one nexy key commitment, {} has {}"
+                                                .format(aid, len(nkeys)))
 
-            diger = self.extractDig(nexter=kever.nexter, tholder=kever.tholder)
+            diger = nkeys[0]
 
             mskeys.append(keys[0])
             msdigers.append(diger)
 
         return mskeys, msdigers
-
-    @staticmethod
-    def extractDig(nexter, tholder):
-        """
-        Extracts the original digest of the public key from the digest created by XORing the
-        key with the signing threshold.  This is used in group identifier event creation to enable
-        creation of the next digest with the combined keys and the group signing threshold.
-
-        Parameters:
-            nexter is Nexter instance of next sith and next signing keys
-            tholder is Tholder instance for event sith
-
-        """
-        dint = int.from_bytes(nexter.raw, 'big')
-
-        limen = tholder.limen
-        ldig = blake3.blake3(limen.encode("utf-8")).digest()
-        sint = int.from_bytes(ldig, 'big')
-        kint = dint ^ sint
-
-        diger = coring.Diger(raw=kint.to_bytes(coring.Matter._rawSize(coring.MtrDex.Blake3_256), 'big'))
-        return diger
 
 
 class MultiSigGroupDoer(doing.DoDoer):

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -719,6 +719,7 @@ class Hab:
             ncount = icount
         if not transferable:
             ncount = 0  # next count
+            nsith = 0
             code = coring.MtrDex.Ed25519N
 
         if secrecies:
@@ -739,11 +740,6 @@ class Hab:
                                                         temp=self.temp)
 
         opre = verfers[0].qb64  # default original pre from key store move below
-        if digers:
-            nxt = coring.Nexter(sith=nst,
-                                digs=[diger.qb64 for diger in digers]).qb64
-        else:
-            nxt = ""
 
         cnfg = []
         if estOnly:
@@ -756,11 +752,13 @@ class Hab:
                                       wits=wits,
                                       toad=toad,
                                       cnfg=cnfg,
-                                      nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64)
+                                      nsith=nst,
+                                      nkeys=[diger.qb64 for diger in digers])
         else:
             serder = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
                                      sith=cst,
-                                     nxt=nxt,
+                                     nsith=nst,
+                                     nkeys=[diger.qb64 for diger in digers],
                                      toad=toad,
                                      wits=wits,
                                      cnfg=cnfg,
@@ -940,12 +938,6 @@ class Hab:
                                                         sith=sith,
                                                         temp=self.temp)
 
-        if digers:
-            nxt = coring.Nexter(sith=nst,
-                                digs=[diger.qb64 for diger in digers]).qb64
-        else:
-            nxt = ""
-
         # this is wrong sith is not kever.tholder.sith as next was different
         if kever.delegator is not None:
             serder = eventing.deltate(pre=kever.prefixer.qb64,
@@ -953,7 +945,8 @@ class Hab:
                                       dig=kever.serder.saider.qb64,
                                       sn=kever.sn + 1,
                                       sith=cst,
-                                      nxt=nxt,
+                                      nsith=nst,
+                                      nkeys=[diger.qb64 for diger in digers],
                                       toad=toad,
                                       wits=kever.wits,
                                       cuts=cuts,
@@ -965,7 +958,8 @@ class Hab:
                                      dig=kever.serder.saider.qb64,
                                      sn=kever.sn + 1,
                                      sith=cst,
-                                     nxt=nxt,
+                                     nsith=nst,
+                                     nkeys=[diger.qb64 for diger in digers],
                                      toad=toad,
                                      wits=kever.wits,
                                      cuts=cuts,

--- a/src/keri/app/kiwiing.py
+++ b/src/keri/app/kiwiing.py
@@ -816,9 +816,47 @@ class MultisigEnd:
         description: Initiate a multisig group inception with the participants identified by the  provided AIDs
         tags:
            - Multisig
+        parameters:
+          - in: path
+            name: alias
+            schema:
+              type: string
+            required: true
+            description: Human readable alias for the identifier to create
+        requestBody:
+           required: true
+           content:
+             application/json:
+               schema:
+                 type: object
+                 properties:
+                   aids:
+                     type: array
+                     items:
+                        type: string
+                     description: List of qb64 AIDs of participants in multisig group
+                   notify:
+                     type: boolean
+                     required: False
+                     description: True means to send mutlsig incept exn message to other participants
+                   toad:
+                     type: integer
+                     description: Witness receipt threshold
+                   witnesses:
+                     type: array
+                     items:
+                        type: string
+                     description: List of qb64 AIDs of witnesses to be used for the new group identfier
+                   isith:
+                     type: string
+                     description: Signing threshold for the new group identifier
+                   nsith:
+                     type: string
+                     description: Next signing threshold for the new group identifier
+
         responses:
-           202:
-              description:  multisig group inception initiated
+           204:
+              description: Multisig group AID inception initiated.
 
         """
         body = req.get_media()

--- a/src/keri/app/watching.py
+++ b/src/keri/app/watching.py
@@ -65,15 +65,11 @@ class KiwiServer(doing.DoDoer):
                                                temp=False)
 
         opre = verfers[0].qb64  # old pre default move below to new pre from incept
-        if digers:
-            nxt = coring.Nexter(sith=nst,
-                                digs=[diger.qb64 for diger in digers]).qb64
-        else:
-            nxt = ""
 
         serder = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
                                  sith=cst,
-                                 nxt=nxt,
+                                 nsith=nst,
+                                 nkeys=[diger.qb64 for diger in digers],
                                  toad=cur.toad,
                                  wits=cur.wits,
                                  code=code)

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -584,10 +584,10 @@ def fetchTsgs(db, saider, snh=None):
     return tsgs
 
 
-
 def incept(keys,
            sith=None,
-           nxt="",
+           nkeys=None,
+           nsith=None,
            toad=None,
            wits=None,
            cnfg=None,
@@ -603,7 +603,8 @@ def incept(keys,
      Parameters:
         keys is list of qb64 signing keys
         sith is int, string, or list format for signing threshold
-        nxt  is qb64 next digest xor
+        nkeys is list of qb64 next key digests
+        nsith  is is int, string, or list format for next signing threshold
         toad is int, or str hex of witness threshold
         wits is list of qb64 witness prefixes
         cnfg is list of strings TraitDex of configuration trait strings
@@ -622,6 +623,16 @@ def incept(keys,
     tholder = Tholder(sith=sith)
     if tholder.size > len(keys):
         raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
+
+    if nsith is None:
+        nsith = 0 if not nkeys else "{:x}".format(max(1, ceil(len(nkeys) / 2)))
+
+    if nkeys is None:
+        nkeys = []
+
+    ntholder = Tholder(sith=nsith)
+    if ntholder.size > len(nkeys):
+        raise ValueError("Invalid nsith = {} for keys = {}".format(nsith, nkeys))
 
     wits = wits if wits is not None else []
     if len(oset(wits)) != len(wits):
@@ -655,7 +666,8 @@ def incept(keys,
                s="{:x}".format(sn),  # hex string no leading zeros lowercase
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nxt,  # hash qual Base64
+               nt=ntholder.sith,
+               n=nkeys,  # hash qual Base64
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                b=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
@@ -684,7 +696,8 @@ def delcept(keys,
             delpre,
             code=None,
             sith=None,
-            nxt="",
+            nkeys=None,
+            nsith=None,
             toad=None,
             wits=None,
             cnfg=None,
@@ -700,8 +713,9 @@ def delcept(keys,
         keys is list of qb64 keys
         delpre is qb64 of delegators's prefix
         code is derivation code for prefix
-        sith is int  of signing threshold
-        nxt  is qb64 next digest xor
+        sith is int of signing threshold
+        nkeys is list of qb64 next key digests
+        nsith  is is int, string, or list format for next signing threshold
         toad is int of str hex of witness threshold
         wits is list of qb64 witness prefixes
         cnfg is list of configuration trait dicts including permissions dicts
@@ -714,13 +728,22 @@ def delcept(keys,
     ilk = Ilks.dip
 
     if sith is None:
-        sith = max(1, ceil(len(keys) / 2))
+        sith = "{:x}".format(max(1, ceil(len(keys) / 2)))
 
-    if isinstance(sith, int):
-        if sith < 1 or sith > len(keys):  # out of bounds sith
-            raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
-    else:  # list sith not yet supported
-        raise ValueError("invalid sith = {}.".format(sith))
+    tholder = Tholder(sith=sith)
+    if tholder.size > len(keys):
+        raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
+
+    if nsith is None:
+        nsith = 0 if not nkeys else "{:x}".format(max(1, ceil(len(nkeys) / 2)))
+
+
+    if nkeys is None:
+        nkeys = []
+
+    ntholder = Tholder(sith=nsith)
+    if ntholder.size > len(nkeys):
+        raise ValueError("Invalid nsith = {} for keys = {}".format(nsith, nkeys))
 
     wits = wits if wits is not None else []
     if len(oset(wits)) != len(wits):
@@ -750,9 +773,10 @@ def delcept(keys,
                d="",
                i="",  # qb64 prefix
                s="{:x}".format(sn),  # hex string no leading zeros lowercase
-               kt="{:x}".format(sith),  # hex string no leading zeros lowercase
+               kt=tholder.sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nxt,  # hash qual Base64
+               nt=ntholder.sith,
+               n=nkeys,  # hash qual Base64
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                b=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config and permission ordered mappings may be empty
@@ -784,7 +808,8 @@ def rotate(pre,
            dig,
            sn=1,
            sith=None,
-           nxt="",
+           nkeys=None,
+           nsith=None,
            toad=None,
            wits=None,  # prior existing wits
            cuts=None,
@@ -803,7 +828,8 @@ def rotate(pre,
         dig is digest of previous event qb64
         sn is int sequence number
         sith is string or list format for signing threshold
-        nxt  is qb64 next digest xor
+        nkeys is list of qb64 next key digests
+        nsith  is is int, string, or list format for next signing threshold
         toad is int or str hex of witness threshold
         wits is list of prior witness prefixes qb64
         cuts is list of witness prefixes to cut qb64
@@ -824,6 +850,17 @@ def rotate(pre,
     tholder = Tholder(sith=sith)
     if tholder.size > len(keys):
         raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
+
+    if nsith is None:
+        nsith = 0 if not nkeys else "{:x}".format(max(1, ceil(len(nkeys) / 2)))
+
+
+    if nkeys is None:
+        nkeys = []
+
+    ntholder = Tholder(sith=nsith)
+    if ntholder.size > len(nkeys):
+        raise ValueError("Invalid sith = {} for keys = {}".format(nsith, nkeys))
 
     wits = wits if wits is not None else []
     witset = oset(wits)
@@ -882,7 +919,8 @@ def rotate(pre,
                p=dig,  # qb64 digest of prior event
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nxt,  # hash qual Base64
+               nt=ntholder.sith,
+               n=nkeys,  # hash qual Base64
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                br=cuts,  # list of qb64 may be empty
                ba=adds,  # list of qb64 may be empty
@@ -898,7 +936,8 @@ def deltate(pre,
             dig,
             sn=1,
             sith=None,
-            nxt="",
+            nkeys=None,
+            nsith=None,
             toad=None,
             wits=None,  # prior existing wits
             cuts=None,
@@ -917,7 +956,8 @@ def deltate(pre,
         dig is digest of previous event qb64
         sn is int sequence number
         sith is int signing threshold
-        nxt  is qb64 next digest xor
+        nkeys is list of qb64 next key digests
+        nsith  is is int, string, or list format for next signing threshold
         toad is int or str hex of witness threshold
         wits is list of prior witness prefixes qb64
         cuts is list of witness prefixes to cut qb64
@@ -934,6 +974,20 @@ def deltate(pre,
 
     if sith is None:
         sith = "{:x}".format(max(1, ceil(len(keys) / 2)))
+
+    tholder = Tholder(sith=sith)
+    if tholder.size > len(keys):
+        raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
+
+    if nsith is None:
+        nsith = 0 if not nkeys else "{:x}".format(max(1, ceil(len(nkeys) / 2)))
+
+    if nkeys is None:
+        nkeys = []
+
+    ntholder = Tholder(sith=nsith)
+    if ntholder.size > len(nkeys):
+        raise ValueError("Invalid nsith = {} for keys = {}".format(nsith, nkeys))
 
     wits = wits if wits is not None else []
     witset = oset(wits)
@@ -992,7 +1046,8 @@ def deltate(pre,
                p=dig,  # qb64 digest of prior event
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nxt,  # hash qual Base64
+               nt=ntholder.sith,
+               n=nkeys,
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                br=cuts,  # list of qb64 may be empty
                ba=adds,  # list of qb64 may be empty
@@ -1086,7 +1141,8 @@ def state(pre,
           eevt,
           stamp=None,  # default current datetime
           sith=None,  # default based on keys
-          nxt="",
+          nkeys=None,
+          nsith=None,
           toad=None,  # default based on wits
           wits=None,  # default to []
           cnfg=None,  # default to []
@@ -1113,7 +1169,8 @@ def state(pre,
         stamp (str):  date-time-stamp RFC-3339 profile of ISO-8601 datetime of
                       creation of message or data
         sith is string or list format for signing threshold
-        nxt  is qb64 next digest xor if any
+        nkeys is list of qb64 next key digests
+        nsith  is is int, string, or list format for next signing threshold
         toad is int of witness threshold
         wits is list of witness prefixes qb64
         cnfg is list of strings TraitDex of configuration traits
@@ -1168,6 +1225,17 @@ def state(pre,
     if tholder.size > len(keys):
         raise ValueError("Invalid sith = {} for keys = {}".format(sith, keys))
 
+    if nsith is None:
+        nsith = 0 if not nkeys else "{:x}".format(max(1, ceil(len(nkeys) / 2)))
+
+    if nkeys is None:
+        nkeys = []
+
+    ntholder = Tholder(sith=nsith)
+    if ntholder.size > len(nkeys):
+        raise ValueError("Invalid nsith = {} for keys = {}".format(nsith, nkeys))
+
+
     wits = wits if wits is not None else []
     witset = oset(wits)
     if len(witset) != len(wits):
@@ -1214,7 +1282,8 @@ def state(pre,
                et=eilk,
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nxt,  # hash qual Base64
+               nt=ntholder.sith,
+               n=nkeys,
                bt="{:x}".format(toad),  # hex string no leading zeros lowercase
                b=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
@@ -1713,7 +1782,7 @@ class Kever:
                 and .nextor is not None
                 False otherwise
         """
-        return (self.nexter is not None and self.prefixer.transferable)
+        return self.nexter is not None and self.nexter.digs and self.prefixer.transferable
 
     def reload(self, state):
         """
@@ -1736,8 +1805,9 @@ class Kever:
         self.dater = Dater(dts=state.ked["dt"])
         self.ilk = state.ked["et"]
         self.tholder = Tholder(sith=state.ked["kt"])
+        self.ntholder = Tholder(sith=state.ked["nt"])
         self.verfers = [Verfer(qb64=key) for key in state.ked["k"]]
-        self.nexter = Nexter(qb64=state.ked["n"]) if state.ked["n"] else None
+        self.nexter = coring.Nexter(digs=state.ked["n"])
         self.toad = int(state.ked["bt"], 16)
         self.wits = state.ked["b"]
         self.cuts = state.ked["ee"]["br"]
@@ -1789,7 +1859,8 @@ class Kever:
             raise ValidationError("Invalid inception nxt not empty for "
                                   "non-transferable prefix = {} for evt = {}."
                                   "".format(self.prefixer.qb64, ked))
-        self.nexter = Nexter(qb64=nxt) if nxt else None
+        self.nexter = serder.nexter
+        self.ntholder = serder.ntholder
 
         self.cuts = []  # always empty at inception since no prev event
         self.adds = []  # always empty at inception since no prev event
@@ -1910,6 +1981,18 @@ class Kever:
                                                             seqner=seqner,
                                                             saider=saider)
 
+            if not self.ntholder.satisfy(indices=self.nexter.indices(sigers=sigers)):
+                self.escrowPSEvent(serder=serder, sigers=sigers, wigers=wigers)
+                if seqner and saider:
+                    self.escrowPACouple(serder=serder, seqner=seqner, saider=saider)
+                raise MissingSignatureError("Failure satisfying nsith = {} on sigs for {}"
+                                            " for evt = {}.".format(self.ntholder.sith,
+                                                                    [siger.qb64 for siger in sigers],
+                                                                    serder.ked))
+
+
+
+
             if delegator != self.delegator:  #
                 raise ValidationError("Erroneous attempted  delegated rotation"
                                       " on either undelegated event or with"
@@ -1930,8 +2013,8 @@ class Kever:
             self.tholder = tholder
             self.verfers = serder.verfers
             # update .nexter
-            nxt = ked["n"]
-            self.nexter = Nexter(qb64=nxt) if nxt else None  # check for empty
+            self.nexter = serder.nexter
+            self.ntholder = serder.ntholder
 
             self.toad = toad
             self.wits = wits
@@ -2062,7 +2145,7 @@ class Kever:
                                       "".format(dig, self.serder.saider.qb64, ked))
 
         # also check derivation code of pre for non-transferable
-        if self.nexter is None:  # empty so rotations not allowed
+        if not self.nexter:  # empty so rotations not allowed
             raise ValidationError("Attempted rotation for nontransferable"
                                   " prefix = {} for evt = {}."
                                   "".format(self.prefixer.qb64, ked))
@@ -2074,12 +2157,13 @@ class Kever:
                                             [verfer.qb64 for verfer in serder.verfers],
                                             ked))
 
-        # verify nxt from prior
+        # verify next keys from prior
+        ntholder = serder.ntholder
         keys = ked["k"]
-        if not self.nexter.verify(limen=tholder.limen, keys=keys):
+        if not self.nexter.verify(keys=keys):
             raise ValidationError("Mismatch nxt digest = {} with rotation"
                                   " sith = {}, keys = {} for evt = {}."
-                                  "".format(self.nexter.qb64, tholder.thold, keys, ked))
+                                  "".format(self.nexter.digs, tholder.thold, keys, ked))
 
         # compute wits from existing .wits with new cuts and adds from event
         # use ordered set math ops to verify and ensure strict ordering of wits
@@ -2478,7 +2562,8 @@ class Kever:
                       keys=[verfer.qb64 for verfer in self.verfers],
                       eevt=eevt,
                       sith=self.tholder.sith,
-                      nxt=self.nexter.qb64 if self.nexter else "",
+                      nsith=self.ntholder.sith if self.ntholder else 0,
+                      nkeys=self.nexter.digs if self.nexter else [],
                       toad=self.toad,
                       wits=self.wits,
                       cnfg=cnfg,

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -5,19 +5,19 @@ def test_boatswain_proxy():
     with habbing.openHby(name="deltest", temp=True) as eeHby, \
             habbing.openHby(name="deltest", temp=True) as orHby:
         orHab = orHby.makeHab("delegator", transferable=True)
-        assert orHab.pre == "E5dAsRrMTpVafiQ3k4fOsATAqO3XgJCotZ42UHZXOpBE"
+        assert orHab.pre == "E3dZohp66V742HBXXX7WxMvYj-2Bb-O5E74GiQv0WmB0"
         eeHab = eeHby.makeHab("del", transferable=True, delpre=orHab.pre,
                               wits=["BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
                                     "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
                                     "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"]
 
                               )
-        assert eeHab.pre == "EjpMeAft7BSVfD3Z4HlSAWrCfvim87Z1kMHDg9-xNbl0"
+        assert eeHab.pre == "EfrzbTSWjccrTdNRsFUUfwaJ2dpYxu9_5jI2PJ-TRri0"
 
         boats = delegating.Boatswain(hby=eeHby)
         phab = boats.proxy("deltest", eeHab.kever)
 
-        assert phab.pre == "EArIzjKa0AeQrmgx8vxkVmRHrPcUck-6IeK4av-moN8I"
+        assert phab.pre == "EskJJZIIjM3h6mdid1rMfFN4xNxEJrXeFGMT1hj_5mLw"
         assert phab.kever.wits == eeHab.kever.wits
         assert phab.kever.toad == eeHab.kever.toad
         assert phab.kever.tholder.sith == eeHab.kever.tholder.sith

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -44,11 +44,11 @@ def test_directing_basic():
 
     # bob inception transferable (nxt digest not empty)
     bobSerder = eventing.incept(keys=[bobSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[bobSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=bobSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     bob = bobSerder.ked["i"]
-    assert bob == 'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY'
+    assert bob == 'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw'
 
     # set of secrets (seeds for private keys)
     eveSecrets = ['AgjD4nRlycmM5cPcAkfOATAp8wVldRsnc9f1tiwctXlw',
@@ -70,11 +70,11 @@ def test_directing_basic():
 
     # eve inception transferable (nxt digest not empty)
     eveSerder = eventing.incept(keys=[eveSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[eveSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=eveSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     eve = eveSerder.ked["i"]
-    assert eve == 'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
+    assert eve == 'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
 
     with habbing.openHby(name="eve", base="test") as eveHby, \
             habbing.openHby(name="bob", base="test") as bobHby:
@@ -118,6 +118,8 @@ def test_directing_basic():
 
         # setup eve
         eveHab = eveHby.makeHab(name="Eve", secrecies=eveSecrecies)
+        print(eveHab.iserder.pretty())
+        print(eveSerder.pretty())
         assert eveHab.iserder.said == eveSerder.said
         assert eveHab.pre == eve
 

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -7,24 +7,6 @@ from keri.core import coring, eventing, parsing
 from keri.db import dbing
 
 
-def test_digest_ungrouping():
-    dig1 = "ECTCqZ6lS49I_57nQ0IYHifKJ7c1KByj45BVdfVrd0zw"
-    dig2 = "ED2dtv5eDcmW-jHJ3hyO-t5vSVSPS_x8bofBwE7Chtvo"
-    dig3 = "EyAWI-dDzLrTWPN9dOiEP833JG3ilueLRmHudceu9zgY"
-
-    tholder = coring.Tholder(sith="1")
-    digs = [dig1, dig2, dig3]
-
-    msdigers = []
-    for dig in digs:
-        nexter = coring.Nexter(qb64=dig)
-
-        dig = grouping.Groupy.extractDig(nexter, tholder)
-        msdigers.append(dig)
-
-    nxt = coring.Nexter(sith="3", digs=[diger.qb64 for diger in msdigers]).qb64
-    assert nxt == "EQL9rtA6EKES8Ig4GEfabNtd7DTvt0_-jp230QhBeaXA"
-
 
 @contextmanager
 def openMutlsig(prefix="test", salt=b'0123456789abcdef', temp=True, **kwa):

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -356,7 +356,7 @@ def test_make_load_hab_with_habery():
         assert id(hby.habByName(hab.name)) == id(hab)
 
         assert hab.name == name
-        assert hab.pre == 'ELB4zp-m8ogjBI02KCHQlc-vYvsqOhi7VkqjIY0fpkwo'
+        assert hab.pre == 'ESDOVXbLrbDjo94qAw_HCo3npFXGBNo-DEQeflDL2RyE'
         assert hab.temp
         assert hab.accepted
         assert hab.inited
@@ -403,7 +403,7 @@ def test_make_load_hab_with_habery():
         assert id(hby.habByName(sueHab.name)) == id(sueHab)
 
         assert sueHab.name == "Sue"
-        assert sueHab.pre == 'EBs3dnsrPXhI0QHmo67OvB346ieVEU-xdZUMzSqHF-qs'
+        assert sueHab.pre == 'EJzql954-toWFugKWCIyN2iAlb7jkLrCUd_6eG-lAE9I'
         assert not sueHab.temp
         assert sueHab.accepted
         assert sueHab.inited
@@ -416,7 +416,7 @@ def test_make_load_hab_with_habery():
         assert id(hby.habByName(bobHab.name)) == id(bobHab)
 
         assert bobHab.name == "Bob"
-        assert bobHab.pre == 'EEqA-fOcJn9OvBmQqZe8UAkP6jrTKBBxE-gyHs7leWqc'
+        assert bobHab.pre == 'EF8fAMlW1-2mARLE8NPEulkM7JmVTye0n5JOLb3WKcOI'
         assert not bobHab.temp
         assert bobHab.accepted
         assert bobHab.inited
@@ -435,8 +435,8 @@ def test_make_load_hab_with_habery():
     assert os.path.exists(hby.ks.path)
 
     # test load from database
-    suePre = 'EBs3dnsrPXhI0QHmo67OvB346ieVEU-xdZUMzSqHF-qs'
-    bobPre = 'EEqA-fOcJn9OvBmQqZe8UAkP6jrTKBBxE-gyHs7leWqc'
+    suePre = 'EJzql954-toWFugKWCIyN2iAlb7jkLrCUd_6eG-lAE9I'
+    bobPre = 'EF8fAMlW1-2mARLE8NPEulkM7JmVTye0n5JOLb3WKcOI'
     base = "hold"
     with habbing.openHby(base=base, temp=False) as hby:  # default is temp=True
         assert hby.cf.path.endswith("keri/cf/hold/test.json")

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -80,17 +80,17 @@ def test_create_cesr_request(mockHelpingNowUTC):
         args = client.args.pop()
         assert args["method"] == "POST"
         assert args["path"] == "/qry/tels"
-        assert args["body"] == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"Efp5Surn_KGO6S4G6ZnExhK83kCEIpVQA3Qi'
-                                b'hDyeHG-Y","dt":"2021-01-01T00:00:00.000000+00:00","r":"tels","rr":"","q":{"i'
-                                b'":"Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4","ri":"ERAY2VjFALVZAAuC3GDM-'
-                                b'36qKD8ZhUaKF55MWtITBFnc"}}')
+        assert args["body"] == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"EdaoDw0LOorX185H3Mu8O8OZ3rSHcuZn75Aj'
+                                b'FwhwgpUA","dt":"2021-01-01T00:00:00.000000+00:00","r":"tels","rr":"","q":{"i'
+                                b'":"Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4","ri":"EAZj_M7DRVHIYEnvkCwo2'
+                                b'0w_ZrjKR_ScNxHXO25Qus9s"}}')
 
         headers = args["headers"]
         assert headers["Content-Type"] == "application/cesr+json"
         assert headers["Content-Length"] == 254
-        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAfmxUPk'
-                                              b'uSzu50ixd9C5NwXzI7Dm2IdtD_PKExpzz0CQRwa9d3fvuWG-iQKiPxPCMCDEOmDw'
-                                              b'x9iBO55UL94q0CAQ')
+        assert headers["CESR-ATTACHMENT"] == bytearray(b'-VAj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAktrA'
+                                                       b'j01PkZlEtu7VPC076cyCvlhXdL9gYcf5pcih5ehlV73947Qp0ZeyP8J3HjFc3K'
+                                                       b'FI0IwhdvBVkQnHkFLlBw')
 
         msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0))
         client = MockClient()
@@ -100,17 +100,17 @@ def test_create_cesr_request(mockHelpingNowUTC):
         args = client.args.pop()
         assert args["method"] == "POST"
         assert args["path"] == "/qry/mbx"
-        assert args["body"] == (b'{"v":"KERI10JSON000104_","t":"qry","d":"ElYIm5ib2SdXRXtoby1-M0BQtA5qTlKE8U7s'
-                                b'-hVSDUDA","dt":"2021-01-01T00:00:00.000000+00:00","r":"mbx","rr":"","q":{"s"'
-                                b':0,"i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","src":"BGKVzj4ve0VSd8z'
+        assert args["body"] == (b'{"v":"KERI10JSON000104_","t":"qry","d":"E1Xdkk3WlmV03aL7R63u5z-VmQzvrRjwXpwC'
+                                b'xrkkMlxg","dt":"2021-01-01T00:00:00.000000+00:00","r":"mbx","rr":"","q":{"s"'
+                                b':0,"i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","src":"BGKVzj4ve0VSd8z'
                                 b'_AmvhLg4lqcC_9WYX90k03q-R_Ydo"}}')
 
         headers = args["headers"]
         assert headers["Content-Type"] == "application/cesr+json"
         assert headers["Content-Length"] == 260
-        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAdeUIE6'
-                                              b'CCnL2MWdEHoq-JHvq2wKxinMWQ1a2MTvs6DfPUgqd4heSESuQb1zkkE-EUZZuHIP'
-                                              b'_UVaaDKnb9X5oBBw')
+        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAuewE0c'
+                                              b'fWF-X9-gcw_XEf5k1NupFKUBUsRxPYs3kNU4pe8lW45GN7SryfCtXcpcmwnCeudJ'
+                                              b'3w32sUULzp2CUoCg')
 
 
 def test_stream_cesr_request(mockHelpingNowUTC):
@@ -129,17 +129,17 @@ def test_stream_cesr_request(mockHelpingNowUTC):
         args = client.args.pop()
         assert args["method"] == "POST"
         assert args["path"] == "/qry/tels"
-        assert args["body"] == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"Efp5Surn_KGO6S4G6ZnExhK83kCEIpVQA3Qi'
-                                b'hDyeHG-Y","dt":"2021-01-01T00:00:00.000000+00:00","r":"tels","rr":"","q":{"i'
-                                b'":"Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4","ri":"ERAY2VjFALVZAAuC3GDM-'
-                                b'36qKD8ZhUaKF55MWtITBFnc"}}')
+        assert args["body"] == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"EdaoDw0LOorX185H3Mu8O8OZ3rSHcuZn75Aj'
+                                b'FwhwgpUA","dt":"2021-01-01T00:00:00.000000+00:00","r":"tels","rr":"","q":{"i'
+                                b'":"Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4","ri":"EAZj_M7DRVHIYEnvkCwo2'
+                                b'0w_ZrjKR_ScNxHXO25Qus9s"}}')
 
         headers = args["headers"]
         assert headers["Content-Type"] == "application/cesr+json"
         assert headers["Content-Length"] == 254
-        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAfmxUPk'
-                                              b'uSzu50ixd9C5NwXzI7Dm2IdtD_PKExpzz0CQRwa9d3fvuWG-iQKiPxPCMCDEOmDw'
-                                              b'x9iBO55UL94q0CAQ')
+        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAktrAj0'
+                                              b'1PkZlEtu7VPC076cyCvlhXdL9gYcf5pcih5ehlV73947Qp0ZeyP8J3HjFc3KFI0I'
+                                              b'whdvBVkQnHkFLlBw')
 
         msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0))
         client = MockClient()
@@ -149,17 +149,17 @@ def test_stream_cesr_request(mockHelpingNowUTC):
         args = client.args.pop()
         assert args["method"] == "POST"
         assert args["path"] == "/qry/mbx"
-        assert args["body"] == (b'{"v":"KERI10JSON000104_","t":"qry","d":"ElYIm5ib2SdXRXtoby1-M0BQtA5qTlKE8U7s'
-                                b'-hVSDUDA","dt":"2021-01-01T00:00:00.000000+00:00","r":"mbx","rr":"","q":{"s"'
-                                b':0,"i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","src":"BGKVzj4ve0VSd8z'
+        assert args["body"] == (b'{"v":"KERI10JSON000104_","t":"qry","d":"E1Xdkk3WlmV03aL7R63u5z-VmQzvrRjwXpwC'
+                                b'xrkkMlxg","dt":"2021-01-01T00:00:00.000000+00:00","r":"mbx","rr":"","q":{"s"'
+                                b':0,"i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","src":"BGKVzj4ve0VSd8z'
                                 b'_AmvhLg4lqcC_9WYX90k03q-R_Ydo"}}')
 
         headers = args["headers"]
         assert headers["Content-Type"] == "application/cesr+json"
         assert headers["Content-Length"] == 260
-        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAdeUIE6'
-                                              b'CCnL2MWdEHoq-JHvq2wKxinMWQ1a2MTvs6DfPUgqd4heSESuQb1zkkE-EUZZuHIP'
-                                              b'_UVaaDKnb9X5oBBw')
+        assert headers["CESR-ATTACHMENT"] == (b'-VAj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAuewE0c'
+                                              b'fWF-X9-gcw_XEf5k1NupFKUBUsRxPYs3kNU4pe8lW45GN7SryfCtXcpcmwnCeudJ'
+                                              b'3w32sUULzp2CUoCg')
 
         msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0))
         msgs.extend(hab.makeOwnEvent(sn=0))
@@ -171,30 +171,30 @@ def test_stream_cesr_request(mockHelpingNowUTC):
         assert args["method"] == "POST"
         assert args["path"] == "/"
 
-        assert args["body"] == (b'{"v":"KERI10JSON000120_","t":"icp","d":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc"'
-                                b',"i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","s":"0","kt":"1","k":["DaYh8uaASu'
-                                b'DjMUd8_BoNyQs3GwupzmJL8_RBsuNtZHQg"],"n":"EZij_Yc1y_3EWLq9hFcHHGBarphq0pX1dIkPw1OHYS6'
-                                b'k","bt":"0","b":[],"c":[],"a":[]}')
+        assert args["body"] == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDp'
+                                b'BGF9Z1Pc","i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","s":"0","kt":"1'
+                                b'","k":["DaYh8uaASuDjMUd8_BoNyQs3GwupzmJL8_RBsuNtZHQg"],"nt":"1","n":["EsBMmy'
+                                b'evdbrDojd73T6UmBvSktf7f-i-Yu0LjsuRr7y4"],"bt":"0","b":[],"c":[],"a":[]}')
         headers = args["headers"]
-        assert headers['Content-Length'] == 288
+        assert headers['Content-Length'] == 299
         assert headers['Content-Type'] == 'application/cesr+json'
-        assert headers['CESR-ATTACHMENT'] == (b'-AABAAa3Md92hkKoYXIvNCUTQR_X6tx1r4fvqcbbGxx-XtJBI7KFKe5H34dyhz229K18H0T'
-                                              b'6eNtyocNu1Lof0V_vkIAA')
+        assert headers['CESR-ATTACHMENT'] == (b'-AABAAzyLnzgjNDU2AqLilXI1HlfIwdEoJzHErxbPv28asokuHZnTK3k_hBYH9tu'
+                                              b'FRlUtE7AP1zX1bhm5GLnSVDu6vCw')
 
         args = client.args.pop()
         assert args["method"] == "POST"
         assert args["path"] == "/"
 
-        assert args["body"] == (b'{"v":"KERI10JSON000105_","t":"qry","d":"EaWkBhJHu8GoqU6fSRtY1kHYMuL3DQM1ZE4n'
-                                b'Jr4yuATc","dt":"2021-01-01T00:00:00.000000+00:00","r":"logs","rr":"","q":{"s'
-                                b'":0,"i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","src":"BGKVzj4ve0VSd8'
+        assert args["body"] == (b'{"v":"KERI10JSON000105_","t":"qry","d":"EStGzLcodkqvmwvbmmPKbMEOanrqsvko-4WT'
+                                b'fD8G_QZ4","dt":"2021-01-01T00:00:00.000000+00:00","r":"logs","rr":"","q":{"s'
+                                b'":0,"i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","src":"BGKVzj4ve0VSd8'
                                 b'z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"}}')
         headers = args["headers"]
         assert headers['Content-Length'] == 261
         assert headers['Content-Type'] == 'application/cesr+json'
-        assert headers['CESR-ATTACHMENT'] == (b'-VAj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAqKSqAb'
-                                              b'nP_68sXvxmeFmsSVtZemIR9x2bu2nlzHldsDAjRY6MMbLIgu7cpuZILgMjbGeWx0'
-                                              b'oBBbBNmnCtoh6AAA')
+        assert headers['CESR-ATTACHMENT'] == (b'-VAj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAA6Hyou7'
+                                              b'rOsNZQ2hs-zPfHLJmLIQni-CDpILSYFjy25XgQ_dRe8b3n7LEv7lgr2r4fFoNB4l'
+                                              b'EMeS0Jtlu-jargBw')
 
 
 if __name__ == '__main__':

--- a/tests/app/test_kiwiing.py
+++ b/tests/app/test_kiwiing.py
@@ -71,24 +71,24 @@ def test_credential_handlers(mockHelpingNowUTC):
         result = client.simulate_post(path="/credentials", body=b)
         assert result.status == falcon.HTTP_200
 
-        tevt = (b'{"v":"KERI10JSON0000ed_","t":"iss","d":"EkkObJoLZkhWlH5rNMAGNwXz'
-                b'u9NrJ5VymB8S8faa91ok","i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_'
-                b'b9sw8NQ","s":"0","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
-                b'yyo","dt":"2021-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAA'
-                b'AAAAAAAAgEc-gQ4RwkHHO0AWmnDD5A2tMIzNv_F9W1rYxCrjbcG7c')
-        kevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"Ec-gQ4RwkHHO0AWmnDD5A2tM'
-                b'IzNv_F9W1rYxCrjbcG7c","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
-                b'KTlh0nc","s":"2","p":"EUEfHVjhRI0f5WmNPF6PxLJigCxQn73ijikUzO9p42'
-                b'f8","a":[{"i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ","s"'
-                b':"0","d":"EkkObJoLZkhWlH5rNMAGNwXzu9NrJ5VymB8S8faa91ok"}]}-AABAA'
-                b'dzceG1ISVULhZWVUOA_jFwp-aC8uTJQuAaG9Fl--jXdm8pUC1KFHIDoMGjoNiCzS'
-                b'jn4PlTyX_5QKgWeQkTYmCQ')
-        cred = (
-            b'{"v":"ACDC10JSON00019b_","d":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ",'
-            b'"s":"ES63gXI-FmM6yQ7ISVIH__hOEhyE6W6-Ev0cArldsxuc","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc",'
-            b'"a":{"d":"EX68IGyVlJbavp7mMFUqDUtZ6M0QVhAI-hZvwEoEZzaM",'
-            b'"i":"Eo-yqSHYEN7C1T7fQLiRCkB_yObnXLpMNXaqBe4-uwBc","dt":"2021-01-01T00:00:00.000000+00:00",'
-            b'"LEI":"1234567890abcdefg","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQyyo"},"p":[]}')
+        tevt = (b'{"v":"KERI10JSON0000ed_","t":"iss","d":"EYp0zprvOVGALuENur3xFYR3'
+                b'f97-prCMjl9RXnKJ7HxI","i":"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC3'
+                b'24D_MUs","s":"0","ri":"EjPXk1a_MtWR3a0qrZiJ34c971FxiHyCZSRo6482K'
+                b'PDs","dt":"2021-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAA'
+                b'AAAAAAAAgEmg5GkO_0R3PG3qlDNYtTpTFVZWbUoHwmAXkpP0cXI2c')
+        kevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"Emg5GkO_0R3PG3qlDNYtTpTF'
+                b'VZWbUoHwmAXkpP0cXI2c","i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpB'
+                b'GF9Z1Pc","s":"2","p":"EhUlcH33N486ITfJu3kG5evVLoivVaR8Wp6ut8rP21'
+                b'gs","a":[{"i":"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs","s"'
+                b':"0","d":"EYp0zprvOVGALuENur3xFYR3f97-prCMjl9RXnKJ7HxI"}]}-AABAA'
+                b'10QegNBAIM_NSA2Tj_u7jEWS5a2S1CX9qWl_TY2r5NnyV7buK3r_aHmtUUcRRrlj'
+                b'xhOAvAECR9x-SAHgtZApCg')
+        cred = (b'{"v":"ACDC10JSON00019b_","d":"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs",'
+                b'"s":"ES63gXI-FmM6yQ7ISVIH__hOEhyE6W6-Ev0cArldsxuc","i":"ECtWlHS2Wbx5M2Rg6nm6'
+                b'9PCtzwb1veiRNvDpBGF9Z1Pc","a":{"d":"E-ZnCrHoereORJlfqYCLRju-Bh78JXuyZjYtwUx2'
+                b'juTU","i":"EqwblUykZNwSsBd4g8pHeRZhlkPj64MhoGDspLCh2qnI","dt":"2021-01-01T00'
+                b':00:00.000000+00:00","LEI":"1234567890abcdefg","ri":"EjPXk1a_MtWR3a0qrZiJ34c'
+                b'971FxiHyCZSRo6482KPDs"},"p":[]}')
 
         assert len(issuer.cues) == 2
         cue = issuer.cues.popleft()
@@ -99,35 +99,35 @@ def test_credential_handlers(mockHelpingNowUTC):
         assert evt == tevt
 
         creder = proving.Credentialer(raw=cred)
-        assert reger.creds.get(b'EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ').raw == creder.raw
+        assert reger.creds.get(b'ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs').raw == creder.raw
 
         # Try to revoke a credential that doesn't exist and get the appropriate error
         result = client.simulate_post(path="/credential/revoke",
-                                      body=b'{"registry": "EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQyyo", "said": '
-                                           b'"EhFUqi_LAldgF0I6XmN9JGjc7Wh7ld1yCRiUxtMDVvow"}')
+                                      body=b'{"registry": "EjPXk1a_MtWR3a0qrZiJ34c971FxiHyCZSRo6482KPDs", "said": '
+                                           b'"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs"}')
         assert result.status == falcon.HTTP_NOT_FOUND
 
         print(creder.saider.qb64)
         # Now revoke the actual credential
         result = client.simulate_delete(path="/credentials",
                                         query_string=("alias=test&"
-                                                      "registry=EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQyyo&"
-                                                      "said=EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ"))
+                                                      "registry=EjPXk1a_MtWR3a0qrZiJ34c971FxiHyCZSRo6482KPDs&"
+                                                      "said=ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs"))
         assert result.status == falcon.HTTP_202
 
-        rev = (b'{"v":"KERI10JSON000120_","t":"rev","d":"EAeIinuz-droPXota2YFXZ16'
-               b'm4-Gyq-yjo56Av0ckoMg","i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_'
-               b'b9sw8NQ","s":"1","ri":"EUmNxM911ZUMWSdndXCq8kSJq6ILtWt7oZBn27iOQ'
-               b'yyo","p":"EkkObJoLZkhWlH5rNMAGNwXzu9NrJ5VymB8S8faa91ok","dt":"20'
-               b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwEmAa'
-               b'D4PJNioOn-jUo96EuN0rz7GalszG_pz90EKR_1qc')
-        rkevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EmAaD4PJNioOn-jUo96EuN0r'
-                 b'z7GalszG_pz90EKR_1qc","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqy'
-                 b'KTlh0nc","s":"3","p":"Ec-gQ4RwkHHO0AWmnDD5A2tMIzNv_F9W1rYxCrjbcG'
-                 b'7c","a":[{"i":"EeBiAoXWrs5fCo0km-8GlPHctMkoSAcQ7DWP_b9sw8NQ","s"'
-                 b':"1","d":"EAeIinuz-droPXota2YFXZ16m4-Gyq-yjo56Av0ckoMg"}]}-AABAA'
-                 b'0gBlBfu1q-vKDi2nn318dJ8Cmbrzg5We80Sg4OgkkBzUvNMSb3xu7NreG5vMRJSb'
-                 b'NQMc9FB2t-efuWbg1YuTAA')
+        rev = (b'{"v":"KERI10JSON000120_","t":"rev","d":"ErO_5RRABj5WhZMvtorj9Lj0'
+               b'3FScWkyvLaWWRhNIn050","i":"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC3'
+               b'24D_MUs","s":"1","ri":"EjPXk1a_MtWR3a0qrZiJ34c971FxiHyCZSRo6482K'
+               b'PDs","p":"EYp0zprvOVGALuENur3xFYR3f97-prCMjl9RXnKJ7HxI","dt":"20'
+               b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwEzsh'
+               b'nUr86BE4aIQLgOP8S7Y-WtvEHaxu0rIZPYliC4ug')
+        rkevt = (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EzshnUr86BE4aIQLgOP8S7Y-'
+                 b'WtvEHaxu0rIZPYliC4ug","i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpB'
+                 b'GF9Z1Pc","s":"3","p":"Emg5GkO_0R3PG3qlDNYtTpTFVZWbUoHwmAXkpP0cXI'
+                 b'2c","a":[{"i":"ESRIYQwCs8z1Fu7Jc6wf1ZDSoQQbKgjW9PiC324D_MUs","s"'
+                 b':"1","d":"ErO_5RRABj5WhZMvtorj9Lj03FScWkyvLaWWRhNIn050"}]}-AABAA'
+                 b'5ZC0m0ttngqIVwmgb6tmkQ1D0DuvglMzQUmF8rtz3hpRDoYMUqjelKjiHmZ5F24N'
+                 b'ykAO4WBSqM5FWPd0hqdTDQ')
 
         assert len(issuer.cues) == 2
         cue = issuer.cues.popleft()
@@ -419,7 +419,7 @@ def test_credential_handlers(mockHelpingNowUTC):
 
 def test_identifier_ends():
     with habbing.openHab(name="test", transferable=True) as (hby, hab):
-        assert hab.pre == "EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc"
+        assert hab.pre == "ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc"
 
         app = falcon.App()
 
@@ -450,7 +450,7 @@ def test_identifier_ends():
         assert result.status == falcon.HTTP_200
 
         assert result.json == [
-            {'name': 'test', 'prefix': 'EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc', 'seq_no': 1, 'delegated': False,
+            {'name': 'test', 'prefix': 'ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc', 'seq_no': 1, 'delegated': False,
              'delegator': None, 'witnesses': [], 'public_keys': ['DaYh8uaASuDjMUd8_BoNyQs3GwupzmJL8_RBsuNtZHQg'],
              'toad': 0, 'isith': '1', 'receipts': 0}]
 
@@ -464,6 +464,6 @@ def test_identifier_ends():
         assert result.status == falcon.HTTP_200
 
         assert result.json == [
-            {'name': 'test', 'prefix': 'EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc', 'seq_no': 2, 'delegated': False,
+            {'name': 'test', 'prefix': 'ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc', 'seq_no': 2, 'delegated': False,
              'delegator': None, 'witnesses': [], 'public_keys': ['DaA39fhkm-AAxCkPcKojluJ0qSCQItz_KT4-TVy6Wdc8'],
              'toad': 0, 'isith': '1', 'receipts': 0}]

--- a/tests/app/test_signing.py
+++ b/tests/app/test_signing.py
@@ -94,8 +94,8 @@ def test_sad_signature():
                         b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
                         b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
                         b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-JAB6AABAAA--FABE'
-                        b'tjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAA'
-                        b'AAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAA7iGoMHHAZf1'
+                        b'rO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAA'
+                        b'AAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAA7iGoMHHAZf1'
                         b'UnqzTQF_r35WgwcmtfM-U5vbJapBX3lZlLd_bZr1bSLV7CTnQ8GMXLp5ocx1boO0'
                         b'mn81roT8XDg')
 
@@ -112,15 +112,15 @@ def test_sad_signature():
                         b'IHUjY","personLegalName":"Anna Jones","engagementContextRole":"P'
                         b'roject Manager"}},"p":[{"qualifiedvLEIIssuervLEICredential":"EGt'
                         b'yThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sHYTGFD"}]}-KAD6AABAAA--JAB6'
-                        b'AABAAA--FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAA'
-                        b'AAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABA'
+                        b'AABAAA--FABErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAA'
+                        b'AAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABA'
                         b'A7iGoMHHAZf1UnqzTQF_r35WgwcmtfM-U5vbJapBX3lZlLd_bZr1bSLV7CTnQ8GM'
-                        b'XLp5ocx1boO0mn81roT8XDg-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56'
-                        b'_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28z'
-                        b'ge56_B2lzdGGLwLpuRBkZ8w-AABAAJqM8t5rLscoH7hq5LXeU8f_k3qPzvXEaZDn'
+                        b'XLp5ocx1boO0mn81roT8XDg-JAB5AABAA-a-FABErO8qhYftaJsAbCb6HUrN4tUy'
+                        b'rV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN'
+                        b'4tUyrV9dMd2VEt7SdG0wh50-AABAAJqM8t5rLscoH7hq5LXeU8f_k3qPzvXEaZDn'
                         b'T9hqK2KQY82-Jmt1Wwn7kuSLpBsGZNFA20IeROzQxS8EpJC_XBA-JAB4AADA-a-p'
-                        b'ersonal-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAA'
-                        b'AAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABA'
+                        b'ersonal-FABErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAA'
+                        b'AAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABA'
                         b'AzwL1MASfBplH3RRW-l51-RS8H0ahSNmQMCZlb0CxX2VNrvkqePjjNv3tIocjapf'
                         b'5pHx8Y7TNUKsQFjK6-qxACA')
 
@@ -144,19 +144,19 @@ def test_sad_signature():
 
         # Sign with multisig transferable identifier defaults to single signature on entire SAD
         sig1 = signing.ratify(hab=hab, serder=cred)
-        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"ElnunisdNcMdaIypzfn3_9l2E8rsLk_2Q1'
-                        b'Mrdqb8igFA","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
-                        b'i":"EsZsrhSSwVZF62GzoINWF5NveSQTwgn2tHSmMKGDNGZg","a":{"d":"EtLL'
-                        b'Edd6k46Zk5Yxni8p9bZlfOk5fPRl41UPJvz4af-0","i":"EhwC_-ISX9helBDUS'
+        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"EsvsOCKSvF_yoBscffaD4u1cCoefDG7Cc9'
+                        b'VyjZPEcNPc","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"EJOvY0hgm0Pfw2dg39rwuhGh7B0t3J8JIZkLIk5R-rPs","a":{"d":"E3vN'
+                        b'Pl0m0nSLXPuXcPwbYUZkO_F4Q0YWfnSPMlfdQyS0","i":"EhwC_-ISX9helBDUS'
                         b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
-                        b':00","LEI":"254900OPPU84GM83MG36","ri":"EnZLgDCpgBbtLdyvrVBCoawO'
-                        b'jRfGcag-uYEqYTHqyhUs"},"p":[]}-JAB6AABAAA--FABEsZsrhSSwVZF62GzoI'
-                        b'NWF5NveSQTwgn2tHSmMKGDNGZg0AAAAAAAAAAAAAAAAAAAAAAAEsZsrhSSwVZF62'
-                        b'GzoINWF5NveSQTwgn2tHSmMKGDNGZg-AADAAR8EhWkTy6qFgyz7afoA1PPvXQQGz'
-                        b'GhJjCP7HeBEm4Z-phNiA3NSpMf0jsOJDOaM7EZ5xeUajZxlG02_P5pzNDAABh6mU'
-                        b'ZuJEo0HVmoAd6cCqqVceZeg3nfwjANlortQp2egedZ_XPXEVVjRco2pNzDz7HIGA'
-                        b'8qNSBEAiQfvEQNO_CAACY5SlzCTKzRnCMGVJFmvHdU0Szcl4nHZYiFGPrTkXBxrj'
-                        b'Ylz09FJ4yzYZwY-7f2iG1HN4_LOow6I288vuwdxfBg')
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"EqHRzdfr0HuRYDZx4xmyFHnQ'
+                        b'_U1n3z54SO7tu02ebn3c"},"p":[]}-JAB6AABAAA--FABEJOvY0hgm0Pfw2dg39'
+                        b'rwuhGh7B0t3J8JIZkLIk5R-rPs0AAAAAAAAAAAAAAAAAAAAAAAEJOvY0hgm0Pfw2'
+                        b'dg39rwuhGh7B0t3J8JIZkLIk5R-rPs-AADAAQTcCdPEHU6Og_435H0k1s6TwZ0Vs'
+                        b'YcoawqmtEalppUdbA1WjyPVk5uYR6rMy4qOLVsDqCXYnnuU7hvhXKUJ-CgABAB86'
+                        b'KkYoIUplPRTPvBBc436X_Wm7hN-odm8XqW2VpTnQRJzDirI_-NYxxlymB_yi6Fbh'
+                        b'ef2cZ_8sDZ7v8VN3AQAC5_zQlmZmkeYRz_JQCUF2Y-GrcDR_Y7D6T2blGw_2a7Te'
+                        b'kBbMMrdf9kszFliQEZhbQfm_hkw31e8jtzlVe0XrBw')
 
         issuer.issue(creder=cred)
         parsing.Parser().parse(ims=sig1, vry=verifier)
@@ -184,16 +184,16 @@ def test_signature_transposition():
 
         # Sign with non-transferable identifier, defaults to single signature on entire SAD
         sig0 = signing.ratify(hab=hab, serder=cred)
-        assert sig0 == (b'{"v":"ACDC10JSON00019e_","d":"E1x9hWR5ypCrhgqMaIUlALI1Id_Y8IgDli'
-                        b'PbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
-                        b'i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w","a":{"d":"E0kF'
-                        b'tfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMGAc","i":"EhwC_-ISX9helBDUS'
+        assert sig0 == (b'{"v":"ACDC10JSON00019e_","d":"E6GIzcFURqWyu_GDtbbrkvuiAFKc_h9NG4'
+                        b'qcJtJkctU8","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50","a":{"d":"EnKO'
+                        b'URQiDR4frA0G1ELi_FsXqI3aBx_u74xct5-NllXg","i":"EhwC_-ISX9helBDUS'
                         b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
-                        b':00","LEI":"254900OPPU84GM83MG36","ri":"Eg1H4eN7P5ndJAWtcymq3ZrY'
-                        b'ZwQsBRYd3-VuZ6wMAwxE"},"p":[]}-JAB6AABAAA--FABEtjehgJ3LiIcPUKIQy'
-                        b'28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPU'
-                        b'KIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZh47Wkoez4lOg'
-                        b'oG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno2eR4DQ')
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"EYzrBEAQFwt_X-BJ3aOcwHwa'
+                        b'cdwysMSWnMr5qDaiE7Ow"},"p":[]}-JAB6AABAAA--FABErO8qhYftaJsAbCb6H'
+                        b'UrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAb'
+                        b'Cb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAAMzaTTgZl2t8CKZIXjsAuW2yzhU1W'
+                        b'86e2cXxL3enAOaxHZ0DkQhTkhMLTeoqBO3U-G1X8EdJEMOcchn-ZlzudAw')
 
         issuer.issue(creder=cred)
         parsing.Parser().parse(ims=sig0, vry=verifier)
@@ -212,8 +212,8 @@ def test_signature_transposition():
         assert seqner.sn == 0
         assert saider.qb64 == hab.kever.lastEst.d
         assert len(sigers) == 1
-        assert sigers[0].qb64b == (b'AADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-'
-                                   b'6mmzno2eR4DQ')
+        assert sigers[0].qb64b == (b'AAMzaTTgZl2t8CKZIXjsAuW2yzhU1W86e2cXxL3enAOaxHZ0DkQhTkhMLTeoqBO3U-G1X8EdJEMO'
+                                   b'cchn-ZlzudAw')
 
         # Transpose the signature to a new root
         scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said, root=coring.Pather(path=["a", "b", "c"]))
@@ -227,8 +227,8 @@ def test_signature_transposition():
         assert seqner.sn == 0
         assert saider.qb64 == hab.kever.lastEst.d
         assert len(sigers) == 1
-        assert sigers[0].qb64b == (b'AADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-'
-                                   b'6mmzno2eR4DQ')
+        assert sigers[0].qb64b == (b'AAMzaTTgZl2t8CKZIXjsAuW2yzhU1W86e2cXxL3enAOaxHZ0DkQhTkhMLTeoqBO3U-G1X8EdJEMO'
+                                   b'cchn-ZlzudAw')
 
         # embed the credential in an exn and transpose the signature
         scre, sadsigers, sadcigars = verifier.reger.cloneCred(said=cred.said, root=coring.Pather(path=["a"]))
@@ -236,22 +236,22 @@ def test_signature_transposition():
         msg = hab.endorse(serder=exn)
         msg.extend(eventing.proofize(sadtsgs=sadsigers, sadcigars=sadcigars))
 
-        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"ELiFf9jptP0iYqy16cStp9W3'
-                       b'plaGIj3cqX8g8JtWKzmI","dt":"2022-01-04T11:58:55.154502+00:00","r'
-                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E1x9hWR5'
-                       b'ypCrhgqMaIUlALI1Id_Y8IgDliPbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZ'
-                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGL'
-                       b'wLpuRBkZ8w","a":{"d":"E0kFtfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMG'
-                       b'Ac","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
+        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"Em0V2Doo4pJ29J11dCOXIqEt'
+                       b'YO-IDpJQIvwjRUzlonCo","dt":"2022-01-04T11:58:55.154502+00:00","r'
+                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E6GIzcFU'
+                       b'RqWyu_GDtbbrkvuiAFKc_h9NG4qcJtJkctU8","s":"ESAItgWbOyCvcNAqkJFBZ'
+                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VE'
+                       b't7SdG0wh50","a":{"d":"EnKOURQiDR4frA0G1ELi_FsXqI3aBx_u74xct5-Nll'
+                       b'Xg","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
                        b'1-06-09T17:35:54.169967+00:00","LEI":"254900OPPU84GM83MG36","ri"'
-                       b':"Eg1H4eN7P5ndJAWtcymq3ZrYZwQsBRYd3-VuZ6wMAwxE"},"p":[]}}-VA0-FA'
-                       b'BEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAA'
-                       b'AAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAiXFJ1sG9K'
-                       b'ZHkAKNPLoOZiz9jhzgIv2lknmmIKa2bHoDubNELBaM9Pli-8A202hbbnAg2tNGQq'
-                       b'73tT9nuCx9VDA-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLw'
-                       b'LpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzd'
-                       b'GGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o'
-                       b'7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno2eR4DQ')
+                       b':"EYzrBEAQFwt_X-BJ3aOcwHwacdwysMSWnMr5qDaiE7Ow"},"p":[]}}-VA0-FA'
+                       b'BErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAA'
+                       b'AAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAAKVAqXhPpD'
+                       b'5O3YLL9OBvsYkgeZX0kmBGyxb6s22IgoZ54SHfIfKipZ3dDRaD3U5YOarxVELgzQ'
+                       b'd4aLpF9STsUDw-JAB5AABAA-a-FABErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt'
+                       b'7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd'
+                       b'2VEt7SdG0wh50-AABAAMzaTTgZl2t8CKZIXjsAuW2yzhU1W86e2cXxL3enAOaxHZ'
+                       b'0DkQhTkhMLTeoqBO3U-G1X8EdJEMOcchn-ZlzudAw')
 
         # issue the credential
         issuer.issue(creder=cred)
@@ -272,23 +272,23 @@ def test_signature_transposition():
 
         # sign with single sig transferable identfier with multiple specified paths
         sig1 = signing.ratify(hab=hab, serder=cred, paths=[[], ["a"], ["a", "ri"]])
-        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"E1x9hWR5ypCrhgqMaIUlALI1Id_Y8IgDli'
-                        b'PbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
-                        b'i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w","a":{"d":"E0kF'
-                        b'tfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMGAc","i":"EhwC_-ISX9helBDUS'
+        assert sig1 == (b'{"v":"ACDC10JSON00019e_","d":"E6GIzcFURqWyu_GDtbbrkvuiAFKc_h9NG4'
+                        b'qcJtJkctU8","s":"ESAItgWbOyCvcNAqkJFBZqxG2-h69fOkw7Rzk0gAqkqo","'
+                        b'i":"ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50","a":{"d":"EnKO'
+                        b'URQiDR4frA0G1ELi_FsXqI3aBx_u74xct5-NllXg","i":"EhwC_-ISX9helBDUS'
                         b'KU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"2021-06-09T17:35:54.169967+00'
-                        b':00","LEI":"254900OPPU84GM83MG36","ri":"Eg1H4eN7P5ndJAWtcymq3ZrY'
-                        b'ZwQsBRYd3-VuZ6wMAwxE"},"p":[]}-KAD6AABAAA--JAB6AABAAA--FABEtjehg'
-                        b'J3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEt'
-                        b'jehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx0Jxn2kpwoiZ'
-                        b'h47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcvhhvw-6mmzno'
-                        b'2eR4DQ-JAB5AABAA-a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ'
-                        b'8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpu'
-                        b'RBkZ8w-AABAA_XSmslk9G08DoUO2S-AT5v1sfASpBzr-tBmFcTpjsjFVPbQVeCfT'
-                        b'YM5qw6N9rA_06Vgmk0wSWvZrTgD3ly-XDg-JAB6AACAAA-a-ri-FABEtjehgJ3Li'
-                        b'IcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehg'
-                        b'J3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAMww_ANw37teZaMDD69pY'
-                        b'1370mw5q0JnBEadHs1n2svQeydApgrvB0ofb2XWeFXquwkzj7fitH2M2nvivNm9tBA')
+                        b':00","LEI":"254900OPPU84GM83MG36","ri":"EYzrBEAQFwt_X-BJ3aOcwHwa'
+                        b'cdwysMSWnMr5qDaiE7Ow"},"p":[]}-KAD6AABAAA--JAB6AABAAA--FABErO8qh'
+                        b'YftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAEr'
+                        b'O8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAAMzaTTgZl2t8CKZIX'
+                        b'jsAuW2yzhU1W86e2cXxL3enAOaxHZ0DkQhTkhMLTeoqBO3U-G1X8EdJEMOcchn-Z'
+                        b'lzudAw-JAB5AABAA-a-FABErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh'
+                        b'500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7Sd'
+                        b'G0wh50-AABAAfVchR1X0_mHOv_OgPFO_wX9JeMlq5wrqZv50y5-wTxhLwPZFLITv'
+                        b'cK588Bnit11C0ZrfqtiO9rkKTSpZLdwnDQ-JAB6AACAAA-a-ri-FABErO8qhYfta'
+                        b'JsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qh'
+                        b'YftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAATMtLZlPsNYWOkc0G8-hA'
+                        b'h5YuBvv1h11AdyWS9tskUOrI3k31OjYOFheIRacNhzZKSjbUREN46SykJx1vDd1FCg')
 
         # Issue the credential and parse into credential store
         issuer.issue(creder=cred)
@@ -310,29 +310,29 @@ def test_signature_transposition():
 
         # attach the transposed signatures for the embedded credential
         msg.extend(eventing.proofize(sadtsgs=sadsigers, sadcigars=sadcigars))
-        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"ELiFf9jptP0iYqy16cStp9W3'
-                       b'plaGIj3cqX8g8JtWKzmI","dt":"2022-01-04T11:58:55.154502+00:00","r'
-                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E1x9hWR5'
-                       b'ypCrhgqMaIUlALI1Id_Y8IgDliPbP0h11tOs","s":"ESAItgWbOyCvcNAqkJFBZ'
-                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGL'
-                       b'wLpuRBkZ8w","a":{"d":"E0kFtfbyhIbjbzVnyHoNTkb64Zk-Wqjj77AjYEJBMG'
-                       b'Ac","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
+        assert msg == (b'{"v":"KERI10JSON000239_","t":"exn","d":"Em0V2Doo4pJ29J11dCOXIqEt'
+                       b'YO-IDpJQIvwjRUzlonCo","dt":"2022-01-04T11:58:55.154502+00:00","r'
+                       b'":"/credential/issue","a":{"v":"ACDC10JSON00019e_","d":"E6GIzcFU'
+                       b'RqWyu_GDtbbrkvuiAFKc_h9NG4qcJtJkctU8","s":"ESAItgWbOyCvcNAqkJFBZ'
+                       b'qxG2-h69fOkw7Rzk0gAqkqo","i":"ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VE'
+                       b't7SdG0wh50","a":{"d":"EnKOURQiDR4frA0G1ELi_FsXqI3aBx_u74xct5-Nll'
+                       b'Xg","i":"EhwC_-ISX9helBDUSKU5j_VEU3G0Jp6ZFRD9dTb4-5c0","dt":"202'
                        b'1-06-09T17:35:54.169967+00:00","LEI":"254900OPPU84GM83MG36","ri"'
-                       b':"Eg1H4eN7P5ndJAWtcymq3ZrYZwQsBRYd3-VuZ6wMAwxE"},"p":[]}}-VA0-FA'
-                       b'BEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAA'
-                       b'AAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAAiXFJ1sG9K'
-                       b'ZHkAKNPLoOZiz9jhzgIv2lknmmIKa2bHoDubNELBaM9Pli-8A202hbbnAg2tNGQq'
-                       b'73tT9nuCx9VDA-KAD6AABAAA--JAB4AAB-a-a-FABEtjehgJ3LiIcPUKIQy28zge'
-                       b'56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy2'
-                       b'8zge56_B2lzdGGLwLpuRBkZ8w-AABAA_XSmslk9G08DoUO2S-AT5v1sfASpBzr-t'
-                       b'BmFcTpjsjFVPbQVeCfTYM5qw6N9rA_06Vgmk0wSWvZrTgD3ly-XDg-JAB5AABAA-'
-                       b'a-FABEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAA'
-                       b'AAAAAAAAAEtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w-AABAADe5tx'
-                       b'0Jxn2kpwoiZh47Wkoez4lOgoG-E6lvjn_IXDIF4o7Oan_fNC22k6WzQKj8mewUcv'
-                       b'hhvw-6mmzno2eR4DQ-JAB4AACA-a-a-ri-FABEtjehgJ3LiIcPUKIQy28zge56_B'
-                       b'2lzdGGLwLpuRBkZ8w0AAAAAAAAAAAAAAAAAAAAAAAEtjehgJ3LiIcPUKIQy28zge'
-                       b'56_B2lzdGGLwLpuRBkZ8w-AABAAMww_ANw37teZaMDD69pY1370mw5q0JnBEadHs'
-                       b'1n2svQeydApgrvB0ofb2XWeFXquwkzj7fitH2M2nvivNm9tBA')
+                       b':"EYzrBEAQFwt_X-BJ3aOcwHwacdwysMSWnMr5qDaiE7Ow"},"p":[]}}-VA0-FA'
+                       b'BErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAA'
+                       b'AAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAAKVAqXhPpD'
+                       b'5O3YLL9OBvsYkgeZX0kmBGyxb6s22IgoZ54SHfIfKipZ3dDRaD3U5YOarxVELgzQ'
+                       b'd4aLpF9STsUDw-KAD6AABAAA--JAB4AAB-a-a-FABErO8qhYftaJsAbCb6HUrN4t'
+                       b'UyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HU'
+                       b'rN4tUyrV9dMd2VEt7SdG0wh50-AABAAfVchR1X0_mHOv_OgPFO_wX9JeMlq5wrqZ'
+                       b'v50y5-wTxhLwPZFLITvcK588Bnit11C0ZrfqtiO9rkKTSpZLdwnDQ-JAB5AABAA-'
+                       b'a-FABErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh500AAAAAAAAAAAAAA'
+                       b'AAAAAAAAAErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50-AABAAMzaTT'
+                       b'gZl2t8CKZIXjsAuW2yzhU1W86e2cXxL3enAOaxHZ0DkQhTkhMLTeoqBO3U-G1X8E'
+                       b'dJEMOcchn-ZlzudAw-JAB4AACA-a-a-ri-FABErO8qhYftaJsAbCb6HUrN4tUyrV'
+                       b'9dMd2VEt7SdG0wh500AAAAAAAAAAAAAAAAAAAAAAAErO8qhYftaJsAbCb6HUrN4t'
+                       b'UyrV9dMd2VEt7SdG0wh50-AABAATMtLZlPsNYWOkc0G8-hAh5YuBvv1h11AdyWS9'
+                       b'tskUOrI3k31OjYOFheIRacNhzZKSjbUREN46SykJx1vDd1FCg')
 
     # signing SAD with non-transferable identifier
     with habbing.openHab(name="wan", temp=True, salt=b'0123456789abcdef', transferable=False) as (hby, hab):

--- a/tests/app/test_watching.py
+++ b/tests/app/test_watching.py
@@ -26,7 +26,7 @@ def test_watcher_rotate_handler(seeder):
         ctrlIcp = ctrl.makeOwnEvent(sn=0)
         parsing.Parser().parse(ims=bytearray(ctrlIcp), kvy=watKvy)
         assert wat.pre == "BZg042qyBYoNC4rII1qdn7sPJPSh5vp5y0xnVYbJPujw"
-        assert ctrl.pre == "EWXKVEUufqmaOdCV27o51QPfvQR5s9qmOIG20HCL5Ebc"
+        assert ctrl.pre == "E5JhBGN4iCe842eVKwq0ZLSNcbHUYwdFFPKJ5atgnXTk"
 
         habr = ctrl.db.habs.get(ctrl.name)
         habr.watchers = list([wat.pre])

--- a/tests/comply/test_direct_mode.py
+++ b/tests/comply/test_direct_mode.py
@@ -2,7 +2,7 @@
 
 import os
 
-from keri.core.coring import Salter, MtrDex, CtrDex, Counter
+from keri.core.coring import Salter, MtrDex
 from keri.core.coring import Seqner
 from keri.app.keeping import Manager, openKS
 from keri.core import  eventing, parsing
@@ -49,7 +49,7 @@ def test_direct_mode_with_manager():
 
         # Controller Event 0  Inception Transferable (nxt digest not empty)
         coeSerder = incept(keys=[coeVerfers[0].qb64],
-                           nxt=eventing.Nexter(digs=[coeDigers[0].qb64]).qb64,
+                           nkeys=[coeDigers[0].qb64],
                            code=MtrDex.Blake3_256)
 
         assert csn == int(coeSerder.ked["s"], 16) == 0
@@ -74,7 +74,7 @@ def test_direct_mode_with_manager():
         valVerfers, valDigers, cst, nst = valMgr.incept(icount=1, ncount=1)
 
         valSerder = incept(keys=[valVerfers[0].qb64],
-                           nxt=eventing.Nexter(digs=[valDigers[0].qb64]).qb64,
+                           nkeys=[valDigers[0].qb64],
                            code=MtrDex.Blake3_256)
 
         assert vsn == int(valSerder.ked["s"], 16) == 0
@@ -216,7 +216,7 @@ def test_direct_mode_with_manager():
         coeSerder = rotate(pre=coeKever.prefixer.qb64,
                            keys=[coeVerfers[0].qb64],
                            dig=coeKever.serder.saider.qb64,
-                           nxt=eventing.Nexter(digs=[coeDigers[0].qb64]).qb64,
+                           nkeys=[coeDigers[0].qb64],
                            sn=csn)
         coe_event_digs.append(coeSerder.said)
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -1637,12 +1637,12 @@ def test_counter():
         'SealSourceCouples': '-G',
         'TransLastIdxSigGroups': '-H',
         'SealSourceTriples': '-I',
+        'PathedMaterialQuadlets': '-L',
         'MessageDataGroups': '-U',
         'AttachedMaterialQuadlets': '-V',
         'MessageDataMaterialQuadlets': '-W',
         'CombinedMaterialQuadlets': '-X',
         'MaterialGroups': '-Y',
-        'PathedMaterialQuadlets': '-T',
         'MaterialQuadlets': '-Z',
         'AnchorSealGroups': '-a',
         'ConfigTraits': '-c',
@@ -1692,7 +1692,7 @@ def test_counter():
         '-J': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-K': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-U': Sizage(hs=2, ss=2, fs=4, ls=0),
-        '-T': Sizage(hs=2, ss=2, fs=4, ls=0),
+        '-L': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-V': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-W': Sizage(hs=2, ss=2, fs=4, ls=0),
         '-X': Sizage(hs=2, ss=2, fs=4, ls=0),
@@ -2989,20 +2989,10 @@ def test_nexter():
     """
     Test the support functionality for Nexter subclass of Diger
     """
-    with pytest.raises(EmptyMaterialError):
-        nexter = Nexter()
-
     # create something to digest and verify
     # verkey, sigkey = pysodium.crypto_sign_keypair()
     # verfer = Verfer(raw=verkey)
     # assert verfer.qb64 == 'BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE'
-
-    sith = "{:x}".format(2)
-    sithdig = blake3.blake3(sith.encode("utf-8")).digest()
-    assert sithdig == b"\x81>\x9br\x91A\xe7\xf3\x85\xaf\xa0\xa2\xd0\xdf>l7\x89\xe4'\xff\xe4\xae\xefVjV[\xc8\xf2\xfe="
-
-    sithdiger = Diger(raw=sithdig, code=MtrDex.Blake3_256)
-    assert sithdiger.qb64 == 'EgT6bcpFB5_OFr6Ci0N8-bDeJ5Cf_5K7vVmpWW8jy_j0'
 
     keys = ['BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE',
             'BujP_71bmWFVcvFmkE9uS8BTZ54GIstZ20nj_UloF8Rk',
@@ -3021,73 +3011,63 @@ def test_nexter():
                     'EO4CXp8gs0yJg1fFhJLs5hH6neqJwhFEY7vrJEdPe87I',
                     'ELWWZEyBpjrfM1UU0n31KIyIXllrCoLEOI5UHD9x7WxI']
 
-    kints = [int.from_bytes(diger.raw, 'big') for diger in digers]
-    sint = int.from_bytes(sithdiger.raw, 'big')
-    for kint in kints:
-        sint ^= kint  # xor together
-
-    raw = sint.to_bytes(Matter._rawSize(MtrDex.Blake3_256), 'big')
-    assert raw == (
-        b'\x0f\xc6/\x0e\xb5\xef\x1a\xe6\x88U\x9e\xbd^\xc0U\x03\x96\r\xda\x93S}\x03\x85\xc2\x07\xa5\xa1Q\xdeX\xab')
-
-    nexter = Nexter(raw=raw)  # defaults provide Blake3_256 digest
-    assert nexter.code == MtrDex.Blake3_256
-    assert nexter.qb64 == 'ED8YvDrXvGuaIVZ69XsBVA5YN2pNTfQOFwgeloVHeWKs'
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
-    assert nexter.verify(raw=raw)
-    assert nexter.verify(raw=raw + b'ABCDEF') == False
-
-    with pytest.raises(ValueError):  # bad code
-        nexter = Nexter(raw=raw, code=MtrDex.Ed25519)
-
     #  defaults provide Blake3_256 digester
     nexter = Nexter(digs=digs)  # compute limen/sith from digs
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
     assert nexter.verify(digs=digs)
-    assert nexter.verify(raw=raw)
 
     nexter = Nexter(keys=keys)  # compute limen/sith from keys
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
+    assert len(nexter.digs) == len(keys)
     assert nexter.verify(keys=keys)
-    assert nexter.verify(raw=raw)
-    assert nexter.verify(raw=raw + b'ABCDEF') == False
+    assert nexter.verify(keys=keys + ['ABCDEF']) is False
 
-    with pytest.raises(EmptyMaterialError):
-        nexter = Nexter(sith=sith)
-
-    nexter = Nexter(sith=1, keys=keys)  # compute sith from int
-    raw1 = nexter.raw
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
-    assert nexter.verify(sith=1, keys=keys)
-    assert nexter.verify(raw=raw1)
-
-    nexter = Nexter(sith=1, digs=digs)
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
-    assert nexter.verify(sith=1, digs=digs)
-    assert nexter.verify(raw=raw1)
-
-    nexter = Nexter(limen='1', digs=digs)
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
-    assert nexter.verify(limen='1', digs=digs)
-    assert nexter.verify(raw=raw1)
-
-    nexter = Nexter(limen="1", keys=keys)
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
-    assert nexter.verify(limen="1", keys=keys)
-    assert nexter.verify(raw=raw1)
-
-    ked = dict(kt=sith, k=keys)  # subsequent event
+    ked = dict(kt=1, k=keys)  # subsequent event
     nexter = Nexter(ked=ked)
-    assert nexter.code == MtrDex.Blake3_256
-    assert len(nexter.raw) == Matter._rawSize(nexter.code)
+    assert len(nexter.digs) == len(keys)
     assert nexter.verify(ked=ked)
-    assert nexter.verify(raw=raw)
+
+    #  Test support for partial rotation
+    keys = [
+        "B6MUd25DuIUaJ6A3nIUay-JeMwWfAcfZcB2u0Vk_k3xE",
+        "BroOPXDvoc9c92GD489iMBp31x9s4asfQSlSNQd-o6d4",
+        "B3YjMzoTrqsZO6iOhab5L-IHVfTtRzc4hQV4XaUiyBTc",
+        "B9A-LD70YW7MkD5xZlrRLzAqPNuxfFoqAIFpe0xy-uvg",
+        "BLazW7nktYdVqRiWRFF-y-bVY-bqJT_AC-X8qAht8YiE",
+        "Bzb6FZt7473h-XIhEMlTSYzpehTVRZ0T9wa_A1Npiwr4",
+        "BpvXdM-xd24gS_ewVp_eS_G3piJh_0kohhNfiWXEW_o0",
+        "BEVlWXsK0fyYUnd-B5_ruTfZQEfTuYlS3ZL3tCSfcRos",
+        "BDRogzlpHFDjciNgt1a2S04Dk33YSA8UNXvQbxOqLl6o",
+        "B12eAgbg9V9fFTKw38S-NnV3bw3jYeKOVixP2leJGMIU",
+    ]
+    digers = [Diger(raw=blake3.blake3(key.encode("utf-8")).digest(), code=MtrDex.Blake3_256) for key in keys]
+
+    # grab first 5 for our nexter
+    cur = [diger.qb64 for diger in digers[0:5]]
+
+    nexter = Nexter(digs=cur)
+
+    # compare against full set
+    digs = cur
+    assert nexter.verify(digs=digs)
+
+    # compare against a proper subset
+    digs = [diger.qb64 for diger in digers[2:5]]
+    assert nexter.verify(digs=digs)
+
+    # compare against a single existing dig
+    digs = [digers[4].qb64]
+    assert nexter.verify(digs=digs)
+
+    # compare against a single existing dig
+    digs = [digers[7].qb64]
+    assert not nexter.verify(digs=digs)
+
+    # compare against non-contiguous subset
+    digs = [digers[1].qb64, digers[3].qb64, digers[4].qb64]
+    assert nexter.verify(digs=digs)
+
+    # compare against non-contiguous subset
+    digs = [digers[1].qb64, digers[3].qb64, digers[6].qb64]
+    assert not nexter.verify(digs=digs)
 
     """ Done Test """
 
@@ -3238,14 +3218,14 @@ def test_prefixer():
                t=ilk,
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nexter.qb64,  # hash qual Base64
+               n=nexter.digs,  # hash qual Base64
                wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                w=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
                )
 
     prefixer = Prefixer(ked=ked, code=MtrDex.Blake3_256)
-    assert prefixer.qb64 == 'E_11RKUF7tLf1pU0vlznGLukpFIzjpmEcFqGKKsJfRV0'
+    assert prefixer.qb64 == 'EDve7ZqtIsIMrx6UVZRTcnLgEnYGGV2is_JI_Ps3hEnE'
     assert prefixer.verify(ked=ked) == True
     assert prefixer.verify(ked=ked, prefixed=True) == False
 
@@ -3276,14 +3256,14 @@ def test_prefixer():
                t=ilk,
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nexter.qb64,  # hash qual Base64
+               n=nexter.digs,  # hash qual Base64
                wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                w=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
                )
 
     prefixer1 = Prefixer(ked=ked, code=MtrDex.Blake3_256)
-    assert prefixer1.qb64 == 'EElXC-USUApr4KQrQD6MTaXnmejFIpMCDhVn81zeC1-E'
+    assert prefixer1.qb64 == 'EJUqcw-yS7Fqk5XAU8-MRwl25hMfURhc1wKqLDG7QZhQ'
     assert prefixer1.verify(ked=ked) == True
     assert prefixer.verify(ked=ked, prefixed=True) == False
 
@@ -3295,14 +3275,14 @@ def test_prefixer():
                t=ilk,
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nexter.qb64,  # hash qual Base64
+               n=nexter.digs,  # hash qual Base64
                wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                w=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
                )
 
     prefixer2 = Prefixer(ked=ked, code=MtrDex.Blake3_256)
-    assert prefixer2.qb64 == 'EMtMcL-SJXet6A1WT_fuiA1wDTYx11OM6bsbjnExMkas'
+    assert prefixer2.qb64 == 'EN1epXqakc6DCsQqPUFVYlz6so0M0BJdDuQy53nBQI4Q'
     assert prefixer2.verify(ked=ked) == True
     assert prefixer.verify(ked=ked, prefixed=True) == False
     assert prefixer2.qb64 != prefixer1.qb64  # semantic diff -> syntactic diff
@@ -3319,7 +3299,7 @@ def test_prefixer():
                t=Ilks.dip,
                kt=sith,  # hex string no leading zeros lowercase
                k=keys,  # list of qb64
-               n=nexter.qb64,  # hash qual Base64
+               n=nexter.digs,  # hash qual Base64
                wt="{:x}".format(toad),  # hex string no leading zeros lowercase
                w=wits,  # list of qb64 may be empty
                c=cnfg,  # list of config ordered mappings may be empty
@@ -3327,7 +3307,7 @@ def test_prefixer():
                )
 
     prefixer = Prefixer(ked=ked, code=MtrDex.Blake3_256)
-    assert prefixer.qb64 == 'ECihxbUGpKKdepTqhKFzraAmzzlcz5X4wxszGAEhztT0'
+    assert prefixer.qb64 == 'ExjPDXRhIuAmgsnKGjrwudZAYuAqHf5SLMPvVscvHh9Y'
     assert prefixer.verify(ked=ked) == True
     assert prefixer.verify(ked=ked, prefixed=True) == False
 
@@ -3338,7 +3318,7 @@ def test_prefixer():
 
     prefixer = Prefixer(ked=ked, code=MtrDex.Blake3_256,
                         allows=[MtrDex.Blake3_256, MtrDex.Ed25519])
-    assert prefixer.qb64 == 'ECihxbUGpKKdepTqhKFzraAmzzlcz5X4wxszGAEhztT0'
+    assert prefixer.qb64 == 'ExjPDXRhIuAmgsnKGjrwudZAYuAqHf5SLMPvVscvHh9Y'
     assert prefixer.verify(ked=ked) == True
     assert prefixer.verify(ked=ked, prefixed=True) == False
 
@@ -4135,11 +4115,11 @@ def test_serder():
     wit0 = 'B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68'
     wit1 = 'Bed2Tpxc8KeCEWoq3_RKKRjU_3P-chSser9J4eAtAK6I'
     srdr = eventing.incept(keys=[pre0], wits=[wit0, wit1])
-    assert srdr.raw == (b'{"v":"KERI10JSON000151_","t":"icp","d":"Eazv_T06u6n_PevJi0BXtvOn7THI5I5tlDUU'
-                        b'XzrGLyl8","i":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
-                        b'","k":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"n":"","bt":"2","b":['
-                        b'"B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68","Bed2Tpxc8KeCEWoq3_RKKRjU_3P-'
-                        b'chSser9J4eAtAK6I"],"c":[],"a":[]}')
+    assert srdr.raw == (b'{"v":"KERI10JSON00015a_","t":"icp","d":"ENivF7rlDvQORxeomP1eGWclQr-hlq49YG6n'
+                        b'EgOb2RIQ","i":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
+                        b'","k":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"nt":"0","n":[],"bt":'
+                        b'"2","b":["B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68","Bed2Tpxc8KeCEWoq3_R'
+                        b'KKRjU_3P-chSser9J4eAtAK6I"],"c":[],"a":[]}')
     # test for serder.verfers and serder.werfers
     assert srdr.pre == pre0
     assert srdr.sn == 0

--- a/tests/core/test_delegating.py
+++ b/tests/core/test_delegating.py
@@ -39,11 +39,11 @@ def test_delegation():
         # Setup Bob by creating inception event
         verfers, digers, cst, nst = bobMgr.incept(stem='bob', temp=True)  # algo default salty and rooted
         bobSrdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
-                                  nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64,
+                                  nkeys=[diger.qb64 for diger in digers],
                                   code=coring.MtrDex.Blake3_256)
 
         bob = bobSrdr.ked["i"]
-        assert bob == 'Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8'
+        assert bob == 'E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0'
 
         bobMgr.move(old=verfers[0].qb64, new=bob)  # move key pair label to prefix
 
@@ -55,12 +55,13 @@ def test_delegation():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == (b'{"v":"KERI10JSON000120_","t":"icp","d":"Et78eYkh8A3H9w6Q87EC5Oci'
-                       b'jiVEJT8KyNtEGdpPVWV8","i":"Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEG'
-                       b'dpPVWV8","s":"0","kt":"1","k":["DqI2cOZ06RwGNwCovYUWExmdKU983Ias'
-                       b'mUKMmZflvWdQ"],"n":"E7FuL3Z_KBgt_QAwuZi1lUFNC69wvyHSxnMFUsKjZHss'
-                       b'","bt":"0","b":[],"c":[],"a":[]}-AABAAJEloPu7b4z8v1455StEJ1b7dMI'
-                       b'z-P0tKJ_GBBCxQA8JEg0gm8qbS4TWGiHikLoZ2GtLA58l9dzIa2x_otJhoDA')
+        assert msg == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"E7YbTIkWWyNwOxZQTTnrs6qn'
+                       b'8jFbu2A8zftQ33JYQFQ0","i":"E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ3'
+                       b'3JYQFQ0","s":"0","kt":"1","k":["DqI2cOZ06RwGNwCovYUWExmdKU983Ias'
+                       b'mUKMmZflvWdQ"],"nt":"1","n":["EOmBSdblll8qB4324PEmETrFN-DhElyZ0B'
+                       b'cBH1q1qukw"],"bt":"0","b":[],"c":[],"a":[]}-AABAAotHSmS5LuCg2LXw'
+                       b'landbAs3MFR0yTC5BbE2iSW_35U2qA0hP9gp66G--mHhiFmfHEIbBKrs3tjcc8yS'
+                       b'vYcpiBg')
 
         # apply msg to bob's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=bobKvy)
@@ -68,7 +69,7 @@ def test_delegation():
         bobK = bobKvy.kevers[bob]
         assert bobK.prefixer.qb64 == bob
         assert bobK.serder.saider.qb64 == bobSrdr.said
-        assert bobK.serder.saider.qb64 == 'Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8'
+        assert bobK.serder.saider.qb64 == 'E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0'
 
         # apply msg to del's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=delKvy)
@@ -80,13 +81,13 @@ def test_delegation():
 
         delSrdr = eventing.delcept(keys=[verfer.qb64 for verfer in verfers],
                                    delpre=bobK.prefixer.qb64,
-                                   nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64)
+                                   nkeys=[diger.qb64 for diger in digers])
 
         delPre = delSrdr.ked["i"]
-        assert delPre == 'Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwyXI'
+        assert delPre == 'ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM0A'
 
         delMgr.move(old=verfers[0].qb64, new=delPre)  # move key pair label to prefix
-        assert delSrdr.said == 'Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwyXI'
+        assert delSrdr.said == 'ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM0A'
 
         # Now create delegating event
         seal = eventing.SealEvent(i=delPre,
@@ -97,7 +98,7 @@ def test_delegation():
                                     sn=bobK.sn + 1,
                                     data=[seal._asdict()])
 
-        assert bobSrdr.said == 'E1_-icBrwC_HhxyFwsQLV6hZEbApOc_McGUjhLONpQuc'
+        assert bobSrdr.said == 'E4ncGiiaG9wbKMHrACX9iPxb7fMSSeBSnngBNIRoZ2_A'
 
         sigers = bobMgr.sign(ser=bobSrdr.raw, verfers=bobK.verfers)
         msg = bytearray(bobSrdr.raw)
@@ -107,13 +108,13 @@ def test_delegation():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"E1_-icBrwC_HhxyFwsQLV6hZ'
-                       b'EbApOc_McGUjhLONpQuc","i":"Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEG'
-                       b'dpPVWV8","s":"1","p":"Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVW'
-                       b'V8","a":[{"i":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwyXI","s"'
-                       b':"0","d":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwyXI"}]}-AABAA'
-                       b'6h5mD5stIwO_rwV9apMuhHXjxrKp2ATa35u-H6DM2X-BKo5NkJ1khzBdHo-VLQ6Z'
-                       b'w_yajj2Ul_WOL8pFSk_ZDg')
+        assert msg == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"E4ncGiiaG9wbKMHrACX9iPxb'
+                       b'7fMSSeBSnngBNIRoZ2_A","i":"E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ3'
+                       b'3JYQFQ0","s":"1","p":"E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQF'
+                       b'Q0","a":[{"i":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM0A","s"'
+                       b':"0","d":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM0A"}]}-AABAA'
+                       b'Rpc88hIeWV9Z2IvzDl7dRHP-g1-EOYZLiDKyjNZB9PDSeGcNTj_SUXgWIVNdssPL'
+                       b'7ajYvglbvxRwIU8teoFHCA')
 
         # apply msg to bob's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=bobKvy)
@@ -144,14 +145,15 @@ def test_delegation():
         msg.extend(seqner.qb64b)
         msg.extend(bobSrdr.saider.qb64b)
 
-        assert msg == (b'{"v":"KERI10JSON000154_","t":"dip","d":"Er4bHXd4piEtsQat1mquwsNZ'
-                       b'XItvuoj_auCUyICmwyXI","i":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUy'
-                       b'ICmwyXI","s":"0","kt":"1","k":["DuK1x8ydpucu3480Jpd1XBfjnCwb3dZ3'
-                       b'x5b1CJmuUphA"],"n":"EWWkjZkZDXF74O2bOQ4H5hu4nXDlKg2m4CBEBkUxibiU'
-                       b'","bt":"0","b":[],"c":[],"a":[],"di":"Et78eYkh8A3H9w6Q87EC5Ociji'
-                       b'VEJT8KyNtEGdpPVWV8"}-AABAA_zcT2-86Zll3FG-hwoQiVuFiT0X28Ft0t4fZGN'
-                       b'FISgtZjH2DCrBGoceko604NDZ0QF0Z3bSgEkN_y0lBafD_Bw-GAB0AAAAAAAAAAA'
-                       b'AAAAAAAAAAAQE1_-icBrwC_HhxyFwsQLV6hZEbApOc_McGUjhLONpQuc')
+        assert msg == (b'{"v":"KERI10JSON00015f_","t":"dip","d":"ESVGDRnpHMCAESkvj2bxKGAm'
+                       b'MloX6K6vxfcmBLTOCM0A","i":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmB'
+                       b'LTOCM0A","s":"0","kt":"1","k":["DuK1x8ydpucu3480Jpd1XBfjnCwb3dZ3'
+                       b'x5b1CJmuUphA"],"nt":"1","n":["Ej1L6zmDszZ8GmBdYGeUYmAwoT90h3Dt9k'
+                       b'RAS90nRyqI"],"bt":"0","b":[],"c":[],"a":[],"di":"E7YbTIkWWyNwOxZ'
+                       b'QTTnrs6qn8jFbu2A8zftQ33JYQFQ0"}-AABAAbb1dks4dZCRcibL74840WKKtk9w'
+                       b'sdMLLlmNFkjb1s7hBfevCqpN8nkZaewQFZu5QWR-rbZtN-Y8DDQ8lh_1WDA-GAB0'
+                       b'AAAAAAAAAAAAAAAAAAAAAAQE4ncGiiaG9wbKMHrACX9iPxb7fMSSeBSnngBNIRoZ'
+                       b'2_A')
 
         # apply Del's delegated inception event message to Del's own Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=delKvy)
@@ -180,9 +182,9 @@ def test_delegation():
                                    keys=[verfer.qb64 for verfer in verfers],
                                    dig=bobDelK.serder.saider.qb64,
                                    sn=bobDelK.sn + 1,
-                                   nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64)
+                                   nkeys=[diger.qb64 for diger in digers])
 
-        assert delSrdr.said == 'ELEnIYF_rAsluR9TI_jh5Dizq61dCXjos22AGN0hiVjw'
+        assert delSrdr.said == 'EnjU4Rc4YtHFV7ezc6FbmXWNdT4QGE2sTtl-yaGXH-ag'
 
         # Now create delegating interaction event
         seal = eventing.SealEvent(i=bobDelK.prefixer.qb64,
@@ -202,13 +204,13 @@ def test_delegation():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == bytearray(b'{"v":"KERI10JSON00013a_","t":"ixn","d":"Eq-MPVuYTPXNUlQSHKfnPhiV'
-                                b'3rWo7hkkLa7ui67OIG68","i":"Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEG'
-                                b'dpPVWV8","s":"2","p":"E1_-icBrwC_HhxyFwsQLV6hZEbApOc_McGUjhLONpQ'
-                                b'uc","a":[{"i":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwyXI","s"'
-                                b':"1","d":"ELEnIYF_rAsluR9TI_jh5Dizq61dCXjos22AGN0hiVjw"}]}-AABAA'
-                                b'-QDEYYQCDtosLkziTAaWTu3mfVdFUxa8tytwQVohRwBJEhefCIaCDIbFhrrEn17K'
-                                b'MwGoOJKBrJ7Da4WqeWbtAA')
+        assert msg == bytearray(b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EAh9mAkWlONIqJPdhMFQ4a9j'
+                                b'x4nZWz7JW6wLp9T2YFqk","i":"E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ3'
+                                b'3JYQFQ0","s":"2","p":"E4ncGiiaG9wbKMHrACX9iPxb7fMSSeBSnngBNIRoZ2'
+                                b'_A","a":[{"i":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM0A","s"'
+                                b':"1","d":"EnjU4Rc4YtHFV7ezc6FbmXWNdT4QGE2sTtl-yaGXH-ag"}]}-AABAA'
+                                b'EGO3wl32as1yxubkrY19x_BwntHVl7jAXHhUpFEPkkpkBxA9lbIG_vhe6-gm-GT6'
+                                b'pwKg_pfPDr7pWTZ5sgR5AQ')
 
         # apply msg to bob's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=bobKvy)
@@ -236,14 +238,15 @@ def test_delegation():
         msg.extend(seqner.qb64b)
         msg.extend(bobSrdr.saider.qb64b)
 
-        assert msg == (b'{"v":"KERI10JSON000155_","t":"drt","d":"ELEnIYF_rAsluR9TI_jh5Diz'
-                       b'q61dCXjos22AGN0hiVjw","i":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUy'
-                       b'ICmwyXI","s":"1","p":"Er4bHXd4piEtsQat1mquwsNZXItvuoj_auCUyICmwy'
-                       b'XI","kt":"1","k":["DTf6QZWoet154o9wvzeMuNhLQRr8JaAUeiC6wjB_4_08"'
-                       b'],"n":"E8kyiXDfkE7idwWnAZQjHbUZMz-kd_yIMH0miptIFFPo","bt":"0","b'
-                       b'r":[],"ba":[],"a":[]}-AABAAer7S2mRuHlXxmJxy6E5lgdBmh3eeKd2Tnkyiv'
-                       b'HlEw83Xhq98h6RBjXRDc_S0Z-TrLUS2u-6FnIkP_yYsOeH0Dg-GAB0AAAAAAAAAA'
-                       b'AAAAAAAAAAAAgEq-MPVuYTPXNUlQSHKfnPhiV3rWo7hkkLa7ui67OIG68')
+        assert msg ==(b'{"v":"KERI10JSON000160_","t":"drt","d":"EnjU4Rc4YtHFV7ezc6FbmXWN'
+                      b'dT4QGE2sTtl-yaGXH-ag","i":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmB'
+                      b'LTOCM0A","s":"1","p":"ESVGDRnpHMCAESkvj2bxKGAmMloX6K6vxfcmBLTOCM'
+                      b'0A","kt":"1","k":["DTf6QZWoet154o9wvzeMuNhLQRr8JaAUeiC6wjB_4_08"'
+                      b'],"nt":"1","n":["EJHd79BFLgnljYhhWP2wmc6RD3A12oHDJhkixwNe2sH0"],'
+                      b'"bt":"0","br":[],"ba":[],"a":[]}-AABAA9-6k6bExTqgFDG8akEA7ifbMPx'
+                      b'sWDe0ttdAXpm3HiYdjfTlY5-vUcDZ1e6RHs6xLADNiNhmKHAuRQW8nmFyPBw-GAB'
+                      b'0AAAAAAAAAAAAAAAAAAAAAAgEAh9mAkWlONIqJPdhMFQ4a9jx4nZWz7JW6wLp9T2'
+                      b'YFqk')
 
         # apply msg to del's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=delKvy)
@@ -265,7 +268,7 @@ def test_delegation():
         msgs = bytearray()
         for msg in delKvy.db.clonePreIter(pre=delPre, fn=0):
             msgs.extend(msg)
-        assert len(msgs) == 1145
+        assert len(msgs) == 1167
         assert couple in msgs
 
     assert not os.path.exists(delKS.path)

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -6,7 +6,6 @@ tests escrows in database primarily logic in Kevery and Kever from keri.core.eve
 import os
 import time
 import datetime
-import pytest
 
 from keri import help
 from keri.help import helping
@@ -43,10 +42,10 @@ def test_partial_signed_escrow():
         assert cst == nst == sith
 
         srdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
-                                  sith=sith,
-                                 nxt=coring.Nexter(sith=nxtsith,
-                                                   digs=[diger.qb64 for diger in digers]).qb64,
-                                 code=coring.MtrDex.Blake3_256)
+                               sith=sith,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
+                               code=coring.MtrDex.Blake3_256)
 
         pre = srdr.ked["i"]
 
@@ -263,8 +262,8 @@ def test_partial_signed_escrow():
                                keys=[verfer.qb64 for verfer in verfers],
                                sith=sith,
                                dig=kvr.serder.saider.qb64,
-                               nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
                                sn=kvr.sn+1,
                                data=[])
 
@@ -294,8 +293,8 @@ def test_partial_signed_escrow():
                                keys=[verfer.qb64 for verfer in verfers],
                                sith=sith,
                                dig=kvr.serder.saider.qb64,
-                               nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
                                sn=kvr.sn+1,
                                data=[])
 
@@ -375,8 +374,8 @@ def test_missing_delegator_escrow():
         # Setup Bob by creating inception event
         verfers, digers, cst, nst = bobMgr.incept(stem='bob', temp=True) # algo default salty and rooted
         bobSrdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
-                                 nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64,
-                                 code=coring.MtrDex.Blake3_256)
+                                  nkeys=[diger.qb64 for diger in digers],
+                                  code=coring.MtrDex.Blake3_256)
 
         bobPre = bobSrdr.ked["i"]
 
@@ -411,7 +410,7 @@ def test_missing_delegator_escrow():
 
         delSrdr = eventing.delcept(keys=[verfer.qb64 for verfer in verfers],
                                    delpre=bobPre,
-                                   nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64)
+                                   nkeys=[diger.qb64 for diger in digers])
 
         delPre = delSrdr.ked["i"]
 
@@ -525,7 +524,7 @@ def test_missing_delegator_escrow():
                                    keys=[verfer.qb64 for verfer in verfers],
                                    dig=bobDelK.serder.saider.qb64,
                                    sn=bobDelK.sn+1,
-                                   nxt=coring.Nexter(digs=[diger.qb64 for diger in digers]).qb64)
+                                   nkeys=[diger.qb64 for diger in digers])
 
         # Now create delegating interaction event
         seal = eventing.SealEvent(i=bobDelK.prefixer.qb64,
@@ -624,10 +623,10 @@ def test_out_of_order_escrow():
         assert cst == nst == sith
 
         srdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
-                                  sith=sith,
-                                 nxt=coring.Nexter(sith=nxtsith,
-                                                   digs=[diger.qb64 for diger in digers]).qb64,
-                                 code=coring.MtrDex.Blake3_256)
+                               sith=sith,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
+                               code=coring.MtrDex.Blake3_256)
 
         pre = srdr.ked["i"]
         icpdig = srdr.said
@@ -669,13 +668,13 @@ def test_out_of_order_escrow():
         assert nst == nxtsith
 
         srdr = eventing.rotate(pre=pre,
-                                  keys=[verfer.qb64 for verfer in verfers],
-                                  sith=sith,
-                                  dig=ixndig,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
-                                  sn=2,
-                                  data=[])
+                               keys=[verfer.qb64 for verfer in verfers],
+                               sith=sith,
+                               dig=ixndig,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
+                               sn=2,
+                               data=[])
 
         rotdig = srdr.said
 
@@ -839,8 +838,8 @@ def test_unverified_receipt_escrow():
 
         srdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
                                sith=sith,
-                               nxt=coring.Nexter(sith=nxtsith,
-                                                 digs=[diger.qb64 for diger in digers]).qb64,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
                                code=coring.MtrDex.Blake3_256)
 
         pre = srdr.ked["i"]
@@ -950,8 +949,8 @@ def test_unverified_receipt_escrow():
                                keys=[verfer.qb64 for verfer in verfers],
                                sith=sith,
                                dig=ixndig,
-                               nxt=coring.Nexter(sith=nxtsith,
-                                                 digs=[diger.qb64 for diger in digers]).qb64,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
                                sn=2,
                                data=[])
 
@@ -1114,10 +1113,10 @@ def test_unverified_trans_receipt_escrow():
         assert cst == nst == sith
 
         srdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
-                                  sith=sith,
-                                 nxt=coring.Nexter(sith=nxtsith,
-                                                   digs=[diger.qb64 for diger in digers]).qb64,
-                                 code=coring.MtrDex.Blake3_256)
+                               sith=sith,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
+                               code=coring.MtrDex.Blake3_256)
 
         pre = srdr.ked["i"]
         icpdig = srdr.said
@@ -1142,8 +1141,8 @@ def test_unverified_trans_receipt_escrow():
         # create recepter's inception event
         rsrdr = eventing.incept(keys=[verfer.qb64 for verfer in rverfers],
                                 sith=rsith,
-                                nxt=coring.Nexter(sith=rsith,
-                                                  digs=[diger.qb64 for diger in rdigers]).qb64,
+                                nsith=rsith,
+                                nkeys=[diger.qb64 for diger in rdigers],
                                 code=coring.MtrDex.Blake3_256)
 
         rpre = rsrdr.ked["i"]
@@ -1207,13 +1206,13 @@ def test_unverified_trans_receipt_escrow():
         rverfers, rdigers, cst, nst = mgr.rotate(pre=rpre, count=3, temp=True)
 
         rsrdr = eventing.rotate(pre=rpre,
-                                  keys=[verfer.qb64 for verfer in rverfers],
-                                  sith=rsith,
-                                  dig=ricpdig,
-                                  nxt=coring.Nexter(sith=rsith,
-                                                    digs=[diger.qb64 for diger in rdigers]).qb64,
-                                  sn=1,
-                                  data=[])
+                                keys=[verfer.qb64 for verfer in rverfers],
+                                sith=rsith,
+                                dig=ricpdig,
+                                nsith=rsith,
+                                nkeys=[diger.qb64 for diger in rdigers],
+                                sn=1,
+                                data=[])
 
         rrotdig = rsrdr.said
 
@@ -1263,13 +1262,13 @@ def test_unverified_trans_receipt_escrow():
         assert nst == nxtsith
 
         srdr = eventing.rotate(pre=pre,
-                                  keys=[verfer.qb64 for verfer in verfers],
-                                  sith=sith,
-                                  dig=ixndig,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
-                                  sn=2,
-                                  data=[])
+                               keys=[verfer.qb64 for verfer in verfers],
+                               sith=sith,
+                               dig=ixndig,
+                               nsith=nxtsith,
+                               nkeys=[diger.qb64 for diger in digers],
+                               sn=2,
+                               data=[])
 
         rotdig = srdr.said
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -13,7 +13,7 @@ from keri import help
 from keri.app import habbing, keeping
 from keri.app.keeping import openKS, Manager
 from keri.core import coring, eventing, parsing
-from keri.core.coring import Ilks
+from keri.core.coring import Ilks, Diger
 from keri.core.coring import MtrDex, Matter, IdrDex, Indexer, CtrDex, Counter
 from keri.core.coring import Salter, Serder, Siger, Cigar
 from keri.core.coring import Seqner, Verfer, Signer, Nexter, Prefixer
@@ -723,17 +723,17 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     keys0 = [signer0.verfer.qb64]
     serder = incept(keys=keys0)  # default nxt is empty so abandoned
     assert serder.ked["i"] == 'BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
-    assert serder.ked["n"] == ""
-    assert serder.raw == (b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EN7i9jZdpGwVJYZBv2nM3-9vVMES8edy5YlI'
-                          b'QljNCIok","i":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
-                          b'","k":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"n":"","bt":"0","b":['
-                          b'],"c":[],"a":[]}')
+    assert serder.ked["n"] == []
+    assert serder.raw == (b'{"v":"KERI10JSON0000fd_","t":"icp","d":"EwslIRt-LtDgutEmsju1WAM9dAf3wzrivvNP'
+                          b'En8ANo4k","i":"BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
+                          b'","k":["BWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"nt":"0","n":[],"bt":'
+                          b'"0","b":[],"c":[],"a":[]}')
     saider = coring.Saider(sad=serder.ked, code=MtrDex.Blake3_256)
     assert saider.verify(serder.ked) is True
 
     with pytest.raises(DerivationError):
         # non-empty nxt with non-transferable code
-        serder = incept(keys=keys0, code=MtrDex.Ed25519N, nxt="ABCDE")
+        serder = incept(keys=keys0, code=MtrDex.Ed25519N, nkeys=["ABCDE"])
 
     with pytest.raises(DerivationError):
         # non-empty witnesses with non-transferable code
@@ -750,11 +750,11 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     keys0 = [signer0.verfer.qb64]
     serder = incept(keys=keys0)  # default nxt is empty so abandoned
     assert serder.ked["i"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
-    assert serder.ked["n"] == ""
-    assert serder.raw == (b'{"v":"KERI10JSON0000f4_","t":"icp","d":"E7S_BfZ8N-efqDdqOp2IqGmoX15eJlibksNo'
-                          b'u11jpkxw","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
-                          b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"n":"","bt":"0","b":['
-                          b'],"c":[],"a":[]}')
+    assert serder.ked["n"] == []
+    assert serder.raw == (b'{"v":"KERI10JSON0000fd_","t":"icp","d":"EdPc03U4_IgGhLQqQP2qxi1s-3r8UHzxFk8i'
+                          b'NO72bap4","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
+                          b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"nt":"0","n":[],"bt":'
+                          b'"0","b":[],"c":[],"a":[]}')
     saider = coring.Saider(sad=serder.ked, code=MtrDex.Blake3_256)
     assert saider.verify(serder.ked) is True
 
@@ -767,19 +767,18 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     assert signer1.verfer.code == MtrDex.Ed25519
     keys1 = [signer1.verfer.qb64]
     # compute nxt digest
-    nexter1 = Nexter(keys=keys1)  # dfault sith is 1
-    nxt1 = nexter1.qb64  # transferable so nxt is not empty
-    assert nxt1 == 'EcBCalw7Oe2ohLDra2ovwlv72PrlQZdQdaoSZ1Vvk5P4'
-    serder0 = incept(keys=keys0, nxt=nxt1)
+    nxt1 = [coring.Diger(ser=signer1.verfer.qb64b).qb64]  # dfault sith is 1
+    assert nxt1 == ['EpitDPyhh6qvfj0tMgO8RiBz5LV07OobY84WKs15XQHk']
+    serder0 = incept(keys=keys0, nkeys=nxt1)
     pre = serder0.ked["i"]
     assert serder0.ked["i"] == 'DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc'
     assert serder0.ked["s"] == '0'
     assert serder0.ked["t"] == Ilks.icp
     assert serder0.ked["n"] == nxt1
-    assert serder0.raw == (b'{"v":"KERI10JSON000120_","t":"icp","d":"EO4Z11IVb8w4dUs4cGqYtp53dYKIV8j-mORG'
-                           b'J7wOdSN8","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
-                           b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"n":"EcBCalw7Oe2ohLDr'
-                           b'a2ovwlv72PrlQZdQdaoSZ1Vvk5P4","bt":"0","b":[],"c":[],"a":[]}')
+    assert serder0.raw == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"EKWhDaMeK0DPrGcdem78_dPpofitWMAg7ZvZ'
+                           b'ceMGi2_4","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0","kt":"1'
+                           b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"nt":"1","n":["EpitDP'
+                           b'yhh6qvfj0tMgO8RiBz5LV07OobY84WKs15XQHk"],"bt":"0","b":[],"c":[],"a":[]}')
 
     saider = coring.Saider(sad=serder0.ked, code=MtrDex.Blake3_256)
     assert saider.qb64 == serder0.said
@@ -790,22 +789,19 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     signer2 = Signer(raw=seed2)  # next signing keypair transferable is default
     assert signer2.code == MtrDex.Ed25519_Seed
     assert signer2.verfer.code == MtrDex.Ed25519
-    keys2 = [signer2.verfer.qb64]
+    keys2 = [coring.Diger(ser=signer2.verfer.qb64b).qb64]
     # compute nxt digest
-    nexter2 = Nexter(keys=keys2)
-    nxt2 = nexter2.qb64  # transferable so nxt is not empty
-    assert nxt2 == 'EAXTvbATMnVRGjyC_VCNuXcPTxxpLanfzj14u3QMsD_U'
-    serder1 = rotate(pre=pre, keys=keys1, dig=serder0.said, nxt=nxt2, sn=1)
+    serder1 = rotate(pre=pre, keys=keys1, dig=serder0.said, nkeys=keys2, sn=1)
     assert serder1.ked["i"] == pre
     assert serder1.ked["s"] == '1'
     assert serder1.ked["t"] == Ilks.rot
-    assert serder1.ked["n"] == nxt2
+    assert serder1.ked["n"] == keys2
     assert serder1.ked["p"] == serder0.said
-    assert serder1.raw == (b'{"v":"KERI10JSON000155_","t":"rot","d":"EAntLipNnDDcGAJfGz9TStcJ8M19YLji3LPN'
-                           b'VpXalwv4","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"1","p":"EO'
-                           b'4Z11IVb8w4dUs4cGqYtp53dYKIV8j-mORGJ7wOdSN8","kt":"1","k":["DHgZa-u7veNZkqk2A'
-                           b'xCnxrINGKfQ0bRiaf9FdA_-_49A"],"n":"EAXTvbATMnVRGjyC_VCNuXcPTxxpLanfzj14u3QMs'
-                           b'D_U","bt":"0","br":[],"ba":[],"a":[]}')
+    assert serder1.raw == (b'{"v":"KERI10JSON000160_","t":"rot","d":"E4cK99hX4C0AdlzihyusaT6zOShm6mPCXSlg'
+                           b'9sBWSTSQ","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"1","p":"EK'
+                           b'WhDaMeK0DPrGcdem78_dPpofitWMAg7ZvZceMGi2_4","kt":"1","k":["DHgZa-u7veNZkqk2A'
+                           b'xCnxrINGKfQ0bRiaf9FdA_-_49A"],"nt":"1","n":["E1082xCJjDJW4LFEpDkePQyHc1P4gNS'
+                           b'U2Fl89uwafq3I"],"bt":"0","br":[],"ba":[],"a":[]}')
     saider = coring.Saider(sad=serder1.ked, code=MtrDex.Blake3_256)
     assert serder1.said == saider.qb64
 
@@ -815,9 +811,9 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     assert serder2.ked["s"] == '2'
     assert serder2.ked["t"] == Ilks.ixn
     assert serder2.ked["p"] == serder1.said
-    assert serder2.raw == (b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"E4hrx06bab0CN3rZoT-9NMtidfOH8PnIP0Iv'
-                           b'qsuUQOZ0","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"2","p":"EA'
-                           b'ntLipNnDDcGAJfGz9TStcJ8M19YLji3LPNVpXalwv4","a":[]}')
+    assert serder2.raw ==(b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EInKU64yZ9yUCog0e9fu4gVaLifTa8xtpLyM'
+                          b'YOhX8w9w","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"2","p":"E4'
+                          b'cK99hX4C0AdlzihyusaT6zOShm6mPCXSlg9sBWSTSQ","a":[]}')
 
     # Receipt
     serder3 = receipt(pre=pre, sn=0, said=serder2.said)
@@ -825,15 +821,15 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     assert serder3.ked["s"] == "0"
     assert serder3.ked["t"] == Ilks.rct
     assert serder3.ked["d"] == serder2.said
-    assert serder3.raw == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E4hrx06bab0CN3rZoT-9NMtidfOH8PnIP0Iv'
-                           b'qsuUQOZ0","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0"}')
+    assert serder3.raw == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EInKU64yZ9yUCog0e9fu4gVaLifTa8xtpLyM'
+                           b'YOhX8w9w","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"0"}')
 
     # Receipt  transferable identifier
-    serderA = incept(keys=keys0, nxt=nxt1, code=MtrDex.Blake3_256)
-    assert serderA.raw == (b'{"v":"KERI10JSON000120_","t":"icp","d":"E3o6jLJ_31vHzyUQBpd3d_oZ_rxl-lloyGL-'
-                           b'qii5E5AU","i":"E3o6jLJ_31vHzyUQBpd3d_oZ_rxl-lloyGL-qii5E5AU","s":"0","kt":"1'
-                           b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"n":"EcBCalw7Oe2ohLDr'
-                           b'a2ovwlv72PrlQZdQdaoSZ1Vvk5P4","bt":"0","b":[],"c":[],"a":[]}')
+    serderA = incept(keys=keys0, nkeys=nxt1, code=MtrDex.Blake3_256)
+    assert serderA.raw == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"EUGHc8RcfrYg3Gg-kwRqrPoJJv6Cl3r1fUs_'
+                           b'BX_Z4yMs","i":"EUGHc8RcfrYg3Gg-kwRqrPoJJv6Cl3r1fUs_BX_Z4yMs","s":"0","kt":"1'
+                           b'","k":["DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc"],"nt":"1","n":["EpitDP'
+                           b'yhh6qvfj0tMgO8RiBz5LV07OobY84WKs15XQHk"],"bt":"0","b":[],"c":[],"a":[]}')
     seal = SealEvent(i=serderA.ked["i"], s=serderA.ked["s"], d=serderA.said)
     assert seal.i == serderA.ked["i"]
     assert seal.d == serderA.said
@@ -844,17 +840,17 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     assert serder4.ked["s"] == "2"
     assert serder4.ked["t"] == Ilks.rct
     assert serder4.ked["d"] == serder2.said
-    assert serder4.raw == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E4hrx06bab0CN3rZoT-9NMtidfOH8PnIP0Iv'
-                           b'qsuUQOZ0","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"2"}')
+    assert serder4.raw == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EInKU64yZ9yUCog0e9fu4gVaLifTa8xtpLyM'
+                           b'YOhX8w9w","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc","s":"2"}')
 
     siger = signer0.sign(ser=serderA.raw, index=0)
     msg = messagize(serder=serder4, sigers=[siger], seal=seal)
-    assert msg == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"E4hrx06bab0CN3rZoT-9NMti'
-                            b'dfOH8PnIP0IvqsuUQOZ0","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1'
-                            b'x4ejhcc","s":"2"}-FABE3o6jLJ_31vHzyUQBpd3d_oZ_rxl-lloyGL-qii5E5A'
-                            b'U0AAAAAAAAAAAAAAAAAAAAAAAE3o6jLJ_31vHzyUQBpd3d_oZ_rxl-lloyGL-qii'
-                            b'5E5AU-AABAAQH0V6EN0DktK_uZ3fRHDLB40rQHBKb2eYz8J27Z_0aGH3ue_i6lR2'
-                            b'gTcLFBjgLMLNUsLt_QKZyF7aewXjBfHAQ')
+    assert msg == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"EInKU64yZ9yUCog0e9fu4gVa'
+                            b'LifTa8xtpLyMYOhX8w9w","i":"DWzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1'
+                            b'x4ejhcc","s":"2"}-FABEUGHc8RcfrYg3Gg-kwRqrPoJJv6Cl3r1fUs_BX_Z4yM'
+                            b's0AAAAAAAAAAAAAAAAAAAAAAAEUGHc8RcfrYg3Gg-kwRqrPoJJv6Cl3r1fUs_BX_'
+                            b'Z4yMs-AABAAL8Wa4NvM8X7djH5lAm2SmmV568mGYpwZ5yR9yOYdbJq9tUMlK3Ldc'
+                            b'8dKIzj8rH29J5UD2syn3IENWdvmOUtpAw')
 
     # Delegated Inception:
     # Transferable not abandoned i.e. next not empty
@@ -867,21 +863,21 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     keysD = [signerD.verfer.qb64]
     # compute nxt digest
     nexterD = Nexter(keys=keysD)  # default sith is 1
-    nxtD = nexterD.qb64  # transferable so nxt is not empty
+    nxtD = nexterD.digs  # transferable so nxt is not empty
 
     delpre = 'ENdHxtdjCQUM-TVO8CgJAKb8ykXsFe4u9epTUQFCL7Yd'
-    serderD = delcept(keys=keysD, delpre=delpre, nxt=nxtD)
+    serderD = delcept(keys=keysD, delpre=delpre, nkeys=nxtD)
     pre = serderD.ked["i"]
-    assert serderD.ked["i"] == 'EK8YaM68D7zf_7IimFxW7YNnTr1LxGVCpneH5gsQwcnE'
+    assert serderD.ked["i"] == 'ECaG4EEg_L2cX3XAE4CGb5JxpHcZ5gMCD8Z8Plaf3_UU'
     assert serderD.ked["s"] == '0'
     assert serderD.ked["t"] == Ilks.dip
     assert serderD.ked["n"] == nxtD
-    assert serderD.raw == (b'{"v":"KERI10JSON000154_","t":"dip","d":"EK8YaM68D7zf_7IimFxW7YNnTr1LxGVCpneH'
-                           b'5gsQwcnE","i":"EK8YaM68D7zf_7IimFxW7YNnTr1LxGVCpneH5gsQwcnE","s":"0","kt":"1'
-                           b'","k":["DHgZa-u7veNZkqk2AxCnxrINGKfQ0bRiaf9FdA_-_49A"],"n":"EcBCalw7Oe2ohLDr'
-                           b'a2ovwlv72PrlQZdQdaoSZ1Vvk5P4","bt":"0","b":[],"c":[],"a":[],"di":"ENdHxtdjCQ'
-                           b'UM-TVO8CgJAKb8ykXsFe4u9epTUQFCL7Yd"}')
-    assert serderD.said == "EK8YaM68D7zf_7IimFxW7YNnTr1LxGVCpneH5gsQwcnE"
+    assert serderD.raw == (b'{"v":"KERI10JSON00015f_","t":"dip","d":"ECaG4EEg_L2cX3XAE4CGb5JxpHcZ5gMCD8Z8'
+                           b'Plaf3_UU","i":"ECaG4EEg_L2cX3XAE4CGb5JxpHcZ5gMCD8Z8Plaf3_UU","s":"0","kt":"1'
+                           b'","k":["DHgZa-u7veNZkqk2AxCnxrINGKfQ0bRiaf9FdA_-_49A"],"nt":"1","n":["EpitDP'
+                           b'yhh6qvfj0tMgO8RiBz5LV07OobY84WKs15XQHk"],"bt":"0","b":[],"c":[],"a":[],"di":'
+                           b'"ENdHxtdjCQUM-TVO8CgJAKb8ykXsFe4u9epTUQFCL7Yd"}')
+    assert serderD.said == "ECaG4EEg_L2cX3XAE4CGb5JxpHcZ5gMCD8Z8Plaf3_UU"
 
     # Delegated Rotation:
     # Transferable not abandoned i.e. next not empty
@@ -893,25 +889,25 @@ def test_keyeventfuncs(mockHelpingNowUTC):
     keysR = [signerR.verfer.qb64]
     # compute nxt digest
     nexterR = Nexter(keys=keysR)  # default sith is 1
-    nxtR = nexterR.qb64  # transferable so nxt is not empty
+    nxtR = nexterR.digs  # transferable so nxt is not empty
 
     delpre = 'ENdHxtdjCQUM-TVO8CgJAKb8ykXsFe4u9epTUQFCL7Yd'
     serderR = deltate(pre=pre,
                       keys=keysR,
                       dig='EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30',
                       sn=4,
-                      nxt=nxtR)
+                      nkeys=nxtR)
 
     assert serderR.ked["i"] == pre
     assert serderR.ked["s"] == '4'
     assert serderR.ked["t"] == Ilks.drt
     assert serderR.ked["n"] == nxtR
-    assert serderR.raw == (b'{"v":"KERI10JSON000155_","t":"drt","d":"EBJ7zaPREcWSeesrDU4d_Cux9k_2XFRTDYr4'
-                           b'Y9nAx0co","i":"EK8YaM68D7zf_7IimFxW7YNnTr1LxGVCpneH5gsQwcnE","s":"4","p":"Eg'
+    assert serderR.raw == (b'{"v":"KERI10JSON000160_","t":"drt","d":"EwKpz0HE3_eGARUswRQOWw7nvJiKxznWToCQ'
+                           b'Cb5SrOJE","i":"ECaG4EEg_L2cX3XAE4CGb5JxpHcZ5gMCD8Z8Plaf3_UU","s":"4","p":"Eg'
                            b'Nkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","kt":"1","k":["D8u3hipCxZnkM_O0j'
-                           b'faZLJMk9ERI428T0psRO0JVgh4c"],"n":"EAXTvbATMnVRGjyC_VCNuXcPTxxpLanfzj14u3QMs'
-                           b'D_U","bt":"0","br":[],"ba":[],"a":[]}')
-    assert serderR.said == 'EBJ7zaPREcWSeesrDU4d_Cux9k_2XFRTDYr4Y9nAx0co'
+                           b'faZLJMk9ERI428T0psRO0JVgh4c"],"nt":"1","n":["E1082xCJjDJW4LFEpDkePQyHc1P4gNS'
+                           b'U2Fl89uwafq3I"],"bt":"0","br":[],"ba":[],"a":[]}')
+    assert serderR.said == 'EwKpz0HE3_eGARUswRQOWw7nvJiKxznWToCQCb5SrOJE'
 
     """ Done Test """
 
@@ -984,8 +980,8 @@ def test_state(mockHelpingNowUTC):
     sith = '1'
     keys = [signerC.verfer.qb64]
     nexter = Nexter(keys=keys)  # compute nxt digest (dummy reuse keys)
-    nxt = nexter.qb64
-    assert nxt == 'E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ'
+    nxt = nexter.digs
+    assert nxt == ['EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM']
 
     # create key pairs for witnesses of KEL
     signerW0 = salter.signer(path="W0", transferable=False, temp=True)
@@ -1026,21 +1022,21 @@ def test_state(mockHelpingNowUTC):
                     keys=keys,
                     eevt=eevt,
                     sith=sith,
-                    nxt=nxt,
+                    nkeys=nxt,
                     toad=toad,
                     wits=wits,
                     )
 
-    assert serderK.raw == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
+    assert serderK.raw == (b'{"v":"KERI10JSON0002ca_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
                            b'"s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"EgNkcl_Qewzr'
                            b'RSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:00.000000+0'
                            b'0:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
-                           b'"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1yt'
-                           b'EFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYWO5lPWOrS'
-                           b'B6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"ee":{"s":"'
-                           b'3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1'
-                           b'IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBK'
-                           b'rBFz_1Y"]},"di":""}')
+                           b'"],"nt":"1","n":["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b'
+                           b'":["BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62L'
+                           b'MYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],'
+                           b'"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTk'
+                           b'stUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6K'
+                           b'c1CQnigIUBKrBFz_1Y"]},"di":""}')
 
     assert serderK.said == 'EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30'
     assert serderK.pre == preC == 'D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
@@ -1056,20 +1052,20 @@ def test_state(mockHelpingNowUTC):
     cigarE = signerE.sign(ser=serderK.raw)
     assert signerE.verfer.verify(sig=cigarE.raw, ser=serderK.raw)
     msg = messagize(serderK, cigars=[cigarE])
-    assert msg == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+    assert msg == (b'{"v":"KERI10JSON0002ca_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
                    b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
                    b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
                    b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
-                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
-                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
-                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
-                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
-                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
-                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
-                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":""}-'
-                   b'CABByvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0BWGCQOoDC5E_VaBs'
-                   b'xLtfB37HLMMhiPnECIW0gSrQa0etFKSX9lKfuHNy4YBLQBtkPCuDQTG4QMgpWRoa'
-                   b'WDolZCw')
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"nt":"1","n":'
+                   b'["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b":["'
+                   b'BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2'
+                   b'GU5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigI'
+                   b'UBKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewz'
+                   b'rRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7K'
+                   b'S2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]'
+                   b'},"di":""}-CABByvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0B1d61'
+                   b'-SOrSSKSyfguotWdJIQ7-AGWBO9rsNU2liCAHm-tavH9x3RFaym1LZM1uRIkDMD8'
+                   b'NXsrw_XPG73I9yNfBA')
 
     # create endorsed ksn with trans endorser
     # create trans key pair for endorder of KSN
@@ -1087,21 +1083,21 @@ def test_state(mockHelpingNowUTC):
     sigerE = signerE.sign(ser=serderK.raw, index=0)
     assert signerE.verfer.verify(sig=sigerE.raw, ser=serderK.raw)
     msg = messagize(serderK, sigers=[sigerE], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0002bf_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+    assert msg == (b'{"v":"KERI10JSON0002ca_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
                    b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
                    b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
                    b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
-                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
-                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
-                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
-                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
-                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
-                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
-                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":""}-'
-                   b'FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAA'
-                   b'AAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAWGCQOoD'
-                   b'C5E_VaBsxLtfB37HLMMhiPnECIW0gSrQa0etFKSX9lKfuHNy4YBLQBtkPCuDQTG4'
-                   b'QMgpWRoaWDolZCw')
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"nt":"1","n":'
+                   b'["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b":["'
+                   b'BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2'
+                   b'GU5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigI'
+                   b'UBKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewz'
+                   b'rRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7K'
+                   b'S2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]'
+                   b'},"di":""}-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAA'
+                   b'AAAAAAAAAAAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-A'
+                   b'ABAA1d61-SOrSSKSyfguotWdJIQ7-AGWBO9rsNU2liCAHm-tavH9x3RFaym1LZM1'
+                   b'uRIkDMD8NXsrw_XPG73I9yNfBA')
 
     # State Delegated (key state notification)
     # create transferable key pair for controller of KEL
@@ -1113,8 +1109,8 @@ def test_state(mockHelpingNowUTC):
     sith = '1'
     keys = [signerC.verfer.qb64]
     nexter = Nexter(keys=keys)  # compute nxt digest (dummy reuse keys)
-    nxt = nexter.qb64
-    assert nxt == 'E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ'
+    nxt = nexter.digs
+    assert nxt == ['EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM']
 
     # create key pairs for witnesses of KEL
     signerW0 = salter.signer(path="W0", transferable=False, temp=True)
@@ -1162,22 +1158,22 @@ def test_state(mockHelpingNowUTC):
                     keys=keys,
                     eevt=eevt,
                     sith=sith,
-                    nxt=nxt,
+                    nkeys=nxt,
                     toad=toad,
                     wits=wits,
                     dpre=preD
                     )
 
-    assert serderK.raw == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
+    assert serderK.raw == (b'{"v":"KERI10JSON0002f6_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0",'
                            b'"s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","d":"EgNkcl_Qewzr'
                            b'RSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4","dt":"2021-01-01T00:00:00.000000+0'
                            b'0:00","et":"ixn","kt":"1","k":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
-                           b'"],"n":"E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1yt'
-                           b'EFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYWO5lPWOrS'
-                           b'B6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],"ee":{"s":"'
-                           b'3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1'
-                           b'IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBK'
-                           b'rBFz_1Y"]},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}')
+                           b'"],"nt":"1","n":["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b'
+                           b'":["BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62L'
+                           b'MYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"],"c":[],'
+                           b'"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO132Z30","br":["BNTk'
+                           b'stUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6K'
+                           b'c1CQnigIUBKrBFz_1Y"]},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}')
 
     assert serderK.said == 'EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30'
     assert serderK.pre == preC == 'D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0'
@@ -1194,20 +1190,20 @@ def test_state(mockHelpingNowUTC):
     cigarE = signerE.sign(ser=serderK.raw)
     assert signerE.verfer.verify(sig=cigarE.raw, ser=serderK.raw)
     msg = messagize(serderK, cigars=[cigarE])
-    assert msg == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+    assert msg == (b'{"v":"KERI10JSON0002f6_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
                    b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
                    b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
                    b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
-                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
-                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
-                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
-                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
-                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
-                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
-                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":"DGz'
-                   b'6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-CABByvCLRr5luWmp7keD'
-                   b'vDuLP0kIqcyBYq79b3Dho1QvrjI0B2qBC_LNRwoFyQnaBbbUdy8oSfsR3IpdHgm4'
-                   b'wsln317OJJ4b2CpYpjtSdbUbddEYOPOOtuiSOY1Hb1LxvC3zNCQ')
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"nt":"1","n":'
+                   b'["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b":["'
+                   b'BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2'
+                   b'GU5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigI'
+                   b'UBKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewz'
+                   b'rRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7K'
+                   b'S2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]'
+                   b'},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-CABByvCLR'
+                   b'r5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0BIV9LO2uGArLX9IQCA0RCwuOh'
+                   b'5Wop0t4u7PoL9XQ7_Xr-Co424PFJs_x7PeHaY5Mos016AKa4JC0SI5nR8rzUBA')
 
     # create endorsed ksn with trans endorser
     # create trans key pair for endorder of KSN
@@ -1225,21 +1221,22 @@ def test_state(mockHelpingNowUTC):
     sigerE = signerE.sign(ser=serderK.raw, index=0)
     assert signerE.verfer.verify(sig=sigerE.raw, ser=serderK.raw)
     msg = messagize(serderK, sigers=[sigerE], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0002eb_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
+    assert msg == (b'{"v":"KERI10JSON0002f6_","i":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPq'
                    b'WVK9ZBNZk0","s":"4","p":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQIO1'
                    b'32Z30","d":"EgNkcl_QewzrRSKH2p9zUskHI462CuIMS_HQIO132Z30","f":"4'
                    b'","dt":"2021-01-01T00:00:00.000000+00:00","et":"ixn","kt":"1","k'
-                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"n":"E9GdMuF9'
-                   b'rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ","bt":"2","b":["BaEI1ytEFHq'
-                   b'aUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2GU5ud62LMYW'
-                   b'O5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"'
-                   b'],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_QewzrRSKH2p9zHQ'
-                   b'IO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7KS2Q6_lG0"],'
-                   b'"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]},"di":"DGz'
-                   b'6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-FABDyvCLRr5luWmp7keD'
-                   b'vDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAAEMuNWHss_H_kH'
-                   b'4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAA2qBC_LNRwoFyQnaBbbUdy8oSfsR'
-                   b'3IpdHgm4wsln317OJJ4b2CpYpjtSdbUbddEYOPOOtuiSOY1Hb1LxvC3zNCQ')
+                   b'":["D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0"],"nt":"1","n":'
+                   b'["EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM"],"bt":"2","b":["'
+                   b'BaEI1ytEFHqaUF26Fu4JgvsHBzeBu7Joaj2ilmx3QPwU","B7vHpy1IDsWWUnHf2'
+                   b'GU5ud62LMYWO5lPWOrSB6ejQ1Eo","BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigI'
+                   b'UBKrBFz_1Y"],"c":[],"ee":{"s":"3","d":"EUskHI462CuIMS_gNkcl_Qewz'
+                   b'rRSKH2p9zHQIO132Z30","br":["BNTkstUfFBJv0R1IoNNjKpWK6zEZPxjgMc7K'
+                   b'S2Q6_lG0"],"ba":["BruKyL_b4D5ETo9u12DtLU1J6Kc1CQnigIUBKrBFz_1Y"]'
+                   b'},"di":"DGz6B3ecka0XQKHaOfs0tpQqwIoHuXecuz733f-zkh7U"}-FABDyvCLR'
+                   b'r5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAAEM'
+                   b'uNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAIV9LO2uGArLX9IQC'
+                   b'A0RCwuOh5Wop0t4u7PoL9XQ7_Xr-Co424PFJs_x7PeHaY5Mos016AKa4JC0SI5nR'
+                   b'8rzUBA')
 
     """Done Test"""
 
@@ -1268,12 +1265,12 @@ def test_messagize():
 
         # Test with pipelined
         msg = messagize(serder, sigers=sigers, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VAX-AABAAuI'
-                                b'SeZIVO_wXjIrGJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphOn'
-                                b'nXbTc51WR4uAvK90EHBg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'X-AABAAVVUmAlrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzT'
+                                b'Ar5P2A73ntpflGMqklHr8IxJziQDw')
 
         # Test with seal
         # create SealEvent for endorsers est evt whose keys use to sign
@@ -1281,112 +1278,115 @@ def test_messagize():
                          s='0',
                          d='EMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z')
         msg = messagize(serder, sigers=sigers, seal=seal)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-FABDyvCLRr5'
-                                b'luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAAEMuN'
-                                b'WHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAuISeZIVO_wXjIrGJ-V'
-                                b'cVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphOnnXbTc51WR4uAvK90'
-                                b'EHBg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-FA'
+                                b'BDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAA'
+                                b'AAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAVVUmAlrVp'
+                                b'7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzTAr5P2A73ntpflGMq'
+                                b'klHr8IxJziQDw')
 
         # Test with pipelined
         msg = messagize(serder, sigers=sigers, seal=seal, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VA0-FABDyvC'
-                                b'LRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAA'
-                                b'EMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAuISeZIVO_wXjIr'
-                                b'GJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphOnnXbTc51WR4uA'
-                                b'vK90EHBg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'0-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAA'
+                                b'AAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAVVUmA'
+                                b'lrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzTAr5P2A73ntpf'
+                                b'lGMqklHr8IxJziQDw')
 
         # Test with wigers
         verfers, digers, cst, nst = mgr.incept(icount=1, ncount=0, transferable=False, stem="W")
         wigers = mgr.sign(ser=serder.raw, verfers=verfers)  # default indexed True
         assert isinstance(wigers[0], Siger)
         msg = messagize(serder, wigers=wigers)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-BABAA3O09Zj'
-                                b'S7exI3cY7rgF54QFS6PVRqZ3LlfJWqEY1Fx7eDzW4TsPP8VTktO4snj-Uk4SP9HC'
-                                b'y7xEkLoRQCkVyiAA')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-BA'
+                                b'BAAN2RwmlUX7gr971K9XLvfoIJkilGtMdZK2v66L_6FhG25p6sjvu2Y-iOJOEVNg'
+                                b'sOxjVnsBi7lxU_EbAJ6lZKACQ')
 
         # Test with wigers and pipelined
         msg = messagize(serder, wigers=wigers, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VAX-BABAA3O'
-                                b'09ZjS7exI3cY7rgF54QFS6PVRqZ3LlfJWqEY1Fx7eDzW4TsPP8VTktO4snj-Uk4S'
-                                b'P9HCy7xEkLoRQCkVyiAA')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'X-BABAAN2RwmlUX7gr971K9XLvfoIJkilGtMdZK2v66L_6FhG25p6sjvu2Y-iOJO'
+                                b'EVNgsOxjVnsBi7lxU_EbAJ6lZKACQ')
 
         # Test with cigars
         verfers, digers, cst, nst = mgr.incept(icount=1, ncount=0, transferable=False, stem="R")
         cigars = mgr.sign(ser=serder.raw, verfers=verfers, indexed=False)
         assert isinstance(cigars[0], Cigar)
         msg = messagize(serder, cigars=cigars)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-CABBmMfUwIO'
-                                b'ywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BNP_qsggBSj8tZ3nM3JH5K5if4O'
-                                b'OIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-CA'
+                                b'BBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BXnaQZ5HNLapcED6GY'
+                                b'GXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9'
+                                b'SMECQ')
 
         # Test with cigars and pipelined
         msg = messagize(serder, cigars=cigars, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VAi-CABBmMf'
-                                b'UwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BNP_qsggBSj8tZ3nM3JH5K5'
-                                b'if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'i-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BXnaQZ5HNLapcE'
+                                b'D6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZq'
+                                b'DgM9SMECQ')
 
         # Test with wigers and cigars
         msg = messagize(serder, wigers=wigers, cigars=cigars)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-BABAA3O09Zj'
-                                b'S7exI3cY7rgF54QFS6PVRqZ3LlfJWqEY1Fx7eDzW4TsPP8VTktO4snj-Uk4SP9HC'
-                                b'y7xEkLoRQCkVyiAA-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM'
-                                b'0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1o'
-                                b'rkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-BA'
+                                b'BAAN2RwmlUX7gr971K9XLvfoIJkilGtMdZK2v66L_6FhG25p6sjvu2Y-iOJOEVNg'
+                                b'sOxjVnsBi7lxU_EbAJ6lZKACQ-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXca'
+                                b'K9G939ArM0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackIt'
+                                b'qcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with wigers and cigars and pipelined
         msg = messagize(serder, cigars=cigars, wigers=wigers, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VA5-BABAA3O'
-                                b'09ZjS7exI3cY7rgF54QFS6PVRqZ3LlfJWqEY1Fx7eDzW4TsPP8VTktO4snj-Uk4S'
-                                b'P9HCy7xEkLoRQCkVyiAA-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G93'
-                                b'9ArM0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTR'
-                                b'n-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'5-BABAAN2RwmlUX7gr971K9XLvfoIJkilGtMdZK2v66L_6FhG25p6sjvu2Y-iOJO'
+                                b'EVNgsOxjVnsBi7lxU_EbAJ6lZKACQ-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjv'
+                                b'nXcaK9G939ArM0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5Za'
+                                b'ckItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with sigers and wigers and cigars
         msg = messagize(serder, sigers=sigers, cigars=cigars, wigers=wigers)
-        assert bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
-                         b'GOM-ijM93o","s":"0","t":"icp","kt":"1","k":["D6J_jzCECalv_iTKSwx'
-                         b'zPnuycxEi5fRuo3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]'
-                         b'}-AABAA0X9eyML4ioPIk9AuBQFN5hGnGeRgywzNorzFydvyFTm-sjjLrFantYynS'
-                         b'BLWXjxYc5c_sW0052it_g6rX30kDA-BABAAWha5gf4wk__OEK_ZvAyA4WYArQVKf'
-                         b'VKevOmZWliDBpdIn7oHsWgvm8T7UvEjfnKobH8lKD1ILacrT6KVIxNeCw-CABBmM'
-                         b'fUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BT7b5PzUBmts-lblgOBzdT'
-                         b'hIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqqUYFmRhABQ-vPywggLATxBDnqQ3aBg')
+        assert bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                         b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                         b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                         b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VB'
+                         b'Q-AABAAVVUmAlrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzT'
+                         b'Ar5P2A73ntpflGMqklHr8IxJziQDw-BABAAN2RwmlUX7gr971K9XLvfoIJkilGtM'
+                         b'dZK2v66L_6FhG25p6sjvu2Y-iOJOEVNgsOxjVnsBi7lxU_EbAJ6lZKACQ-CABBmM'
+                         b'fUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BXnaQZ5HNLapcED6GYGXOV'
+                         b'38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with sigers and wigers and cigars and pipelines
         msg = messagize(serder, sigers=sigers, cigars=cigars, wigers=wigers, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VBQ-AABAAuI'
-                                b'SeZIVO_wXjIrGJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphOn'
-                                b'nXbTc51WR4uAvK90EHBg-BABAA3O09ZjS7exI3cY7rgF54QFS6PVRqZ3LlfJWqEY'
-                                b'1Fx7eDzW4TsPP8VTktO4snj-Uk4SP9HCy7xEkLoRQCkVyiAA-CABBmMfUwIOywRk'
-                                b'yc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo'
-                                b'-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VB'
+                                b'Q-AABAAVVUmAlrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzT'
+                                b'Ar5P2A73ntpflGMqklHr8IxJziQDw-BABAAN2RwmlUX7gr971K9XLvfoIJkilGtM'
+                                b'dZK2v66L_6FhG25p6sjvu2Y-iOJOEVNgsOxjVnsBi7lxU_EbAJ6lZKACQ-CABBmM'
+                                b'fUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM0BXnaQZ5HNLapcED6GYGXOV'
+                                b'38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with receipt message
         ked = serder.ked
@@ -1398,57 +1398,58 @@ def test_messagize():
         wigers = mgr.sign(ser=serder.raw, verfers=verfers, indexed=True)
         assert isinstance(wigers[0], Siger)
         msg = messagize(serder, wigers=wigers)
-        assert bytearray(b'{"v":"KERI10JSON0000c1_","i":"ECE-_06hkl9stCfQu4IluYevW5_YlxHc6e'
-                         b'GOM-ijM93o","s":"0","t":"icp","kt":"1","k":["D6J_jzCECalv_iTKSwx'
-                         b'zPnuycxEi5fRuo3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]'
-                         b'}-BABAAT7b5PzUBmts-lblgOBzdThIQjKCbq8gMinhymgr4_dD0JyfN6CjZhsOqq'
-                         b'UYFmRhABQ-vPywggLATxBDnqQ3aBg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-BA'
+                                b'BAAXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6W'
+                                b'BaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with cigars
         cigars = mgr.sign(ser=serder.raw, verfers=verfers, indexed=False)  # sign event not receipt
         msg = messagize(reserder, cigars=cigars)
-        assert msg == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0"}-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939Ar'
-                                b'M0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1'
-                                b'orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0"}-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939Ar'
+                                b'M0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6W'
+                                b'BaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with wigers and cigars
         msg = messagize(serder, wigers=wigers, cigars=cigars, )
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-BABAANP_qsg'
-                                b'gBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1orkihaoyt'
-                                b'rm49HHK2CPiapCCg-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G939ArM'
-                                b'0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1o'
-                                b'rkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-BA'
+                                b'BAAXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgEGN6W'
+                                b'BaEcPJ6aTvjLLDZqDgM9SMECQ-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXca'
+                                b'K9G939ArM0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackIt'
+                                b'qcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with wigers and cigars and pipelined
         msg = messagize(serder, wigers=wigers, cigars=cigars, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VA5-BABAANP'
-                                b'_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTRn-1orkih'
-                                b'aoytrm49HHK2CPiapCCg-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjvnXcaK9G93'
-                                b'9ArM0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0aUxo_wUTR'
-                                b'n-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VA'
+                                b'5-BABAAXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5ZackItqcgE'
+                                b'GN6WBaEcPJ6aTvjLLDZqDgM9SMECQ-CABBmMfUwIOywRkyc5GyQXfgDA4UOAMvjv'
+                                b'nXcaK9G939ArM0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7XXY-A5Za'
+                                b'ckItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with sigers and seal and wigers and cigars and pipelined
         msg = messagize(serder, sigers=sigers, seal=seal, wigers=wigers,
                         cigars=cigars, pipelined=True)
-        assert msg == bytearray(b'{"v":"KERI10JSON0000f4_","t":"icp","d":"EZOIsLsfrVdBvULlg3Hg_Y1r'
-                                b'-hadS82ZpglBLojPIQhg","i":"EZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBL'
-                                b'ojPIQhg","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
-                                b'o3UUN7T0CVGM"],"n":"","bt":"0","b":[],"c":[],"a":[]}-VBt-FABDyvC'
-                                b'LRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAAA'
-                                b'EMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAuISeZIVO_wXjIr'
-                                b'GJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphOnnXbTc51WR4uA'
-                                b'vK90EHBg-BABAANP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8Ac2EpTE0a'
-                                b'Uxo_wUTRn-1orkihaoytrm49HHK2CPiapCCg-CABBmMfUwIOywRkyc5GyQXfgDA4'
-                                b'UOAMvjvnXcaK9G939ArM0BNP_qsggBSj8tZ3nM3JH5K5if4OOIEo-sHyHkfshz8A'
-                                b'c2EpTE0aUxo_wUTRn-1orkihaoytrm49HHK2CPiapCCg')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ExYUckri7vGPH0L-9DmE3Znm'
+                                b'6dc47brGolln481gZ38Q","i":"ExYUckri7vGPH0L-9DmE3Znm6dc47brGolln4'
+                                b'81gZ38Q","s":"0","kt":"1","k":["D6J_jzCECalv_iTKSwxzPnuycxEi5fRu'
+                                b'o3UUN7T0CVGM"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-VB'
+                                b't-FABDyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAA'
+                                b'AAAAAAAAAEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAVVUmA'
+                                b'lrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzTAr5P2A73ntpf'
+                                b'lGMqklHr8IxJziQDw-BABAAXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1Me8w88y7'
+                                b'XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ-CABBmMfUwIOywRkyc5'
+                                b'GyQXfgDA4UOAMvjvnXcaK9G939ArM0BXnaQZ5HNLapcED6GYGXOV38RRWSrotdH1'
+                                b'Me8w88y7XXY-A5ZackItqcgEGN6WBaEcPJ6aTvjLLDZqDgM9SMECQ')
 
         # Test with query message
         ked = serder.ked
@@ -1462,18 +1463,18 @@ def test_messagize():
         assert msg == (b'{"v":"KERI10JSON0000c9_","t":"qry","d":"E-WvgxrllmjGFhpn0oOiBkAV'
                        b'z3-dEm3bbiV_5qwj81xo","dt":"2021-01-01T00:00:00.000000+00:00","r'
                        b'":"log","rr":"","q":{"i":"DyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho'
-                       b'1QvrjI"}}-HABEZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBLojPIQhg-AABAAu'
-                       b'ISeZIVO_wXjIrGJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpqVphO'
-                       b'nnXbTc51WR4uAvK90EHBg')
+                       b'1QvrjI"}}-HABExYUckri7vGPH0L-9DmE3Znm6dc47brGolln481gZ38Q-AABAAV'
+                       b'VUmAlrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzTAr5P2A73'
+                       b'ntpflGMqklHr8IxJziQDw')
 
         # create SealEvent for endorsers est evt whose keys use to sign
         msg = messagize(qserder, sigers=sigers, seal=seal, pipelined=True)
         assert msg == (b'{"v":"KERI10JSON0000c9_","t":"qry","d":"E-WvgxrllmjGFhpn0oOiBkAV'
                        b'z3-dEm3bbiV_5qwj81xo","dt":"2021-01-01T00:00:00.000000+00:00","r'
                        b'":"log","rr":"","q":{"i":"DyvCLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho'
-                       b'1QvrjI"}}-VAj-HABEZOIsLsfrVdBvULlg3Hg_Y1r-hadS82ZpglBLojPIQhg-AA'
-                       b'BAAuISeZIVO_wXjIrGJ-VcVMxr285OkKzAqVEQqVPFx8Ht2A9GQFB-zRA18J1lpq'
-                       b'VphOnnXbTc51WR4uAvK90EHBg')
+                       b'1QvrjI"}}-VAj-HABExYUckri7vGPH0L-9DmE3Znm6dc47brGolln481gZ38Q-AA'
+                       b'BAAVVUmAlrVp7CJnjpa4urI9FnsWEnuMfxR-DE6XVCKzmBaHJqc4DRo5bBzTAr5P'
+                       b'2A73ntpflGMqklHr8IxJziQDw')
 
         """ Done Test """
 
@@ -1504,11 +1505,10 @@ def test_kever(mockHelpingNowUTC):
         skp1 = salter.signer(path="N", temp=True)
         assert skp1.code == MtrDex.Ed25519_Seed
         assert skp1.verfer.code == MtrDex.Ed25519
-        nxtkeys = [skp1.verfer.qb64]
         # compute nxt digest
-        nexter = Nexter(keys=nxtkeys)
-        nxt = nexter.qb64
-        assert nxt == "E_d8cX6vuQwmD5P62_b663OeaVCLbiBFsirRHJsHn9co"  # transferable so nxt is not empty
+        nexter = Diger(ser=skp1.verfer.qb64b)
+        nxt = [nexter.qb64]
+        assert nxt == ['EK-TF941B0sh9R48gp9pbwgWVR8aw10OpE7VUQMRUUU0']  # transferable so nxt is not empty
 
         sn = 0  # inception event so 0
         toad = 0  # no witnesses
@@ -1533,7 +1533,7 @@ def test_kever(mockHelpingNowUTC):
         assert aid0.code == MtrDex.Ed25519
         assert aid0.qb64 == skp0.verfer.qb64 == 'DBQOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4'
         _, ked0 = coring.Saider.saidify(sad=ked0)
-        assert ked0['d'] == "EEBXg6K31gEQjdzjFqIcoSKkTADTd4v0e_r-heUdBRSM"
+        assert ked0['d'] == "EXo8l7KYph7GtQepz37He-AN6MAhfRqqk91O4WqRF_-I"
 
         # update ked with pre
         ked0["i"] = aid0.qb64
@@ -1553,7 +1553,7 @@ def test_kever(mockHelpingNowUTC):
         assert kever.prefixer.qb64 == aid0.qb64
         assert kever.sn == 0
         assert [verfer.qb64 for verfer in kever.verfers] == [skp0.verfer.qb64]
-        assert kever.nexter.qb64 == nexter.qb64
+        assert kever.nexter.digs == [nexter.qb64]
         state = kever.db.states.get(keys=kever.prefixer.qb64)
         assert state.sn == kever.sn == 0
         feqner = kever.db.fons.get(keys=(kever.prefixer.qb64, kever.serder.said))
@@ -1565,12 +1565,12 @@ def test_kever(mockHelpingNowUTC):
         assert serderK.sn == kever.sn
         assert ([verfer.qb64 for verfer in serderK.verfers] ==
                 [verfer.qb64 for verfer in kever.verfers])
-        assert serderK.raw == (b'{"v":"KERI10JSON0001ab_","i":"DBQOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4",'
-                               b'"s":"0","p":"","d":"EEBXg6K31gEQjdzjFqIcoSKkTADTd4v0e_r-heUdBRSM","f":"0","d'
+        assert serderK.raw == (b'{"v":"KERI10JSON0001b6_","i":"DBQOqSaf6GqVAoPxb4UARrklS8kLYj3JqsR6b4AASDd4",'
+                               b'"s":"0","p":"","d":"EXo8l7KYph7GtQepz37He-AN6MAhfRqqk91O4WqRF_-I","f":"0","d'
                                b't":"2021-01-01T00:00:00.000000+00:00","et":"icp","kt":"1","k":["DBQOqSaf6GqV'
-                               b'AoPxb4UARrklS8kLYj3JqsR6b4AASDd4"],"n":"E_d8cX6vuQwmD5P62_b663OeaVCLbiBFsirR'
-                               b'HJsHn9co","bt":"0","b":[],"c":[],"ee":{"s":"0","d":"EEBXg6K31gEQjdzjFqIcoSKk'
-                               b'TADTd4v0e_r-heUdBRSM","br":[],"ba":[]},"di":""}')
+                               b'AoPxb4UARrklS8kLYj3JqsR6b4AASDd4"],"nt":"0","n":["EK-TF941B0sh9R48gp9pbwgWVR'
+                               b'8aw10OpE7VUQMRUUU0"],"bt":"0","b":[],"c":[],"ee":{"s":"0","d":"EXo8l7KYph7Gt'
+                               b'Qepz37He-AN6MAhfRqqk91O4WqRF_-I","br":[],"ba":[]},"di":""}')
 
     with openDB() as db:  # Non-Transferable case
         # Setup inception key event dict
@@ -1588,7 +1588,7 @@ def test_kever(mockHelpingNowUTC):
         nxtkeys = [skp1.verfer.qb64]
         # compute nxt digest
         nexter = Nexter(keys=nxtkeys)
-        nxt = nexter.qb64  # nxt is not empty so error
+        nxt = nexter.digs  # nxt is not empty so error
 
         sn = 0  # inception event so 0
         toad = 0  # no witnesses
@@ -1868,10 +1868,10 @@ def test_keyeventsequence_0():
         keys0 = [signers[0].verfer.qb64]
         # compute nxt digest from keys1
         keys1 = [signers[1].verfer.qb64]
-        nexter1 = Nexter(keys=keys1)
-        nxt1 = nexter1.qb64  # transferable so nxt is not empty
-        assert nxt1 == 'EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU'
-        serder0 = incept(keys=keys0, nxt=nxt1)
+        nexter1 = coring.Diger(ser=signers[1].verfer.qb64b)
+        nxt1 = [nexter1.qb64]  # transferable so nxt is not empty
+        assert nxt1 == ['E67B6WkwQrEfSA2MylxmF28HJc_HxfHRyK1kRXSYeMiI']
+        serder0 = incept(keys=keys0, nkeys=nxt1)
         pre = serder0.ked["i"]
         event_digs.append(serder0.said)
         assert serder0.ked["i"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
@@ -1879,7 +1879,7 @@ def test_keyeventsequence_0():
         assert serder0.ked["kt"] == '1'
         assert serder0.ked["k"] == keys0
         assert serder0.ked["n"] == nxt1
-        assert serder0.said == 'EG4EuTsxPiRM7soX10XXzNsS1KqXKUp8xsQ-kW_tWHoI'
+        assert serder0.said == 'ELeMG3OOxWi5n1Zud603_Bn6Hzm3hIRZXlQnSgC5lU7A'
 
         # sign serialization and verify signature
         sig0 = signers[0].sign(serder0.raw, index=0)
@@ -1892,17 +1892,17 @@ def test_keyeventsequence_0():
         assert kever.ilk == Ilks.icp
         assert kever.tholder.thold == 1
         assert [verfer.qb64 for verfer in kever.verfers] == keys0
-        assert kever.nexter.qb64 == nxt1
-        assert kever.estOnly == False
-        assert kever.transferable == True
+        assert kever.nexter.digs == nxt1
+        assert kever.estOnly is False
+        assert kever.transferable is True
 
         # Event 1 Rotation Transferable
         # compute nxt digest from keys2
         keys2 = [signers[2].verfer.qb64]
-        nexter2 = Nexter(keys=keys2)
-        nxt2 = nexter2.qb64  # transferable so nxt is not empty
-        assert nxt2 == 'E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI'
-        serder1 = rotate(pre=pre, keys=keys1, dig=serder0.said, nxt=nxt2, sn=1)
+        nexter2 = coring.Diger(ser=signers[2].verfer.qb64b)
+        nxt2 = [nexter2.qb64]  # transferable so nxt is not empty
+        assert nxt2 == ['EL-1w3eYVzNy0-RQV6r2ZORG-Y4gmOF-S7t9aeZMERXU']
+        serder1 = rotate(pre=pre, keys=keys1, dig=serder0.said, nkeys=nxt2, sn=1)
         event_digs.append(serder1.said)
         assert serder1.ked["i"] == pre
         assert serder1.ked["s"] == '1'
@@ -1921,14 +1921,14 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder1.said
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys1
-        assert kever.nexter.qb64 == nxt2
+        assert kever.nexter.digs == nxt2
 
         # Event 2 Rotation Transferable
         # compute nxt digest from keys3
         keys3 = [signers[3].verfer.qb64]
-        nexter3 = Nexter(keys=keys3)
-        nxt3 = nexter3.qb64  # transferable so nxt is not empty
-        serder2 = rotate(pre=pre, keys=keys2, dig=serder1.said, nxt=nxt3, sn=2)
+        nexter3 = coring.Diger(ser=signers[3].verfer.qb64b)
+        nxt3 = [nexter3.qb64]  # transferable so nxt is not empty
+        serder2 = rotate(pre=pre, keys=keys2, dig=serder1.said, nkeys=nxt3, sn=2)
         event_digs.append(serder2.said)
         assert serder2.ked["i"] == pre
         assert serder2.ked["s"] == '2'
@@ -1946,7 +1946,7 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder2.said
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys2
-        assert kever.nexter.qb64 == nxt3
+        assert kever.nexter.digs == nxt3
 
         # Event 3 Interaction
         serder3 = interact(pre=pre, dig=serder2.said, sn=3)
@@ -1965,7 +1965,7 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder3.said
         assert kever.ilk == Ilks.ixn
         assert [verfer.qb64 for verfer in kever.verfers] == keys2  # no change
-        assert kever.nexter.qb64 == nxt3  # no change
+        assert kever.nexter.digs == nxt3  # no change
 
         # Event 4 Interaction
         serder4 = interact(pre=pre, dig=serder3.said, sn=4)
@@ -1984,14 +1984,14 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder4.said
         assert kever.ilk == Ilks.ixn
         assert [verfer.qb64 for verfer in kever.verfers] == keys2  # no change
-        assert kever.nexter.qb64 == nxt3  # no change
+        assert kever.nexter.digs == nxt3  # no change
 
         # Event 5 Rotation Transferable
         # compute nxt digest from keys4
         keys4 = [signers[4].verfer.qb64]
-        nexter4 = Nexter(keys=keys4)
-        nxt4 = nexter4.qb64  # transferable so nxt is not empty
-        serder5 = rotate(pre=pre, keys=keys3, dig=serder4.said, nxt=nxt4, sn=5)
+        nexter4 = coring.Diger(ser=signers[4].verfer.qb64b)
+        nxt4 = [nexter4.qb64]  # transferable so nxt is not empty
+        serder5 = rotate(pre=pre, keys=keys3, dig=serder4.said, nkeys=nxt4, sn=5)
         event_digs.append(serder5.said)
         assert serder5.ked["i"] == pre
         assert serder5.ked["s"] == '5'
@@ -2009,7 +2009,7 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder5.said
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys3
-        assert kever.nexter.qb64 == nxt4
+        assert kever.nexter.digs == nxt4
 
         # Event 6 Interaction
         serder6 = interact(pre=pre, dig=serder5.said, sn=6)
@@ -2028,16 +2028,15 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder6.said
         assert kever.ilk == Ilks.ixn
         assert [verfer.qb64 for verfer in kever.verfers] == keys3  # no change
-        assert kever.nexter.qb64 == nxt4  # no change
+        assert kever.nexter.digs == nxt4  # no change
 
         # Event 7 Rotation to null NonTransferable Abandon
-        nxt5 = ""  # nxt digest is empty
-        serder7 = rotate(pre=pre, keys=keys4, dig=serder6.said, nxt=nxt5, sn=7)
+        serder7 = rotate(pre=pre, keys=keys4, dig=serder6.said, sn=7)
         event_digs.append(serder7.said)
         assert serder7.ked["i"] == pre
         assert serder7.ked["s"] == '7'
         assert serder7.ked["k"] == keys4
-        assert serder7.ked["n"] == nxt5
+        assert serder7.ked["n"] == []
         assert serder7.ked["p"] == serder6.said
 
         # sign serialization and verify signature
@@ -2050,7 +2049,7 @@ def test_keyeventsequence_0():
         assert kever.serder.saider.qb64 == serder7.said
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys4
-        assert kever.nexter == None
+        assert kever.nexter.digs == []
         assert not kever.transferable
 
         # Event 8 Interaction
@@ -2068,9 +2067,9 @@ def test_keyeventsequence_0():
 
         # Event 8 Rotation
         keys5 = [signers[5].verfer.qb64]
-        nexter5 = Nexter(keys=keys5)
-        nxt5 = nexter4.qb64  # transferable so nxt is not empty
-        serder8 = rotate(pre=pre, keys=keys5, dig=serder7.said, nxt=nxt5, sn=8)
+        nexter5 = coring.Diger(ser=signers[5].verfer.qb64b)
+        nxt5 = [nexter4.qb64]  # transferable so nxt is not empty
+        serder8 = rotate(pre=pre, keys=keys5, dig=serder7.said, nkeys=nxt5, sn=8)
         assert serder8.ked["i"] == pre
         assert serder8.ked["s"] == '8'
         assert serder8.ked["p"] == serder7.said
@@ -2130,10 +2129,10 @@ def test_keyeventsequence_1():
         keys0 = [signers[0].verfer.qb64]
         # compute nxt digest from keys1
         keys1 = [signers[1].verfer.qb64]
-        nexter1 = Nexter(keys=keys1)
-        nxt1 = nexter1.qb64  # transferable so nxt is not empty
+        nexter1 = coring.Diger(ser=signers[1].verfer.qb64b)
+        nxt1 = [nexter1.qb64]  # transferable so nxt is not empty
         cnfg = [TraitDex.EstOnly]  # EstOnly
-        serder0 = incept(keys=keys0, nxt=nxt1, cnfg=cnfg)
+        serder0 = incept(keys=keys0, nkeys=nxt1, cnfg=cnfg)
         event_digs.append(serder0.said)
         pre = serder0.ked["i"]
         assert serder0.ked["i"] == 'DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA'
@@ -2153,9 +2152,9 @@ def test_keyeventsequence_1():
         assert kever.ilk == Ilks.icp
         assert kever.tholder.thold == 1
         assert [verfer.qb64 for verfer in kever.verfers] == keys0
-        assert kever.nexter.qb64 == nxt1
-        assert kever.estOnly == True
-        assert kever.transferable == True
+        assert kever.nexter.digs == nxt1
+        assert kever.estOnly is True
+        assert kever.transferable is True
 
         # Event 1 Interaction. Because EstOnly, this event not included in KEL
         serder1 = interact(pre=pre, dig=serder0.said, sn=1)
@@ -2171,11 +2170,10 @@ def test_keyeventsequence_1():
 
         # Event 1 Rotation Transferable
         # compute nxt digest from keys2  but from event0
-        keys2 = [signers[2].verfer.qb64]
-        nexter2 = Nexter(keys=keys2)
-        nxt2 = nexter2.qb64  # transferable so nxt is not empty
-        assert nxt2 == 'E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI'
-        serder2 = rotate(pre=pre, keys=keys1, dig=serder0.said, nxt=nxt2, sn=1)
+        nexter2 = coring.Diger(ser=signers[2].verfer.qb64b)
+        nxt2 = [nexter2.qb64]  # transferable so nxt is not empty
+        assert nxt2 == ['EL-1w3eYVzNy0-RQV6r2ZORG-Y4gmOF-S7t9aeZMERXU']
+        serder2 = rotate(pre=pre, keys=keys1, dig=serder0.said, nkeys=nxt2, sn=1)
         event_digs.append(serder2.said)
         assert serder2.ked["i"] == pre
         assert serder2.ked["s"] == '1'
@@ -2194,7 +2192,7 @@ def test_keyeventsequence_1():
         assert kever.serder.saider.qb64 == serder2.said
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys1
-        assert kever.nexter.qb64 == nxt2
+        assert kever.nexter.digs == nxt2
 
         db_digs = [bytes(val).decode("utf-8") for val in kever.db.getKelIter(pre)]
         assert db_digs == event_digs
@@ -2231,13 +2229,13 @@ def test_multisig_digprefix():
         #  2 0f 3 multisig
 
         keys = [signers[0].verfer.qb64, signers[1].verfer.qb64, signers[2].verfer.qb64]
-        nxtkeys = [signers[3].verfer.qb64, signers[4].verfer.qb64, signers[5].verfer.qb64]
+        nxtkeys = [signers[3].verfer.qb64b, signers[4].verfer.qb64b, signers[5].verfer.qb64b]
         sith = "2"
         code = MtrDex.Blake3_256  # Blake3 digest of incepting data
         serder = incept(keys=keys,
                         code=code,
                         sith=sith,
-                        nxt=Nexter(keys=nxtkeys).qb64)
+                        nkeys=[coring.Diger(ser=sig).qb64 for sig in nxtkeys])
 
         # create sig counter
         count = len(keys)
@@ -2252,27 +2250,28 @@ def test_multisig_digprefix():
         for siger in sigers:
             msgs.extend(siger.qb64b)
 
-        assert msgs == bytearray(b'{"v":"KERI10JSON00017e_","t":"icp","d":"ELYk-z-SuTIeDncLr6GhwVUK'
-                                 b'nv3n3F1bF18qkXNd2bpk","i":"ELYk-z-SuTIeDncLr6GhwVUKnv3n3F1bF18qk'
-                                 b'XNd2bpk","s":"0","kt":"2","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
+        assert msgs == bytearray(b'{"v":"KERI10JSON0001e7_","t":"icp","d":"EZrJQSdhdiyXNpEzHo-dR0EE'
+                                 b'bLfcIopBSImdLnQGOKkg","i":"EZrJQSdhdiyXNpEzHo-dR0EEbLfcIopBSImdL'
+                                 b'nQGOKkg","s":"0","kt":"2","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
                                  b'OoeKtWTOunRA","DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI","DT'
-                                 b'1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"n":"E9izzBkXX76sqt'
-                                 b'0N-tfLzJeRqj0W56p4pDQ_ZqNCDpyw","bt":"0","b":[],"c":[],"a":[]}-A'
-                                 b'ADAA39j08U7pcU66OPKsaPExhBuHsL5rO1Pjq5zMgt_X6jRbezevis6YBUg074ZN'
-                                 b'KAGdUwHLqvPX_kse4buuuSUpAQABphobpuQEZ6EhKLhBuwgJmIQu80ZUV1GhBL0H'
-                                 b't47Hsl1rJiMwE2yW7-yi8k3idw2ahlpgdd9ka9QOP9yQmMWGAQACM7yfK1b86p1H'
-                                 b'62gonh1C7MECDCFBkoH0NZRjHKAEHebvd2_LLz6cpCaqKWDhbM2Rq01f9pgyDTFN'
-                                 b'LJMxkC-fAQ')
+                                 b'1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8"],"nt":"2","n":["E_Ik'
+                                 b'dcjsIFrFba-LS1sJDjpec_4vM3XtIPa6D51GcUIw","EU28GjHFKeXzncPxgwlHQ'
+                                 b'Z0iO7f09Y89vy-3VkZ23bBI","E2PRzip7UZ5UTA_1ucb5eoAzxeRS3sIThrSbZh'
+                                 b'dRaZY8"],"bt":"0","b":[],"c":[],"a":[]}-AADAAzclB26m4VWp5R8ANlTU'
+                                 b'2qhqE6GA9siAK_vhtqtNNR6qhVed-xEoXRadnL5Jc0kxPZi8XUqSk5KSaOnke_Sx'
+                                 b'XDAABX--x4JGI0Dp0Ran-t1LMg3NEgizu1Jb85LTImofYqD6jz9w5TTPNAmj7rfI'
+                                 b'Fvd4mfJ_ioH0Z0mzLWuIvTIFCBAACQTiHacY3flY9y_Wup66bNzcyQvJUT-WGkv4'
+                                 b'CPgqkMwq5mOEFf2ps74bur1AE9OSGgrEBlcOQ9HWuTcr80FMKCg')
 
         # Event 1 Rotation Transferable
-        keys = nxtkeys
+        keys = [signers[3].verfer.qb64, signers[4].verfer.qb64, signers[5].verfer.qb64]
         sith = "2"
-        nxtkeys = [signers[5].verfer.qb64, signers[6].verfer.qb64, signers[7].verfer.qb64]
+        nxtkeys = [signers[5].verfer.qb64b, signers[6].verfer.qb64b, signers[7].verfer.qb64b]
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=keys,
                         sith=sith,
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=nxtkeys).qb64,
+                        nkeys=[coring.Diger(ser=sig).qb64 for sig in nxtkeys],
                         sn=1)
         # create sig counter
         count = len(keys)
@@ -2321,12 +2320,11 @@ def test_multisig_digprefix():
 
         # Event 7 Rotation to null NonTransferable Abandon
         # nxt digest is empty
-        keys = nxtkeys
+        keys = [signers[5].verfer.qb64, signers[6].verfer.qb64, signers[7].verfer.qb64]
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=keys,
                         sith="2",
                         dig=kever.serder.saider.qb64,
-                        nxt="",
                         sn=4)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs, count=count)  # default is count = 1
@@ -2340,7 +2338,7 @@ def test_multisig_digprefix():
         for siger in sigers:
             msgs.extend(siger.qb64b)
 
-        assert len(msgs) == 2954
+        assert len(msgs) == 3173
 
         kevery = Kevery(db=vallgr)
         parsing.Parser().parse(ims=msgs, kvy=kevery)
@@ -2387,7 +2385,7 @@ def test_recovery():
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[signers[esn].verfer.qb64],
-                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64)
+                        nkeys=[coring.Diger(ser=signers[esn + 1].verfer.qb64b).qb64])
 
         assert sn == int(serder.ked["s"], 16) == 0
 
@@ -2410,7 +2408,7 @@ def test_recovery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[esn + 1].verfer.qb64b).qb64],
                         sn=sn)
 
         event_digs.append(serder.said)
@@ -2452,7 +2450,7 @@ def test_recovery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[esn + 1].verfer.qb64b).qb64],
                         sn=sn)
         event_digs.append(serder.said)
         # create sig counter
@@ -2532,7 +2530,7 @@ def test_recovery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[esn].verfer.qb64],
                         dig=event_digs[sn - 1],
-                        nxt=Nexter(keys=[signers[esn + 1].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[esn + 1].verfer.qb64b).qb64],
                         sn=sn)
         event_digs.append(serder.said)
         # create sig counter
@@ -2662,7 +2660,7 @@ def test_receipt():
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[coeSigners[esn].verfer.qb64],
-                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64)
+                        nkeys=[coring.Diger(ser=coeSigners[esn + 1].verfer.qb64b).qb64])
 
         assert sn == int(serder.ked["s"], 16) == 0
         coepre = serder.ked["i"]
@@ -2698,7 +2696,7 @@ def test_receipt():
         # sign event not receipt
         valCigar = valSigner.sign(ser=serder.raw)  # returns Cigar cause no index
         assert valCigar.qb64 == \
-               '0BbUeX7VXSTUMbR3f5nPRqVZTJ04RuzzbgyE6780JATE9dS2xxPDk2piRMkNzanS6NXP8TioMMiGELLsSGIV87CA'
+               '0BEaTtTANB15o8ekvghBiJXAqIPRP-fpZtSwmjTZCH89FE1zg6OaLz9llY6_yUpXIXTBcTjHEUHCul9kOf-9rRBw'
         recnt = Counter(code=CtrDex.NonTransReceiptCouples, count=1)
         assert recnt.qb64 == '-CAB'
 
@@ -2706,11 +2704,11 @@ def test_receipt():
         res.extend(recnt.qb64b)
         res.extend(valPrefixer.qb64b)
         res.extend(valCigar.qb64b)
-        assert res == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"EG4EuTsxPiRM7soX10XXzNsS'
-                                b'1KqXKUp8xsQ-kW_tWHoI","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
+        assert res == bytearray(b'{"v":"KERI10JSON000091_","t":"rct","d":"ELeMG3OOxWi5n1Zud603_Bn6'
+                                b'Hzm3hIRZXlQnSgC5lU7A","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
                                 b'WTOunRA","s":"0"}-CABB8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiM'
-                                b'c0BbUeX7VXSTUMbR3f5nPRqVZTJ04RuzzbgyE6780JATE9dS2xxPDk2piRMkNzan'
-                                b'S6NXP8TioMMiGELLsSGIV87CA')
+                                b'c0BEaTtTANB15o8ekvghBiJXAqIPRP-fpZtSwmjTZCH89FE1zg6OaLz9llY6_yUp'
+                                b'XIXTBcTjHEUHCul9kOf-9rRBw')
 
         parsing.Parser().parse(ims=res, kvy=coeKevery)
         # coeKevery.process(ims=res)  #  coe process the receipt from val
@@ -2774,7 +2772,7 @@ def test_receipt():
         serder = rotate(pre=coeKever.prefixer.qb64,
                         keys=[coeSigners[esn].verfer.qb64],
                         dig=coeKever.serder.saider.qb64,
-                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=coeSigners[esn + 1].verfer.qb64b).qb64],
                         sn=sn)
 
         event_digs.append(serder.said)
@@ -2821,7 +2819,7 @@ def test_receipt():
         serder = rotate(pre=coeKever.prefixer.qb64,
                         keys=[coeSigners[esn].verfer.qb64],
                         dig=coeKever.serder.saider.qb64,
-                        nxt=Nexter(keys=[coeSigners[esn + 1].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=coeSigners[esn + 1].verfer.qb64b).qb64],
                         sn=sn)
         event_digs.append(serder.said)
         # create sig counter
@@ -2974,12 +2972,12 @@ def test_direct_mode():
 
         # Coe Event 0  Inception Transferable (nxt digest not empty)
         coeSerder = incept(keys=[coeSigners[cesn].verfer.qb64],
-                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=coeSigners[cesn + 1].verfer.qb64b).qb64],
                            code=MtrDex.Blake3_256)
 
         assert csn == int(coeSerder.ked["s"], 16) == 0
         coepre = coeSerder.ked["i"]
-        assert coepre == 'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY'
+        assert coepre == 'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw'
 
         coe_event_digs.append(coeSerder.said)
         # create sig counter
@@ -2991,12 +2989,13 @@ def test_direct_mode():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'{"v":"KERI10JSON000120_","t":"icp","d":"EsZuhYAPBDnexP3SOl9YsGvW'
-                                 b'BrYkjYcRjomUYmCcLAYY","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                                 b'mCcLAYY","s":"0","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
-                                 b'OoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU'
-                                 b'","bt":"0","b":[],"c":[],"a":[]}-AABAAWKO9bl3OhABTaevxYiXQ1poRIG'
-                                 b'fM9ndMPq4bvrKmU_3pTN3VLNDYOI8pJBeAQxRtajQn4CSWOqgdGnmeG6fBCQ')
+        assert cmsg == bytearray(b'{"v":"KERI10JSON00012b_","t":"icp","d":"EdwS_D6wppLqfIp5LSgly8GT'
+                                 b'Scg5OWBaa7thzEnBqHvw","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                                 b'EnBqHvw","s":"0","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
+                                 b'OoeKtWTOunRA"],"nt":"1","n":["E67B6WkwQrEfSA2MylxmF28HJc_HxfHRyK'
+                                 b'1kRXSYeMiI"],"bt":"0","b":[],"c":[],"a":[]}-AABAAEtmk7qXsdCpK8Uh'
+                                 b'ruVzPpIITUg4UPodQuzNsR29tUIT1sCWnjXOEVUC_mlYrgquYSZSE1Xq8r9OOlI3'
+                                 b'ELJEMAw')
 
         # create own Coe Kever in  Coe's Kevery
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3006,12 +3005,12 @@ def test_direct_mode():
 
         # Val Event 0  Inception Transferable (nxt digest not empty)
         valSerder = incept(keys=[valSigners[vesn].verfer.qb64],
-                           nxt=Nexter(keys=[valSigners[vesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=valSigners[vesn + 1].verfer.qb64b).qb64],
                            code=MtrDex.Blake3_256)
 
         assert vsn == int(valSerder.ked["s"], 16) == 0
         valpre = valSerder.ked["i"]
-        assert valpre == 'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
+        assert valpre == 'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
 
         val_event_digs.append(valSerder.said)
         # create sig counter
@@ -3023,12 +3022,13 @@ def test_direct_mode():
         vmsg = bytearray(valSerder.raw)
         vmsg.extend(counter.qb64b)
         vmsg.extend(siger.qb64b)
-        assert vmsg == bytearray(b'{"v":"KERI10JSON000120_","t":"icp","d":"E7pB5IKuaYh3aIWKxtexyYFh'
-                                 b'pSjDNTEGSQuxeJbWiylg","i":"E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxe'
-                                 b'JbWiylg","s":"0","kt":"1","k":["D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9'
-                                 b'yzhDNZlEKiMc"],"n":"EOWDAJvex5dZzDxeHBANyaIoUG3F4-ic81G6GwtnC4f4'
-                                 b'","bt":"0","b":[],"c":[],"a":[]}-AABAAsnbd4AkK3mlX2Z3quAfTznEPmF'
-                                 b'JInT9CE9i0aisswqaSW7QNp6XlPHo3natTevQCmS0H9J4Kb-H_V-BtpqavBA')
+        assert vmsg == bytearray(b'{"v":"KERI10JSON00012b_","t":"icp","d":"E0VtKUgXnnXq9EtfgKAd_l5l'
+                                 b'hyhx_Rlf0Uj1XejaNNoo","i":"E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1X'
+                                 b'ejaNNoo","s":"0","kt":"1","k":["D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9'
+                                 b'yzhDNZlEKiMc"],"nt":"1","n":["E71sZjtEedBeNrGYRXmeTdmgbCJUTpXX5T'
+                                 b'W-VpNxxRXk"],"bt":"0","b":[],"c":[],"a":[]}-AABAAxXn_f_GuWg9ON12'
+                                 b'x59DXir636vEsdwAozFRDcLgx_TmTY8WuhRbW_zWAEFX7d_YYMtYNNVk7uoxp7s5'
+                                 b'U8m4FDA')
 
         # create own Val Kever in  Val's Kevery
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3054,21 +3054,21 @@ def test_direct_mode():
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIcpDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
-        assert coeIcpDig == coeK.serder.saider.qb64b == b'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY'
+        assert coeIcpDig == coeK.serder.saider.qb64b == b'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw'
         coeIcpRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeIcpDig)))
-        assert coeIcpRaw == (b'{"v":"KERI10JSON000120_","t":"icp","d":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomU'
-                             b'YmCcLAYY","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY","s":"0","kt":"1'
-                             b'","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBK'
-                             b'kzX1kxSPGYBWaIya3slgCOyOtlqU","bt":"0","b":[],"c":[],"a":[]}')
+        assert coeIcpRaw == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7th'
+                             b'zEnBqHvw","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw","s":"0","kt":"1'
+                             b'","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRA"],"nt":"1","n":["E67B6W'
+                             b'kwQrEfSA2MylxmF28HJc_HxfHRyK1kRXSYeMiI"],"bt":"0","b":[],"c":[],"a":[]}')
         siger = valSigners[vesn].sign(ser=coeIcpRaw, index=0)  # return Siger if index
-        assert siger.qb64 == 'AAlIts3z2kNyis9l0Pfu54HhVN_yZHEV7NWIVoSTzl5IABelbY8xi7VRyW42ZJvBaaFTGtiqwMOywloVNpG_ZHAQ'
+        assert siger.qb64 == 'AAhqa4qdyKUYl0gphqZp9511p3NfDecpUMvedi7pPxIVnufTeg3NpQ77GD9FNHTTtXZnQkZ2r8j_1-Iqi7ZMPlBg'
         rmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert rmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EsZuhYAPBDnexP3SOl9YsGvW'
-                        b'BrYkjYcRjomUYmCcLAYY","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                        b'mCcLAYY","s":"0"}-FABE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiyl'
-                        b'g0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJb'
-                        b'Wiylg-AABAAlIts3z2kNyis9l0Pfu54HhVN_yZHEV7NWIVoSTzl5IABelbY8xi7V'
-                        b'RyW42ZJvBaaFTGtiqwMOywloVNpG_ZHAQ')
+        assert rmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EdwS_D6wppLqfIp5LSgly8GT'
+                        b'Scg5OWBaa7thzEnBqHvw","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                        b'EnBqHvw","s":"0"}-FABE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNo'
+                        b'o0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1Xej'
+                        b'aNNoo-AABAAhqa4qdyKUYl0gphqZp9511p3NfDecpUMvedi7pPxIVnufTeg3NpQ7'
+                        b'7GD9FNHTTtXZnQkZ2r8j_1-Iqi7ZMPlBg')
 
         # process own Val receipt in Val's Kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(rmsg), kvy=valKevery)
@@ -3089,9 +3089,9 @@ def test_direct_mode():
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
-        assert bytes(result[0]) == (b'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKu'
-                                    b'aYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylgAAlIts3z2kNyis9l0Pfu54HhVN_yZHEV7NWIVoST'
-                                    b'zl5IABelbY8xi7VRyW42ZJvBaaFTGtiqwMOywloVNpG_ZHAQ')
+        assert bytes(result[0]) == (b'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgX'
+                                    b'nnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNooAAhqa4qdyKUYl0gphqZp9511p3NfDecpUMvedi7p'
+                                    b'PxIVnufTeg3NpQ77GD9FNHTTtXZnQkZ2r8j_1-Iqi7ZMPlBg')
 
         # create receipt to escrow use invalid dig and sn so not in coe's db
         fake = reserder.said  # some other dig
@@ -3103,12 +3103,12 @@ def test_direct_mode():
 
         # create message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EsZuhYAPBDnexP3SOl9YsGvW'
-                        b'BrYkjYcRjomUYmCcLAYY","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                        b'mCcLAYY","s":"a"}-FABE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiyl'
-                        b'g0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJb'
-                        b'Wiylg-AABAAlIts3z2kNyis9l0Pfu54HhVN_yZHEV7NWIVoSTzl5IABelbY8xi7V'
-                        b'RyW42ZJvBaaFTGtiqwMOywloVNpG_ZHAQ')
+        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EdwS_D6wppLqfIp5LSgly8GT'
+                        b'Scg5OWBaa7thzEnBqHvw","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                        b'EnBqHvw","s":"a"}-FABE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNo'
+                        b'o0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1Xej'
+                        b'aNNoo-AABAAhqa4qdyKUYl0gphqZp9511p3NfDecpUMvedi7pPxIVnufTeg3NpQ7'
+                        b'7GD9FNHTTtXZnQkZ2r8j_1-Iqi7ZMPlBg')
         parsing.Parser().parse(ims=vmsg, kvy=coeKevery)
         # coeKevery.process(ims=vmsg)  #  coe process the escrow receipt from val
         #  check if receipt quadruple in escrow database
@@ -3134,23 +3134,23 @@ def test_direct_mode():
         # sign vals's event not receipt
         # look up event to sign from coe's kever for val
         valIcpDig = bytes(coeKevery.db.getKeLast(key=snKey(pre=valpre, sn=vsn)))
-        assert valIcpDig == valK.serder.saider.qb64b == b'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
+        assert valIcpDig == valK.serder.saider.qb64b == b'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
         valIcpRaw = bytes(coeKevery.db.getEvt(key=dgKey(pre=valpre, dig=valIcpDig)))
-        assert valIcpRaw == (b'{"v":"KERI10JSON000120_","t":"icp","d":"E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQux'
-                             b'eJbWiylg","i":"E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg","s":"0","kt":"1'
-                             b'","k":["D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc"],"n":"EOWDAJvex5dZzDxe'
-                             b'HBANyaIoUG3F4-ic81G6GwtnC4f4","bt":"0","b":[],"c":[],"a":[]}')
+        assert valIcpRaw == (b'{"v":"KERI10JSON00012b_","t":"icp","d":"E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1'
+                             b'XejaNNoo","i":"E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo","s":"0","kt":"1'
+                             b'","k":["D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc"],"nt":"1","n":["E71sZj'
+                             b'tEedBeNrGYRXmeTdmgbCJUTpXX5TW-VpNxxRXk"],"bt":"0","b":[],"c":[],"a":[]}')
 
         siger = coeSigners[vesn].sign(ser=valIcpRaw, index=0)  # return Siger if index
-        assert siger.qb64 == 'AASM6cqwheGr368o-3D2LOGQmdpgpGsq3knHiuQ7pMmSQb4roLy99a26roE6xJVVdh1rqsHst3nLBwguanw99IAg'
+        assert siger.qb64 == 'AAwRTBCuNLZdEpmDQcTBzNpUlvX7P7ihE9Hh5A_USAbT-8ILfEBvqfUEdbbdR5WrYCJvQQbQui63Kx-5z1z5uDBw'
         # create receipt message
         cmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert cmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E7pB5IKuaYh3aIWKxtexyYFh'
-                        b'pSjDNTEGSQuxeJbWiylg","i":"E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxe'
-                        b'JbWiylg","s":"0"}-FABEsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAY'
-                        b'Y0AAAAAAAAAAAAAAAAAAAAAAAEsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmC'
-                        b'cLAYY-AABAASM6cqwheGr368o-3D2LOGQmdpgpGsq3knHiuQ7pMmSQb4roLy99a2'
-                        b'6roE6xJVVdh1rqsHst3nLBwguanw99IAg')
+        assert cmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E0VtKUgXnnXq9EtfgKAd_l5l'
+                        b'hyhx_Rlf0Uj1XejaNNoo","i":"E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1X'
+                        b'ejaNNoo","s":"0"}-FABEdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHv'
+                        b'w0AAAAAAAAAAAAAAAAAAAAAAAEdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEn'
+                        b'BqHvw-AABAAwRTBCuNLZdEpmDQcTBzNpUlvX7P7ihE9Hh5A_USAbT-8ILfEBvqfU'
+                        b'EdbbdR5WrYCJvQQbQui63Kx-5z1z5uDBw')
 
         # coe process own receipt in own Kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3167,9 +3167,9 @@ def test_direct_mode():
                                     Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.saider.qb64b +
                                     siger.qb64b)
-        assert bytes(result[0]) == (b'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY0AAAAAAAAAAAAAAAAAAAAAAAEsZuhYAP'
-                                    b'BDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYYAASM6cqwheGr368o-3D2LOGQmdpgpGsq3knHiuQ7'
-                                    b'pMmSQb4roLy99a26roE6xJVVdh1rqsHst3nLBwguanw99IAg')
+        assert bytes(result[0]) == (b'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw0AAAAAAAAAAAAAAAAAAAAAAAEdwS_D6w'
+                                    b'ppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvwAAwRTBCuNLZdEpmDQcTBzNpUlvX7P7ihE9Hh5A_U'
+                                    b'SAbT-8ILfEBvqfUEdbbdR5WrYCJvQQbQui63Kx-5z1z5uDBw')
 
         # Coe Event 1 RotationTransferable
         csn += 1
@@ -3178,7 +3178,7 @@ def test_direct_mode():
         coeSerder = rotate(pre=coeKever.prefixer.qb64,
                            keys=[coeSigners[cesn].verfer.qb64],
                            dig=coeKever.serder.saider.qb64,
-                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=coeSigners[cesn + 1].verfer.qb64b).qb64],
                            sn=csn)
         coe_event_digs.append(coeSerder.said)
         # create sig counter
@@ -3190,13 +3190,13 @@ def test_direct_mode():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'{"v":"KERI10JSON000155_","t":"rot","d":"ETF6q3lFDmkJyhhfuzfPXzq5'
-                                 b'gI2NVj0vnC5nNrhaTQC8","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                                 b'mCcLAYY","s":"1","p":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLA'
-                                 b'YY","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"'
-                                 b'],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fI","bt":"0","b'
-                                 b'r":[],"ba":[],"a":[]}-AABAAkiwNdxsz5w0j1MtQo-0YpB37OsDNap7zthbG4'
-                                 b'RtNkh814zBHeFD2p0AjiFup_CQvK7r0B3yIQsD2uWtsOGMZBg')
+        assert cmsg == bytearray(b'{"v":"KERI10JSON000160_","t":"rot","d":"EPGhF0L32Ay6HAD0qLtM7Crr'
+                                 b'1UVTp3D2pH2TdJ_8sG8Y","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                                 b'EnBqHvw","s":"1","p":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqH'
+                                 b'vw","kt":"1","k":["DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJI"'
+                                 b'],"nt":"1","n":["EL-1w3eYVzNy0-RQV6r2ZORG-Y4gmOF-S7t9aeZMERXU"],'
+                                 b'"bt":"0","br":[],"ba":[],"a":[]}-AABAARP1SU3CTLKkLhubMeFQbpe3wgL'
+                                 b'qOTWyy3rojOhtzPrnzxpy1_MSKhnWAWSkfPF4Pp5elleoLrKfZvaswXbNcDQ')
 
         # update coe's key event verifier state
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3224,24 +3224,24 @@ def test_direct_mode():
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeRotDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
-        assert coeRotDig == coeK.serder.saider.qb64b == b'ETF6q3lFDmkJyhhfuzfPXzq5gI2NVj0vnC5nNrhaTQC8'
+        assert coeRotDig == coeK.serder.saider.qb64b == b'EPGhF0L32Ay6HAD0qLtM7Crr1UVTp3D2pH2TdJ_8sG8Y'
         coeRotRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeRotDig)))
-        assert coeRotRaw == (b'{"v":"KERI10JSON000155_","t":"rot","d":"ETF6q3lFDmkJyhhfuzfPXzq5gI2NVj0vnC5n'
-                             b'NrhaTQC8","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY","s":"1","p":"Es'
-                             b'ZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY","kt":"1","k":["DVcuJOOJF1IE8svqE'
-                             b'trSuyQjGTd2HhfAkt9y2QkUtFJI"],"n":"E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a3'
-                             b'4fI","bt":"0","br":[],"ba":[],"a":[]}')
+        assert coeRotRaw == (b'{"v":"KERI10JSON000160_","t":"rot","d":"EPGhF0L32Ay6HAD0qLtM7Crr1UVTp3D2pH2T'
+                             b'dJ_8sG8Y","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw","s":"1","p":"Ed'
+                             b'wS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw","kt":"1","k":["DVcuJOOJF1IE8svqE'
+                             b'trSuyQjGTd2HhfAkt9y2QkUtFJI"],"nt":"1","n":["EL-1w3eYVzNy0-RQV6r2ZORG-Y4gmOF'
+                             b'-S7t9aeZMERXU"],"bt":"0","br":[],"ba":[],"a":[]}')
 
         siger = valSigners[vesn].sign(ser=coeRotRaw, index=0)  # return Siger if index
-        assert siger.qb64 == 'AA5g3iVnNhaFpkzjlJ-NWLAgJFSzikVIOIhpPJXdOL7PUOyJiQPqT2j2ZR1SB8a4Cn35YEktZ5L5nrL3AE-dyfAg'
+        assert siger.qb64 == 'AACKy97UIP4Bgh267LhWTXvrHXXQjsh8nJ5xwvwE_r-guPZdzjQZUqCbs3C6fVKU5sXLdDEa5fNkJ1wzoWu6CgBQ'
         # val create receipt message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"ETF6q3lFDmkJyhhfuzfPXzq5'
-                        b'gI2NVj0vnC5nNrhaTQC8","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                        b'mCcLAYY","s":"1"}-FABE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiyl'
-                        b'g0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJb'
-                        b'Wiylg-AABAA5g3iVnNhaFpkzjlJ-NWLAgJFSzikVIOIhpPJXdOL7PUOyJiQPqT2j'
-                        b'2ZR1SB8a4Cn35YEktZ5L5nrL3AE-dyfAg')
+        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EPGhF0L32Ay6HAD0qLtM7Crr'
+                        b'1UVTp3D2pH2TdJ_8sG8Y","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                        b'EnBqHvw","s":"1"}-FABE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNo'
+                        b'o0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1Xej'
+                        b'aNNoo-AABAACKy97UIP4Bgh267LhWTXvrHXXQjsh8nJ5xwvwE_r-guPZdzjQZUqC'
+                        b'bs3C6fVKU5sXLdDEa5fNkJ1wzoWu6CgBQ')
 
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3259,9 +3259,9 @@ def test_direct_mode():
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
 
-        assert bytes(result[0]) == (b'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKu'
-                                    b'aYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylgAA5g3iVnNhaFpkzjlJ-NWLAgJFSzikVIOIhpPJXd'
-                                    b'OL7PUOyJiQPqT2j2ZR1SB8a4Cn35YEktZ5L5nrL3AE-dyfAg')
+        assert bytes(result[0]) == (b'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgX'
+                                    b'nnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNooAACKy97UIP4Bgh267LhWTXvrHXXQjsh8nJ5xwvwE'
+                                    b'_r-guPZdzjQZUqCbs3C6fVKU5sXLdDEa5fNkJ1wzoWu6CgBQ')
 
         # Next Event 2 Coe Interaction
         csn += 1  # do not increment esn
@@ -3280,11 +3280,11 @@ def test_direct_mode():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EPGjQ1uYGgCc9g_u7Sj3MXnS'
-                                 b'A4lnDKXkWRUa0cW8CZ8A","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                                 b'mCcLAYY","s":"2","p":"ETF6q3lFDmkJyhhfuzfPXzq5gI2NVj0vnC5nNrhaTQ'
-                                 b'C8","a":[]}-AABAARgUUfnVfVzQ6NHBcEvbtfi-Uzaj1SCK7n-NYXmilXufoCV7'
-                                 b'Vq3eXRxdPdUwdpJD7JBGa9LecpQC4tNom2gV3Bw')
+        assert cmsg == bytearray(b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EKK-xQ6k-JyAkg40UNtFCv2C'
+                                 b'7HAhXY-fKUYG2GPG6Q08","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                                 b'EnBqHvw","s":"2","p":"EPGhF0L32Ay6HAD0qLtM7Crr1UVTp3D2pH2TdJ_8sG'
+                                 b'8Y","a":[]}-AABAAdS2iIv6OtwlulpyF0DI9pqvLh90iazJWCcFDF1jXidQcWrw'
+                                 b'Ttr0LNWHB5AlZ-3DLtVYR0Yp7P58gAO5CYnGSDA')
 
         # update coe's key event verifier state
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3312,21 +3312,21 @@ def test_direct_mode():
         # sign coe's event not receipt
         # look up event to sign from val's kever for coe
         coeIxnDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
-        assert coeIxnDig == coeK.serder.saider.qb64b == b'EPGjQ1uYGgCc9g_u7Sj3MXnSA4lnDKXkWRUa0cW8CZ8A'
+        assert coeIxnDig == coeK.serder.saider.qb64b == b'EKK-xQ6k-JyAkg40UNtFCv2C7HAhXY-fKUYG2GPG6Q08'
         coeIxnRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeIxnDig)))
-        assert coeIxnRaw == (b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EPGjQ1uYGgCc9g_u7Sj3MXnSA4lnDKXkWRUa'
-                             b'0cW8CZ8A","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY","s":"2","p":"ET'
-                             b'F6q3lFDmkJyhhfuzfPXzq5gI2NVj0vnC5nNrhaTQC8","a":[]}')
+        assert coeIxnRaw == (b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EKK-xQ6k-JyAkg40UNtFCv2C7HAhXY-fKUYG'
+                             b'2GPG6Q08","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw","s":"2","p":"EP'
+                             b'GhF0L32Ay6HAD0qLtM7Crr1UVTp3D2pH2TdJ_8sG8Y","a":[]}')
         siger = valSigners[vesn].sign(ser=coeIxnRaw, index=0)  # return Siger if index
-        assert siger.qb64 == 'AACQbob55M9R58TGyUNClT1Xb8tm9ifeUE4yAIxeDC3guzsT09TuHpHSebeZUGQT50hwbIsYnAiIQPrA_3sKMBCQ'
+        assert siger.qb64 == 'AA7hc9eseXL2v5STGffKtukn_s27XmNG_KfxeuH1nMxePeOWuE2ObVyAoPT-hgV-Kag9zl3MVigPyYPe0goWQMBw'
         # create receipt message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EPGjQ1uYGgCc9g_u7Sj3MXnS'
-                        b'A4lnDKXkWRUa0cW8CZ8A","i":"EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUY'
-                        b'mCcLAYY","s":"2"}-FABE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiyl'
-                        b'g0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJb'
-                        b'Wiylg-AABAACQbob55M9R58TGyUNClT1Xb8tm9ifeUE4yAIxeDC3guzsT09TuHpH'
-                        b'SebeZUGQT50hwbIsYnAiIQPrA_3sKMBCQ')
+        assert vmsg == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EKK-xQ6k-JyAkg40UNtFCv2C'
+                        b'7HAhXY-fKUYG2GPG6Q08","i":"EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thz'
+                        b'EnBqHvw","s":"2"}-FABE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNo'
+                        b'o0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1Xej'
+                        b'aNNoo-AABAA7hc9eseXL2v5STGffKtukn_s27XmNG_KfxeuH1nMxePeOWuE2ObVy'
+                        b'AoPT-hgV-Kag9zl3MVigPyYPe0goWQMBw')
 
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3344,9 +3344,9 @@ def test_direct_mode():
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
 
-        assert bytes(result[0]) == (b'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg0AAAAAAAAAAAAAAAAAAAAAAAE7pB5IKu'
-                                    b'aYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylgAACQbob55M9R58TGyUNClT1Xb8tm9ifeUE4yAIxe'
-                                    b'DC3guzsT09TuHpHSebeZUGQT50hwbIsYnAiIQPrA_3sKMBCQ')
+        assert bytes(result[0]) == (b'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo0AAAAAAAAAAAAAAAAAAAAAAAE0VtKUgX'
+                                    b'nnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNooAA7hc9eseXL2v5STGffKtukn_s27XmNG_KfxeuH1'
+                                    b'nMxePeOWuE2ObVyAoPT-hgV-Kag9zl3MVigPyYPe0goWQMBw')
 
         #  verify final coe event state
         assert coeKever.verfers[0].qb64 == coeSigners[cesn].verfer.qb64
@@ -3354,9 +3354,9 @@ def test_direct_mode():
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(coepre)]
         assert len(db_digs) == len(coe_event_digs) == csn + 1
-        assert db_digs == coe_event_digs == ['EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY',
-                                             'ETF6q3lFDmkJyhhfuzfPXzq5gI2NVj0vnC5nNrhaTQC8',
-                                             'EPGjQ1uYGgCc9g_u7Sj3MXnSA4lnDKXkWRUa0cW8CZ8A']
+        assert db_digs == coe_event_digs == ['EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw',
+                                             'EPGhF0L32Ay6HAD0qLtM7Crr1UVTp3D2pH2TdJ_8sG8Y',
+                                             'EKK-xQ6k-JyAkg40UNtFCv2C7HAhXY-fKUYG2GPG6Q08']
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(coepre)]
         assert len(db_digs) == len(coe_event_digs) == csn + 1
@@ -3368,7 +3368,7 @@ def test_direct_mode():
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(valpre)]
         assert len(db_digs) == len(val_event_digs) == vsn + 1
-        assert db_digs == val_event_digs == ['E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg']
+        assert db_digs == val_event_digs == ['E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo']
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(valpre)]
         assert len(db_digs) == len(val_event_digs) == vsn + 1
@@ -3437,7 +3437,7 @@ def test_direct_mode_cbor_mgpk():
 
         # Coe Event 0  Inception Transferable (nxt digest not empty)
         coeSerder = incept(keys=[coeSigners[cesn].verfer.qb64],
-                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=coeSigners[cesn + 1].verfer.qb64b).qb64],
                            code=MtrDex.Blake3_256,
                            kind=Serials.cbor)
 
@@ -3454,12 +3454,12 @@ def test_direct_mode_cbor_mgpk():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'\xacavqKERI10CBOR0000f3_atcicpadx,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSk'
-                                 b'hSJpA3oLdH0aix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa0b'
-                                 b'kta1ak\x81x,DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRAanx,EPYuj8m'
-                                 b'q_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqUbbta0ab\x80ac\x80aa\x80-AABA'
-                                 b'AruKWKZ2QO_7rJXGDFVnvUgYCEz982jTkm3W5dlNpb2u3E73E9nL_kU-15dFhr9q'
-                                 b'6gREHXPMEXjJYNa6Bzyn_BQ')
+        assert cmsg == bytearray(b'\xadavqKERI10CBOR0000f9_atcicpadx,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQ'
+                                 b'lavnq3JpKZwaix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa0b'
+                                 b'kta1ak\x81x,DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRAbnta1an'
+                                 b'\x81x,E67B6WkwQrEfSA2MylxmF28HJc_HxfHRyK1kRXSYeMiIbbta0ab\x80a'
+                                 b'c\x80aa\x80-AABAA4j4IbpmAYY3eHUlN2pOn2og3JOs_vJ_KkCfK08tOsyFnHClFj'
+                                 b'7xzRwiTam3uauPwE-_9EwgcCIsBQB4-8nXwAQ')
 
         # create own Coe Kever in  Coe's Kevery
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3469,7 +3469,7 @@ def test_direct_mode_cbor_mgpk():
 
         # Val Event 0  Inception Transferable (nxt digest not empty)
         valSerder = incept(keys=[valSigners[vesn].verfer.qb64],
-                           nxt=Nexter(keys=[valSigners[vesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=valSigners[vesn + 1].verfer.qb64b).qb64],
                            code=MtrDex.Blake3_256,
                            kind=Serials.mgpk)
 
@@ -3486,13 +3486,13 @@ def test_direct_mode_cbor_mgpk():
         vmsg = bytearray(valSerder.raw)
         vmsg.extend(counter.qb64b)
         vmsg.extend(siger.qb64b)
-        assert vmsg == bytearray(b'\x8c\xa1v\xb1KERI10MGPK0000f3_\xa1t\xa3icp\xa1d\xd9,E2KeJD7a_ksFn'
-                                 b'gDFpVk9FtvYjLQtVKiwEw9_UjSzk4SA\xa1i\xd9,E2KeJD7a_ksFngDFpVk9FtvYj'
-                                 b'LQtVKiwEw9_UjSzk4SA\xa1s\xa10\xa2kt\xa11\xa1k\x91\xd9,D8KY1sKmgyj'
-                                 b'AiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc\xa1n\xd9,EOWDAJvex5dZzDxeHBANyaI'
-                                 b'oUG3F4-ic81G6GwtnC4f4\xa2bt\xa10\xa1b\x90\xa1c\x90\xa1a\x90-AABA'
-                                 b'Aq5zAhLjBxxCapdpxreXYdvOthAHFj9mFRUQB3Iz_zEFbTy6BRcKmJ8vgG0CuAqX'
-                                 b'k-yNbTM5T8ZpzbittzEzsAQ')
+        assert vmsg == bytearray(b'\x8d\xa1v\xb1KERI10MGPK0000f9_\xa1t\xa3icp\xa1d\xd9,EAICGQrxtqsZw'
+                                 b'l6s4D1jzCepnScs7j35Lt5-wX-bjd_Q\xa1i\xd9,EAICGQrxtqsZwl6s4D1jzCepn'
+                                 b'Scs7j35Lt5-wX-bjd_Q\xa1s\xa10\xa2kt\xa11\xa1k\x91\xd9,D8KY1sKmgyj'
+                                 b'AiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc\xa2nt\xa11\xa1n\x91\xd9,E71sZjtEe'
+                                 b'dBeNrGYRXmeTdmgbCJUTpXX5TW-VpNxxRXk\xa2bt\xa10\xa1b\x90\xa1'
+                                 b'c\x90\xa1a\x90-AABAA8EF2RDzaaXZSqMUUhtr8tl31iVg2F1EmamOkbwGW4EQBR'
+                                 b'AYT7Tk9mWcQtHJlOggrDJNZELaihAgBcDws248OAQ')
 
         # create own Val Kever in  Val's Kevery
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3521,20 +3521,20 @@ def test_direct_mode_cbor_mgpk():
         coeIcpDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
         assert coeIcpDig == coeK.serder.saider.qb64b
         coeIcpRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeIcpDig)))
-        assert coeIcpRaw == (b'\xacavqKERI10CBOR0000f3_atcicpadx,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oL'
-                             b'dH0aix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa0bkta1ak\x81x,DSuhyBc'
-                             b'PZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRAanx,EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3sl'
-                             b'gCOyOtlqUbbta0ab\x80ac\x80aa\x80')
+        assert coeIcpRaw == (b'\xadavqKERI10CBOR0000f9_atcicpadx,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3Jp'
+                             b'KZwaix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa0bkta1ak\x81x,DSuhyBc'
+                             b'PZEZLK-fcw5tzHn2N46wRCG_ZOoeKtWTOunRAbnta1an\x81x,E67B6WkwQrEfSA2MylxmF28HJ'
+                             b'c_HxfHRyK1kRXSYeMiIbbta0ab\x80ac\x80aa\x80')
 
         siger = valSigners[vesn].sign(ser=coeIcpRaw, index=0)  # return Siger if index
         # process own Val receipt in Val's Kevery so have copy in own log
         rmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert rmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,EqBbANsWWzNR8'
-                        b'Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0\xa1i\xd9,EqBbANsWWzNR8Q6LO1ItP23LS'
-                        b'-rxViiSkhSJpA3oLdH0\xa1s\xa10-FABE2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwE'
-                        b'w9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a_ksFngDFpVk9FtvYjLQtV'
-                        b'KiwEw9_UjSzk4SA-AABAAsfQxbSiTQzJJX5oKUyNv7kuE2mlH890aXXB2zimZvf2'
-                        b'kVfTyWOPs8SV5YBgm8lRamfhDhqqEjn0fUko2c9JiCw')
+        assert rmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,Eq51AFQINHs4Q'
+                        b'63X7hk-MQwQojnPA0QbQlavnq3JpKZw\xa1i\xd9,Eq51AFQINHs4Q63X7hk-MQwQo'
+                        b'jnPA0QbQlavnq3JpKZw\xa1s\xa10-FABEAICGQrxtqsZwl6s4D1jzCepnScs7j35L'
+                        b't5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrxtqsZwl6s4D1jzCepnScs7'
+                        b'j35Lt5-wX-bjd_Q-AABAAK_mb99LNCFTOo2euzvNlVuxbXis0FTIfXUqaSmKV-7G'
+                        b'4BaHcKWS6T__vOfTpuohAosPPLqJiUjvX0_wGO54XCQ')
 
         parsing.Parser().parseOne(ims=bytearray(rmsg), kvy=valKevery)
         # valKevery.processOne(ims=bytearray(rmsg))  # process copy of rmsg
@@ -3555,9 +3555,9 @@ def test_direct_mode_cbor_mgpk():
                                     Seqner(sn=valKever.sn).qb64b +
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
-        assert bytes(result[0]) == (b'E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a'
-                                    b'_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SAAAsfQxbSiTQzJJX5oKUyNv7kuE2mlH890aXXB2zi'
-                                    b'mZvf2kVfTyWOPs8SV5YBgm8lRamfhDhqqEjn0fUko2c9JiCw')
+        assert bytes(result[0]) == (b'EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrx'
+                                    b'tqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_QAAK_mb99LNCFTOo2euzvNlVuxbXis0FTIfXUqaSm'
+                                    b'KV-7G4BaHcKWS6T__vOfTpuohAosPPLqJiUjvX0_wGO54XCQ')
 
         # create receipt to escrow use invalid dig so not in coe's db
         fake = reserder.said  # some other dig
@@ -3570,12 +3570,12 @@ def test_direct_mode_cbor_mgpk():
 
         # create message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,EqBbANsWWzNR8'
-                        b'Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0\xa1i\xd9,EqBbANsWWzNR8Q6LO1ItP23LS'
-                        b'-rxViiSkhSJpA3oLdH0\xa1s\xa1a-FABE2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwE'
-                        b'w9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a_ksFngDFpVk9FtvYjLQtV'
-                        b'KiwEw9_UjSzk4SA-AABAAsfQxbSiTQzJJX5oKUyNv7kuE2mlH890aXXB2zimZvf2'
-                        b'kVfTyWOPs8SV5YBgm8lRamfhDhqqEjn0fUko2c9JiCw')
+        assert vmsg ==(b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,Eq51AFQINHs4Q'
+                       b'63X7hk-MQwQojnPA0QbQlavnq3JpKZw\xa1i\xd9,Eq51AFQINHs4Q63X7hk-MQwQo'
+                       b'jnPA0QbQlavnq3JpKZw\xa1s\xa1a-FABEAICGQrxtqsZwl6s4D1jzCepnScs7j35L'
+                       b't5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrxtqsZwl6s4D1jzCepnScs7'
+                       b'j35Lt5-wX-bjd_Q-AABAAK_mb99LNCFTOo2euzvNlVuxbXis0FTIfXUqaSmKV-7G'
+                       b'4BaHcKWS6T__vOfTpuohAosPPLqJiUjvX0_wGO54XCQ')
 
         parsing.Parser().parse(ims=vmsg, kvy=coeKevery)
         # coeKevery.process(ims=vmsg)  #  coe process the escrow receipt from val
@@ -3605,21 +3605,21 @@ def test_direct_mode_cbor_mgpk():
         valIcpDig = bytes(coeKevery.db.getKeLast(key=snKey(pre=valpre, sn=vsn)))
         assert valIcpDig == valK.serder.saider.qb64b
         valIcpRaw = bytes(coeKevery.db.getEvt(key=dgKey(pre=valpre, dig=valIcpDig)))
-        assert valIcpRaw == (b'\x8c\xa1v\xb1KERI10MGPK0000f3_\xa1t\xa3icp\xa1d\xd9,E2KeJD7a_ksFngDFpVk9F'
-                             b'tvYjLQtVKiwEw9_UjSzk4SA\xa1i\xd9,E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk'
-                             b'4SA\xa1s\xa10\xa2kt\xa11\xa1k\x91\xd9,D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzh'
-                             b'DNZlEKiMc\xa1n\xd9,EOWDAJvex5dZzDxeHBANyaIoUG3F4-ic81G6GwtnC4f4\xa2bt'
-                             b'\xa10\xa1b\x90\xa1c\x90\xa1a\x90')
+        assert valIcpRaw == (b'\x8d\xa1v\xb1KERI10MGPK0000f9_\xa1t\xa3icp\xa1d\xd9,EAICGQrxtqsZwl6s4D1jz'
+                             b'CepnScs7j35Lt5-wX-bjd_Q\xa1i\xd9,EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bj'
+                             b'd_Q\xa1s\xa10\xa2kt\xa11\xa1k\x91\xd9,D8KY1sKmgyjAiUDdUBPNPyrSz_ad_Qf9yzh'
+                             b'DNZlEKiMc\xa2nt\xa11\xa1n\x91\xd9,E71sZjtEedBeNrGYRXmeTdmgbCJUTpXX5TW-VpNxx'
+                             b'RXk\xa2bt\xa10\xa1b\x90\xa1c\x90\xa1a\x90')
 
         siger = coeSigners[vesn].sign(ser=valIcpRaw, index=0)  # return Siger if index
         # create receipt message
         cmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert cmsg == (b'\xa5avqKERI10CBOR00007f_atcrctadx,E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwE'
-                        b'w9_UjSzk4SAaix,E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SAasa0-'
-                        b'FABEqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH00AAAAAAAAAAAAAAAA'
-                        b'AAAAAAAEqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0-AABAAgSgZRQP'
-                        b'5G-tI7LSJqICSxf6q9RZ8buamJmJTzSZTzhZTkE_wCGa_E2aHgJkeFZ8wGuQiBXK'
-                        b'Q4NM0khTnId5-Ag')
+        assert cmsg == (b'\xa5avqKERI10CBOR00007f_atcrctadx,EAICGQrxtqsZwl6s4D1jzCepnScs7j35L'
+                        b't5-wX-bjd_Qaix,EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_Qasa0-'
+                        b'FABEq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZw0AAAAAAAAAAAAAAAA'
+                        b'AAAAAAAEq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZw-AABAAC0FNeUL'
+                        b'OkyGqfKiiUSRxeU6lCaGKqAKc44wysmSshNabIhDis0lc-X8Y-IYGTG3SFrvGuBl'
+                        b'rzfa8NFqLRHqzAA')
 
         # coe process own receipt in own Kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3636,9 +3636,9 @@ def test_direct_mode_cbor_mgpk():
                                     Seqner(sn=coeKever.sn).qb64b +
                                     coeKever.serder.saider.qb64b +
                                     siger.qb64b)
-        assert bytes(result[0]) == (b'EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH00AAAAAAAAAAAAAAAAAAAAAAAEqBbANsW'
-                                    b'WzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0AAgSgZRQP5G-tI7LSJqICSxf6q9RZ8buamJmJTzS'
-                                    b'ZTzhZTkE_wCGa_E2aHgJkeFZ8wGuQiBXKQ4NM0khTnId5-Ag')
+        assert bytes(result[0]) == (b'Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZw0AAAAAAAAAAAAAAAAAAAAAAAEq51AFQI'
+                                    b'NHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwAAC0FNeULOkyGqfKiiUSRxeU6lCaGKqAKc44wysm'
+                                    b'SshNabIhDis0lc-X8Y-IYGTG3SFrvGuBlrzfa8NFqLRHqzAA')
 
         # Coe RotationTransferable
         csn += 1
@@ -3647,7 +3647,7 @@ def test_direct_mode_cbor_mgpk():
         coeSerder = rotate(pre=coeKever.prefixer.qb64,
                            keys=[coeSigners[cesn].verfer.qb64],
                            dig=coeKever.serder.saider.qb64,
-                           nxt=Nexter(keys=[coeSigners[cesn + 1].verfer.qb64]).qb64,
+                           nkeys=[coring.Diger(ser=coeSigners[cesn + 1].verfer.qb64b).qb64],
                            sn=csn,
                            kind=Serials.cbor)
         coe_event_digs.append(coeSerder.said)
@@ -3660,13 +3660,13 @@ def test_direct_mode_cbor_mgpk():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'\xadavqKERI10CBOR000125_atcrotadx,EDfT9YrTj5Q4hUVv0rkcCoaNE1mtE_TcU'
-                                 b'Ih16A_Vnau8aix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa1a'
-                                 b'px,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0bkta1ak\x81x,DVcuJOO'
-                                 b'JF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJIanx,E-dapdcC6XR1KWmWDsNl4J_'
-                                 b'OxcGxNZw1Xd95JH5a34fIbbta0bbr\x80bba\x80aa\x80-AABAAnDby8W5kMVC04'
-                                 b'V0Wj1A7PfoKfnwUiIGbagWNzx3m9Fc5b8AeFLeDf8aq-8nfI0ttn_uH95hJWEukL'
-                                 b'8fyb2jbDQ')
+        assert cmsg == bytearray(b'\xaeavqKERI10CBOR00012b_atcrotadx,E5UktJ1jLc5V3nsh80g3kRA7CA_-3tumM'
+                                 b'Pte77QniEM4aix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa1a'
+                                 b'px,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwbkta1ak\x81x,DVcuJOO'
+                                 b'JF1IE8svqEtrSuyQjGTd2HhfAkt9y2QkUtFJIbnta1an\x81x,EL-1w3eYVzNy0-RQV'
+                                 b'6r2ZORG-Y4gmOF-S7t9aeZMERXUbbta0bbr\x80bba\x80aa\x80-AABAABK8wth4'
+                                 b'fMaOPfA7bRcN61uar_zqBrZQ2x2X5eWyhYZvcE3A52eralD1xfZnzGBwdilbhW7f'
+                                 b'ACoDe0-DEHNxOBg')
 
         # update coe's key event verifier state
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3697,21 +3697,21 @@ def test_direct_mode_cbor_mgpk():
         coeRotDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
         assert coeRotDig == coeK.serder.saider.qb64b
         coeRotRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeRotDig)))
-        assert coeRotRaw == (b'\xadavqKERI10CBOR000125_atcrotadx,EDfT9YrTj5Q4hUVv0rkcCoaNE1mtE_TcUIh16A_Vn'
-                             b'au8aix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa1apx,EqBbANsWWzNR8Q6LO'
-                             b'1ItP23LS-rxViiSkhSJpA3oLdH0bkta1ak\x81x,DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9'
-                             b'y2QkUtFJIanx,E-dapdcC6XR1KWmWDsNl4J_OxcGxNZw1Xd95JH5a34fIbbta0bbr\x80bb'
-                             b'a\x80aa\x80')
+        assert coeRotRaw == (b'\xaeavqKERI10CBOR00012b_atcrotadx,E5UktJ1jLc5V3nsh80g3kRA7CA_-3tumMPte77Qni'
+                             b'EM4aix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa1apx,Eq51AFQINHs4Q63X7'
+                             b'hk-MQwQojnPA0QbQlavnq3JpKZwbkta1ak\x81x,DVcuJOOJF1IE8svqEtrSuyQjGTd2HhfAkt9'
+                             b'y2QkUtFJIbnta1an\x81x,EL-1w3eYVzNy0-RQV6r2ZORG-Y4gmOF-S7t9aeZMERXUbbta0'
+                             b'bbr\x80bba\x80aa\x80')
 
         siger = valSigners[vesn].sign(ser=coeRotRaw, index=0)  # return Siger if index
         # create receipt message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,EDfT9YrTj5Q4h'
-                        b'UVv0rkcCoaNE1mtE_TcUIh16A_Vnau8\xa1i\xd9,EqBbANsWWzNR8Q6LO1ItP23LS'
-                        b'-rxViiSkhSJpA3oLdH0\xa1s\xa11-FABE2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwE'
-                        b'w9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a_ksFngDFpVk9FtvYjLQtV'
-                        b'KiwEw9_UjSzk4SA-AABAAbVxVM9JJ1U4Pc9m7OyKjia28pk5T2PUTISdG2HwfiuB'
-                        b'dTnT3lL9C7LvyWjW6VB-VhUSgZiWz9qil17DY5og2Cw')
+        assert vmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,E5UktJ1jLc5V3'
+                        b'nsh80g3kRA7CA_-3tumMPte77QniEM4\xa1i\xd9,Eq51AFQINHs4Q63X7hk-MQwQo'
+                        b'jnPA0QbQlavnq3JpKZw\xa1s\xa11-FABEAICGQrxtqsZwl6s4D1jzCepnScs7j35L'
+                        b't5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrxtqsZwl6s4D1jzCepnScs7'
+                        b'j35Lt5-wX-bjd_Q-AABAAVlFzvafwR5JKq-EhF90pEUDOqQBQL-FSxOBza4IygFk'
+                        b'4lV1GIErW8aZ_TRa9jN_bbFLnk6gQgnfqxRJUWkD1DA')
 
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3729,9 +3729,9 @@ def test_direct_mode_cbor_mgpk():
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
 
-        assert bytes(result[0]) == (b'E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a'
-                                    b'_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SAAAbVxVM9JJ1U4Pc9m7OyKjia28pk5T2PUTISdG2H'
-                                    b'wfiuBdTnT3lL9C7LvyWjW6VB-VhUSgZiWz9qil17DY5og2Cw')
+        assert bytes(result[0]) == (b'EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrx'
+                                    b'tqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_QAAVlFzvafwR5JKq-EhF90pEUDOqQBQL-FSxOBza4'
+                                    b'IygFk4lV1GIErW8aZ_TRa9jN_bbFLnk6gQgnfqxRJUWkD1DA')
 
         # Next Event Coe Interaction
         csn += 1  # do not increment esn
@@ -3751,11 +3751,11 @@ def test_direct_mode_cbor_mgpk():
         cmsg = bytearray(coeSerder.raw)
         cmsg.extend(counter.qb64b)
         cmsg.extend(siger.qb64b)
-        assert cmsg == bytearray(b'\xa7avqKERI10CBOR0000b2_atcixnadx,EoudO5pE1nsn7NqgZU-8mJGYPoR4ovdHe'
-                                 b'mPozIDPb8lgaix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa2a'
-                                 b'px,EDfT9YrTj5Q4hUVv0rkcCoaNE1mtE_TcUIh16A_Vnau8aa\x80-AABAAKqFSHJxe'
-                                 b'eMmhGIcMs-ua1Z-VCLTCvZ_E_W0D6i0lSLbnQwLcnynOwrqJJv6_-48BoLYT_WNl'
-                                 b'xoCVDA_EpXqDAg')
+        assert cmsg == bytearray(b'\xa7avqKERI10CBOR0000b2_atcixnadx,EpU_Dr1beH3JWNBV3LEvoH3hjeYgJRbwN'
+                                 b'J2sQEUEN4HEaix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa2a'
+                                 b'px,E5UktJ1jLc5V3nsh80g3kRA7CA_-3tumMPte77QniEM4aa\x80-AABAAPexu7tgA'
+                                 b'NhixOSKM_ROtuOyxqpaSoZoqzGWxOGRIQDvCVC5vwdK0zVQTq28Q5MVeRhIWlYbb'
+                                 b'cvjERWbqUJFsBw')
 
         # update coe's key event verifier state
         parsing.Parser().parseOne(ims=bytearray(cmsg), kvy=coeKevery)
@@ -3786,19 +3786,19 @@ def test_direct_mode_cbor_mgpk():
         coeIxnDig = bytes(valKevery.db.getKeLast(key=snKey(pre=coepre, sn=csn)))
         assert coeIxnDig == coeK.serder.saider.qb64b
         coeIxnRaw = bytes(valKevery.db.getEvt(key=dgKey(pre=coepre, dig=coeIxnDig)))
-        assert coeIxnRaw == (b'\xa7avqKERI10CBOR0000b2_atcixnadx,EoudO5pE1nsn7NqgZU-8mJGYPoR4ovdHemPozIDPb'
-                             b'8lgaix,EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0asa2apx,EDfT9YrTj5Q4hUVv0'
-                             b'rkcCoaNE1mtE_TcUIh16A_Vnau8aa\x80')
+        assert coeIxnRaw == (b'\xa7avqKERI10CBOR0000b2_atcixnadx,EpU_Dr1beH3JWNBV3LEvoH3hjeYgJRbwNJ2sQEUEN'
+                             b'4HEaix,Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZwasa2apx,E5UktJ1jLc5V3nsh8'
+                             b'0g3kRA7CA_-3tumMPte77QniEM4aa\x80')
 
         siger = valSigners[vesn].sign(ser=coeIxnRaw, index=0)  # return Siger if index
         # create receipt message
         vmsg = messagize(serder=reserder, sigers=[siger], seal=seal)
-        assert vmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,EoudO5pE1nsn7'
-                        b'NqgZU-8mJGYPoR4ovdHemPozIDPb8lg\xa1i\xd9,EqBbANsWWzNR8Q6LO1ItP23LS'
-                        b'-rxViiSkhSJpA3oLdH0\xa1s\xa12-FABE2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwE'
-                        b'w9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a_ksFngDFpVk9FtvYjLQtV'
-                        b'KiwEw9_UjSzk4SA-AABAASxMBN7VI016sgW02FZbnOm_nEsfRIJeTqMtCZaye4EV'
-                        b'_A6z1ZmdjRBBN3QXq_AuTbbP2Ngrm2dIAkcJgoQHvAA')
+        assert vmsg == (b'\x85\xa1v\xb1KERI10MGPK00007f_\xa1t\xa3rct\xa1d\xd9,EpU_Dr1beH3JW'
+                        b'NBV3LEvoH3hjeYgJRbwNJ2sQEUEN4HE\xa1i\xd9,Eq51AFQINHs4Q63X7hk-MQwQo'
+                        b'jnPA0QbQlavnq3JpKZw\xa1s\xa12-FABEAICGQrxtqsZwl6s4D1jzCepnScs7j35L'
+                        b't5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrxtqsZwl6s4D1jzCepnScs7'
+                        b'j35Lt5-wX-bjd_Q-AABAArq12oDvsHfjELzwRo8M0kt4_EhNO7qF9FYLgMU3X5qp'
+                        b'77sjZZa71blAGGYm-Of23QFsynB3UZHPDzlvXM_mtAA')
 
         # val process own receipt in own kevery so have copy in own log
         parsing.Parser().parseOne(ims=bytearray(vmsg), kvy=valKevery)
@@ -3816,9 +3816,9 @@ def test_direct_mode_cbor_mgpk():
                                     valKever.serder.saider.qb64b +
                                     siger.qb64b)
 
-        assert bytes(result[0]) == (b'E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SA0AAAAAAAAAAAAAAAAAAAAAAAE2KeJD7a'
-                                    b'_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SAAASxMBN7VI016sgW02FZbnOm_nEsfRIJeTqMtCZa'
-                                    b'ye4EV_A6z1ZmdjRBBN3QXq_AuTbbP2Ngrm2dIAkcJgoQHvAA')
+        assert bytes(result[0]) == (b'EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_Q0AAAAAAAAAAAAAAAAAAAAAAAEAICGQrx'
+                                    b'tqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_QAArq12oDvsHfjELzwRo8M0kt4_EhNO7qF9FYLgMU'
+                                    b'3X5qp77sjZZa71blAGGYm-Of23QFsynB3UZHPDzlvXM_mtAA')
 
         #  verify final coe event state
         assert coeKever.verfers[0].qb64 == coeSigners[cesn].verfer.qb64
@@ -3826,9 +3826,9 @@ def test_direct_mode_cbor_mgpk():
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(coepre)]
         assert len(db_digs) == len(coe_event_digs) == csn + 1
-        assert db_digs == coe_event_digs == ['EqBbANsWWzNR8Q6LO1ItP23LS-rxViiSkhSJpA3oLdH0',
-                                             'EDfT9YrTj5Q4hUVv0rkcCoaNE1mtE_TcUIh16A_Vnau8',
-                                             'EoudO5pE1nsn7NqgZU-8mJGYPoR4ovdHemPozIDPb8lg']
+        assert db_digs == coe_event_digs == ['Eq51AFQINHs4Q63X7hk-MQwQojnPA0QbQlavnq3JpKZw',
+                                             'E5UktJ1jLc5V3nsh80g3kRA7CA_-3tumMPte77QniEM4',
+                                             'EpU_Dr1beH3JWNBV3LEvoH3hjeYgJRbwNJ2sQEUEN4HE']
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(coepre)]
         assert len(db_digs) == len(coe_event_digs) == csn + 1
@@ -3840,7 +3840,7 @@ def test_direct_mode_cbor_mgpk():
 
         db_digs = [bytes(v).decode("utf-8") for v in valKever.db.getKelIter(valpre)]
         assert len(db_digs) == len(val_event_digs) == vsn + 1
-        assert db_digs == val_event_digs == ['E2KeJD7a_ksFngDFpVk9FtvYjLQtVKiwEw9_UjSzk4SA']
+        assert db_digs == val_event_digs == ['EAICGQrxtqsZwl6s4D1jzCepnScs7j35Lt5-wX-bjd_Q']
 
         db_digs = [bytes(v).decode("utf-8") for v in coeKever.db.getKelIter(valpre)]
         assert len(db_digs) == len(val_event_digs) == vsn + 1
@@ -3954,7 +3954,7 @@ def test_process_transferable():
     nxtkeys = [skp1.verfer.qb64]
     # compute nxt digest
     nexter = Nexter(keys=nxtkeys)
-    nxt = nexter.qb64  # transferable so next is not empty
+    nxt = nexter.digs  # transferable so next is not empty
 
     sn = 0  # inception event so 0
     toad = 0  # no witnesses
@@ -4024,7 +4024,7 @@ def test_process_transferable():
     assert raid0.verify(ked=rser0.ked)
 
     # verify nxt digest from event is still valid
-    rnxt1 = Nexter(qb64=rser0.ked["n"])
+    rnxt1 = Nexter(digs=rser0.ked["n"])
     assert rnxt1.verify(keys=nxtkeys)
     """ Done Test """
 
@@ -4182,7 +4182,7 @@ def test_reload_kever(mockHelpingNowUTC):
 
         assert natHab.kever.sn == 6
         assert natHab.kever.fn == 6
-        assert natHab.kever.serder.said == 'EafakcO2q8Rz7LoXJrhTmtLu4h0wUAgcjhxKNAI0Fl_s'
+        assert natHab.kever.serder.said == 'EbjxjMV9atsoyxBVAnoe3B22Gprbu1dvYTpubyxrOfSk'
         ldig = bytes(natHab.db.getKeLast(dbing.snKey(natHab.pre, natHab.kever.sn)))
         assert ldig == natHab.kever.serder.saidb
         serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre, ldig))))
@@ -4191,14 +4191,15 @@ def test_reload_kever(mockHelpingNowUTC):
 
         state = natHab.db.states.get(keys=natHab.pre)  # Serder instance
         assert state.raw == (
-            b'{"v":"KERI10JSON000235_","i":"EiXaIz5NZjuUox4mSkubMccYOywQuWqLTcyoc8JKd_0M",'
-            b'"s":"6","p":"EwWxIGzkPYYF8fAoMjPcUQkBNJ3D8r6cGyPmbJNtKFxU","d":"EafakcO2q8Rz'
-            b'7LoXJrhTmtLu4h0wUAgcjhxKNAI0Fl_s","f":"6","dt":"2021-01-01T00:00:00.000000+0'
-            b'0:00","et":"ixn","kt":"2","k":["DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew'
-            b'","D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg","D36Ev0IqfpZ2wg0QbbTtPilJ2N'
-            b'owjFT1IqF954cLB-9M"],"n":"EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg","bt"'
-            b':"0","b":[],"c":[],"ee":{"s":"2","d":"E7aJm3kFAe7qWgoMFXKlaiMZDfxVjgoMHctI3Z'
-            b'LUdGAQ","br":[],"ba":[]},"di":""}')
+             b'{"v":"KERI10JSON00029e_","i":"EXB_8Qm1dNl-0kXq1c5H8wsT4bzKjuvduJPY0fn6blMM",'
+             b'"s":"6","p":"EDsxS0J2wVS7h1xLeeF0EgPDLWk-NCBDMtLmGuuP-9ys","d":"EbjxjMV9atso'
+             b'yxBVAnoe3B22Gprbu1dvYTpubyxrOfSk","f":"6","dt":"2021-01-01T00:00:00.000000+0'
+             b'0:00","et":"ixn","kt":"2","k":["DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew'
+             b'","D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg","D36Ev0IqfpZ2wg0QbbTtPilJ2N'
+             b'owjFT1IqF954cLB-9M"],"nt":"2","n":["EBoVvSj1Y_Lm1nvIP-wGSlAv-O2Xfy6uNZEHiceA'
+             b'o5s0","EjnuygssSKA4D6cX1O6KPrroQv0EBLZ6W9X6TH2z1FzU","EwUwluAAcCqy2FsV9Vuh5u'
+             b'zrJ0tWrPz0h32DvFEXAC70"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EKqCJJbQL'
+             b'utszUHQO2TxDRFFLwnFLAjhDklXWCtEQgmY","br":[],"ba":[]},"di":""}')
         assert state.sn == 6
         assert state.ked["f"] == '6'
         assert state.ked == nstate.ked
@@ -4213,14 +4214,15 @@ def test_reload_kever(mockHelpingNowUTC):
         kstate = kever.state()
         assert kstate.ked == state.ked
         assert state.raw == (
-            b'{"v":"KERI10JSON000235_","i":"EiXaIz5NZjuUox4mSkubMccYOywQuWqLTcyoc8JKd_0M",'
-            b'"s":"6","p":"EwWxIGzkPYYF8fAoMjPcUQkBNJ3D8r6cGyPmbJNtKFxU","d":"EafakcO2q8Rz'
-            b'7LoXJrhTmtLu4h0wUAgcjhxKNAI0Fl_s","f":"6","dt":"2021-01-01T00:00:00.000000+0'
+            b'{"v":"KERI10JSON00029e_","i":"EXB_8Qm1dNl-0kXq1c5H8wsT4bzKjuvduJPY0fn6blMM",'
+            b'"s":"6","p":"EDsxS0J2wVS7h1xLeeF0EgPDLWk-NCBDMtLmGuuP-9ys","d":"EbjxjMV9atso'
+            b'yxBVAnoe3B22Gprbu1dvYTpubyxrOfSk","f":"6","dt":"2021-01-01T00:00:00.000000+0'
             b'0:00","et":"ixn","kt":"2","k":["DI5E8Zqgy0j9HIkVRMjOTTF3Nr_PqwFDZ7bDNi0QCzew'
             b'","D2NIcFtglppQom493fiftJFiJkeKvC9b5CIdG19G8GHg","D36Ev0IqfpZ2wg0QbbTtPilJ2N'
-            b'owjFT1IqF954cLB-9M"],"n":"EyIxjAmcXOeiFzlIlRpRa7byustaKPabVGDXIIQHvBHg","bt"'
-            b':"0","b":[],"c":[],"ee":{"s":"2","d":"E7aJm3kFAe7qWgoMFXKlaiMZDfxVjgoMHctI3Z'
-            b'LUdGAQ","br":[],"ba":[]},"di":""}')
+            b'owjFT1IqF954cLB-9M"],"nt":"2","n":["EBoVvSj1Y_Lm1nvIP-wGSlAv-O2Xfy6uNZEHiceA'
+            b'o5s0","EjnuygssSKA4D6cX1O6KPrroQv0EBLZ6W9X6TH2z1FzU","EwUwluAAcCqy2FsV9Vuh5u'
+            b'zrJ0tWrPz0h32DvFEXAC70"],"bt":"0","b":[],"c":[],"ee":{"s":"2","d":"EKqCJJbQL'
+            b'utszUHQO2TxDRFFLwnFLAjhDklXWCtEQgmY","br":[],"ba":[]},"di":""}')
 
     assert not os.path.exists(natHby.ks.path)
     assert not os.path.exists(natHby.db.path)

--- a/tests/core/test_expose.py
+++ b/tests/core/test_expose.py
@@ -53,8 +53,8 @@ def test_expose():
     sith = '1'
     keys = [signerC.verfer.qb64]
     nexter = Nexter(keys=keys)  # compute nxt digest (dummy reuse keys)
-    nxt = nexter.qb64
-    assert nxt == 'E9GdMuF9rZZ9uwTjqgiCGA8r2mRsC5SQDHCyOpsW5AqQ'
+    nxt = nexter.digs
+    assert nxt == ['EIlyVEHnE9F6QYkl82ERnHSj5iv9punbGhS2dwMAKpiM']
 
     # create key pairs for witnesses of KEL
     signerW0 = salter.signer(path="W0", transferable=False, temp=True)

--- a/tests/core/test_kevery.py
+++ b/tests/core/test_kevery.py
@@ -3,13 +3,13 @@ import os
 import pytest
 
 from keri import help
-from keri.app import keeping, habbing
+from keri.app import habbing
 from keri.core import parsing, eventing, coring
 from keri.core.coring import CtrDex, Counter
-from keri.core.coring import Signer, Nexter
+from keri.core.coring import Signer
 from keri.core.eventing import Kever, Kevery
 from keri.core.eventing import (incept, rotate, interact)
-from keri.db import basing, dbing
+from keri.db import dbing
 from keri.db.basing import openDB
 from keri.kering import (ValidationError)
 
@@ -46,7 +46,7 @@ def test_kevery():
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[signers[0].verfer.qb64],
-                        nxt=Nexter(keys=[signers[1].verfer.qb64]).qb64)
+                        nkeys=[coring.Diger(ser=signers[1].verfer.qb64b).qb64])
         event_digs.append(serder.said)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -59,18 +59,19 @@ def test_kevery():
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
 
-        assert msgs == bytearray(b'{"v":"KERI10JSON000120_","t":"icp","d":"EG4EuTsxPiRM7soX10XXzNsS'
-                                 b'1KqXKUp8xsQ-kW_tWHoI","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
+        assert msgs == bytearray(b'{"v":"KERI10JSON00012b_","t":"icp","d":"ELeMG3OOxWi5n1Zud603_Bn6'
+                                 b'Hzm3hIRZXlQnSgC5lU7A","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
                                  b'WTOunRA","s":"0","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
-                                 b'OoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU'
-                                 b'","bt":"0","b":[],"c":[],"a":[]}-AABAA0aSisI4ZZTH_6JCqsvAsEpuf_J'
-                                 b'q6bDbvPWj_eCDnAGbSARqYHipNs-9W7MHnwnMfIXwLpcoJkKGrQ-SiaklhAw')
+                                 b'OoeKtWTOunRA"],"nt":"1","n":["E67B6WkwQrEfSA2MylxmF28HJc_HxfHRyK'
+                                 b'1kRXSYeMiI"],"bt":"0","b":[],"c":[],"a":[]}-AABAAw6czYydWCMpfs-X'
+                                 b'pUPi-h2OuBHP6ji5IU7YbK0pnsQt237sI4jaALv7Guc30y1zh8j5hrou-zOoUrVI'
+                                 b'NlhSICw')
 
         # Event 1 Rotation Transferable
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[1].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[2].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[2].verfer.qb64b).qb64],
                         sn=1)
         event_digs.append(serder.said)
         # create sig counter
@@ -88,7 +89,7 @@ def test_kevery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[2].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[3].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[3].verfer.qb64b).qb64],
                         sn=2)
         event_digs.append(serder.said)
         # create sig counter
@@ -138,7 +139,7 @@ def test_kevery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[3].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[4].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[4].verfer.qb64b).qb64],
                         sn=5)
         event_digs.append(serder.said)
         # create sig counter
@@ -173,7 +174,6 @@ def test_kevery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[4].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt="",
                         sn=7)
         event_digs.append(serder.said)
         # create sig counter
@@ -207,7 +207,7 @@ def test_kevery():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[4].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[5].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[5].verfer.qb64b).qb64],
                         sn=8)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -221,7 +221,7 @@ def test_kevery():
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
 
-        assert len(msgs) == 3681
+        assert len(msgs) == 3745
 
         pre = kever.prefixer.qb64
 
@@ -282,38 +282,37 @@ def test_witness_state():
 
         ixn0 = hab.interact()
         assert ixn0 == (
-            b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EnmIjmjrCQ9MJGzk6sg44zO9'
-            b'QAfPhgRtgmdnG6kAwEv0","i":"ENE4HtoyZuPMjz6rI_hV9alLNTrDLwKwEnbAN'
-            b'A91WPHA","s":"1","p":"ENE4HtoyZuPMjz6rI_hV9alLNTrDLwKwEnbANA91WP'
-            b'HA","a":[]}-AABAAVmp0AsKRYDnl1hjObV1m6waHErFu2czgWkhOVMHsuy9TR-5'
-            b'e_oJKup5Pxf9IK5LViMZF6DgUsR0ctk_2H27iDw')
+            b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EAj8A9YX36o_F_F18vojk41Y'
+            b'tzObAiN9p9rdPWDcN8sc","i":"EpUpvOQ_6hy5pxlqhSLI0vq6X72n3RxiDVv6m'
+            b'9-OjSzs","s":"1","p":"EpUpvOQ_6hy5pxlqhSLI0vq6X72n3RxiDVv6m9-OjS'
+            b'zs","a":[]}-AABAA2vgTktL0z1iU_NEQTzyyLsKFWPNhukavjYWgMqI4cjXWS5A'
+            b'HjicN_tW6rU96c94FzxEkzlz6Y0wHT8UUEnBfDw')
         wit1 = hab.kvy.fetchWitnessState(hab.pre, 1)
         assert [w.qb64 for w in wit1] == [wits[0], wits[1]]
 
         rot1 = hab.rotate()
         assert rot1 == (
-            b'{"v":"KERI10JSON000155_","t":"rot","d":"EITSN2f52JXziJEChYETgxHf'
-            b'SdHRj1h4VzjwZXl1coII","i":"ENE4HtoyZuPMjz6rI_hV9alLNTrDLwKwEnbAN'
-            b'A91WPHA","s":"2","p":"EnmIjmjrCQ9MJGzk6sg44zO9QAfPhgRtgmdnG6kAwE'
-            b'v0","kt":"1","k":["DODc-zWRbn5SLtdAzxLFpGDqf6zXaJlAX85rfiIRn1-M"'
-            b'],"n":"E7giSjZhH8qC_oXAqUoA8JoOlal15MsEtTr30JTMwgi0","bt":"2","b'
-            b'r":[],"ba":[],"a":[]}-AABAADjFwzRpvRMcqMVYeXHRJzNRWm2Ev3d6jbWrGS'
-            b'0WIC6WCnFwCY8ENVWM3BWkHUBxMGnuImxPqj_xCFJaxWbIRCw')
+            b'{"v":"KERI10JSON000160_","t":"rot","d":"EqMb-eKPfBYgoV61l-wxEFeR'
+            b'RheeXs2I6QmYcxhMpnNQ","i":"EpUpvOQ_6hy5pxlqhSLI0vq6X72n3RxiDVv6m'
+            b'9-OjSzs","s":"2","p":"EAj8A9YX36o_F_F18vojk41YtzObAiN9p9rdPWDcN8'
+            b'sc","kt":"1","k":["DODc-zWRbn5SLtdAzxLFpGDqf6zXaJlAX85rfiIRn1-M"'
+            b'],"nt":"1","n":["EODNLJb7oY2FBAgG8COTdOGGqebkSbZPo17znQzaDJqo"],'
+            b'"bt":"2","br":[],"ba":[],"a":[]}-AABAAl8_nVOVgIpGab3e-IJP24GzfE9'
+            b'kr5XhFa6LqXi9-DwGxTUIeWnbvLYvgO1vI-lSBUSJ2wTwv5A1z2opMUjpGAg')
         wit2 = hab.kvy.fetchWitnessState(hab.pre, 2)
         assert [w.qb64 for w in wit2] == [wits[0], wits[1]]
 
         rot2 = hab.rotate(cuts=[wits[0]], adds=wits[7:])
-        assert rot2 == (
-            b'{"v":"KERI10JSON00020f_","t":"rot","d":"E-KoW6rnZsHnwupnRGIUFgfH'
-            b'ntxsCdE-R0tvkaN3uuro","i":"ENE4HtoyZuPMjz6rI_hV9alLNTrDLwKwEnbAN'
-            b'A91WPHA","s":"3","p":"EITSN2f52JXziJEChYETgxHfSdHRj1h4VzjwZXl1co'
-            b'II","kt":"1","k":["DqWc3AKqVH6kvMH6n0mWb472P1Ckl-JzWynqS2H0N6LQ"'
-            b'],"n":"EhAly7aOUUvArcUdJgqag1K4nf7mODsgDnZhJGQnOBzE","bt":"3","b'
-            b'r":["BqMUu4hpUYY4FKd4LtsvpMN6claZKF2AUmXIgXiAI9ZQ"],"ba":["B7ejs'
-            b'kZg8S5rVMvTb_8qB240UxP6NKk_HRVKiCK_FwSc","BnfnWbP3CTkWapC7rQxSkp'
-            b'ioxkb-nbmhs-JoHbiwU5q4","BA6_tnL-DK0s7bYdVFfm_AufLsimGGUMK6V3QXN'
-            b'OKSu0"],"a":[]}-AABAArVCLfOe0erkyekHEWRNd2nYuRt5hZEYcf71Sg8ZkkG6'
-            b'Os_iqV6xu1qwOQGPtiDUC5O0_u3mftpoWUkEteZblCg')
+        assert rot2 == (b'{"v":"KERI10JSON00021a_","t":"rot","d":"E7cxivZWgAHJMyX_nV4FRwZM'
+                        b'RfG0fArlZdZKkbThLPos","i":"EpUpvOQ_6hy5pxlqhSLI0vq6X72n3RxiDVv6m'
+                        b'9-OjSzs","s":"3","p":"EqMb-eKPfBYgoV61l-wxEFeRRheeXs2I6QmYcxhMpn'
+                        b'NQ","kt":"1","k":["DqWc3AKqVH6kvMH6n0mWb472P1Ckl-JzWynqS2H0N6LQ"'
+                        b'],"nt":"1","n":["EUjKrRYU7wzHV0jbf2MJBykwobF3lUZrGBJlafwx9o7Y"],'
+                        b'"bt":"3","br":["BqMUu4hpUYY4FKd4LtsvpMN6claZKF2AUmXIgXiAI9ZQ"],"'
+                        b'ba":["B7ejskZg8S5rVMvTb_8qB240UxP6NKk_HRVKiCK_FwSc","BnfnWbP3CTk'
+                        b'WapC7rQxSkpioxkb-nbmhs-JoHbiwU5q4","BA6_tnL-DK0s7bYdVFfm_AufLsim'
+                        b'GGUMK6V3QXNOKSu0"],"a":[]}-AABAAjjA6Tweb9rTR62DMMADKx9RFnndIXI46'
+                        b'DRvEykrdMQx_L9Z5fFjGJIL5_ECgPq1Vs3Bwwl5eMX9pIAqFnIhtCg')
         wit3 = hab.kvy.fetchWitnessState(hab.pre, 3)
         assert [w.qb64 for w in wit3] == [wits[1], wits[7], wits[8], wits[9]]
 
@@ -382,7 +381,7 @@ def test_stale_event_receipts():
                                  #wits=[wesHab.pre, wilHab.pre, wanHab.pre], toad=2, temp=True)
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, transferable=True,
                                 wits=[wesHab.pre, wilHab.pre, wanHab.pre], toad=2,)
-        assert bobHab.pre == "EDRGkqe1-ZvMzy8SRx-KMNrC_KmbJWe2EgAyD9q3nBgQ"
+        assert bobHab.pre == "EOI2V_nrmRn1UtXuJvRWQCVoImvKl1YAbwZY_TutEvaU"
 
         bamKvy = eventing.Kevery(db=bamHby.db, lax=False, local=False)
 

--- a/tests/core/test_keystate.py
+++ b/tests/core/test_keystate.py
@@ -76,7 +76,7 @@ def test_keystate(mockHelpingNowUTC):
                                  #wits=[wesHab.pre], temp=True)
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, transferable=True,
                                 wits=[wesHab.pre],)
-        assert bobHab.pre == "ECJTKtR-GlybCmn1PCiVwIuGBjaOUXI09XWDdXkrJNj0"
+        assert bobHab.pre == "EGaV8sWx4qxaWgad0Teaj0VZLlblc8vFMpMUR1WhfYBs"
 
         # Create Bob's icp, pass to Wes.
         wesKvy = eventing.Kevery(db=wesHby.db, lax=False, local=False)
@@ -142,7 +142,7 @@ def test_keystate(mockHelpingNowUTC):
         #bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1,
                                  #transferable=True, temp=True)
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, transferable=True)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         # Create Bob's icp, pass to Wes.
         wesKvy = eventing.Kevery(db=wesHby.db, lax=False, local=False)
@@ -219,7 +219,7 @@ def test_keystate(mockHelpingNowUTC):
         #bobHab = habbing.Habitat(name="bob", ks=bobKS, db=bobDB, isith=1, icount=1,
                                  #transferable=True, temp=True)
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, transferable=True)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         # Create Bob's icp, pass to Wes.
         wesKvy = eventing.Kevery(db=wesHby.db, lax=False, local=False)
@@ -261,7 +261,7 @@ def test_keystate(mockHelpingNowUTC):
                                  #transferable=True,
                                  #wits=[], temp=True)
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, transferable=True)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         # Get ksn from Bob and verify
         ksn = bobHab.kever.state()

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -11,7 +11,7 @@ from hio.help import decking
 from keri.app import habbing
 from keri.kering import ValidationError
 from keri.core import parsing, coring
-from keri.core.coring import (CtrDex, Counter, Signer, Nexter)
+from keri.core.coring import (CtrDex, Counter, Signer)
 from keri.core.eventing import (Kever, Kevery, incept, rotate, interact)
 from keri.db.basing import openDB
 
@@ -50,7 +50,7 @@ def test_parser():
 
         # Event 0  Inception Transferable (nxt digest not empty)
         serder = incept(keys=[signers[0].verfer.qb64],
-                        nxt=Nexter(keys=[signers[1].verfer.qb64]).qb64)
+                        nkeys=[coring.Diger(ser=signers[1].verfer.qb64b).qb64])
         event_digs.append(serder.said)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -63,18 +63,19 @@ def test_parser():
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
 
-        assert msgs == bytearray(b'{"v":"KERI10JSON000120_","t":"icp","d":"EG4EuTsxPiRM7soX10XXzNsS'
-                                 b'1KqXKUp8xsQ-kW_tWHoI","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
+        assert msgs == bytearray(b'{"v":"KERI10JSON00012b_","t":"icp","d":"ELeMG3OOxWi5n1Zud603_Bn6'
+                                 b'Hzm3hIRZXlQnSgC5lU7A","i":"DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_ZOoeKt'
                                  b'WTOunRA","s":"0","kt":"1","k":["DSuhyBcPZEZLK-fcw5tzHn2N46wRCG_Z'
-                                 b'OoeKtWTOunRA"],"n":"EPYuj8mq_PYYsoBKkzX1kxSPGYBWaIya3slgCOyOtlqU'
-                                 b'","bt":"0","b":[],"c":[],"a":[]}-AABAA0aSisI4ZZTH_6JCqsvAsEpuf_J'
-                                 b'q6bDbvPWj_eCDnAGbSARqYHipNs-9W7MHnwnMfIXwLpcoJkKGrQ-SiaklhAw')
+                                 b'OoeKtWTOunRA"],"nt":"1","n":["E67B6WkwQrEfSA2MylxmF28HJc_HxfHRyK'
+                                 b'1kRXSYeMiI"],"bt":"0","b":[],"c":[],"a":[]}-AABAAw6czYydWCMpfs-X'
+                                 b'pUPi-h2OuBHP6ji5IU7YbK0pnsQt237sI4jaALv7Guc30y1zh8j5hrou-zOoUrVI'
+                                 b'NlhSICw')
 
         # Event 1 Rotation Transferable
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[1].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[2].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[2].verfer.qb64b).qb64],
                         sn=1)
         event_digs.append(serder.said)
         # create sig counter
@@ -92,7 +93,7 @@ def test_parser():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[2].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[3].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[3].verfer.qb64b).qb64],
                         sn=2)
         event_digs.append(serder.said)
         # create sig counter
@@ -142,7 +143,7 @@ def test_parser():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[3].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[4].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[4].verfer.qb64b).qb64],
                         sn=5)
         event_digs.append(serder.said)
         # create sig counter
@@ -177,7 +178,6 @@ def test_parser():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[4].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt="",
                         sn=7)
         event_digs.append(serder.said)
         # create sig counter
@@ -211,7 +211,7 @@ def test_parser():
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=[signers[4].verfer.qb64],
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=[signers[5].verfer.qb64]).qb64,
+                        nkeys=[coring.Diger(ser=signers[5].verfer.qb64b).qb64],
                         sn=8)
         # create sig counter
         counter = Counter(CtrDex.ControllerIdxSigs)  # default is count = 1
@@ -225,7 +225,7 @@ def test_parser():
         msgs.extend(counter.qb64b)
         msgs.extend(siger.qb64b)
 
-        assert len(msgs) == 3681
+        assert len(msgs) == 3745
 
         pre = kever.prefixer.qb64
 
@@ -270,11 +270,11 @@ def test_pathed_material():
         b'zY9_ic6mddsG-lC_qLyW5wxLS8GBdIETx-m9eA"],"n":"Egtz7luAa9zYv__wE1Y1NuuJgFrzfdKoFS0dl0m1OrYc","bt":"3","br":[],'
         b'"ba":[],"a":[{"i":"EdUB40PiRIGD5KK12ixqtg-iOzdB53mvquFxEMY95Sjc","s":"0","d":"EdUB40PiRIGD5KK12ixqtg-iOzdB53m'
         b'vquFxEMY95Sjc"}]}]}-CABBgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c0BYb31eFKSIfTxztT6-ft9xmH4ozf9T4OcXK3L'
-        b'T-qINq0tgxFDrftGt5WCRIPNhFes3bbZt3I1HpMh0IftvGh4Bw-TBt4AAB-a-0-VBq-AABAA57gKX2fuFDQueMfjVZP2t8TKxyR8GrUkQV9yk'
+        b'T-qINq0tgxFDrftGt5WCRIPNhFes3bbZt3I1HpMh0IftvGh4Bw-LBt4AAB-a-0-VBq-AABAA57gKX2fuFDQueMfjVZP2t8TKxyR8GrUkQV9yk'
         b'At0UAdQzk24E2c4g4X4pJmu9z8Ab6iolHfxYYqWXubUDA7LCQ-BADAAakx_iP6JIlUg8gb45IdMJI9IXU1F3OrUCSG0RYXPt_-vcFTJ7f_MOT'
         b'nC8fwc4kLO_57z_kZFwnjpw_zJNY83BwABOQbSEplzc_AK76CK18GVcy4NeNMh3FMAd19nO3oQYiW2_v6BTRDKuSAvTA7JaeoT9sq28U3umfd'
         b'iuxEnuqphAgAC-YGArB4QGi9JxuduvzThCALaA7WWdDVeW4aNCUe_k45Ur6-U9MAWH0epAHx5Pu9BBmoM0i53tGBXWRkYAe-yBA-EAB0AAAAA'
-        b'AAAAAAAAAAAAAAAAAA1AAG2022-02-27T18c02c09d640135p00c00-TBt4AAB-a-1-VBq-AABAAh8GcgHc4gvZzNOHxcjGMDxQZkuHeR9H4w'
+        b'AAAAAAAAAAAAAAAAAA1AAG2022-02-27T18c02c09d640135p00c00-LBt4AAB-a-1-VBq-AABAAh8GcgHc4gvZzNOHxcjGMDxQZkuHeR9H4w'
         b'7MKWlIyeg-4Cx815rya5RBTpsjlg0DhYcacQutrJHI4jzS5tj7UBQ-BADAAPZd8UNgjPNGE0mLWhF81jQW10KtKwPwn0A18jnSZekoiC3meFq'
         b'ZFObZphYDsI8PGJY9j7Xv7klG7jTdL0DkjDgABNMO7i7vjVfi7G-AbeDbnu1zl86Ia_BSWVLt6ykylfGRZaIIaWBC-YrsX1bQCNIzkaf2WEj3'
         b'-7KvwtNaAxXnxCQACgztaYp19Ho6nTgBDB2Ytfp5POVRedbwtD1u9JhRBt8filMay6K65IbspoPK-MYv3t2UNvBqK8Qt1piiFT_lNCQ-EAB0A'

--- a/tests/core/test_partial_rotation.py
+++ b/tests/core/test_partial_rotation.py
@@ -1,0 +1,219 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.core.test_partial_rotation module
+
+"""
+import pytest
+
+from keri import kering
+from keri.core import coring, eventing
+from keri.db.basing import openDB
+
+secrets = [
+    'ArwXoACJgOleVZ2PY7kXn7rA0II0mHYDhc6WrBH8fDAc',
+    'A6zz7M08-HQSFq92sJ8KJOT2cZ47x7pXFQLPB0pckB3Q',
+    'AcwFTk-wgk3ZT2buPRIbK-zxgPx-TKbaegQvPEivN90Y',
+    'Alntkt3u6dDgiQxTATr01dy8M72uuaZEf9eTdM-70Gk8',
+    'A1-QxDkso9-MR1A8rZz_Naw6fgaAtayda8hrbkRVVu1E',
+    'AKuYMe09COczwf2nIoD5AE119n7GLFOVFlNLxZcKuswc',
+    'AxFfJTcSuEE11FINfXMqWttkZGnUZ8KaREhrnyAXTsjw',
+    'ALq-w1UKkdrppwZzGTtz4PWYEeWm0-sDHzOv5sq96xJY',
+    "AAD8sznuHWMw7cl6eZJQLm8PGBKvCjQzDH1Ui9ygH0Uo",
+    "ANqQNn_9UjfayUJNdQobmixrH9qJF1cltKDwDMVkiLg8",
+    "A1t7ix1GuZIP48r6ljsoo8jPsB9dEnnWNfhy2XNl1r-c",
+    "AhzCysVY12fWXfkH1QkAOCY6oYbVwXOaUjf7YPtIfC8U",
+    "A4HrsYq9XfxYK76ffoceNzj9n8tBkXrWNBIXUNdoe5ME",
+    "AhpAiPtDqDcEeU_eXlJ8Bk3kJE0g0jdezyXZdBKfXslU",
+    "AzN9fKZAZEIn9jMN2fZ2B35MNMQJPAZrNrJQRMi_S_8g",
+    "AkNrzLqnqRx9WCpJAwTAOE5oNaDlOgOYiuM9bL4HM9R0",
+    "ALjR-EE3jUF2yXW7Tq7WJSh3OFc6-BNxXJ9jGdfwA6Bs",
+    "AvpsEhige2ssBrMxskK2xXpeKfed4cvcZCIdRh7fhgiI",
+]
+
+
+def test_partial_rotation():
+
+    # partial rotation with numeric thresholds
+    with openDB(name="controller") as db:
+        signers = [coring.Signer(qb64=secret) for secret in secrets]  # faster
+        assert [signer.qb64 for signer in signers] == secrets
+
+        nkeys = [coring.Diger(ser=signers[1].verfer.qb64b).qb64]
+
+        # raises ValueError because nsith 2 is invalud for 1 nkey
+        with pytest.raises(ValueError):
+            _ = eventing.incept(keys=[signers[0].verfer.qb64],
+                                nsith=2,
+                                nkeys=nkeys,
+                                code=coring.MtrDex.Blake3_256)
+
+        # 5 keys for the next rotation
+        nkeys = [
+            coring.Diger(ser=signers[1].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[2].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[3].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[4].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[5].verfer.qb64b).qb64,
+        ]
+
+        serder = eventing.incept(keys=[signers[0].verfer.qb64],
+                                 nsith=2,  # next signed event must satisfy this along with the new `kt`
+                                 nkeys=nkeys,
+                                 code=coring.MtrDex.Blake3_256)
+
+        siger = signers[0].sign(serder.raw, index=0)  # return siger
+
+        # create key event verifier state
+        kever = eventing.Kever(serder=serder, sigers=[siger], db=db)
+
+        assert kever.prefixer.qb64 == "Eozz_fD_4KNiIZAggGCPcCEbV-mDbvLH_UfVMsC83yLo"
+
+        # partial rotation so only select subset of the keys
+        keys = [
+            signers[2].verfer.qb64,
+            signers[4].verfer.qb64,
+            signers[5].verfer.qb64
+        ]
+        nkeys = [
+            coring.Diger(ser=signers[6].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[7].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[8].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[9].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[10].verfer.qb64b).qb64
+        ]
+        rotser = eventing.rotate(pre=kever.prefixer.qb64,
+                                 sith=3,
+                                 keys=keys,
+                                 dig=kever.serder.saider.qb64,
+                                 nsith=4,
+                                 nkeys=nkeys,
+                                 sn=1)
+
+        # sign serialization
+        siger0 = signers[2].sign(rotser.raw, index=0)  # returns siger
+        siger1 = signers[4].sign(rotser.raw, index=1)  # returns siger
+        siger2 = signers[5].sign(rotser.raw, index=2)  # returns siger
+        # update key event verifier state
+        kever.update(serder=rotser, sigers=[siger0, siger1, siger2])
+
+        assert kever.sn == 1
+        assert kever.ntholder.sith == "4"
+        keys = [verfer.qb64 for verfer in kever.verfers]
+        assert keys == [
+            "DT1iAhBWCkvChxNWsby2J0pJyxBIxbAtbLA0Ljx-Grh8",
+            "D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU",
+            "D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM",
+        ]
+
+        # partial rotation that will fail because it does not have enough sigs for prior threshold (`nt`)
+        keys = [
+            signers[6].verfer.qb64,
+            signers[7].verfer.qb64,
+            signers[8].verfer.qb64
+        ]
+        nkeys = [
+            coring.Diger(ser=signers[11].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[12].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[13].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[14].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[15].verfer.qb64b).qb64
+        ]
+        rotser = eventing.rotate(pre=kever.prefixer.qb64,
+                                 sith=3,
+                                 keys=keys,
+                                 dig=kever.serder.saider.qb64,
+                                 nsith=2,
+                                 nkeys=nkeys,
+                                 sn=2)
+
+        # sign serialization
+        siger0 = signers[6].sign(rotser.raw, index=0)  # returns siger
+        siger1 = signers[7].sign(rotser.raw, index=1)  # returns siger
+        siger2 = signers[8].sign(rotser.raw, index=2)  # returns siger
+
+        # update key event verifier state
+        with pytest.raises(kering.MissingSignatureError):
+            kever.update(serder=rotser, sigers=[siger0, siger1, siger2])
+
+    # partial rotation with weighted thresholds
+    with openDB(name="controller") as db:
+        signers = [coring.Signer(qb64=secret) for secret in secrets]  # faster
+        assert [signer.qb64 for signer in signers] == secrets
+
+        # 5 keys for the next rotation
+        nkeys = [
+            coring.Diger(ser=signers[1].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[2].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[3].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[4].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[5].verfer.qb64b).qb64,
+        ]
+
+        serder = eventing.incept(keys=[signers[0].verfer.qb64],
+                                 nsith=["1/2", "1/2", "1/3", "1/3", "1/3"],
+                                 nkeys=nkeys,
+                                 code=coring.MtrDex.Blake3_256)
+
+        siger = signers[0].sign(serder.raw, index=0)  # return siger
+
+        # create key event verifier state
+        kever = eventing.Kever(serder=serder, sigers=[siger], db=db)
+
+        assert kever.prefixer.qb64 == "EtxZNMpv5OheTzkisPAILhrPpvqTEI52tLldrlhPSKxA"
+
+        # partial rotation so only select subset of the keys
+        keys = [
+            signers[3].verfer.qb64,
+            signers[4].verfer.qb64,
+            signers[5].verfer.qb64
+        ]
+        nkeys = [
+            coring.Diger(ser=signers[11].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[12].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[13].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[14].verfer.qb64b).qb64,
+            coring.Diger(ser=signers[15].verfer.qb64b).qb64
+        ]
+        rotser = eventing.rotate(pre=kever.prefixer.qb64,
+                                 sith=["1/2", "1/2", "1/3"],
+                                 keys=keys,
+                                 dig=kever.serder.saider.qb64,
+                                 nsith=["1/2", "1/2", "1/3", "1/3", "1/3"],
+                                 nkeys=nkeys,
+                                 sn=1)
+
+        # sign serialization
+        siger0 = signers[3].sign(rotser.raw, index=0)  # returns siger
+        siger1 = signers[4].sign(rotser.raw, index=1)  # returns siger
+        siger2 = signers[5].sign(rotser.raw, index=2)  # returns siger
+        # update key event verifier state
+        kever.update(serder=rotser, sigers=[siger0, siger1, siger2])
+
+        assert kever.sn == 1
+        assert kever.ntholder.sith == ["1/2", "1/2", "1/3", "1/3", "1/3"]
+        keys = [verfer.qb64 for verfer in kever.verfers]
+        assert keys == ['DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ',
+                        'D1kcBE7h0ImWW6_Sp7MQxGYSshZZz6XM7OiUE5DXm0dU',
+                        'D4JDgo3WNSUpt-NG14Ni31_GCmrU0r38yo7kgDuyGkQM']
+
+        # partial rotation that will fail because threshold not met for prior threshold (`nt`)
+        keys = [
+            signers[13].verfer.qb64,
+            signers[14].verfer.qb64,
+        ]
+        nkeys = []
+        rotser = eventing.rotate(pre=kever.prefixer.qb64,
+                                 sith=2,
+                                 keys=keys,
+                                 dig=kever.serder.saider.qb64,
+                                 nsith=0,
+                                 nkeys=nkeys,
+                                 sn=2)
+
+        # sign serialization
+        siger0 = signers[13].sign(rotser.raw, index=0)  # returns siger
+        siger1 = signers[14].sign(rotser.raw, index=1)  # returns siger
+
+        # update key event verifier state
+        with pytest.raises(kering.MissingSignatureError):
+            kever.update(serder=rotser, sigers=[siger0, siger1])

--- a/tests/core/test_replay.py
+++ b/tests/core/test_replay.py
@@ -3,16 +3,13 @@
 tests delegation primaily from keri.core.eventing
 
 """
-import os
 import datetime
-
-import pytest
+import os
 
 from keri import help
-from keri.help import helping
-from keri.db import dbing, basing
-from keri.app import habbing, keeping, directing
+from keri.app import habbing
 from keri.core import coring, eventing, parsing
+from keri.help import helping
 
 logger = help.ogler.getLogger()
 
@@ -69,65 +66,69 @@ def test_replay():
         debMsgs.extend(debHab.interact())
         debMsgs.extend(debHab.interact())
 
-        assert debMsgs == (b'{"v":"KERI10JSON00018e_","t":"icp","d":"EgmiU27BZtfnJclZw6K_X67h'
-                           b'wf6SDT3nJW1dr3Jq9D3s","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr'
-                           b'3Jq9D3s","s":"0","kt":["1/2","1/2","1/2"],"k":["DRxCLERO9eSvG4fl'
+        assert debMsgs == (b'{"v":"KERI10JSON000207_","t":"icp","d":"Eban8TbpEQ4HX5hwefKvH5-7'
+                           b'eP5SOctXFdAkliMo-Rbk","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkl'
+                           b'iMo-Rbk","s":"0","kt":["1/2","1/2","1/2"],"k":["DRxCLERO9eSvG4fl'
                            b'uzOsK52GCWCtKOZClVwA38Oa--MA","DCxzT16ikP6LKVJfr6hv1jmhynm6I4-Ko'
-                           b'GYkJtd9uBro","DsDl5xSHnIlcGo13u5jDRr1jJMkQ34nEc5R6NYsdPS2k"],"n"'
-                           b':"Eer5S019j0eEFNFLb0R0UDMoNLavlLiQ73fHGU7MUHXg","bt":"0","b":[],'
-                           b'"c":[],"a":[]}-AADAAxwDO7vCR4Lxkg1ZCFB7YiCr1I7Cx9CBEYuS8uf5gc0m1'
-                           b'n3x5fYylz5Loc-X3-d_4vPgkORVRDlLc9CDnrMekAAABgd5x9CqbFnAQevnZ5oUN'
-                           b'UCxOEaW77c6P9lOTFFYL9rmVMHbbxGw4a_hzi3ZaUoU5lG3r_sR9E79Y0Fjv5kde'
-                           b'CgACcuVpvt8Z-EHOwb6OSstNvJ4lMWVAowfhOK122xJIga-REzjiyZ5OWgU-c_X9'
-                           b'QVesC-dB2ReU8ILaOe7XZuakCQ{"v":"KERI10JSON0000cb_","t":"ixn","d"'
-                           b':"Eoy3g6inBwl9tU4XObauVN6HGcrspyJn-8zDHpjRDArQ","i":"EgmiU27BZtf'
-                           b'nJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"1","p":"EgmiU27BZtfnJclZ'
-                           b'w6K_X67hwf6SDT3nJW1dr3Jq9D3s","a":[]}-AADAASUrG-BrIfFUUtN1X0Rz4m'
-                           b'LdfA-ZQM_noyzaaMrBW6DEh2PhKHumi8FPOstrk8pW0Wdkq3FS_ElBnUch0yYOJC'
-                           b'gABfWYYABCGm6utumn3svN0nokuHVWI4KeHR71ENgD-UlU9WkL7OCTxSfg2vDf28'
-                           b'OMtCxFmTCcJKr4wdBKst2bRBAACacww3k98TR_HE0IcbYN2p1g-1yz9EmbvZJxDD'
-                           b'e-ocPcPjkaNmN_9MnTHaMTj_uO6smWexygCHQRv4iJRgR0VCQ{"v":"KERI10JSO'
-                           b'N0001c3_","t":"rot","d":"EgRAXqREqw3EvxZsTOGHKU2Aa70IJmd0XC6y7AQ'
-                           b'gjwns","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"2'
-                           b'","p":"Eoy3g6inBwl9tU4XObauVN6HGcrspyJn-8zDHpjRDArQ","kt":["1/2"'
-                           b',"1/2","1/2"],"k":["Dj-DUwfCmOrE3ijqucR0I89_fYTFbyotaqeQyDfupkEU'
-                           b'","DL-k_8BanjLYaAdm6WWKIpHcHwcbF834vnLPgpW1NL8k","DWG2ZFsWYUsbDI'
-                           b'1Kmu8JH22iGaVDGvM7pnuT4y2oR3VI"],"n":"EYd4ha92A2yttnCoLMqFGRzh6n'
-                           b'sgduE910LD-scP7C3Q","bt":"0","br":[],"ba":[],"a":[]}-AADAAbw0Nbe'
-                           b'6hdYBpeDQq_JspQQRupajov_vF92N1M7XJ1EUMEAoHGpS3wXnT34t5jV6xnoAHxe'
-                           b'b3XjQhOingYPQmDwABGuC0zlEg2Efcohgfw-K3_ikX9wnbrWJwKEKe5wz2uLrncJ'
-                           b'VokI-s23CEbG8Sdpefm7SABCJS-Xi476T5ebXVBQACdLvWJKf-LraSwpjvCdeEYc'
-                           b'3nku8QhrRh7SyUZ4DEr2OX29dfuV2OstTDHc-A52P1vnl-DCVadAoChUm6yfAdBw'
-                           b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"EHlKLWTe1lCakBrg-s_sSEbz'
-                           b'a24YDvi9rxDQS5Wuph5E","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr'
-                           b'3Jq9D3s","s":"3","p":"EgRAXqREqw3EvxZsTOGHKU2Aa70IJmd0XC6y7AQgjw'
-                           b'ns","a":[]}-AADAAKCxcesxrP3Fx0os-p56b4n-8QlLrVJKMiCVJxWZGpfRVFKR'
-                           b'DOMEPe6PvwxwwJ3ksF8VwGsxOUZ8BglK1y-EEAQABlTVNnnK717gZGNKKfH2fYji'
-                           b'sfaLA5tIvS6Hc79tCwSboFZkljaIiosNbL-ZYCRjR4r_0_kNkUheo3eGxJM3CCQA'
-                           b'CCk6sYXHME_4M2__75SCWEQ7q_LAbhhZG5ih5153vbXkY1B_Df44vYRIvo2hVzUK'
-                           b't2pHJPgx_XIOinb7qWAFJDw{"v":"KERI10JSON0000cb_","t":"ixn","d":"E'
-                           b'JVdSFO631gld44xpJipwzQHqKP4cS_tcoBfrBG07BYI","i":"EgmiU27BZtfnJc'
-                           b'lZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"4","p":"EHlKLWTe1lCakBrg-s_'
-                           b'sSEbza24YDvi9rxDQS5Wuph5E","a":[]}-AADAAbZOTjHCPR1fG4pVPYYi5_1pT'
-                           b'YcE06ZdlvniCNFrk69IU7pc5hg3DUEjRTjqiq6IEp2Y8KcL5Tb4Da8Kzw0bECwAB'
-                           b'JBRsCTvAsmjR0B_y2HEnL8lsZ8g6fwBvo8jo6KuRDF7Rosg15ZOBZjSiEq2iHO-H'
-                           b'QanM7YJrqcqz3E_NzENJCgACBUy5ZHcYEUq6q02LiCWB8TnnIi0wGIjPjTA9nLX5'
-                           b'MWBOYTxYNXKRt8OeQ1pEqZPwpEFLgAsBATDnWJr0xfK_Bg{"v":"KERI10JSON00'
-                           b'00cb_","t":"ixn","d":"EYcmtiV1Z__uV7iCSxk5lbcDqMV8lE_zxFGgwc4bRs'
-                           b'rg","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"5","'
-                           b'p":"EJVdSFO631gld44xpJipwzQHqKP4cS_tcoBfrBG07BYI","a":[]}-AADAAO'
-                           b'2BfTpTFyMRG_Q3C0SHRLjxRdtblQg_dpNdEPOsAa24-vBtvd5cX34SqmBh7UF2-d'
-                           b'LpVkAqXs-i-Sj0krYGPCAABKOYuKg2lPx0v-Z6M-FLaHq_F1381vxi3GIRkeJA6V'
-                           b'KBSg9jUQ4mYs7GbNi-kKwbakNAid-9X5EAR-dUNMaAGCwACphP6wVjRAnREENf3y'
-                           b'VxYsdiFsUmAI7n0v7kSyvmkhfo64nX5hHga-cTnxspjd3Kk3r2YcSkq6MhUvCG32'
-                           b'm28AQ{"v":"KERI10JSON0000cb_","t":"ixn","d":"EQ4_P5u46hGceGpc8hu'
-                           b'rR7pTox-VkvkExLj6_CMtVejw","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3n'
-                           b'JW1dr3Jq9D3s","s":"6","p":"EYcmtiV1Z__uV7iCSxk5lbcDqMV8lE_zxFGgw'
-                           b'c4bRsrg","a":[]}-AADAAVlO5R4sIWQXTgkmA5Mlf4_7cvWzxgExYs-yDOV_CAc'
-                           b'ipXaSGs34xQh0GXZ6jWon8Hn_KrYtuLAHH_vV8Mq5dBAABJ2anAFF8T4ELwbkG8v'
-                           b'-RbYSoUveWu3ir2yyf-6gjGDYAJ03xWpLYAWAmBOZr6ALE5BStOU6Zyd9DR_5Byg'
-                           b'fJBwACIs8GWSkGuRqR0Mayo6QBHYax8mIDyBrGYZeZEtim7s51ERVZ3q0_A6YqRk'
-                           b'z9Sy_fzFdiQM-GSDD4hEjVpbwkAg')
+                           b'GYkJtd9uBro","DsDl5xSHnIlcGo13u5jDRr1jJMkQ34nEc5R6NYsdPS2k"],"nt'
+                           b'":["1/2","1/2","1/2"],"n":["E1jYwSdDo3A59-KuFE7ZDb8oJl3mCXkqR8gm'
+                           b'4sUPFcFg","Eb0d6f-KcOc0Pti8w8kRWG6b7qlLv0LVe97Hn73Gx1Tw","EQkLya'
+                           b'hIDBh-IYFo3UxTuScoZbz7DVx3z2WZcm9XBQwo"],"bt":"0","b":[],"c":[],'
+                           b'"a":[]}-AADAAVrPSS8sfubmKKLLzvlHAVD8Zy7atX_CJk0YXq_YVV-oyroXaLVQ'
+                           b'lpJwLPX0CyhzDSg7U6HBeA3xQejfzS3ALDQABSPMBXtxqaRLsv5qmxzSTgO-QcqM'
+                           b'tw-GZKoKZxP4lS8AAODQHFNt8cppD6ZqI3QAbEJIy9QKtCrIdo3nUxdCwDgACpPY'
+                           b'lToFb_RIs3878JshYs5gg_6OxkVyDluanpjedrJ0lxPANXUW2XvPb0VWE9X7nmGU'
+                           b'tqFw0BHfeaEUNcrzfBQ{"v":"KERI10JSON0000cb_","t":"ixn","d":"E0EFb'
+                           b'DrGf49mevhj9LjqdDF9Zv1e3xZrVV-o74knmodI","i":"Eban8TbpEQ4HX5hwef'
+                           b'KvH5-7eP5SOctXFdAkliMo-Rbk","s":"1","p":"Eban8TbpEQ4HX5hwefKvH5-'
+                           b'7eP5SOctXFdAkliMo-Rbk","a":[]}-AADAA-MLip3S7FemcusKfo6FA05i_Z45I'
+                           b'WO1mMDpvjpwHnyXEhEvSQlVcQV_T7efrl7RmqAXwoyD3XNssCcR9igY9AgABl6FV'
+                           b'b5wIrkHw9tzoauSQg3IM4-aFYP8u7Bw4-GL24yVFN47SfcOanNEhVNo-P9PM3zwj'
+                           b'cUTJiFdkQ4zW-E8LDgAC7h1fDyGoOPyj5PYOtC_T5Cjm8rZLA8H7UGr7bBSQDP0W'
+                           b'_ouYByk4-UF10YnjIiCExAcxmdK6Q8Sm9Q_UKAQ-AA{"v":"KERI10JSON00023c'
+                           b'_","t":"rot","d":"EsZ2thB6qZ8l_eaxur-1YtY7D9PBxL7yhCdC93hYvX1M",'
+                           b'"i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"2","p":"'
+                           b'E0EFbDrGf49mevhj9LjqdDF9Zv1e3xZrVV-o74knmodI","kt":["1/2","1/2",'
+                           b'"1/2"],"k":["Dj-DUwfCmOrE3ijqucR0I89_fYTFbyotaqeQyDfupkEU","DL-k'
+                           b'_8BanjLYaAdm6WWKIpHcHwcbF834vnLPgpW1NL8k","DWG2ZFsWYUsbDI1Kmu8JH'
+                           b'22iGaVDGvM7pnuT4y2oR3VI"],"nt":["1/2","1/2","1/2"],"n":["EhmOyqs'
+                           b'UMujcjLHWJaam_AEdv9OXgnS6n2WHGtwdPVIM","EAKmM34UmvEqzao5s-wEGox1'
+                           b'XWgf4o-vsX7ZUPnbtj2M","EZpn1keK-72sCwF23w_IQ1Q6kT5ROcUw5V0iprub4'
+                           b'K4I"],"bt":"0","br":[],"ba":[],"a":[]}-AADAALL5ItV9rkzyErrEK427X'
+                           b'py95OFPM_xLorhaoShNRiV_mTjun3b4lHJJ-oimf2sER9YnxSsw-NajY4P9hS6pK'
+                           b'BAAB1r0tNgvrKm0czmjRxtoHLG54rTHEAFaNd9YqnGQ6R4PnLZvMShkp0wL_YcGS'
+                           b'qxKRxVz0QDX7A2UPl2qJc0N9AgACEci2PEK6giZ82QP-qOqhCtMtdG5R0g5HTOzj'
+                           b'307f-BcIZxXnhpMTYX6O-cai0fA-blHwby-bgwjvBNns80eNCg{"v":"KERI10JS'
+                           b'ON0000cb_","t":"ixn","d":"EvnHJz9YFtaiMlCbyq4wMulC3TXAZ9JyH2pTyX'
+                           b'kd93Lw","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"'
+                           b'3","p":"EsZ2thB6qZ8l_eaxur-1YtY7D9PBxL7yhCdC93hYvX1M","a":[]}-AA'
+                           b'DAATSxYMGzBdshao1-RhVekwwEW4AWXHT21-bH_nkpatGdlzK1bz9ybZ9xvAt3R7'
+                           b'Csf7V4H1pjRsgoB49jVSToJAAABZTay5Nz6q-Kj6yf0XF8fBT5bJ2Zf39mPr79h4'
+                           b'RpohPoURI9tXJfBcmjNjJanNxwlEv2RGSljtHGgWuUUDuuaDQACXn0pu-vHMqd2j'
+                           b'V54VpyFMwAOqSUXs4lftpwUktYko-V6QGphD9nyc0Qdra2nEuN5ET3sTtS1sh7Fw'
+                           b'veoD3atCA{"v":"KERI10JSON0000cb_","t":"ixn","d":"EQigFoXAX3U0JLw'
+                           b'8LSRtzqJENPEotsV6N_7Cl9X9GTK4","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5S'
+                           b'OctXFdAkliMo-Rbk","s":"4","p":"EvnHJz9YFtaiMlCbyq4wMulC3TXAZ9JyH'
+                           b'2pTyXkd93Lw","a":[]}-AADAAZHpUM53Az9glxch1V76b1Id44j4YGuQMNLeSU9'
+                           b'EhktXb1zNeEhjfioSYjdpAhlv2kq6smMfXX4axZyroxd8OCQABouL7UZzySw9q7g'
+                           b'DbRwvlCCdR9LlkBo2aNrDjdMbo2YoGsT9wLxoMPL_Q3XO5HK0DmTHzmSfyfVjtE6'
+                           b'maiFbFCQACVVERmP2XE5Z6h5hkGGeRquq31rJrvmy69ZG-Kma2TUnlnYpU6eAKhR'
+                           b'nI9PciQLpFk6VjNI_nofnZzfp-6-aoAw{"v":"KERI10JSON0000cb_","t":"ix'
+                           b'n","d":"EEoiyGRkxjb-bRZQUIiEfkijxg8c1_jzJYE6p0YeWZ-0","i":"Eban8'
+                           b'TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"5","p":"EQigFoXAX3'
+                           b'U0JLw8LSRtzqJENPEotsV6N_7Cl9X9GTK4","a":[]}-AADAAvMdmu5ppGll9w5Z'
+                           b'cc_V1Q6D66_lq4e6ACPSrSOwRqEHAXdG6ZRBXMhTuxZ9zUwstf9THEfLEvo-FCxM'
+                           b'ka3-yBQAB_02jO4KLKlaHmYrV3a99-uTlwRlkZ6OOhWaOgMQihYzSSj7dus1rR0l'
+                           b'TgszUOjOT6k7liOWR7aWtBhgDNqOgCQACQchXgBhmk51GnZW6ThdhB4xPsOmn73p'
+                           b'A9ADrBk2vCgmmJAof5_8sRWUvvZFgcwJlqQ65ZrD6bg7yaQTSQQwnCQ{"v":"KER'
+                           b'I10JSON0000cb_","t":"ixn","d":"ECwRGikXaPuVHZplHFnVWv6cYG-ovQpso'
+                           b'sZXEX93uLgU","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk",'
+                           b'"s":"6","p":"EEoiyGRkxjb-bRZQUIiEfkijxg8c1_jzJYE6p0YeWZ-0","a":['
+                           b']}-AADAAo2CED43TfZBRKdUUjIWhMf2IdFgXhgIPn4AZ7PBS7LtZP3v6Hm6UPKYL'
+                           b'BBeIriMcnPc1FkK0vGwu6cexsqEkAgAB7ztsDrbLfkJ7hOsfiPgfC5E7adjLmddE'
+                           b'TKFkXrSFGq13680q_5D6RJV7sgqvSoLLVDG10_jXPRDQUUB34dZ2AgACA2BbjvAS'
+                           b'mEfCbXPWuBij8WYjHQMJgQnj5AA0TVqMVuOv48N4DMkGpLOjgs2WRravAHlMB0hR'
+                           b'J2XaoSekBCMjCQ')
 
         # Play debMsgs to Cam
         # create non-local kevery for Cam to process msgs from Deb
@@ -142,74 +143,76 @@ def test_replay():
 
         # get disjoints receipts (vrcs) from Cam of Deb's events by processing Cam's cues
         camMsgs = camHab.processCues(camKevery.cues)
-        assert camMsgs == (b'{"v":"KERI10JSON00017e_","t":"icp","d":"E-kW2C8JK7v59OdT-2Yit5gt'
-                           b'sny-4VdoZdYRpszkwkr4","i":"E-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRp'
-                           b'szkwkr4","s":"0","kt":"2","k":["DJBtEHHnzNtE-zxH1xeX4wxs9rEfUQ8d'
+        assert camMsgs == (b'{"v":"KERI10JSON0001e7_","t":"icp","d":"EGifcQT5E5KKdvND2j7dLTWh'
+                           b'7YH1GaEVuq8UHe4YlmPk","i":"EGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UH'
+                           b'e4YlmPk","s":"0","kt":"2","k":["DJBtEHHnzNtE-zxH1xeX4wxs9rEfUQ8d'
                            b'1ancgJJ1BLKk","DMu6yPITjrOBoTPfsY-r1Rc0ead8GKmoCxA_BugKehgY","Df'
-                           b'hpvbNyYu1fxTBTXy8eCgghMcOYnxkgoGPBr0ZBZPQA"],"n":"EJ85AI0se7UiFB'
-                           b'FL1Vl80PnmQ-0dU6q_NXCh6BlSJcKg","bt":"0","b":[],"c":[],"a":[]}-A'
-                           b'ADAABX9ffcpdqwmRKypAQ3t7suKTKwkiWH0lrKjenKjRVgkbRxo6yLgLGsPVgfxI'
-                           b'hC-ofx-noe4mUdg5UcZ7PFBRDQABcX7FO3nbiMcAIDWOA209Dn1ASvNbV-zB1BF3'
-                           b'B2CiQD6pBDnYileVsx2RiR6YvfhkXo-R3B_oUvRk2sahf-XaAgAChzdee55ownrC'
-                           b'm-AhVpL3WiGj1a_9N3oeYRZH1hUWDB_Vr3SgahzH6L07PdeNUfmU5o3qTAcqdK3s'
-                           b'dvL93tuYCg{"v":"KERI10JSON000091_","t":"rct","d":"EgmiU27BZtfnJc'
-                           b'lZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","i":"EgmiU27BZtfnJclZw6K_X67hwf6'
-                           b'SDT3nJW1dr3Jq9D3s","s":"0"}-FABE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZ'
-                           b'dYRpszkwkr40AAAAAAAAAAAAAAAAAAAAAAAE-kW2C8JK7v59OdT-2Yit5gtsny-4'
-                           b'VdoZdYRpszkwkr4-AADAA70M7un3lxttBK2ig8ZU-RjInM-9IzoXry16g0-K_exO'
-                           b'TxBzhZK5Z749n96Q6D0Cw6tDPZ-Op5FrA83-mVOEPDgABdd7yuRAY95sGthqlo5B'
-                           b'p3TWS5TYb1BQbO4UZKIowOzW0QzwrPXanUf6Cez63AsLZ_9W4wGQcd4RzzIKuJTW'
-                           b'UBAACbg6UWYrfPKEWP42MdgSRrJLk7dXklyoCWhOFrqRRPGLW60s0AD5oB_fZjwa'
-                           b'kLqtgiNWq7ERopN2kmCXaUpkTBQ{"v":"KERI10JSON000091_","t":"rct","d'
-                           b'":"Eoy3g6inBwl9tU4XObauVN6HGcrspyJn-8zDHpjRDArQ","i":"EgmiU27BZt'
-                           b'fnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"1"}-FABE-kW2C8JK7v59OdT'
-                           b'-2Yit5gtsny-4VdoZdYRpszkwkr40AAAAAAAAAAAAAAAAAAAAAAAE-kW2C8JK7v5'
-                           b'9OdT-2Yit5gtsny-4VdoZdYRpszkwkr4-AADAALnLgaMzcwy-HD1Q_eRNLyXkskw'
-                           b'R8x5veIwy1-ku524iZ-o4pO6HpWlsmkNNCDsIBqzJo03WjYU7Du2cnTBV6BgAB9Z'
-                           b'6XXimtVgFVO5g0JRojEg50q_0aWUWOTEHsUQy62gcrDe5sWnY1qtm3-8mo_jRBTV'
-                           b'us7hYFK1R63-rt1OFMBQACzr2RoNjy7bj4Dgl1BZZ0qEVYpuZvbdlznXUOB_mvye'
-                           b'ZEw9V0bSzgkiw2scfHV0tl4ofltZSREW3uKCmg35BmBA{"v":"KERI10JSON0000'
-                           b'91_","t":"rct","d":"EgRAXqREqw3EvxZsTOGHKU2Aa70IJmd0XC6y7AQgjwns'
-                           b'","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"2"}-FA'
-                           b'BE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr40AAAAAAAAAAAAAAAAAA'
-                           b'AAAAAE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr4-AADAAZqp1jGr-W'
-                           b'cIJ8c-1BzNLIYbMtnVGVym3EJYz9sWmMO-6fVzQfJej711kl1Wkiv358vL0jY3Wm'
-                           b'4n4SzNaEdJ6CgABWCAIaIGMY8-Sit4vfFhSmut8RRG4cvZtJ4IxyDh0BB5j_DzNZ'
-                           b'6Deev_sDLdOO5deSlNB_TvSEYxYV68a-0FdBQAC378zkWXfshbQnJjvonnTr2M2V'
-                           b'HwckFwWXYIz13YBiap2EFuDitBAU8p27eKG2qYt4lGERrES_OTIK52upuH0AA{"v'
-                           b'":"KERI10JSON000091_","t":"rct","d":"EHlKLWTe1lCakBrg-s_sSEbza24'
-                           b'YDvi9rxDQS5Wuph5E","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq'
-                           b'9D3s","s":"3"}-FABE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr40A'
-                           b'AAAAAAAAAAAAAAAAAAAAAAE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwk'
-                           b'r4-AADAAy4D-vvwrR2UtRf0-JwgsAphcsuWtaA6JU5VxJtKxdbY0oVQH7kOT6q9K'
-                           b'eG4LyS3WM_l4h7HnV1sXFOPuHcnCCgABUpV9oJE7HfAJCkq0MU1_bonwXCcwF6DS'
-                           b'nK_PbEvCx0DR3WpjGA9tzgbt7lb27S7_cn5dMQZcQPPTRM18VF8IBwAC6M_rY8eF'
-                           b'gneD5j-vylXyRYLkfbUdxASDVhp6n8cyi1wPSKqv8zXnhYnhslsDPJNJkSI52TRM'
-                           b'0jDdbMk1zKRWDg{"v":"KERI10JSON000091_","t":"rct","d":"EJVdSFO631'
-                           b'gld44xpJipwzQHqKP4cS_tcoBfrBG07BYI","i":"EgmiU27BZtfnJclZw6K_X67'
-                           b'hwf6SDT3nJW1dr3Jq9D3s","s":"4"}-FABE-kW2C8JK7v59OdT-2Yit5gtsny-4'
-                           b'VdoZdYRpszkwkr40AAAAAAAAAAAAAAAAAAAAAAAE-kW2C8JK7v59OdT-2Yit5gts'
-                           b'ny-4VdoZdYRpszkwkr4-AADAATIUtLtJYFRe0Or8d4GeHW-36tkhm010IKqWJoQt'
-                           b'U4I5bNFoMbChd6ruxV-EcBFaapjFxl4lX5LOKOIQWHkQbDgABBymHY6_fhjHdhQU'
-                           b'tgOJygQC-lmwCohosoxdgax8BOloCs_8irPKYDmj9mjRCOv78B-6eeatuldYm1UH'
-                           b'9uk9CDQACPN55PAq6vZUUTlr2snI2G3SvjTXMGE7vpaVclEQOn4tNcBz_ERwCD-p'
-                           b'GJbtgS71kk2sDg3L4hUTX6v_GIBZiCQ{"v":"KERI10JSON000091_","t":"rct'
-                           b'","d":"EYcmtiV1Z__uV7iCSxk5lbcDqMV8lE_zxFGgwc4bRsrg","i":"EgmiU2'
-                           b'7BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"5"}-FABE-kW2C8JK7v5'
-                           b'9OdT-2Yit5gtsny-4VdoZdYRpszkwkr40AAAAAAAAAAAAAAAAAAAAAAAE-kW2C8J'
-                           b'K7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr4-AADAA6fqo4-7JahfKXF1ZZIHzvf'
-                           b'tSJmRfC2qHKAXHVd24La1gBz-jQGHRy3pbuogJ7LuiOfHZ5S-FJ-PHu2LCobfPBA'
-                           b'ABDU2RCWxo1Cpt31VSgRROSzH3fKmNDcbpUw0ZEwgMwGwBmA0UW_eD2t75h4tfq_'
-                           b'9UznmQ-UWy6vYq9r9fD-jHDgACQfpV88d4OTwNkAkigUyYXDHjhlplaYyucAlDdq'
-                           b'0zEFI_QU1hKXbfXabGeiK9L4vGOFDHhEi61RCx-0VyCtsPCQ{"v":"KERI10JSON'
-                           b'000091_","t":"rct","d":"EQ4_P5u46hGceGpc8hurR7pTox-VkvkExLj6_CMt'
-                           b'Vejw","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"6"'
-                           b'}-FABE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr40AAAAAAAAAAAAAA'
-                           b'AAAAAAAAAE-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRpszkwkr4-AADAAXyUC9'
-                           b'nmRPtqMXG9ci4D1JITFGz7JhzDq0iFtXPHKE2l5jIsDHvm_wNb5CJn_lxCr50qtq'
-                           b'LfV6ifPVKFqd0zNCQAB24NytxoFP110Gwcd6O7Rwceq5IhP819pVBAen0ZD_etJa'
-                           b'MZE40IVaI_HqX7dULyTMbowfRYGTKLe60j8JpNlCQACe_UgWZTeu_7dE6A90oHu8'
-                           b'M4pPWdg8tQumgHKw7refciRJDx87i5nz4UC81Mj6og-UPwaoW_UmBQKMkhEJ48sCw')
+                           b'hpvbNyYu1fxTBTXy8eCgghMcOYnxkgoGPBr0ZBZPQA"],"nt":"2","n":["Eq-s'
+                           b'_yaBaeq3BavwLMc7Q4TM1N1cxK0JFIiJEKNU18tA","EwGXfFpxspo-1acgIRGvY'
+                           b'h6Vn76V3XpLKSXURpl35bO0","EzX47juZp1pl0qMZU8yUCNNhLx5Lte9GtYRV50'
+                           b'xS3EKg"],"bt":"0","b":[],"c":[],"a":[]}-AADAArIlwP9SZ7tQYTH90KUI'
+                           b'7P8dlwvf24JW0LjF01Udc3Rns3T3LvvScQ9rZTEMdgfFXiEEXe8ZjG_VZqNHb66m'
+                           b'3BQABuHWYMgm_tZ3hzIJARVCJYia9f4UpWPH7KTor0X-KxPbh5hHi6wYCksaf73o'
+                           b'0xZH9V1OQrxdbaL4t3CupspQ4CwAC5ynsGiCew_9rZue8_DAzZohQIOWutyVY4nD'
+                           b'0989WSjBkAXVxmoTSn306htquWndjPPtqoI465YoFb5mNpdEuBw{"v":"KERI10J'
+                           b'SON000091_","t":"rct","d":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkl'
+                           b'iMo-Rbk","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":'
+                           b'"0"}-FABEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk0AAAAAAAAAAA'
+                           b'AAAAAAAAAAAAEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk-AADAAUp'
+                           b'_cOQDlxQ1UIFLlj3TFujVJiaWdR1vA-Xtfzrreo2edQqnOSdm-E3NJSLDyJYD_zm'
+                           b'dfmI3LYxVtR92mXOmuBgABLv94hqxM8bbdfZf6WwSZl64By-Ej4dwN9mSyddjL5G'
+                           b'g5B8atYP6Oa8IZxX1HqJ330BotXcgjaGIjAoNfboEqAwACZdxxR4o4UXvRfqqjc0'
+                           b'C9SEXlFlfuNG6UEZUTAj8OtffsZR2gJaNNf_Mz14GUz4xAzV-XnK3mVeIBi4laNC'
+                           b'FXAA{"v":"KERI10JSON000091_","t":"rct","d":"E0EFbDrGf49mevhj9Ljq'
+                           b'dDF9Zv1e3xZrVV-o74knmodI","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXF'
+                           b'dAkliMo-Rbk","s":"1"}-FABEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4'
+                           b'YlmPk0AAAAAAAAAAAAAAAAAAAAAAAEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8'
+                           b'UHe4YlmPk-AADAAM209g6h3ILA1zvNU1o7Zg416UHVZTGu671pUjC_BOVGa7QAqb'
+                           b'RBRMQ3WlzeK6hshaPx15L71-8xLG2UteHXiCAAB3uz7fveuGtlpjgd8mkfw_DxA7'
+                           b'BkpgEp_-72aYRNoQxuVFX-SrPKU-Uiz9oOHA1F639d4siDCnKv9hm32trwSAAACe'
+                           b'XGbEJ21PyNUbLgRCDz4fkbu8YWGJ9H76MpojO4LHtjLTsbvibYpJupDsmAoaiNhm'
+                           b'-UfB4owHgAeFEKYqiCPAA{"v":"KERI10JSON000091_","t":"rct","d":"EsZ'
+                           b'2thB6qZ8l_eaxur-1YtY7D9PBxL7yhCdC93hYvX1M","i":"Eban8TbpEQ4HX5hw'
+                           b'efKvH5-7eP5SOctXFdAkliMo-Rbk","s":"2"}-FABEGifcQT5E5KKdvND2j7dLT'
+                           b'Wh7YH1GaEVuq8UHe4YlmPk0AAAAAAAAAAAAAAAAAAAAAAAEGifcQT5E5KKdvND2j'
+                           b'7dLTWh7YH1GaEVuq8UHe4YlmPk-AADAA5mDJQRG9bdXCOplYYUzwpFvpcLMrH09J'
+                           b'sbGe9qsHNjaTv44UZc-BwiDgthviCjNPSTTwkqR6IP_osSIIkBcPBAABOadA5-ZL'
+                           b'r57TGIj3ZN3dICmfe94OxzMXkmv6FnZbctQ64uQtcFrVHNG_DOEpzNmFMT0MqY1h'
+                           b'T3v_rSOXqStrCQACg89jpowxSZaDXgzqwtBsddK-aSD-9IRuByZ2fzESMePvyBIK'
+                           b'VeQBkgp4cfQAtWFNry_gP3OyB1Nhxtg2wM-QDg{"v":"KERI10JSON000091_","'
+                           b't":"rct","d":"EvnHJz9YFtaiMlCbyq4wMulC3TXAZ9JyH2pTyXkd93Lw","i":'
+                           b'"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"3"}-FABEGifc'
+                           b'QT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk0AAAAAAAAAAAAAAAAAAAAAAAE'
+                           b'GifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk-AADAAHkKSxBrCTAp3S3i'
+                           b'p12D0_64Bl37fETH3LFGGvoF0a7uMnKZ_YgsHw8Pt4NMKbNHEgDsIm5Vl5fU8Ls-'
+                           b'qNguJCQAB3fTvkA2jLXwI4tgL7OhOWlTCVoSwRTe9Y0jInmuP3pBKRUKGqcNIvwY'
+                           b'ma3kf33gUSNs8d4jUA3FZbRydmQV7CgAC0lDZfsM6AWa9XNwyaD5JJBA-dWjsb4p'
+                           b'RBkshcthhzbeXfVa7q9-C6j0RjI7bYZOxScz3oOLvWe0UFtVjGiwlBA{"v":"KER'
+                           b'I10JSON000091_","t":"rct","d":"EQigFoXAX3U0JLw8LSRtzqJENPEotsV6N'
+                           b'_7Cl9X9GTK4","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk",'
+                           b'"s":"4"}-FABEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk0AAAAAAA'
+                           b'AAAAAAAAAAAAAAAAEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UHe4YlmPk-AAD'
+                           b'AAeqzcOLqnBpH8JtJt86Zr0w3kakOp7UHg_HNxEb-K63dvoFTBwWk_GT9zKYwWPu'
+                           b'z4YpS8drx4nBF8kkazE1mBBgABsYKOB3bQR6T0Q3Rw4F0WxOfWjoGcAwCL7rYC0l'
+                           b'e7b3W8FhzUFKVbcMHasegXltXEod0bNi-vXPbWNqh2teXPDgACs8a-QfePlA8mcC'
+                           b'JzHJ3A3OKaasuGV3rc36ep0mBJx2B53AW22VZ_Y1v8_fL6HtE8iAo8XM9Wjc3R35'
+                           b'TG7F3JBA{"v":"KERI10JSON000091_","t":"rct","d":"EEoiyGRkxjb-bRZQ'
+                           b'UIiEfkijxg8c1_jzJYE6p0YeWZ-0","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SO'
+                           b'ctXFdAkliMo-Rbk","s":"5"}-FABEGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8'
+                           b'UHe4YlmPk0AAAAAAAAAAAAAAAAAAAAAAAEGifcQT5E5KKdvND2j7dLTWh7YH1GaE'
+                           b'Vuq8UHe4YlmPk-AADAAIncXU_AogkuFeiIe5REZJnDQTiaje3MFpoePRUUOaj1xW'
+                           b'On3LgmwUO75eF-S5oWr4floZDd20JCdz_qDZOO3AAABuoTcnV1TL7Vli6Ffyh6Si'
+                           b'PIjjOwEars3FFhGP3D_WeklRwPELLmAxftNCPdPiko4dYMK3Gp8Bq3AUB1L4hpSB'
+                           b'QACliE514Ps-MfOJnK7HuZshd6HETvXm4550yaeOTNdNPus0q5JL8wtoZ2XERBs0'
+                           b'h8BiR8cNCFVGNocnfxV64lGBA{"v":"KERI10JSON000091_","t":"rct","d":'
+                           b'"ECwRGikXaPuVHZplHFnVWv6cYG-ovQpsosZXEX93uLgU","i":"Eban8TbpEQ4H'
+                           b'X5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"6"}-FABEGifcQT5E5KKdvND2j'
+                           b'7dLTWh7YH1GaEVuq8UHe4YlmPk0AAAAAAAAAAAAAAAAAAAAAAAEGifcQT5E5KKdv'
+                           b'ND2j7dLTWh7YH1GaEVuq8UHe4YlmPk-AADAAP0rhZlAaxWG5ZD3Iy5oMJhp-qapt'
+                           b'Rsb9x3GWcwgPqKr99aR_mIceVk3NkTb-Vc0NjKLYsv6cHoBHZpLvgj8FCwAB_Dlj'
+                           b'947F5wJr8etCsQjLWzeKyX9OMgZFKeLGofA9aH0kqfKkZdUw6JpoJlCfYlbe_61g'
+                           b'jyw8SbTD3mQAQ8E2AwACyZf2HploOJN7iQYmIMj_tJ6RPDwwMpFMnDrl1FLPF1Qd'
+                           b'CWZoZfikZvGWPeLjCEob0eZ185eHN7V25WWcjc_GDg')
 
         # Play camMsgs to Deb
         # create non-local kevery for Deb to process msgs from Cam
@@ -224,15 +227,15 @@ def test_replay():
 
         # get disjoints receipts (vrcs) from Deb of Cam's events by processing Deb's cues
         debCamVrcs = debHab.processCues(debKevery.cues)
-        assert debCamVrcs == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E-kW2C8JK7v59OdT-2Yit5gt'
-                              b'sny-4VdoZdYRpszkwkr4","i":"E-kW2C8JK7v59OdT-2Yit5gtsny-4VdoZdYRp'
-                              b'szkwkr4","s":"0"}-FABEgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3'
-                              b's0AAAAAAAAAAAAAAAAAAAAAAgEgRAXqREqw3EvxZsTOGHKU2Aa70IJmd0XC6y7AQ'
-                              b'gjwns-AADAAEJw4Xod7bMCI6hlKQ-m2XzXj-sT3nuAhX3_SvSZosFfyGQj1hi_3o'
-                              b'vDEFCh04QnGf5WbrcECY16QggKsVMMyBAAB4KEEjzcwbWMEry3PsGk8vdrzJ5c0m'
-                              b'guNotQQKaRmEIPhazsh9lPJCbAQdJ-X5Nmo15VcYYIOi2RrNWUJ74KMAQACWQSkw'
-                              b'Ma_Kqew9GeYDxobaN2aD5rSmIWLbkpj6m2q9inbW7KCbaz9vgWZMu124vIefGRcz'
-                              b'oekARWPuCwgSXZfAQ')
+        assert debCamVrcs == (b'{"v":"KERI10JSON000091_","t":"rct","d":"EGifcQT5E5KKdvND2j7dLTWh'
+                              b'7YH1GaEVuq8UHe4YlmPk","i":"EGifcQT5E5KKdvND2j7dLTWh7YH1GaEVuq8UH'
+                              b'e4YlmPk","s":"0"}-FABEban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rb'
+                              b'k0AAAAAAAAAAAAAAAAAAAAAAgEsZ2thB6qZ8l_eaxur-1YtY7D9PBxL7yhCdC93h'
+                              b'YvX1M-AADAAFgIYCUZpSPL3YkJmPJvkVv2ObazNX9Aiy_8EiqViACWuRdOCBo5iq'
+                              b'62y1GiMarTUBp2sqS_ZpCz3hRBTVWFyCgABe22VhixbyQmBPBHU4mG3txPTw_0Iu'
+                              b'u-QNesBMI4Xqn3YEpS0VeYl4WN8pCnL6tFk7ZqOqR7zA7dCyFHc8666AQACvGsH6'
+                              b'RtNPoF4ZdhJecQFTohQn-MzbanFlMqLQfPQhFidNNuqoGBNKS7tDOnqgQjrbj1t8'
+                              b'8Fkrkv9peEHd_w7AQ')
 
         # Play disjoints debCamVrcs to Cam
         parsing.Parser().parseOne(ims=bytearray(debCamVrcs), kvy=camKevery)
@@ -251,42 +254,43 @@ def test_replay():
 
         # get disjoints receipts (rcts) from Bev of Deb's events by processing Bevs's cues
         bevMsgs = bevHab.processCues(bevKevery.cues)
-        assert bevMsgs == (b'{"v":"KERI10JSON0000f4_","t":"icp","d":"E91pCFGs1Hm_B43_LIi0jCOV'
-                           b'7DpPHn-HqHon4uJINaNw","i":"BCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-Gp'
+        assert bevMsgs == (b'{"v":"KERI10JSON0000fd_","t":"icp","d":"ENE38noQTiyoAneEYmNSKNIu'
+                           b'v6lTMp20wSWanPkcA_L4","i":"BCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-Gp'
                            b'QBPaurA","s":"0","kt":"1","k":["BCqmHiYBZx_uaQiCTVeum-vt1ZPti8ch'
-                           b'qb-GpQBPaurA"],"n":"","bt":"0","b":[],"c":[],"a":[]}-AABAA2NToUy'
-                           b'43Ua8Ok1UOUTJGWoglnKVQmoEexxjbf9cUqe76Gh4CdeeK2NfT58F-18RWi6WXoP'
-                           b'hAhnaKmdKnK2J_Aw{"v":"KERI10JSON000091_","t":"rct","d":"EgmiU27B'
-                           b'ZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","i":"EgmiU27BZtfnJclZw6K_X'
-                           b'67hwf6SDT3nJW1dr3Jq9D3s","s":"0"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZP'
-                           b'ti8chqb-GpQBPaurA0BCay0z3y9YFHQO6Z7jy5xh_t74Y_4lJcvTdF46uvAJzV09'
-                           b'GGQLXtKK4tplwyKHT58yy9uqAV0_0wOFZGIEG5lBQ{"v":"KERI10JSON000091_'
-                           b'","t":"rct","d":"Eoy3g6inBwl9tU4XObauVN6HGcrspyJn-8zDHpjRDArQ","'
-                           b'i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"1"}-CABBC'
-                           b'qmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0BRqTp4tQjRgtrJk1Hl_92'
-                           b'MHYQonDUnWmjU61Af0zpAFBSGorap6Br5flNdBpTIfCDHPNru_V771ynDi-Rwj2v'
-                           b'Bg{"v":"KERI10JSON000091_","t":"rct","d":"EgRAXqREqw3EvxZsTOGHKU'
-                           b'2Aa70IJmd0XC6y7AQgjwns","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1'
-                           b'dr3Jq9D3s","s":"2"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPa'
-                           b'urA0BVjnMzuWPHd_QM9P7OnL4tU7yIENr3K2B2p3KQZRj67b5Wkinv67ro_gltaB'
-                           b'FK4PXb8LouUckRL8dgRnsvZtWDQ{"v":"KERI10JSON000091_","t":"rct","d'
-                           b'":"EHlKLWTe1lCakBrg-s_sSEbza24YDvi9rxDQS5Wuph5E","i":"EgmiU27BZt'
-                           b'fnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"3"}-CABBCqmHiYBZx_uaQiC'
-                           b'TVeum-vt1ZPti8chqb-GpQBPaurA0BSbNEMSxwResaiMT5Al3GyyXIZs4Ya4zI91'
-                           b'DsO24iBUgGug7XUo2qSQJ1cbC-ZMphbACYvLonvlfVkFy6Ptx4BA{"v":"KERI10'
-                           b'JSON000091_","t":"rct","d":"EJVdSFO631gld44xpJipwzQHqKP4cS_tcoBf'
-                           b'rBG07BYI","i":"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s"'
-                           b':"4"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0B3GwlHrRTK'
-                           b'PWw5AF3dIyIc0Csl7WMPbZlmGOlMKbhFdIq8nt-pcCe-wRDrdXk78ese3kGCEPR7'
-                           b'5RuPmff_fymBg{"v":"KERI10JSON000091_","t":"rct","d":"EYcmtiV1Z__'
-                           b'uV7iCSxk5lbcDqMV8lE_zxFGgwc4bRsrg","i":"EgmiU27BZtfnJclZw6K_X67h'
-                           b'wf6SDT3nJW1dr3Jq9D3s","s":"5"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8'
-                           b'chqb-GpQBPaurA0BXOSv2uyENysIcooyC6tys5EWswI1rxNs2ClH3wqlCqGkxr97'
-                           b'Rx6vPqbxImrGJ-nKMhYkqS413MkAPNwuWhqFAA{"v":"KERI10JSON000091_","'
-                           b't":"rct","d":"EQ4_P5u46hGceGpc8hurR7pTox-VkvkExLj6_CMtVejw","i":'
-                           b'"EgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3s","s":"6"}-CABBCqmH'
-                           b'iYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0BXj-h3cIdc5sbMlCpcsxVZx6'
-                           b'TaFS11tX0_zttjmlHrPrq5Kk_zPuSSAti47dRmpN_2tSoRYtGByllWGzGnNn2Bw')
+                           b'qb-GpQBPaurA"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-AA'
+                           b'BAAozuDFSORYWsy7Jl9asA7bicvf5xLaneMbo7Yl2lvkAT0HSjvhI8QUh9agW9e4'
+                           b'APcy_xphMdRzlDPNRfixqlWCg{"v":"KERI10JSON000091_","t":"rct","d":'
+                           b'"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","i":"Eban8TbpEQ4H'
+                           b'X5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"0"}-CABBCqmHiYBZx_uaQiCTV'
+                           b'eum-vt1ZPti8chqb-GpQBPaurA0B4DXMxgfIL54GtKxHFwmblsGpT3SHcAWz49kn'
+                           b'MuSfPcV41Yd0NFi1BgK5YrB9f2HGVtkr5cIGtETpz-L8k4JZBg{"v":"KERI10JS'
+                           b'ON000091_","t":"rct","d":"E0EFbDrGf49mevhj9LjqdDF9Zv1e3xZrVV-o74'
+                           b'knmodI","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"'
+                           b'1"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0BzsAJ_ozo7HX'
+                           b'Kdbbx_FU1YIZfOGn2f-qhh3pP4hfDSxt9m6QBdWRy6bAkAhXmg5g4qRkZyEu-XqJ'
+                           b'DEBCGMe3dCw{"v":"KERI10JSON000091_","t":"rct","d":"EsZ2thB6qZ8l_'
+                           b'eaxur-1YtY7D9PBxL7yhCdC93hYvX1M","i":"Eban8TbpEQ4HX5hwefKvH5-7eP'
+                           b'5SOctXFdAkliMo-Rbk","s":"2"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8ch'
+                           b'qb-GpQBPaurA0B2feSG3gWubwMdbhB4FAx9EKJUCEkhmahECvFYx784dp-atqnpJ'
+                           b'fW0ngmYM8hFKqx-Ahbxg1t00lK2gbWL1I4CQ{"v":"KERI10JSON000091_","t"'
+                           b':"rct","d":"EvnHJz9YFtaiMlCbyq4wMulC3TXAZ9JyH2pTyXkd93Lw","i":"E'
+                           b'ban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"3"}-CABBCqmHiY'
+                           b'BZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0Bzb-G2a56g6vhAVGvlCpcKBAWS'
+                           b'wC1NTzxj5YVteYsFWEMHhhgdn49Hy82CT8Deiqs64DydxlQLTuCdA5aN09lBg{"v'
+                           b'":"KERI10JSON000091_","t":"rct","d":"EQigFoXAX3U0JLw8LSRtzqJENPE'
+                           b'otsV6N_7Cl9X9GTK4","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo'
+                           b'-Rbk","s":"4"}-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0B'
+                           b'OMJ_BkHWf1IYQXP4mf2flEokBYU9FakIMJFO4lLtYg8WLVnVyc9k_wIoUMJTWM9R'
+                           b'llnTMEqODSVayvXjWwMmAA{"v":"KERI10JSON000091_","t":"rct","d":"EE'
+                           b'oiyGRkxjb-bRZQUIiEfkijxg8c1_jzJYE6p0YeWZ-0","i":"Eban8TbpEQ4HX5h'
+                           b'wefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"5"}-CABBCqmHiYBZx_uaQiCTVeum'
+                           b'-vt1ZPti8chqb-GpQBPaurA0BTYb-mi5zkMhOBDmlwNBUlWCDFlm1OaWDkj6GgwL'
+                           b'OTOfkClUxo16TDIl8jdfA_mdfXn7ipKFg_osGkBUI5IRHAg{"v":"KERI10JSON0'
+                           b'00091_","t":"rct","d":"ECwRGikXaPuVHZplHFnVWv6cYG-ovQpsosZXEX93u'
+                           b'LgU","i":"Eban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rbk","s":"6"}'
+                           b'-CABBCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-GpQBPaurA0BVqibBPSzBELmCw'
+                           b'VX-rivkcfRUEHPbaHo4031l6al0bsoBc3Jp7l-9UCul9prLPTJijkPY1irJvtqyz'
+                           b'fq8rn7Dg')
 
         # Play bevMsgs to Deb
         parsing.Parser().parse(ims=bytearray(bevMsgs), kvy=debKevery)
@@ -297,15 +301,15 @@ def test_replay():
 
         # get disjoints receipts (vrcs) from Deb of Bev's events by processing Deb's cues
         debBevVrcs = debHab.processCues(debKevery.cues)
-        assert debBevVrcs == (b'{"v":"KERI10JSON000091_","t":"rct","d":"E91pCFGs1Hm_B43_LIi0jCOV'
-                              b'7DpPHn-HqHon4uJINaNw","i":"BCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-Gp'
-                              b'QBPaurA","s":"0"}-FABEgmiU27BZtfnJclZw6K_X67hwf6SDT3nJW1dr3Jq9D3'
-                              b's0AAAAAAAAAAAAAAAAAAAAAAgEgRAXqREqw3EvxZsTOGHKU2Aa70IJmd0XC6y7AQ'
-                              b'gjwns-AADAAolzi_N7g0q792H7aQoB_bVwaNPMQ61UhXDKxrhX5uS6BhCuxHHCIb'
-                              b'ELjpyjLUBQvKAs0rMQOgDI0sOGvZa6hBAABfBLZZ60qWfcVVnRx25T4FP8cCg7nH'
-                              b'QiF_rowNlbvXjI_sUUgsojVlEm570AwosNockcJr1QLkO-wb0bz59DxBAACQ6gcg'
-                              b'0EPlK-VURztqz3IXy_0ASludvqiA2DnV5N918b6fmCTCW01bSrJzEVlo8u1ZazLB'
-                              b'ZHWxPUbYUT2FpSrBg')
+        assert debBevVrcs == (b'{"v":"KERI10JSON000091_","t":"rct","d":"ENE38noQTiyoAneEYmNSKNIu'
+                              b'v6lTMp20wSWanPkcA_L4","i":"BCqmHiYBZx_uaQiCTVeum-vt1ZPti8chqb-Gp'
+                              b'QBPaurA","s":"0"}-FABEban8TbpEQ4HX5hwefKvH5-7eP5SOctXFdAkliMo-Rb'
+                              b'k0AAAAAAAAAAAAAAAAAAAAAAgEsZ2thB6qZ8l_eaxur-1YtY7D9PBxL7yhCdC93h'
+                              b'YvX1M-AADAA6zpBCPrz6-mmX3JSjgBZYWde2FZbZp1UfDmJWg1K6b6AUs-yEdboQ'
+                              b'ZxNpao_zFftmJomy3D3yT8PKnqfmmxbAAABZTWv3ic3Ppf7s0jWhqiA6453XBoxM'
+                              b'P4Q9mCfHCL1MGHH8BA5ncj7fmRYSi7nL23scwG-DJAwNBZq193ma4NcDgACPMTbW'
+                              b'D67Wv3864TercRAX3NOdUrBrtqsky2uLub95yf_ojgG49JfGJ7ACe1Rr0WxDCes5'
+                              b'o8GorLlyvGFuv3NBw')
 
         # Play disjoints debBevVrcs to Bev
         parsing.Parser().parseOne(ims=bytearray(debBevVrcs), kvy=bevKevery)
@@ -320,7 +324,7 @@ def test_replay():
         fn = 0
         cloner = debHab.db.clonePreIter(pre=debHab.pre, fn=fn)  # create iterator
         msg = next(cloner)  # get zeroth event with attachments
-        assert len(msg) == 1474
+        assert len(msg) == 1595
         debFelMsgs.extend(msg)
 
         # parse msg
@@ -408,7 +412,7 @@ def test_replay():
         serder = coring.Serder(raw=msg)
         assert serder.sn == fn  # no recovery forks so sn == fn
         assert serder.ked["t"] == coring.Ilks.rot
-        assert len(msg) == 1527
+        assert len(msg) == 1648
         assert ([verfer.qb64 for verfer in serder.verfers] ==
                 [verfer.qb64 for verfer in debHab.kever.verfers])
         debFelMsgs.extend(msg)
@@ -423,7 +427,7 @@ def test_replay():
             debFelMsgs.extend(msg)
             fn += 1
 
-        assert len(debFelMsgs) == 9396
+        assert len(debFelMsgs) == 9638
         cloner.close()  # must close or get lmdb error upon with exit
 
         msgs = debHab.replay()
@@ -446,7 +450,7 @@ def test_replay():
         camDebFelMsgs = camHab.replay(pre=debHab.pre)
         bevDebFelMsgs = bevHab.replay(pre=debHab.pre)
 
-        assert len(bevDebFelMsgs) == len(camDebFelMsgs) == len(debFelMsgs) == 9396
+        assert len(bevDebFelMsgs) == len(camDebFelMsgs) == len(debFelMsgs) == 9638
 
         # create non-local kevery for Art to process conjoint replay msgs from Deb
         artKevery = eventing.Kevery(db=artHab.db,
@@ -466,7 +470,7 @@ def test_replay():
         assert artKevery.kevers[debHab.pre].sn == debHab.kever.sn == 6
         assert len(artKevery.cues) == 8
         artDebFelMsgs = artHab.replay(pre=debHab.pre)
-        assert len(artDebFelMsgs) == 9396
+        assert len(artDebFelMsgs) == 9638
 
     assert not os.path.exists(artHby.ks.path)
     assert not os.path.exists(artHby.db.path)
@@ -609,7 +613,7 @@ def test_replay_all():
 
         # now setup replay
         debAllFelMsgs = debHab.replayAll()
-        assert len(debAllFelMsgs) == 11726
+        assert len(debAllFelMsgs) == 12082
 
         # create non-local kevery for Art to process conjoint replay msgs from Deb
         artKevery = eventing.Kevery(db=artHab.db,
@@ -627,7 +631,7 @@ def test_replay_all():
         assert artKevery.kevers[debHab.pre].sn == debHab.kever.sn == 6
         assert len(artKevery.cues) == 9
         artAllFelMsgs = artHab.replayAll()
-        assert len(artAllFelMsgs) == 10922
+        assert len(artAllFelMsgs) == 11287
 
     assert not os.path.exists(artHby.ks.path)
     assert not os.path.exists(artHby.db.path)

--- a/tests/core/test_reply.py
+++ b/tests/core/test_reply.py
@@ -596,26 +596,26 @@ def test_reply(mockHelpingNowUTC):
         serderR = eventing.reply(route=route, data=data, )
         assert serderR.ked['dt'] == help.helping.DTS_BASE_0
 
-        assert serderR.raw == (b'{"v":"KERI10JSON000113_","t":"rpy","d":"E1tyBXV54fRzS4WSCIzOUueOoBArQpFBtIB2'
-                               b'L2Krdy48","dt":"2021-01-01T00:00:00.000000+00:00","r":"/end/role/add","a":{"'
-                               b'cid":"E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4","role":"witness","eid":"'
+        assert serderR.raw == (b'{"v":"KERI10JSON000113_","t":"rpy","d":"Ekd189yFsX1eLhQ2NffI6AaF8ZxKXyej_jfn'
+                               b'4wMNJq-w","dt":"2021-01-01T00:00:00.000000+00:00","r":"/end/role/add","a":{"'
+                               b'cid":"EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0","role":"witness","eid":"'
                                b'BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"}}')
 
-        assert serderR.said == 'E1tyBXV54fRzS4WSCIzOUueOoBArQpFBtIB2L2Krdy48'
+        assert serderR.said == 'Ekd189yFsX1eLhQ2NffI6AaF8ZxKXyej_jfn4wMNJq-w'
 
         # Sign Reply
         msg = tamHab.endorse(serder=serderR)
-        assert msg == (b'{"v":"KERI10JSON000113_","t":"rpy","d":"E1tyBXV54fRzS4WSCIzOUueO'
-                       b'oBArQpFBtIB2L2Krdy48","dt":"2021-01-01T00:00:00.000000+00:00","r'
-                       b'":"/end/role/add","a":{"cid":"E45sehIW71DobP0x5jLAxQSIyYIYZk74Bx'
-                       b'CpMTZ4vxs4","role":"witness","eid":"BFUOWBaJz-sB_6b-_u_P9W8hgBQ8'
-                       b'Su9mAtN9cY2sVGiY"}}-VBg-FABE45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpM'
-                       b'TZ4vxs40AAAAAAAAAAAAAAAAAAAAAAAE45sehIW71DobP0x5jLAxQSIyYIYZk74B'
-                       b'xCpMTZ4vxs4-AADAASMn1I-N17pc7xNAFK5ZJ7-MKB2ljT-4uSBXihMiO_XwJIzg'
-                       b'6U6H7crRK2b4fJyDffL0CV-DQ0w0ab9v6i5HOBgAB9L5xfg2clkqDURVLFO2XxdT'
-                       b'nqme1aZJvmbbpOZ6avtJFPciNZ8ArUD7xx24DPhconiPDIaiLxwMieaSTiP7KCgA'
-                       b'CSK9xe7PbN6fz6BiUdg8k-y3bAOO7i80W-qBPl_Sb8MwBjpDgWoSRGxbIofU_9uy'
-                       b'iyOqYKGARl34FHG-E9_nRCg')
+        assert msg == (b'{"v":"KERI10JSON000113_","t":"rpy","d":"Ekd189yFsX1eLhQ2NffI6AaF'
+                       b'8ZxKXyej_jfn4wMNJq-w","dt":"2021-01-01T00:00:00.000000+00:00","r'
+                       b'":"/end/role/add","a":{"cid":"EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_v'
+                       b'tPbPPglDK0","role":"witness","eid":"BFUOWBaJz-sB_6b-_u_P9W8hgBQ8'
+                       b'Su9mAtN9cY2sVGiY"}}-VBg-FABEhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPb'
+                       b'PPglDK00AAAAAAAAAAAAAAAAAAAAAAAEhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_'
+                       b'vtPbPPglDK0-AADAATiGjpZDg1yRqXF8MCmFDHwyQjDhlW2H0_E69OMadr9GOXtD'
+                       b'5ZdT1-RlE6MQpmVQmuLYY5JrIuRev2rp7uh6PAwABxnyvlaARkPXW6XTa5eBuFBo'
+                       b'UCRCGrI8WK8N80B7XFil2Gt4g02PrsVmgZCvuE44d3neCeJ29D4neyItmGz5nBwA'
+                       b'CfBrfHowPaBBliHpSQk5o3f_wu8H7deO_upUE0I1qB4sRaHhDH4a28u7fS6UH9xl'
+                       b'-9_BiQbDYRYhhn2yH0bl_AQ')
 
         # use Nel's parser and kevery to authZ wes as tam end witness
         nelPrs.parse(ims=bytearray(msg))  # no kel for tam so escrow
@@ -655,26 +655,26 @@ def test_reply(mockHelpingNowUTC):
         serderR = eventing.reply(route=route, data=data, )
         assert serderR.ked['dt'] == help.helping.DTS_BASE_0
 
-        assert serderR.raw == (b'{"v":"KERI10JSON000108_","t":"rpy","d":"EHefj0-x3Garz6zAjBO3TipXaVO6onAN__wZ'
-                               b'PUrtx3cU","dt":"2021-01-01T00:00:00.000000+00:00","r":"/loc/scheme","a":{"ei'
-                               b'd":"E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4","scheme":"http","url":"htt'
+        assert serderR.raw == (b'{"v":"KERI10JSON000108_","t":"rpy","d":"EbAwspDQjS-Ve-tzDtAuzx4K8uhh-0AyXWZr'
+                               b'SKm64PFQ","dt":"2021-01-01T00:00:00.000000+00:00","r":"/loc/scheme","a":{"ei'
+                               b'd":"EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0","scheme":"http","url":"htt'
                                b'p://localhost:8080/controller/tam"}}')
 
-        assert serderR.said == 'EHefj0-x3Garz6zAjBO3TipXaVO6onAN__wZPUrtx3cU'
+        assert serderR.said == 'EbAwspDQjS-Ve-tzDtAuzx4K8uhh-0AyXWZrSKm64PFQ'
 
         # Sign Reply
         msg = tamHab.endorse(serder=serderR)
-        assert msg == (b'{"v":"KERI10JSON000108_","t":"rpy","d":"EHefj0-x3Garz6zAjBO3TipX'
-                       b'aVO6onAN__wZPUrtx3cU","dt":"2021-01-01T00:00:00.000000+00:00","r'
-                       b'":"/loc/scheme","a":{"eid":"E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCp'
-                       b'MTZ4vxs4","scheme":"http","url":"http://localhost:8080/controlle'
-                       b'r/tam"}}-VBg-FABE45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs40AAA'
-                       b'AAAAAAAAAAAAAAAAAAAAE45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4'
-                       b'-AADAAmqnXkPMlIJj6wjnrila2jV2Q1vSYscwvqDGr_rHdGoVLNycKZwCwkFgzn4'
-                       b'u1ZKGGcY-lo3nDwc8iJ_4NZUu7BQABQDm1pDATlf7WDFDw7XxBFS2N3sgBxZZF45'
-                       b'NI-HQEXL_DqzvesII6lwphD_7daeTPWcPLNRO7v5xW1adcMNVpCQACaMzNsoPbvb'
-                       b'Jg47kr2npFsFsl9mQc5ls168JXsjlZbzzM5suIMdOH1hllACYgYCMfBOxzq15gV4'
-                       b'WB7fZINs1pCA')
+        assert msg == (b'{"v":"KERI10JSON000108_","t":"rpy","d":"EbAwspDQjS-Ve-tzDtAuzx4K'
+                       b'8uhh-0AyXWZrSKm64PFQ","dt":"2021-01-01T00:00:00.000000+00:00","r'
+                       b'":"/loc/scheme","a":{"eid":"EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtP'
+                       b'bPPglDK0","scheme":"http","url":"http://localhost:8080/controlle'
+                       b'r/tam"}}-VBg-FABEhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK00AAA'
+                       b'AAAAAAAAAAAAAAAAAAAAEhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0'
+                       b'-AADAAbKvjN_n2vekrW8HDcyo-zlUatI7GRMaxg7DpLMgrtxCBZNwYOLoturPS1Q'
+                       b'2CHyg1bmc__ilw2kjqq5po-6oZDAABCVRE_ciDlCBQtLq1GxqOLIS1w-aFPOlZFQ'
+                       b'tTrBMPl0PWwEewonv9BRXPLVvoMwTsiii1dFSVoW8zp0OXLYNFBAACUwwIoXD5BL'
+                       b'3zBrZfutOyeO1ShSY-1hjDsOrCzpxEsgUIY0ob1V5Z701NDJO6NXqxy3Xjie6wMc'
+                       b'j1Ui8xxi1sCA')
 
         # use Tam's parser and kevery to process
         nelPrs.parse(ims=bytearray(msg))  # no kel for tam so escrow
@@ -993,15 +993,15 @@ def test_reply(mockHelpingNowUTC):
         # get all roles in ends
         items = [(keys, ender.allowed) for keys, ender
                  in nelHab.db.ends.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'controller',
-                           'E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4'),
+                           'EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BpVvny4hN_jxigw_PxIE5NXAuBM70FjigRdE-hgg4Stc'),
                           True)]
@@ -1019,9 +1019,9 @@ def test_reply(mockHelpingNowUTC):
 
         items = [(keys, ender.allowed) for keys, ender
                  in tamHab.db.ends.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'controller',
-                           'E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4'),
+                           'EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0'),
                           True)]
 
         items = [(keys, ender.allowed) for keys, ender
@@ -1039,7 +1039,7 @@ def test_reply(mockHelpingNowUTC):
         # nel locs
         items = [(keys, locer.url) for keys, locer
                  in nelHab.db.locs.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4', 'http'),
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0', 'http'),
                           'http://localhost:8088/controller/tam')]
 
         items = [(keys, locer.url) for keys, locer
@@ -1067,7 +1067,7 @@ def test_reply(mockHelpingNowUTC):
         # tam locs
         items = [(keys, locer.url) for keys, locer
                  in tamHab.db.locs.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4', 'http'),
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0', 'http'),
                           'http://localhost:8088/controller/tam')]
 
         items = [(keys, locer.url) for keys, locer
@@ -1107,7 +1107,7 @@ def test_reply(mockHelpingNowUTC):
                                          {'http': 'http://localhost:8080/watcher/wat'}}}
 
         rurls = tamHab.fetchRoleUrls(cid=tamHab.pre)
-        assert rurls == Mict([('controller', Mict([('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+        assert rurls == Mict([('controller', Mict([('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                                                     Mict([('http', 'http://localhost:8088/controller/tam')]))]))])
 
         rurls = tamHab.fetchRoleUrls(cid=nelHab.pre)
@@ -1167,19 +1167,19 @@ def test_reply(mockHelpingNowUTC):
         # get all roles in ends
         items = [(keys, ender.allowed) for keys, ender
                  in nelHab.db.ends.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'controller',
-                           'E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4'),
+                           'EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BHKrk1-LQqCiERonyH0msupuFf_BrJIVJcqyC6bERhCk'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BpVvny4hN_jxigw_PxIE5NXAuBM70FjigRdE-hgg4Stc'),
                           True)]
@@ -1201,19 +1201,19 @@ def test_reply(mockHelpingNowUTC):
 
         items = [(keys, ender.allowed) for keys, ender
                  in tamHab.db.ends.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'controller',
-                           'E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4'),
+                           'EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BHKrk1-LQqCiERonyH0msupuFf_BrJIVJcqyC6bERhCk'),
                           True),
-                         (('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4',
+                         (('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0',
                            'witness',
                            'BpVvny4hN_jxigw_PxIE5NXAuBM70FjigRdE-hgg4Stc'),
                           True)]
@@ -1236,7 +1236,7 @@ def test_reply(mockHelpingNowUTC):
         # tam locs
         items = [(keys, locer.url) for keys, locer
                  in tamHab.db.locs.getItemIter(keys=(tamHab.pre, ""))]
-        assert items == [(('E45sehIW71DobP0x5jLAxQSIyYIYZk74BxCpMTZ4vxs4', 'http'),
+        assert items == [(('EhlsdBaCvxnW0z3m2OXxStaZkG76g0zC_vtPbPPglDK0', 'http'),
                           'http://localhost:8088/controller/tam')]
 
         items = [(keys, locer.url) for keys, locer

--- a/tests/core/test_weighted_threshold.py
+++ b/tests/core/test_weighted_threshold.py
@@ -41,8 +41,8 @@ def test_weighted():
 
         wesSrdr = eventing.incept(keys=[verfer.qb64 for verfer in verfers],
                                   sith=sith,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                                  nsith=nxtsith,
+                                  nkeys=[diger.qb64 for diger in digers],
                                   code=coring.MtrDex.Blake3_256)
 
         wesPre = wesSrdr.ked["i"]
@@ -58,17 +58,19 @@ def test_weighted():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == bytearray(b'{"v":"KERI10JSON00018e_","t":"icp","d":"EZgXYINAQWXFpxAmWI9AwOwj'
-                                b'VOYXzjyEE_-DdTfkEk8s","i":"EZgXYINAQWXFpxAmWI9AwOwjVOYXzjyEE_-Dd'
-                                b'TfkEk8s","s":"0","kt":["1/2","1/2","1/2"],"k":["DK4OJI8JOr6oEEUM'
+        assert msg == bytearray(b'{"v":"KERI10JSON000207_","t":"icp","d":"EOsgPPbBijCbpu3R9N-TMdUR'
+                                b'gcoFqrjUf3rQiIaJ5L7M","i":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQi'
+                                b'IaJ5L7M","s":"0","kt":["1/2","1/2","1/2"],"k":["DK4OJI8JOr6oEEUM'
                                 b'eSF_X-SbKysfwpKwW-ho5KARvH5c","D1RZLgYke0GmfZm-CH8AsW4HoTU4m-2mF'
-                                b'gu8kbwp8jQU","DBVwzum-jPfuUXUcHEWdplB4YcoL3BWGXK0TMoF_NeFU"],"n"'
-                                b':"EhJGhyJQTpSlZ9oWfQT-lHNl1woMazLC42O89fRHocTI","bt":"0","b":[],'
-                                b'"c":[],"a":[]}-AADAAo74mzRNAT5WEVRYaUWs4apfEY9oblVL2MtNSORwsEVFN'
-                                b'oyH8Vh_w_WC9TGfH-_zqN8dISIy102JtmBwllvHnBAABYQAmtsf2yhqi0zvF--TV'
-                                b'Wp7kfzVRy3BQkTdYmJrfOZFnvp0kbXlG-PCXPO7OXbKM0ZLJ1Ga_qVJ_y-ERIMac'
-                                b'CwACInxprKSzFp2-LNPn7eVAAc8z0XO0KbUE26vv_PXt5IMwyx6S5A1nCC4DQrv6'
-                                b'bYHmmXP0YQpkOIm-tRHrPCOuDg')
+                                b'gu8kbwp8jQU","DBVwzum-jPfuUXUcHEWdplB4YcoL3BWGXK0TMoF_NeFU"],"nt'
+                                b'":["1/2","1/2","1/2"],"n":["E9tzF91cgL0Xu4UkCqlCbDxXK-HnxmmTIwTi'
+                                b'_ySgjGLc","Ez53UFJ6euROznsDhnPr4auhJGgzeM5ln5i-Tlp8V3L4","EPF1ap'
+                                b'CK5AUL7k4AlFG4pSEgQX0h-kosQ_tfUtPJ_Ti0"],"bt":"0","b":[],"c":[],'
+                                b'"a":[]}-AADAAjCyfd63fzueQfpOHGgSl4YvEXsc3IYpdlvXDKfpbicV8pGj2v-T'
+                                b'WBDyFqkzIdB7hMhG1iR3IeS7vy3a3catGDgABhGYRTHmUMPIj2LV5iJLe6BtaO_o'
+                                b'hLAVyP9mW0U4DdYT0Uiqh293sGFJ6e47uCkOqoLu9B6dF7wl-llurp3o5BAACJz5'
+                                b'biC59pvOpb3aUadlNr_BZb-laG1zgX7FtO5Q0M_HPJObtlhVtUghTBythEb8FpoL'
+                                b'ze8WnEWUayJnpLsYjAA')
 
         # apply msg to Wes's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)
@@ -92,14 +94,14 @@ def test_weighted():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == bytearray(b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"E8LhfiGHj_YPjzZWu7xxMrla'
-                                b'8Bz3Fn-L6tJFlQcgeA_0","i":"EZgXYINAQWXFpxAmWI9AwOwjVOYXzjyEE_-Dd'
-                                b'TfkEk8s","s":"1","p":"EZgXYINAQWXFpxAmWI9AwOwjVOYXzjyEE_-DdTfkEk'
-                                b'8s","a":[]}-AADAAvVH0h_W7QuioTt0OmcRgtZSksfQ7MOTYMd4Nc14rdJ9U6j1'
-                                b'ycr06YCtuGTM-J34d0ADnG3f_0F3t3dX_lZacBQAB5LMjFgsQe_k-dxRgGcIBbEa'
-                                b'30rPKkCOCNyqnjw56vl-V7RtOlAGIJ_KsyBrF0GD5vZp1NSGsmgTM5Ww36pqQAgA'
-                                b'C077aW784R0cRErpzhndWsrbFs32lmhOdJ0QyAQ4MlKE0Li6dR20XtEoRLtGCcPo'
-                                b'i6C188Gu1TwzmYOPlUjW2Bw')
+        assert msg == bytearray(b'{"v":"KERI10JSON0000cb_","t":"ixn","d":"ErcMMcfO4fdplItWB_42GwyY'
+                                b'21u0pJkQEVDvMmrLVgFc","i":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQi'
+                                b'IaJ5L7M","s":"1","p":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQiIaJ5L'
+                                b'7M","a":[]}-AADAAye1jlp6iz6h5raVAavZEEahPQ7mUVHxegfjgZCjaWA-UcSQ'
+                                b'i5ic59-PKQ0tlEHlNHaeKIPts0lvONpW71dgOAgABHu-KLKX52wTZCwE4u_MEWrv'
+                                b'PQ8kC_XSgzQ7Mqmrhv4imCCTaoiCCH2JbebIvfOHXlmwVwntz9B89qbf7SLT8BgA'
+                                b'C5W2JKWRhhp6ZS8UQ0k_2-1-W0ZwgQAPDGDumFQ4CBTOH4srb4PVb5GCNx8Ygmpx'
+                                b'OLplnVjVkkiQjKgLrHVvOBg')
 
         # apply msg to wes's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)
@@ -116,8 +118,8 @@ def test_weighted():
                                   keys=[verfer.qb64 for verfer in verfers],
                                   sith=sith,
                                   dig=wesK.serder.saider.qb64,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                                  nsith=nxtsith,
+                                  nkeys=[diger.qb64 for diger in digers],
                                   sn=wesK.sn + 1,
                                   data=[])
 
@@ -160,8 +162,8 @@ def test_weighted():
                                   keys=[verfer.qb64 for verfer in verfers],
                                   sith=sith,
                                   dig=wesK.serder.saider.qb64,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                                  nsith=nxtsith,
+                                  nkeys=[diger.qb64 for diger in digers],
                                   sn=wesK.sn + 1,
                                   data=[])
 
@@ -174,18 +176,21 @@ def test_weighted():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == bytearray(b'{"v":"KERI10JSON0001c3_","t":"rot","d":"Ebhb0Fnink_-r0JfJQIVr15G'
-                                b'0Ew8upPjo94-cT3SzdlU","i":"EZgXYINAQWXFpxAmWI9AwOwjVOYXzjyEE_-Dd'
-                                b'TfkEk8s","s":"3","p":"EzkHD4jwDn4EGqEvQtPnt6iWj0zwDCTj8zbM6tBCGH'
-                                b'Ng","kt":["1/2","1/2","1/2"],"k":["D7WWKDLVwYxYMLAjDceIEs66xPMY4'
+        assert msg == bytearray(b'{"v":"KERI10JSON0002aa_","t":"rot","d":"EpaAOKbdwjjI7CAikCJDCr6r'
+                                b'zmN14frB_cwif4MBnsTk","i":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQi'
+                                b'IaJ5L7M","s":"3","p":"EXlVGTrAuFlYjj1o1389Vfr1SecFYKJq4J9HkjlPyV'
+                                b'qY","kt":["1/2","1/2","1/2"],"k":["D7WWKDLVwYxYMLAjDceIEs66xPMY4'
                                 b'Afzx-RQw2x0mQzI","Dmg6Aah8qyKKDiQyNXTiO71QJwizjZfGM61BA-s0A5F4",'
-                                b'"DS3fhKpvPCDL5WmfN4_PkmJMMsSCdRTxG24OQuf_EmHQ"],"n":"EcM4iw7fElX'
-                                b'Whad8V-za4Px7nBKjndxoh3XZRkohghKY","bt":"0","br":[],"ba":[],"a":'
-                                b'[]}-AADAAR0IDqMweOsLfeTDzXo6kPPjoBwAGJNRm9MuYNA07_ky8vNJ5d-0Fcln'
-                                b'yHjnJcRN26DRIjyfVh5tAzgv9PuhIBAABiB2hbNyJ6oCKNSF4akuxF4fbuwVUsCn'
-                                b'YhW9n9LjFxO8GCkcfKdeDllLkGjhMCCrTV_HI5-5SWQUvLlOGsxolAgAC9Yw0Kt_'
-                                b'uYktLvZQIBq-eGNx7kJNvKxsedaOkY-j1yrjtfyOHEwY65JsQ7dG-anckc0KfhPC'
-                                b'ld47DBRtVPSjLAQ')
+                                b'"DS3fhKpvPCDL5WmfN4_PkmJMMsSCdRTxG24OQuf_EmHQ"],"nt":[["1/2","1/'
+                                b'2","1/2"],["1/1","1/1"]],"n":["Ehru1umWyy696CK10v2ROEOv8csx-S4Kt'
+                                b'YZHF4RbV3gc","EdsEn6HJLVLrhle11lqgImN0s7BQV03CfqxYpxs0qcrg","ED2'
+                                b'DjOJWZyGUxGr_CFKA45dsmV72LvIvJWcB1xpuVGvM","EMwx5v3RMAjQ0GHdg5VR'
+                                b'7XG2-2Cg4Kgslmn2lMCJ-oYs","EHN09tKWiJl83SPiBB_KDN1TKDutErXADGnl3'
+                                b'TSx7ZLk"],"bt":"0","br":[],"ba":[],"a":[]}-AADAAHjkEbbFN_QkGinYu'
+                                b'rCnQphjMOgfDdfuIyVNgn9krq-vYuJSlwhilVWquumLiJL7oCOJmF6aFDWcKKScN'
+                                b'KiPHDgABQsjiEna5VZ7vE5ayRPswdjW2z19xRUyg4pktVGGw3yv9OvP6XUDRbvxU'
+                                b's36hndwWE6y894bVbx5XUWWe5jDnCgACMMQCX8qjNcbHik2ukkv9mV45p3wgcxhu'
+                                b'k_LMpXwt8KUT0eRwBHtnYuhFvXHYIDvaLTao4RxBg8AJhx8L-OdsDg')
 
         # apply msg to Wes's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)
@@ -204,8 +209,8 @@ def test_weighted():
                                   keys=[verfer.qb64 for verfer in verfers],
                                   sith=sith,
                                   dig=wesK.serder.saider.qb64,
-                                  nxt=coring.Nexter(sith=nxtsith,
-                                                    digs=[diger.qb64 for diger in digers]).qb64,
+                                  nsith=nxtsith,
+                                  nkeys=[diger.qb64 for diger in digers],
                                   sn=wesK.sn + 1,
                                   data=[])
 
@@ -218,22 +223,26 @@ def test_weighted():
         for siger in sigers:
             msg.extend(siger.qb64b)
 
-        assert msg == bytearray(b'{"v":"KERI10JSON000231_","t":"rot","d":"EDK-dx1__PH_ZJXeZBfxVnod'
-                                b'jUsaczSocKCNluEV6Cec","i":"EZgXYINAQWXFpxAmWI9AwOwjVOYXzjyEE_-Dd'
-                                b'TfkEk8s","s":"4","p":"Ebhb0Fnink_-r0JfJQIVr15G0Ew8upPjo94-cT3Szd'
-                                b'lU","kt":[["1/2","1/2","1/2"],["1/1","1/1"]],"k":["DToUWoemnetqJ'
+        assert msg == bytearray(b'{"v":"KERI10JSON000318_","t":"rot","d":"EL9yfne-tGwzQvcwIBAEfLUb'
+                                b'Vys6JF9ejzbd1mZmfKHc","i":"EOsgPPbBijCbpu3R9N-TMdURgcoFqrjUf3rQi'
+                                b'IaJ5L7M","s":"4","p":"EpaAOKbdwjjI7CAikCJDCr6rzmN14frB_cwif4MBns'
+                                b'Tk","kt":[["1/2","1/2","1/2"],["1/1","1/1"]],"k":["DToUWoemnetqJ'
                                 b'oLFIqDI7lxIJEfF0W7xG5ZlqAseVUQc","Drz-IZjko61q-sPMDIW6n-0NGFubbX'
                                 b'iZhzWZrO_BZ0Wc","DiGwL3hjQqiUgQlFPeA6kRR1EBXX0vSLm9b6QhPS8IkQ","'
                                 b'Dxj5pcStgZ6CbQ2YktNaj8KLE_g9YAOZF6AL9fyLcWQw","DE5zr5eH8EUVQXyAa'
-                                b'xWfQUWkGCId-QDCvvxMT77ibj2Q"],"n":"E3in3Z14va0kk4Wqd3vcCAojKNtQq'
-                                b'7ZTrQaavR8x0yu4","bt":"0","br":[],"ba":[],"a":[]}-AAFAAt2EjEPyJO'
-                                b'MqtUdrp2EaRenlwriXviQ0hJ4Wx0agCok1sU3QMFS5hRdwX_NEFca9OnKGVjOag6'
-                                b'K_F4yOs1BiuDQABN30bxBTVoemwfv6bPMqi9aIBKAuqm5IjcXFpS6vdnSdcQiz5V'
-                                b'Wb5DzpjhBztZyTiBbmxihl4tGyJ8xMTlIcmAwACq5YQaTJ45Smm2UwhyX5YLVkvx'
-                                b'eJxt9oewmGAhOxyp-_tu0KAe2mehFHa6s9BlcqE-401mQh5EcniFbdHx3eAAQADR'
-                                b'8Mtsn-7UKC-LjWq45-tKJfV8QVTaAXGiQsXye6DC7cf5iKQeUw7NXIcuxb-CXLL3'
-                                b'AIMg3ZfhYy44-wW6pq6BgAEPtQg63EnWDfhwQjqgIlAHGupkeE_2hZhEp2Lcx0m5'
-                                b'x4w0S6XqR9_Lx86RMnrzc3G9W3CJ_V5iEJhNQAqdTFqCw')
+                                b'xWfQUWkGCId-QDCvvxMT77ibj2Q"],"nt":[["1/2","1/2","1/2"],["1/1","'
+                                b'1/1"]],"n":["E3oSx8M1W9oMIqORgzoxTMtq4loSjOLs_IBYT7-IykMk","E1HU'
+                                b'bg5n7JAOr8eSimUkgKNLZGuOoPFzuif3p8uSyxyc","E4uh2oW3SCRE09y8lkOXq'
+                                b'T_bNwYyTxqi8azw2OP-USmc","ElNsZ_J-kqXAEfEqsQ_3nWXTg2v8oLHMzGbNFQ'
+                                b'yq1bM4","EAu4l6xy-_8a_jaDhftZCN8jjus7h17BJVPc8L9naTHE"],"bt":"0"'
+                                b',"br":[],"ba":[],"a":[]}-AAFAArIHrHuHj5D4H6y3lLMsFh3puF3r7iq5Loy'
+                                b'at_UBNVrlxvdsawSfw2aaUGPewlIacEU4qmXE_jfnkkYuu9ILyAAABXdCyY-Lzp_'
+                                b'erM6e75ucr69f543Z1B14siUu2VvNhmXDtg5oB7Huzk5R-pq51QwiokdEEKVnqfw'
+                                b'UkDAFS8UGeAQACQ7LP-P8pvxjNTn-WI6p4mfUVk-yw321gyzoI9L2MKHtyLBm_NL'
+                                b'86wqjXrhPHw8efeHMr7hYPf_om7YZ3RTJPDQADefKpouU2FmtypJV9QgJw4Jl7te'
+                                b'ujJU-dsXlGdfdSVTRNIjv2RmGWuL0_r3F3pU4A_5ZVuOx7WjpHqwuh7gA0CwAEeR'
+                                b'KbC2k_f7Im0HR7fqbLsaUvKMpF2Y14CYVKI-dabphSRRiB24_17hjSENPKO7t_4r'
+                                b'7UTdxAqoTWUjCb1babCA')
 
         # apply msg to Wes's Kevery
         parsing.Parser().parse(ims=bytearray(msg), kvy=wesKvy)

--- a/tests/core/test_witness.py
+++ b/tests/core/test_witness.py
@@ -4,15 +4,11 @@ tests delegation primaily from keri.core.eventing
 
 """
 import os
-import datetime
-
-import pytest
 
 from keri import help
-from keri.help import helping
-from keri.db import dbing, basing
-from keri.app import habbing, keeping, directing
+from keri.app import habbing
 from keri.core import coring, eventing, parsing
+from keri.db import dbing
 
 logger = help.ogler.getLogger()
 
@@ -137,7 +133,7 @@ def test_indexed_witness_replay():
             assert len(kvy.cues) == 1  # queued receipt cue
             hab = camWitHabs[i]
             rctMsg = hab.processCues(kvy.cues)  # process cue returns rct msg
-            assert len(rctMsg) == 617
+            assert len(rctMsg) == 626
             rctMsgs.append(rctMsg)
 
         for msg in rctMsgs:  # process rct msgs from all witnesses
@@ -233,7 +229,7 @@ def test_indexed_witness_replay():
         # Cam update Wil all event witnessed events for Cam by replay
         # Cam update itself with Wil receipts including Wils inception
         camReplayMsg = camHab.replay()
-        assert len(camReplayMsg) == 1933
+        assert len(camReplayMsg) == 2038
         parsing.Parser().parse(ims=bytearray(camReplayMsg), kvy=wilKvy)
         # wilKvy.process(ims=bytearray(camReplayMsg))
         assert camHab.pre in wilKvy.kevers
@@ -446,7 +442,7 @@ def test_nonindexed_witness_receipts():
             assert kvy.kevers[camHab.pre].sn == 0
             assert len(kvy.cues) == 1  # queued receipt cue
             rctMsg = camWitHabs[i].processCues(kvy.cues)  # process cue returns rct msg
-            assert len(rctMsg) == 617
+            assert len(rctMsg) == 626
             rctMsgs.append(rctMsg)
 
         for msg in rctMsgs:  # Cam process rct msgs from all witnesses
@@ -554,7 +550,7 @@ def test_nonindexed_witness_receipts():
         #    Cam update Wil all event witnessed events for Cam by replay
         #    Cam update itself with Wil receipts including Wils inception
         camReplayMsg = camHab.replay()
-        assert len(camReplayMsg) == 1933
+        assert len(camReplayMsg) == 2038
         parsing.Parser().parse(ims=bytearray(camReplayMsg), kvy=wilKvy)
 
         assert camHab.pre in wilKvy.kevers
@@ -663,7 +659,7 @@ def test_out_of_order_witnessed_events():
         assert wesHab.pre == "BK4OJI8JOr6oEEUMeSF_X-SbKysfwpKwW-ho5KARvH5c"
 
         bobHab = bobHby.makeHab(name='bob', isith=1, icount=1, wits=[wesHab.pre])
-        assert bobHab.pre == "EgJtvKj2tUD9K-t92Y_xkf0AGHIHwOmMqTZTy6dxrPUs"
+        assert bobHab.pre == "EfDNEAeF-UHrU7RfoEry1RHKGNlG__BsVx0qkMBoRhu0"
 
         # Create Bob's icp, pass to Wes and generate receipt.
         wesKvy = eventing.Kevery(db=wesHby.db, lax=False, local=False)

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -9,11 +9,11 @@ import os
 import lmdb
 import pytest
 from hio.base import doing
-from keri.app import habbing, keeping
+from keri.app import habbing
 from keri.core import coring, eventing
 from keri.core.coring import MtrDex
 from keri.core.coring import Serials, Versify
-from keri.core.coring import Signer, Nexter
+from keri.core.coring import Signer
 from keri.core.eventing import incept, rotate, interact, Kever
 from keri.db import basing
 from keri.db import dbing
@@ -1715,7 +1715,7 @@ def test_clean_baser():
 
         assert natHab.kever.sn == 6
         assert natHab.kever.fn == 6
-        assert natHab.kever.serder.said == 'EafakcO2q8Rz7LoXJrhTmtLu4h0wUAgcjhxKNAI0Fl_s'
+        assert natHab.kever.serder.said == 'EbjxjMV9atsoyxBVAnoe3B22Gprbu1dvYTpubyxrOfSk'
         ldig = bytes(natHab.db.getKeLast(dbing.snKey(natHab.pre, natHab.kever.sn)))
         assert ldig == natHab.kever.serder.saidb
         serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre,ldig))))
@@ -1744,7 +1744,7 @@ def test_clean_baser():
                                       dig=natHab.kever.serder.said,
                                       sn=natHab.kever.sn+1,
                                       sith=2,
-                                      nxt=natHab.kever.nexter.qb64)
+                                      nkeys=natHab.kever.nexter.digs)
             fn, dts = natHab.kever.logEvent(serder=badsrdr, first=True)
             natHab.db.states.pin(keys=natHab.pre, val=natHab.kever.state())
 
@@ -1770,7 +1770,7 @@ def test_clean_baser():
         # see if kevers dict is back to what it was before
         assert natHab.kever.sn == 6
         assert natHab.kever.fn == 6
-        assert natHab.kever.serder.said == 'EafakcO2q8Rz7LoXJrhTmtLu4h0wUAgcjhxKNAI0Fl_s'
+        assert natHab.kever.serder.said == 'EbjxjMV9atsoyxBVAnoe3B22Gprbu1dvYTpubyxrOfSk'
         assert natHab.pre in natHab.prefixes
         assert natHab.pre in natHab.kevers
 
@@ -1937,13 +1937,13 @@ def test_usebaser():
         # Event 0  Inception Transferable (nxt digest not empty) 2 0f 3 multisig
         keys = [signers[0].verfer.qb64, signers[1].verfer.qb64, signers[2].verfer.qb64]
         count = len(keys)
-        nxtkeys = [signers[3].verfer.qb64, signers[4].verfer.qb64, signers[5].verfer.qb64]
+        nxtkeys = [signers[3].verfer.qb64b, signers[4].verfer.qb64b, signers[5].verfer.qb64b]
         sith = "2"
         code = MtrDex.Blake3_256  # Blake3 digest of incepting data
         serder = incept(keys=keys,
                         code=code,
                         sith=sith,
-                        nxt=Nexter(keys=nxtkeys).qb64)
+                        nkeys=[coring.Diger(ser=key).qb64 for key in nxtkeys])
 
 
         # sign serialization
@@ -1952,13 +1952,13 @@ def test_usebaser():
         kever = Kever(serder=serder, sigers=sigers, db=db)
 
         # Event 1 Rotation Transferable
-        keys = nxtkeys
-        nxtkeys = [signers[5].verfer.qb64, signers[6].verfer.qb64, signers[7].verfer.qb64]
+        keys = [signers[3].verfer.qb64, signers[4].verfer.qb64, signers[5].verfer.qb64]
+        nxtkeys = [signers[5].verfer.qb64b, signers[6].verfer.qb64b, signers[7].verfer.qb64b]
         serder = rotate(pre=kever.prefixer.qb64,
                         keys=keys,
                         sith=sith,
                         dig=kever.serder.saider.qb64,
-                        nxt=Nexter(keys=nxtkeys).qb64,
+                        nkeys=[coring.Diger(ser=key).qb64 for key in nxtkeys],
                         sn=1)
 
         # sign serialization

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -3,20 +3,17 @@
 tests.db.dbing module
 
 """
-import os
 import logging
-import time
+import os
 
+import time
 from hio.base import doing
-from hio.help import timing
 from hio.core.tcp import clienting, serving
 
-from keri.app import habbing, keeping, directing
-from keri.db import dbing, basing
+from keri import help  # logger support
+from keri.app import habbing, directing
 from keri.core import eventing, coring
 from keri.demo import demoing
-
-from keri import help  # logger support
 
 
 def test_direct_mode_bob_eve_demo():
@@ -47,11 +44,11 @@ def test_direct_mode_bob_eve_demo():
 
     # bob inception transferable (nxt digest not empty)
     bobSerder = eventing.incept(keys=[bobSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[bobSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=bobSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     bob = bobSerder.ked["i"]
-    assert bob == 'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY'
+    assert bob == 'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw'
 
 
     # set of secrets (seeds for private keys)
@@ -74,12 +71,11 @@ def test_direct_mode_bob_eve_demo():
 
     # eve inception transferable (nxt digest not empty)
     eveSerder = eventing.incept(keys=[eveSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[eveSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=eveSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     eve = eveSerder.ked["i"]
-    assert eve == 'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
-
+    assert eve == 'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
 
     with habbing.openHby(name="eve", base="test") as eveHby, \
          habbing.openHby(name="bob", base="test") as bobHby:
@@ -94,6 +90,8 @@ def test_direct_mode_bob_eve_demo():
 
         # setup bob
         bobHab = bobHby.makeHab(name="Bob", secrecies=bobSecrecies)
+        print(bobHab.iserder.pretty())
+        print(bobSerder.pretty())
 
         assert bobHab.iserder.said == bobSerder.said
         assert bobHab.pre == bob
@@ -207,11 +205,11 @@ def test_direct_mode_sam_eve_demo():
 
     # Sam inception transferable (nxt digest not empty)
     samSerder = eventing.incept(keys=[samSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[samSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=samSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     sam = samSerder.ked["i"]
-    assert sam == 'EsZuhYAPBDnexP3SOl9YsGvWBrYkjYcRjomUYmCcLAYY'
+    assert sam == 'EdwS_D6wppLqfIp5LSgly8GTScg5OWBaa7thzEnBqHvw'
 
 
     # set of secrets (seeds for private keys)
@@ -234,14 +232,11 @@ def test_direct_mode_sam_eve_demo():
 
     # eve inception transferable (nxt digest not empty)
     eveSerder = eventing.incept(keys=[eveSigners[0].verfer.qb64],
-                                nxt=coring.Nexter(keys=[eveSigners[1].verfer.qb64]).qb64,
+                                nkeys=[coring.Diger(ser=eveSigners[1].verfer.qb64b).qb64],
                                 code=coring.MtrDex.Blake3_256)
 
     eve = eveSerder.ked["i"]
-    assert eve == 'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
-
-    #with basing.openDB(name="eve") as eveDB, keeping.openKS(name="eve") as eveKS, \
-         #basing.openDB(name="sam") as samDB, keeping.openKS(name="sam") as samKS:
+    assert eve == 'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
 
     with habbing.openHby(name="eve", base="test") as eveHby, \
          habbing.openHby(name="sam", base="test") as samHby:
@@ -558,19 +553,19 @@ def test_indirect_mode_sam_cam_wit_demo():
         # setup cam
         # cam inception transferable (nxt digest not empty)
         camSerder = eventing.incept(keys=[camSigners[0].verfer.qb64],
-                                    nxt=coring.Nexter(keys=[camSigners[1].verfer.qb64]).qb64,
+                                    nkeys=[coring.Diger(ser=camSigners[1].verfer.qb64b).qb64],
                                     code=coring.MtrDex.Blake3_256)
 
         cam = camSerder.ked["i"]
-        assert cam == 'E7pB5IKuaYh3aIWKxtexyYFhpSjDNTEGSQuxeJbWiylg'
+        assert cam == 'E0VtKUgXnnXq9EtfgKAd_l5lhyhx_Rlf0Uj1XejaNNoo'
 
         # sam inception transferable (nxt digest not empty)
         samSerder = eventing.incept(keys=[samSigners[0].verfer.qb64], wits=[wit],
-                                    nxt=coring.Nexter(keys=[samSigners[1].verfer.qb64]).qb64,
+                                    nkeys=[coring.Diger(ser=samSigners[1].verfer.qb64b).qb64],
                                     code=coring.MtrDex.Blake3_256)
 
         sam = samSerder.ked["i"]
-        assert sam == 'EU2vtu6GkN2UmI8H2_fi961IGnYcat6Hk9Di5S8GcAvs'
+        assert sam == 'Ec5GiUblxFy6Xlj77VQ0-ksleIA8FR-WThpcd4c0Y3gw'
 
         samHab = samHby.makeHab(name="Sam", wits=[wit], secrecies=samSecrecies)
         #samHab = habbing.Habitat(name='Sam',

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -70,9 +70,9 @@ def test_signature_designature():
 
         # setup habitat
         #hab = habbing.Habitat(name=name, ks=ks, db=db, temp=temp, icount=3)
-        assert hab.pre == 'EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk'
+        assert hab.pre == 'E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI'
         digest = hab.kever.serder.said
-        assert digest == 'EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk'
+        assert digest == 'E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI'
 
         # example body text
         text = (b'{"seid":"B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68","name":"wit0","dts":"'
@@ -112,8 +112,8 @@ def test_signature_designature():
                                  kind="CESR")
         header = ending.signature([signage])  # put it in a list
         assert header == ({
-            'Signature': 'indexed="?1";signer="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";ordinal="0";digest'
-                         '="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";kind="CESR";0'
+            'Signature': 'indexed="?1";signer="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";ordinal="0";digest'
+                         '="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";kind="CESR";0'
                          '="AA9ag025o3YY8TAWRQhkEDwnt5Vh1Q4O7-F2x_UcXQkWpu32OxKGmCVgw0KvyD3YGvtXUMJf8cteY8tsJku-2jAQ";1'
                          '="ABqyC_jrRNyGZ6desKYAGDxjnEAPXGypyMtT8C8EykIMm49KVadKwNF9-vOuwM7ZpFitLOd20vMZIGUW9CwPlKDQ";2'
                          '="ACcB8zH46Xwi1EyoVPaRxftt0oypIJy0POl_vLEK_RmDIlV834CC3t8tVE0GF1onO1cwo27nn8ngoFhsrqoL7oDQ"'})
@@ -164,11 +164,11 @@ def test_signature_designature():
 
         header = ending.signature(signages)
         assert header == ({
-            'Signature': 'indexed="?1";signer="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";kind="CESR";0'
+            'Signature': 'indexed="?1";signer="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";kind="CESR";0'
                          '="AA9ag025o3YY8TAWRQhkEDwnt5Vh1Q4O7-F2x_UcXQkWpu32OxKGmCVgw0KvyD3YGvtXUMJf8cteY8tsJku-2jAQ";1'
                          '="ABqyC_jrRNyGZ6desKYAGDxjnEAPXGypyMtT8C8EykIMm49KVadKwNF9-vOuwM7ZpFitLOd20vMZIGUW9CwPlKDQ";2'
                          '="ACcB8zH46Xwi1EyoVPaRxftt0oypIJy0POl_vLEK_RmDIlV834CC3t8tVE0GF1onO1cwo27nn8ngoFhsrqoL7oDQ",'
-                         'indexed="?0";signer="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";kind="CESR'
+                         'indexed="?0";signer="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";kind="CESR'
                          '";DCLZNpE1W0aZXx5JS-ocgHNPMiCtCLnu8rPDlK-bLuPA="0B9ag025o3YY8TAWRQhkEDwnt5Vh1Q4O7'
                          '-F2x_UcXQkWpu32OxKGmCVgw0KvyD3YGvtXUMJf8cteY8tsJku-2jAQ'
                          '";D0rYoWcvSNQaWa9kdGx7sfA0ZV22Qz45G9Nl8XDuYNu0'
@@ -207,12 +207,12 @@ def test_signature_designature():
 
         header = ending.signature(signages)
         assert header == ({
-            'Signature': 'indexed="?1";signer="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";kind="CESR";wit0'
+            'Signature': 'indexed="?1";signer="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";kind="CESR";wit0'
                          '="AA9ag025o3YY8TAWRQhkEDwnt5Vh1Q4O7-F2x_UcXQkWpu32OxKGmCVgw0KvyD3YGvtXUMJf8cteY8tsJku-2jAQ'
                          '";wit1="ABqyC_jrRNyGZ6desKYAGDxjnEAPXGypyMtT8C8EykIMm49KVadKwNF9'
                          '-vOuwM7ZpFitLOd20vMZIGUW9CwPlKDQ";wit2'
                          '="ACcB8zH46Xwi1EyoVPaRxftt0oypIJy0POl_vLEK_RmDIlV834CC3t8tVE0GF1onO1cwo27nn8ngoFhsrqoL7oDQ",'
-                         'indexed="?0";signer="EGgvuN8lsYvxc0OU0v-sTHXR24ibVZKN5Mf_-artOAMk";kind="CESR";wit0'
+                         'indexed="?0";signer="E7OEpshFozj2X9iNWUW6_QZ74z7UemsSAjIe3lnNYlMI";kind="CESR";wit0'
                          '="0B9ag025o3YY8TAWRQhkEDwnt5Vh1Q4O7-F2x_UcXQkWpu32OxKGmCVgw0KvyD3YGvtXUMJf8cteY8tsJku-2jAQ'
                          '";wit1="0BqyC_jrRNyGZ6desKYAGDxjnEAPXGypyMtT8C8EykIMm49KVadKwNF9'
                          '-vOuwM7ZpFitLOd20vMZIGUW9CwPlKDQ";wit2'
@@ -348,7 +348,7 @@ def test_seid_api():
         client = testing.TestClient(app=app)
 
         aid0 = hab.pre
-        assert aid0 == 'E71ij5aKAiPAlMPnj_UA2SNnJrlxEDuWvmptGw1VDvV4'
+        assert aid0 == 'EfP89RN2Kc-8lAKtecc0Fdy6EqXL8db13Xs1buu1jji4'
         wit0 = 'B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68'
         wit1 = 'Bed2Tpxc8KeCEWoq3_RKKRjU_3P-chSser9J4eAtAK6I'
         wit2 = 'BljDbmdNfb63KOpGV4mmPKwyyp3OzDsRzpNrdL1BRQts'
@@ -380,14 +380,14 @@ def test_seid_api():
                                '0="AAH-y80HeaPE4s8R265y1dCSFbE6xqbkRhWS-veWTXHZpLlE2A4P0lVGI1Ep2JMPjCRbeTylaD3QVLovzNyOV3Dg"'})
 
         endpath = "/end/{}/{}".format(aid, role)
-        assert endpath == '/end/E71ij5aKAiPAlMPnj_UA2SNnJrlxEDuWvmptGw1VDvV4/witness'
+        assert endpath == '/end/EfP89RN2Kc-8lAKtecc0Fdy6EqXL8db13Xs1buu1jji4/witness'
         rep = client.simulate_post(path=endpath,
                                    content_type=falcon.MEDIA_JSON,
                                    headers=header,
                                    body=text)  # accepts bytes
         assert rep.status == falcon.HTTP_OK
         assert rep.json == dict(aid=aid, role=role, data=data)
-        assert rep.text == ('{"aid": "E71ij5aKAiPAlMPnj_UA2SNnJrlxEDuWvmptGw1VDvV4", "role": "witness", '
+        assert rep.text == ('{"aid": "EfP89RN2Kc-8lAKtecc0Fdy6EqXL8db13Xs1buu1jji4", "role": "witness", '
                             '"data": {"seid": "B389hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68", "name": '
                             '"wit0", "dts": "2021-01-01T00:00:00.000000+00:00", "scheme": "http", "host": '
                             '"localhost", "port": 8080, "path": "/witness"}}')

--- a/tests/vc/test_handling.py
+++ b/tests/vc/test_handling.py
@@ -21,10 +21,9 @@ def test_issuing():
     assert wanSalt == '0Ad2Fubi10aGUtd2l0bmVzcw'
 
     with viring.openReg(name="red") as redPDB, \
-         habbing.openHby(name="red", base="test") as redHby, \
-         habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby, \
-         habbing.openHby(name="wan", base="test", salt=wanSalt) as wanHby:
-
+            habbing.openHby(name="red", base="test") as redHby, \
+            habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby, \
+            habbing.openHby(name="wan", base="test", salt=wanSalt) as wanHby:
         wanDoers = indirecting.setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642)
 
         limit = 1.0
@@ -34,7 +33,7 @@ def test_issuing():
         sidHab = sidHby.makeHab(name="test",
                                 wits=["BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"])
         sidPre = sidHab.pre
-        assert sidPre == "EeBZcaNdy0ZkuquN367PMj4Plg1201MSevpLREfB3Pxs"
+        assert sidPre == "EWVYH1T4J09x5RePLfVyTfno3aHzJ-YqnL9Bm0Kyx6UE"
 
         redKvy = eventing.Kevery(db=redHby.db)
 
@@ -61,20 +60,20 @@ def test_issuing():
                             subject=d,
                             status=issuer.regk)
 
-        assert creder.said == "EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzXn7ocm0lb9A"
+        assert creder.said == "EsiP8zuliRsbzqDYtf_mV-X5_bFrdF6kLwfxDmEFPpUc"
 
         issuer.issue(creder=creder)
         msg = signing.ratify(sidHab, serder=creder, pipelined=True)
-        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzX'
-                       b'n7ocm0lb9A","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
-                       b'i":"EeBZcaNdy0ZkuquN367PMj4Plg1201MSevpLREfB3Pxs","a":{"d":"Ec6X'
-                       b'brY7znoeIUhxj5Xqk6sOby9MtCcUJGHolM-a6-Vc","i":"EeBZcaNdy0ZkuquN3'
-                       b'67PMj4Plg1201MSevpLREfB3Pxs","dt":"2021-06-27T21:26:21.233257+00'
-                       b':00","LEI":"254900OPPU84GM83MG36","ri":"ETxWu1_j6teP1VYBjRerXG3S'
-                       b'91Xs2ESrLgtBPlXkrQfw"},"p":[]}-VA3-JAB6AABAAA--FABEeBZcaNdy0Zkuq'
-                       b'uN367PMj4Plg1201MSevpLREfB3Pxs0AAAAAAAAAAAAAAAAAAAAAAAEeBZcaNdy0'
-                       b'ZkuquN367PMj4Plg1201MSevpLREfB3Pxs-AABAAh8MqB8-SlX1AkYHyMIaJ54Xv'
-                       b'cUkx-daOLsnyRbbBRZ5uZdfNUP_rpidW-r4f10jEUSFccI8x1IH_DGMOl_y2Dw')
+        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EsiP8zuliRsbzqDYtf_mV-X5_bFrdF6kLw'
+                       b'fxDmEFPpUc","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
+                       b'i":"EWVYH1T4J09x5RePLfVyTfno3aHzJ-YqnL9Bm0Kyx6UE","a":{"d":"E3EX'
+                       b'dMDqLATJe0a-Oc9jT531EPvpYZNeCTrk48MovNTM","i":"EWVYH1T4J09x5RePL'
+                       b'fVyTfno3aHzJ-YqnL9Bm0Kyx6UE","dt":"2021-06-27T21:26:21.233257+00'
+                       b':00","LEI":"254900OPPU84GM83MG36","ri":"EScaN0EobGIzPq-3S05vY2Fj'
+                       b'BOeXBQ_7wTR9ChFUGUOU"},"p":[]}-VA3-JAB6AABAAA--FABEWVYH1T4J09x5R'
+                       b'ePLfVyTfno3aHzJ-YqnL9Bm0Kyx6UE0AAAAAAAAAAAAAAAAAAAAAAAEWVYH1T4J0'
+                       b'9x5RePLfVyTfno3aHzJ-YqnL9Bm0Kyx6UE-AABAAPyuL-gPw5xNHOaYU2WLEsbwX'
+                       b'1XjJejaaG9Ozz7H7pFG2PELpIo5tfgAXWRybVhjLvud7z0EpGPONQZP9U8qECg')
 
         # Create the issue credential payload
         pl = dict(
@@ -92,14 +91,14 @@ def test_issuing():
         doist.do(doers=doers)
         assert doist.tyme == limit
 
-        ser = (b'{"v":"ACDC10JSON00019e_","d":"EA8Uibg-dQsaMQvDQbMNqj2pBEW2iz6DzXn7ocm0lb9A",'
-               b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"EeBZcaNdy0ZkuquN367P'
-               b'Mj4Plg1201MSevpLREfB3Pxs","a":{"d":"Ec6XbrY7znoeIUhxj5Xqk6sOby9MtCcUJGHolM-a'
-               b'6-Vc","i":"EeBZcaNdy0ZkuquN367PMj4Plg1201MSevpLREfB3Pxs","dt":"2021-06-27T21'
-               b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"ETxWu1_j6teP1VYBjRer'
-               b'XG3S91Xs2ESrLgtBPlXkrQfw"},"p":[]}')
-        sig0 = (b'AAh8MqB8-SlX1AkYHyMIaJ54XvcUkx-daOLsnyRbbBRZ5uZdfNUP_rpidW-r4f10jEUSFccI8x1I'
-                b'H_DGMOl_y2Dw')
+        ser = (b'{"v":"ACDC10JSON00019e_","d":"EsiP8zuliRsbzqDYtf_mV-X5_bFrdF6kLwfxDmEFPpUc",'
+               b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"EWVYH1T4J09x5RePLfVy'
+               b'Tfno3aHzJ-YqnL9Bm0Kyx6UE","a":{"d":"E3EXdMDqLATJe0a-Oc9jT531EPvpYZNeCTrk48Mo'
+               b'vNTM","i":"EWVYH1T4J09x5RePLfVyTfno3aHzJ-YqnL9Bm0Kyx6UE","dt":"2021-06-27T21'
+               b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"EScaN0EobGIzPq-3S05v'
+               b'Y2FjBOeXBQ_7wTR9ChFUGUOU"},"p":[]}')
+        sig0 = (b'AAPyuL-gPw5xNHOaYU2WLEsbwX1XjJejaaG9Ozz7H7pFG2PELpIo5tfgAXWRybVhjLvud7z0EpGP'
+                b'ONQZP9U8qECg')
 
         # verify we can load serialized VC by SAID
         creder, sadsigers, sadcigars = redPDB.cloneCred(said=creder.said)
@@ -122,26 +121,25 @@ def test_proving():
     hanSalt = coring.Salter(raw=b'abcdef0123456789').qb64
     vicSalt = coring.Salter(raw=b'fedcba9876543210').qb64
 
-    #with basing.openDB(name="sid") as sidDB, \
-            #keeping.openKS(name="sid") as sidKS, \
-            #basing.openDB(name="vic") as vicDB, \
-            #keeping.openKS(name="vic") as vicKS, \
-            #basing.openDB(name="han") as hanDB, \
-            #keeping.openKS(name="han") as hanKS, \
-            #viring.openReg(name="han") as hanPDB:
+    # with basing.openDB(name="sid") as sidDB, \
+    # keeping.openKS(name="sid") as sidKS, \
+    # basing.openDB(name="vic") as vicDB, \
+    # keeping.openKS(name="vic") as vicKS, \
+    # basing.openDB(name="han") as hanDB, \
+    # keeping.openKS(name="han") as hanKS, \
+    # viring.openReg(name="han") as hanPDB:
 
     with viring.openReg(name="han") as hanPDB, \
-         habbing.openHby(name="han", base="test", salt=hanSalt) as hanHby, \
-         habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby, \
-         habbing.openHby(name="vic", base="test", salt=vicSalt) as vicHby:
-
+            habbing.openHby(name="han", base="test", salt=hanSalt) as hanHby, \
+            habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby, \
+            habbing.openHby(name="vic", base="test", salt=vicSalt) as vicHby:
         limit = 1.0
         tock = 1.0
         doist = doing.Doist(limit=limit, tock=tock)
 
         # sidHab = habbing.Habitat(ks=sidKS, db=sidDB, salt=sidSalt, temp=True)
         sidHab = sidHby.makeHab(name="test")
-        assert sidHab.pre == "EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc"
+        assert sidHab.pre == "ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc"
         sidIcpMsg = sidHab.makeOwnInception()
 
         hanKvy = eventing.Kevery(db=hanHby.db)
@@ -150,7 +148,7 @@ def test_proving():
 
         # hanHab = habbing.Habitat(ks=hanKS, db=hanDB, salt=hanSalt, temp=True)
         hanHab = hanHby.makeHab(name="test")
-        assert hanHab.pre == "EXs465M4avETtnmCD2cd02CDwE5K-1vyTnyfk15_PRPs"
+        assert hanHab.pre == "EJcjV4DalEqAtaOdlEcjNvo75HCs0lN5K3BbQwJ5kN6o"
         hanIcpMsg = hanHab.makeOwnInception()
 
         vicKvy = eventing.Kevery(db=vicHby.db)
@@ -159,7 +157,7 @@ def test_proving():
 
         # vicHab = habbing.Habitat(ks=vicKS, db=vicDB, salt=vicSalt, temp=True)
         vicHab = vicHby.makeHab(name="test")
-        assert vicHab.pre == "EvOnXBWyrNJbR4wf__Qn79YAf-u3GynE3ychvkuiGnEI"
+        assert vicHab.pre == "ET9X4cK2jPatbfYzEprxjdYLKazxZ7Rufj_jY10NC-t8"
         vicIcpMsg = vicHab.makeOwnInception()
 
         parsing.Parser().parse(ims=bytearray(vicIcpMsg), kvy=hanKvy)
@@ -183,7 +181,7 @@ def test_proving():
                             status=issuer.regk,
                             )
 
-        assert creder.said == "EkHBr-04I1Id_bXI4luPZsASLVJ4ZOsI3a5ChZgE0iug"
+        assert creder.said == "Ep47HwcVCCmW2e4kYm0BNCrK1zVfEK0TANpZEDB-q6k8"
 
         msg = signing.ratify(sidHab, serder=creder)
         hanWallet = Wallet(reger=hanPDB)
@@ -237,9 +235,9 @@ def test_proving():
         assert len(vcs) == 1
 
         proof = (
-            "-JAB6AABAAA--FABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0Mctny"
-            "-6AfglVOKnJje8-vqyKTlh0nc-AABAA6W18DO1EXT8Qeu_kaPqEQBPIlQQE_EoLDzxJb_M71EqQEC"
-            "-lA1lsW4R9lWTkj55jSvWIuTbTkXoTJVCyzKSTBA")
+            '-JAB6AABAAA--FABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc0AAAAAAAAAAAAAAAAAAAAAAAECtWlHS2Wbx5M2Rg6nm69'
+            'PCtzwb1veiRNvDpBGF9Z1Pc-AABAAof2YkuOFlbe5fTXsbjrh0lorAQcGx2mwPcXhSRnjssLIeCV2s_q7YLOYPlNyB_ICj82bpXBKOMEY'
+            'l7rU9PV3Aw')
 
         assert vcs[0]["proof"] == proof
 

--- a/tests/vc/test_proving.py
+++ b/tests/vc/test_proving.py
@@ -5,11 +5,10 @@ tests.vc.proving module
 """
 import pytest
 
-from keri.app import keeping, habbing
+from keri.app import habbing
 from keri.core import coring, scheming, parsing
-from keri.core.coring import Serials, Counter, CtrDex, Prefixer, Seqner, Diger, Siger, Vstrings
+from keri.core.coring import Serials, Counter, CtrDex, Prefixer, Seqner, Diger, Siger
 from keri.core.scheming import CacheResolver
-from keri.db import basing
 from keri.kering import Versionage
 from keri.vc.proving import Credentialer, credential
 from keri.vdr import verifying, issuing, viring
@@ -20,7 +19,7 @@ def test_proving():
 
     with habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby:
         sidHab = sidHby.makeHab(name="test", )
-        assert sidHab.pre == "EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc"
+        assert sidHab.pre == "ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc"
         sed = dict()
         sed["$id"] = ""
         sed["$schema"] = "http://json-schema.org/draft-07/schema#"
@@ -52,16 +51,16 @@ def test_proving():
                             subject=credSubject)
 
         msg = sidHab.endorse(serder=creder)
-        assert msg == (b'{"v":"ACDC10JSON000174_","d":"EEJi2IYzwRTtvYIBx8-PjlpIiLyRrT6GWw'
-                       b'GOwycuX7vM","s":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","'
-                       b'i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"E6wI'
+        assert msg == (b'{"v":"ACDC10JSON000174_","d":"ENVrGj6YRuZPpLsce03s1eb9bARz6pD19U'
+                       b'GLmhjluhyM","s":"EeCCZi1R5xHUlhsyQNm_7NrUQTEKZH5P9vBomnc9AihY","'
+                       b'i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","a":{"d":"E6wI'
                        b'oXUVrUsFm4pHAFDMbLloniDNvEWizHO8BNPwcyBA","i":"EPmpiN6bEM8EI0Mct'
                        b'ny-6AfglVOKnJje8-vqyKTlh0nc","lei":"254900OPPU84GM83MG36","issua'
-                       b'nceDate":"2021-06-27T21:26:21.233257+00:00"},"p":[]}-VA0-FABEPmp'
-                       b'iN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAA'
-                       b'EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAC2EQIRhx8mBH6a'
-                       b'zYQIFT8sokz7IBle8dZdwz_XsYh84mY3YbrasTT0pHxQ9Y2nV9UdEiM4UiunmjzB'
-                       b'ZtTvqaCA')
+                       b'nceDate":"2021-06-27T21:26:21.233257+00:00"},"p":[]}-VA0-FABECtW'
+                       b'lHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc0AAAAAAAAAAAAAAAAAAAAAAA'
+                       b'ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAKopwmWrs4gSFxY'
+                       b'6xhu6r8HYGNANGo5yfrs0ra0DkCRGJf4Cwwscj9-LB_RAVOupQwRgD3VhQ5bWJ5d'
+                       b'lwvbHIAQ')
 
         creder = Credentialer(raw=msg)
         proof = msg[creder.size:]
@@ -225,7 +224,7 @@ def test_credential():
 def test_credential_parsator():
     with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as (hby, hab), \
             viring.openReg() as reg:
-        assert hab.pre == "EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w"
+        assert hab.pre == "ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50"
 
         issuer = issuing.Issuer(hab=hab, reger=reg, noBackers=True, estOnly=True, temp=True)
 

--- a/tests/vc/test_walleting.py
+++ b/tests/vc/test_walleting.py
@@ -16,7 +16,7 @@ def test_wallet():
 
     with habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby:
         sidHab = sidHby.makeHab(name="test")
-        assert sidHab.pre == "EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc"
+        assert sidHab.pre == "ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc"
 
         schema = "EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg"
         credSubject = dict(
@@ -33,31 +33,31 @@ def test_wallet():
                             schema=schema,
                             subject=credSubject,
                             status=issuer.regk)
-        assert creder.said == "EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T9UwPhRwMBE"
+        assert creder.said == "EyKc0_j73el3U8NhgFSV79g1K7MBOriOGyNNd_gu5Usw"
 
         issuer.issue(creder=creder)
 
         msg = signing.ratify(sidHab, serder=creder)
-        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T'
-                       b'9UwPhRwMBE","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
-                       b'i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"EKEo'
-                       b'g6cZnQv8kcaWJ02670LEKGVTIMzXdXYlXRc2B3Ws","i":"EPmpiN6bEM8EI0Mct'
-                       b'ny-6AfglVOKnJje8-vqyKTlh0nc","dt":"2021-06-27T21:26:21.233257+00'
-                       b':00","LEI":"254900OPPU84GM83MG36","ri":"ERAY2VjFALVZAAuC3GDM-36q'
-                       b'KD8ZhUaKF55MWtITBFnc"},"p":[]}-JAB6AABAAA--FABEPmpiN6bEM8EI0Mctn'
-                       b'y-6AfglVOKnJje8-vqyKTlh0nc0AAAAAAAAAAAAAAAAAAAAAAAEPmpiN6bEM8EI0'
-                       b'Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAArws9pEH-d7eDwd847W2TzFrxCfuc'
-                       b'rVxPC0AsEKpdcT4oWg3chxmdxydMNndFDFqSPSOnvsetBSLz_qYdPkG6Ag')
+        assert msg == (b'{"v":"ACDC10JSON00019e_","d":"EyKc0_j73el3U8NhgFSV79g1K7MBOriOGy'
+                       b'NNd_gu5Usw","s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","'
+                       b'i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","a":{"d":"Ep8Q'
+                       b'YVg3peYovtbtg-wVsA2bwV7qYpYjt3CsLY49Kqw4","i":"ECtWlHS2Wbx5M2Rg6'
+                       b'nm69PCtzwb1veiRNvDpBGF9Z1Pc","dt":"2021-06-27T21:26:21.233257+00'
+                       b':00","LEI":"254900OPPU84GM83MG36","ri":"EAZj_M7DRVHIYEnvkCwo20w_'
+                       b'ZrjKR_ScNxHXO25Qus9s"},"p":[]}-JAB6AABAAA--FABECtWlHS2Wbx5M2Rg6n'
+                       b'm69PCtzwb1veiRNvDpBGF9Z1Pc0AAAAAAAAAAAAAAAAAAAAAAAECtWlHS2Wbx5M2'
+                       b'Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAApJuHxb31AX6fBwobpzt-0MjhPhI3'
+                       b'Ert3Sqkwi3Xym0YArZi_2VL2-Fuw4rZpJegnpGMRaQcuY0Is4G4L79cnAg')
 
-        ser = (b'{"v":"ACDC10JSON00019e_","d":"EQ7QPgGGZOKQHYCGp9Phm_EQzKHK1xMv_T9UwPhRwMBE",'
-               b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"EPmpiN6bEM8EI0Mctny-'
-               b'6AfglVOKnJje8-vqyKTlh0nc","a":{"d":"EKEog6cZnQv8kcaWJ02670LEKGVTIMzXdXYlXRc2'
-               b'B3Ws","i":"EPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc","dt":"2021-06-27T21'
-               b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"ERAY2VjFALVZAAuC3GDM'
-               b'-36qKD8ZhUaKF55MWtITBFnc"},"p":[]}')
+        ser = (b'{"v":"ACDC10JSON00019e_","d":"EyKc0_j73el3U8NhgFSV79g1K7MBOriOGyNNd_gu5Usw",'
+               b'"s":"EIZPo6FxMZvZkX-463o9Og3a2NEKEJa-E9J5BXOsdpVg","i":"ECtWlHS2Wbx5M2Rg6nm6'
+               b'9PCtzwb1veiRNvDpBGF9Z1Pc","a":{"d":"Ep8QYVg3peYovtbtg-wVsA2bwV7qYpYjt3CsLY49'
+               b'Kqw4","i":"ECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc","dt":"2021-06-27T21'
+               b':26:21.233257+00:00","LEI":"254900OPPU84GM83MG36","ri":"EAZj_M7DRVHIYEnvkCwo'
+               b'20w_ZrjKR_ScNxHXO25Qus9s"},"p":[]}')
 
-        sig0 = (b'AArws9pEH-d7eDwd847W2TzFrxCfucrVxPC0AsEKpdcT4oWg3chxmdxydMNndFDFqSPSOnvsetBS'
-                b'Lz_qYdPkG6Ag')
+        sig0 = (b'AApJuHxb31AX6fBwobpzt-0MjhPhI3Ert3Sqkwi3Xym0YArZi_2VL2-Fuw4rZpJegnpGMRaQcuY0'
+                b'Is4G4L79cnAg')
 
         parsing.Parser().parse(ims=msg, vry=verifier)
 

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -415,8 +415,8 @@ def test_tever_escrow():
                               cnfg=[],
                               code=MtrDex.Blake3_256)
         regk = vcp.pre
-        assert regk == "EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg"
-        assert vcp.said == "EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg"
+        assert regk == "EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI"
+        assert vcp.said == "EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI"
         assert vcp.ked["ii"] == hab.pre
 
         # anchor to nothing, exception expected
@@ -444,12 +444,11 @@ def test_tever_escrow():
 
         dgkey = dgKey(pre=regk, dig=vcp.said)
         vcp = reg.getTvt(dgkey)
-        assert bytes(vcp) == (
-            b'{"v":"KERI10JSON0000dc_","t":"vcp","d":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZN'
-            b'kA6zVVqg","i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","ii":"EhtDTO-ax'
-            b'8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw","s":"0","c":[],"bt":"0","b":[]}')
+        assert bytes(vcp) == (b'{"v":"KERI10JSON0000dc_","t":"vcp","d":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQP'
+                              b'hmwgZdTI","i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","ii":"Evzy4Lumz'
+                              b'atnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A","s":"0","c":[],"bt":"0","b":[]}')
         dig = reg.getTae(snKey(pre=regk, sn=0))
-        assert bytes(dig) == b'EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg'
+        assert bytes(dig) == b'EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI'
 
     # registry with backers, no signatures.  should escrow
     with basing.openDB() as db, keeping.openKS() as kpr, viring.openReg() as reg:
@@ -475,18 +474,16 @@ def test_tever_escrow():
 
         dgkey = dgKey(pre=regk, dig=vcp.said)
         vcp = reg.getTvt(dgkey)
-        assert bytes(vcp) == (
-            b'{"v":"KERI10JSON00010a_","t":"vcp","d":"E0Ms9ILpZ8GuFe8CHwXAvQLSezWO2B0xPUt7'
-            b'ZSjYeKPI","i":"E0Ms9ILpZ8GuFe8CHwXAvQLSezWO2B0xPUt7ZSjYeKPI","ii":"EhtDTO-ax'
-            b'8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw","s":"0","c":[],"bt":"1","b":["BoOcciw30'
-            b'IVQsaenKXpiyMVrjtPDW3KeD_6KFnSfoaqI"]}')
+        assert bytes(vcp) == (b'{"v":"KERI10JSON00010a_","t":"vcp","d":"EQhGx1YZPUxBsU65XCexYKt70GJJpMDmX5jd'
+                              b'908l_wzo","i":"EQhGx1YZPUxBsU65XCexYKt70GJJpMDmX5jd908l_wzo","ii":"Evzy4Lumz'
+                              b'atnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A","s":"0","c":[],"bt":"1","b":["BoOcciw30'
+                              b'IVQsaenKXpiyMVrjtPDW3KeD_6KFnSfoaqI"]}')
 
         anc = reg.getAnc(dgkey)
-        assert bytes(anc) == (
-            b'0AAAAAAAAAAAAAAAAAAAAAAQEr7va7WJFKgsve4RQn0OGezwzDVRoP9zoHJfjF7t-APQ')
+        assert bytes(anc) == b'0AAAAAAAAAAAAAAAAAAAAAAQE5YSIArcAunhL6XoOZoUaWrg41Lj8r1fQsI-LrLNADBg'
         assert reg.getTel(snKey(pre=regk, sn=0)) is None
         dig = reg.getTwe(snKey(pre=regk, sn=0))
-        assert bytes(dig) == b'E0Ms9ILpZ8GuFe8CHwXAvQLSezWO2B0xPUt7ZSjYeKPI'
+        assert bytes(dig) == b'EQhGx1YZPUxBsU65XCexYKt70GJJpMDmX5jd908l_wzo'
 
 
 def test_tever_no_backers(mockHelpingNowUTC):
@@ -518,13 +515,13 @@ def test_tever_no_backers(mockHelpingNowUTC):
 
         dgkey = dgKey(pre=regk, dig=vcp.said)
         assert bytes(reg.getTvt(dgkey)) == (
-            b'{"v":"KERI10JSON0000e0_","t":"vcp","d":"EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97p'
-            b'hizdlEnk","i":"EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk","ii":"EhtDTO-ax'
-            b'8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw","s":"0","c":["NB"],"bt":"0","b":[]}')
+            b'{"v":"KERI10JSON0000e0_","t":"vcp","d":"E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGC'
+            b'jD_Es5JY","i":"E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY","ii":"Evzy4Lumz'
+            b'atnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A","s":"0","c":["NB"],"bt":"0","b":[]}')
 
         assert bytes(reg.getAnc(dgkey)) == (
-            b'0AAAAAAAAAAAAAAAAAAAAAAQEkCsZ5u26aBvQmflS0TCLmSpRAaeAVdkf6alYf7PkKzc')
-        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk'
+            b'0AAAAAAAAAAAAAAAAAAAAAAQEi9EdKy3RpXAxMEsDmZDXid1fIxz5O5zCaGL4VnWBZuU')
+        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY'
         assert reg.getTibs(dgkey) == []
         assert reg.getTwe(snKey(pre=regk, sn=0)) is None
 
@@ -556,11 +553,11 @@ def test_tever_no_backers(mockHelpingNowUTC):
         vci = nsKey([regk, vcdig])
         dgkey = dgKey(pre=vci, dig=iss.said)
         assert bytes(reg.getTvt(dgkey)) == (
-            b'{"v":"KERI10JSON0000ed_","t":"iss","d":"E122GnEykj7MC8d2DhnhrelyuzW_jndbCWyQ'
-            b'72_XidQQ","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","s":"0","ri":"E'
-            b'kOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk","dt":"2021-01-01T00:00:00.00000'
-            b'0+00:00"}')
-        assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAAwE959gkLRP958bSrIJsdDm9UUQMiSV6GO0SnfP3VBAEyU'
+             b'{"v":"KERI10JSON0000ed_","t":"iss","d":"E4lqgH82PmHK3HVjRNSOuAwM2O2Q2nkXkQ5y'
+             b'0I45vT_8","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","s":"0","ri":"E'
+             b'_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY","dt":"2021-01-01T00:00:00.00000'
+             b'0+00:00"}')
+        assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAAwEcNpKC4Bz7xQNAwFTnfKPGDz0fzGLp-UQk1YNF4y9cLw'
 
         # revoke vc with no backers
         rev = eventing.revoke(vcdig=vcdig.decode("utf-8"), regk=regk, dig=iss.said)
@@ -575,10 +572,10 @@ def test_tever_no_backers(mockHelpingNowUTC):
         tev.update(rev, seqner=seqner, saider=diger)
         dgkey = dgKey(pre=vci, dig=rev.said)
         assert bytes(reg.getTvt(dgkey)) == (
-            b'{"v":"KERI10JSON000120_","t":"rev","d":"ERIAt8fmcGrig-gxF-rTLMpCU6emky4jhOEI'
-            b'5e4hWcb4","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","s":"1","ri":"E'
-            b'kOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk","p":"E122GnEykj7MC8d2Dhnhrelyuz'
-            b'W_jndbCWyQ72_XidQQ","dt":"2021-01-01T00:00:00.000000+00:00"}')
+             b'{"v":"KERI10JSON000120_","t":"rev","d":"EUHu2XZeFqYWGBBfWgF_SFeO3m-_9JzF67aX'
+             b'uI-R7wVI","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","s":"1","ri":"E'
+             b'_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY","p":"E4lqgH82PmHK3HVjRNSOuAwM2O'
+             b'2Q2nkXkQ5y0I45vT_8","dt":"2021-01-01T00:00:00.000000+00:00"}')
 
         # assert reg.getAnc(dgkey) == b'0AAAAAAAAAAAAAAAAAAAAABAECgc6yHeTRhsKh1M7k65feWZGCf_MG0dWoei5Q6SwgqU'
 
@@ -617,15 +614,14 @@ def test_tever_backers(mockHelpingNowUTC):
 
         dgkey = dgKey(pre=regk, dig=vcp.said)
         assert bytes(reg.getTvt(dgkey)) == (
-            b'{"v":"KERI10JSON00010a_","t":"vcp","d":"E7lLqa2iDEV27pYjU_dimgi7-yuTeP-VK2nq'
-            b'4dUgIV68","i":"E7lLqa2iDEV27pYjU_dimgi7-yuTeP-VK2nq4dUgIV68","ii":"EhtDTO-ax'
-            b'8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw","s":"0","c":[],"bt":"1","b":["B8KY1sKmg'
-            b'yjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc"]}')
-        assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAAQE5j8uXoyWjowmvyrz8D809bSmw7Z88oALuqke9pNfEuE'
-        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'E7lLqa2iDEV27pYjU_dimgi7-yuTeP-VK2nq4dUgIV68'
-        assert [bytes(tib) for tib in reg.getTibs(dgkey)] == [
-            b'AAjUNMr9N_rZXstoBimgMWAIRRahn5iG_L6gTfNE01rvzFq1Mhx3zb7JIUgGIxy5A1JkrU-Gy7Cq'
-            b'842EEWc5myBg']
+             b'{"v":"KERI10JSON00010a_","t":"vcp","d":"EzqFcON23zc1VlQhr5MfpKM4yGtVSixhQS5I'
+             b'cesHqOPI","i":"EzqFcON23zc1VlQhr5MfpKM4yGtVSixhQS5IcesHqOPI","ii":"Evzy4Lumz'
+             b'atnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A","s":"0","c":[],"bt":"1","b":["B8KY1sKmg'
+             b'yjAiUDdUBPNPyrSz_ad_Qf9yzhDNZlEKiMc"]}')
+        assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAAQEa7IUvK3pKHJDWuAHVQuu7405DX6mufvYquOANEviGXU'
+        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'EzqFcON23zc1VlQhr5MfpKM4yGtVSixhQS5IcesHqOPI'
+        assert [bytes(tib) for tib in reg.getTibs(dgkey)] == [b'AAF_-Lvkq31vu3765Cp1riy1VCCFeFMfDgOrk4DBoRxTmbg3yje19JA'
+                                                              b'gBd9GJv5YAzSN7UpIzQ_OxQcV-rnbqmDw']
         assert reg.getTwe(snKey(pre=regk, sn=0)) is None
 
         debSecret = 'AKUotEE0eAheKdDJh9QvNmSEmO_bjIav8V_GmctGpuCQ'
@@ -670,11 +666,11 @@ def test_tever_backers(mockHelpingNowUTC):
         vci = nsKey([regk, vcdig])
         dgkey = dgKey(pre=vci, dig=bis.said)
         assert bytes(reg.getTvt(dgkey)) == (
-            b'{"v":"KERI10JSON000160_","t":"bis","d":"E_eCcpAC6KgR57o0TJXzYaBc9S5aN5QEpoG0'
-            b'SC6t3fwE","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","ii":"E7lLqa2iD'
-            b'EV27pYjU_dimgi7-yuTeP-VK2nq4dUgIV68","s":"0","ra":{"i":"E7lLqa2iDEV27pYjU_di'
-            b'mgi7-yuTeP-VK2nq4dUgIV68","s":1,"d":"EXoO-Bf9qJ6wffRo6yASLsxMmCwqrgzxGph7Hpy'
-            b'7XXKg"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+             b'{"v":"KERI10JSON000160_","t":"bis","d":"E6Bye-WYEeNPuVHQv5ChRqFMIZsixfIVV7A_'
+             b'T9-I7xi8","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","ii":"EzqFcON23'
+             b'zc1VlQhr5MfpKM4yGtVSixhQS5IcesHqOPI","s":"0","ra":{"i":"EzqFcON23zc1VlQhr5Mf'
+             b'pKM4yGtVSixhQS5IcesHqOPI","s":1,"d":"EoP5JLeyqYq1sTkS7skNH0XMqpHeRkOFLrHHJW_'
+             b'R04A8"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
 
 def test_tevery():
@@ -758,7 +754,7 @@ def test_tevery_process_escrow():
         rseal = keventing.SealEvent(i=regk, s=vcp.ked["s"], d=vcp.saider.qb64)
 
         seqner = Seqner(sn=1)
-        diger = coring.Diger(qb64b=b'EkCsZ5u26aBvQmflS0TCLmSpRAaeAVdkf6alYf7PkKzc')
+        diger = coring.Diger(qb64b=b'Ei9EdKy3RpXAxMEsDmZDXid1fIxz5O5zCaGL4VnWBZuU')
 
         tvy = Tevery(reger=reg, db=db)
 

--- a/tests/vdr/test_issuing.py
+++ b/tests/vdr/test_issuing.py
@@ -22,86 +22,86 @@ def test_issuer(mockHelpingNowUTC):
         issuer = Issuer(hab=hab, name="bob", reger=reg, temp=True)
         kevt, tevt = events(issuer)
         assert kevt == (
-            b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EyvWVkV1ktMFvJxKwsSbTxaq'
-            b'JC9ppB0l37IHuSG03uEU","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
-            b'SV_sdGw","s":"1","p":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sd'
-            b'Gw","a":[{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
-            b':"0","d":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg"}]}-AABAA'
-            b'D7drxQaaOMhJtPt3DI3NgX3syAYNhAwVHKy0gsooCoZDstumF60PBPv9XQQ9T7-p'
-            b'dvU4MnDwCs0k-UhoNHYmBQ')
+             b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EHuiZ2zC5kfJlBV9wRh9pZxa'
+             b'QbJwmAhieX2odN-KuJYM","i":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dR'
+             b'GI0Br6A","s":"1","p":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br'
+             b'6A","a":[{"i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s"'
+             b':"0","d":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI"}]}-AABAA'
+             b'Ojwa_pLjlTnFDR_p0Bc5PsgW65gi0xFr1JIh49-RxBbpN28ReEPeTP_PlmAt_j-z'
+             b'93KrJkwRS9zD2rLH1cKoBA')
         assert tevt == (
-            b'{"v":"KERI10JSON0000dc_","t":"vcp","d":"EuUK4Q1-XrmsPZW44_HwGmRz'
-            b'WGzWkYbc0NZNkA6zVVqg","i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNk'
-            b'A6zVVqg","ii":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw","s"'
-            b':"0","c":[],"bt":"0","b":[]}-GAB0AAAAAAAAAAAAAAAAAAAAAAQEyvWVkV1'
-            b'ktMFvJxKwsSbTxaqJC9ppB0l37IHuSG03uEU')
+            b'{"v":"KERI10JSON0000dc_","t":"vcp","d":"EWKCDqk4W2wseV-VnW-KpzvM'
+            b'pe2Y08bChQQPhmwgZdTI","i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPh'
+            b'mwgZdTI","ii":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A","s"'
+            b':"0","c":[],"bt":"0","b":[]}-GAB0AAAAAAAAAAAAAAAAAAAAAAQEHuiZ2zC'
+            b'5kfJlBV9wRh9pZxaQbJwmAhieX2odN-KuJYM')
 
         # ensure the digest in the seal from the key event matches the transacript event digest
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg'
+        assert ser.saider.qb64 == 'EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI'
 
         res = issuer.rotate(adds=["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU"])
         tsn = issuer.tevers[issuer.regk].state()
         assert res is True
         kevt, tevt = events(issuer)
         assert kevt == (
-            b'{"v":"KERI10JSON00013a_","t":"ixn","d":"ElQ-JFNVR4I_wumyv-S6YGv7'
-            b'6eGuXjx2coApDSyCEInM","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
-            b'SV_sdGw","s":"2","p":"EyvWVkV1ktMFvJxKwsSbTxaqJC9ppB0l37IHuSG03u'
-            b'EU","a":[{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
-            b':"1","d":"EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U"}]}-AABAA'
-            b'q3hIjRYRHDBQ1ies2l-ZhH1WhO0aJqYVKz3tFJ62Hkt2si6xtD6UUjftGk0KF3iW'
-            b'05oyNhzukT7gaXJMmsm2AA')
+            b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EaK53gpNuE4qiQFxIvxcrreE'
+            b'pu2_lEt0lz3GxvCHLIaw","i":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dR'
+            b'GI0Br6A","s":"2","p":"EHuiZ2zC5kfJlBV9wRh9pZxaQbJwmAhieX2odN-KuJ'
+            b'YM","a":[{"i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s"'
+            b':"1","d":"EyN9LfEwJS4_YDDIdLqe6P_DknpF5AdojA0zTF9yo6J4"}]}-AABAA'
+            b'9ylhjYwYK9dBk1XUkP-n75WgCIzps3GfJ6nPQHK3-43GFSZXzi0l0HwwvzFpy75V'
+            b'GbAhw7L-9n8tJ78P4cGhAw')
         assert tevt == (
-            b'{"v":"KERI10JSON00010b_","t":"vrt","d":"EEOByNw2UfZgk7kqNF_JE8jU'
-            b'XDVde4V_KnODfZBmap1U","i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNk'
-            b'A6zVVqg","p":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s":'
+            b'{"v":"KERI10JSON00010b_","t":"vrt","d":"EyN9LfEwJS4_YDDIdLqe6P_D'
+            b'knpF5AdojA0zTF9yo6J4","i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPh'
+            b'mwgZdTI","p":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s":'
             b'"1","bt":"1","br":[],"ba":["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNp'
-            b'WnZU_YEU"]}-GAB0AAAAAAAAAAAAAAAAAAAAAAgElQ-JFNVR4I_wumyv-S6YGv76'
-            b'eGuXjx2coApDSyCEInM')
+            b'WnZU_YEU"]}-GAB0AAAAAAAAAAAAAAAAAAAAAAgEaK53gpNuE4qiQFxIvxcrreEp'
+            b'u2_lEt0lz3GxvCHLIaw')
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U'
+        assert ser.saider.qb64 == 'EyN9LfEwJS4_YDDIdLqe6P_DknpF5AdojA0zTF9yo6J4'
 
         creder = credential(hab=hab, regk=issuer.regk)
         issuer.issue(creder=creder)
         kevt, tevt = events(issuer)
-        assert tevt == (b'{"v":"KERI10JSON000160_","t":"bis","d":"EnUnO5Ucu7GBYJyLOmcGxug8'
-                        b'NQ7wA247m2OkzusQwNdY","i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQ'
-                        b'rmexr2M","ii":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
-                        b':"0","ra":{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s'
-                        b'":1,"d":"EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U"},"dt":"20'
-                        b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwE6GX'
-                        b'FH72iGFS8Eci4prowJBTMevUJu_qzAUl9Gdl2rP4')
-        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"E6GXFH72iGFS8Eci4prowJBT'
-                        b'MevUJu_qzAUl9Gdl2rP4","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
-                        b'SV_sdGw","s":"3","p":"ElQ-JFNVR4I_wumyv-S6YGv76eGuXjx2coApDSyCEI'
-                        b'nM","a":[{"i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQrmexr2M","s"'
-                        b':"0","d":"EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwNdY"}]}-AABAA'
-                        b'MovKqyqvUTTZEKhP9upAlslkGFK611vyonvDT5VDns5AgBGAXLveWTEfzEj0ZwLT'
-                        b'8eIBNsSdPa4TyKgiiG9QDw')
+        assert tevt == (b'{"v":"KERI10JSON000160_","t":"bis","d":"E9LBqA1-92yyBhzAVvflg5tf'
+                        b'_pBI4v0bWDcj_TX3ma1E","i":"EQPbbAIPxTwrjnaycNJn5B0pVa_qiYVCmOYgV'
+                        b'2VI9yGI","ii":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s"'
+                        b':"0","ra":{"i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s'
+                        b'":1,"d":"EyN9LfEwJS4_YDDIdLqe6P_DknpF5AdojA0zTF9yo6J4"},"dt":"20'
+                        b'21-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAAAwEv6k'
+                        b'TfdcCDLXoHIWJskfhNY-ugUJUzStnEWl-S2DuMM0')
+        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"Ev6kTfdcCDLXoHIWJskfhNY-'
+                        b'ugUJUzStnEWl-S2DuMM0","i":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dR'
+                        b'GI0Br6A","s":"3","p":"EaK53gpNuE4qiQFxIvxcrreEpu2_lEt0lz3GxvCHLI'
+                        b'aw","a":[{"i":"EQPbbAIPxTwrjnaycNJn5B0pVa_qiYVCmOYgV2VI9yGI","s"'
+                        b':"0","d":"E9LBqA1-92yyBhzAVvflg5tf_pBI4v0bWDcj_TX3ma1E"}]}-AABAA'
+                        b'1sdM4fSuuDtpZPnTmvE7NTci_bxkC2hQr_8zeu_7kgrUyosnkMx4_T4GBWlDhwzR'
+                        b'7LQ32X_dPz81J9nRS5_wDg')
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwNdY'
+        assert ser.saider.qb64 == 'E9LBqA1-92yyBhzAVvflg5tf_pBI4v0bWDcj_TX3ma1E'
 
         tsn = issuer.tevers[issuer.regk].vcState(vcpre=ser.pre)
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
-        assert tevt == (b'{"v":"KERI10JSON00015f_","t":"brv","d":"ENjTuCK2EuiNXWJ0PmiyQ6BL'
-                        b'z0DhYCBEcGEOue6VOyLc","i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQ'
-                        b'rmexr2M","s":"1","p":"EnUnO5Ucu7GBYJyLOmcGxug8NQ7wA247m2OkzusQwN'
-                        b'dY","ra":{"i":"EuUK4Q1-XrmsPZW44_HwGmRzWGzWkYbc0NZNkA6zVVqg","s"'
-                        b':1,"d":"EEOByNw2UfZgk7kqNF_JE8jUXDVde4V_KnODfZBmap1U"},"dt":"202'
-                        b'1-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAABAEIILm'
-                        b'MSBDAjPtAUb7bcqI2JxNcExTE6yRQcnDRUwA5qw')
-        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"EIILmMSBDAjPtAUb7bcqI2Jx'
-                        b'NcExTE6yRQcnDRUwA5qw","i":"EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0di'
-                        b'SV_sdGw","s":"4","p":"E6GXFH72iGFS8Eci4prowJBTMevUJu_qzAUl9Gdl2r'
-                        b'P4","a":[{"i":"EWzNx2FG2PRGSj8q6spOfKAUNY0RRIGdnDcWQrmexr2M","s"'
-                        b':"1","d":"ENjTuCK2EuiNXWJ0PmiyQ6BLz0DhYCBEcGEOue6VOyLc"}]}-AABAA'
-                        b'fbkuXoKyHvwWnofgexkzaY6dUHLiLCEeoxQTSfQrMoay3kGlSK2aifFMGLgK2-sM'
-                        b'mHRX_YjZgx4Ib8DZzLy6CQ')
+        assert tevt == (b'{"v":"KERI10JSON00015f_","t":"brv","d":"ECs2aL_9Od-cLh_4BYgqWjD9'
+                        b'oki7NlhvfWUheOGMcFHg","i":"EQPbbAIPxTwrjnaycNJn5B0pVa_qiYVCmOYgV'
+                        b'2VI9yGI","s":"1","p":"E9LBqA1-92yyBhzAVvflg5tf_pBI4v0bWDcj_TX3ma'
+                        b'1E","ra":{"i":"EWKCDqk4W2wseV-VnW-KpzvMpe2Y08bChQQPhmwgZdTI","s"'
+                        b':1,"d":"EyN9LfEwJS4_YDDIdLqe6P_DknpF5AdojA0zTF9yo6J4"},"dt":"202'
+                        b'1-01-01T00:00:00.000000+00:00"}-GAB0AAAAAAAAAAAAAAAAAAAAABAE_Vea'
+                        b'au6PP2idV-HqF-RqfTgZ4A4i_HVON_-jEgW6cU0')
+        assert kevt == (b'{"v":"KERI10JSON00013a_","t":"ixn","d":"E_Veaau6PP2idV-HqF-RqfTg'
+                        b'Z4A4i_HVON_-jEgW6cU0","i":"Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dR'
+                        b'GI0Br6A","s":"4","p":"Ev6kTfdcCDLXoHIWJskfhNY-ugUJUzStnEWl-S2DuM'
+                        b'M0","a":[{"i":"EQPbbAIPxTwrjnaycNJn5B0pVa_qiYVCmOYgV2VI9yGI","s"'
+                        b':"1","d":"ECs2aL_9Od-cLh_4BYgqWjD9oki7NlhvfWUheOGMcFHg"}]}-AABAA'
+                        b'qTPSn0wsf6LTmdbTXvnaxNdvsydNd4IR-G-Ne6YUSBPT7_DEEAElGgzI2zNO2dtj'
+                        b'yr5DeV9fwXnAPwV77e7wDQ')
         ser = Serder(raw=tevt)
-        assert ser.saider.qb64 == 'ENjTuCK2EuiNXWJ0PmiyQ6BLz0DhYCBEcGEOue6VOyLc'
+        assert ser.saider.qb64 == 'ECs2aL_9Od-cLh_4BYgqWjD9oki7NlhvfWUheOGMcFHg'
 
         with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
             hby, hab = buildHab(db, kpr)
@@ -110,19 +110,19 @@ def test_issuer(mockHelpingNowUTC):
             kevt, tevt = events(issuer)
 
             ser = Serder(raw=tevt)
-            assert ser.pre == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+            assert ser.pre == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
             assert ser.ked["t"] == "vcp"
             assert ser.ked["c"] == ["NB"]
             assert ser.ked["b"] == []
             assert ser.ked["bt"] == "0"
 
             ser = Serder(raw=kevt)
-            assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+            assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
             assert ser.ked["t"] == "ixn"
             seal = ser.ked["a"][0]
-            assert seal["i"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+            assert seal["i"] == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
             assert seal["s"] == "0"
-            assert seal["d"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+            assert seal["d"] == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
 
             with pytest.raises(ValueError):
                 issuer.rotate(adds=["EqoNZAX5Lu8RuHzwwyn5tCZTe-mDBq5zusCrRo5TDugs"])
@@ -137,33 +137,33 @@ def test_issuer(mockHelpingNowUTC):
             issuer.issue(creder=creder)
             kevt, tevt = events(issuer)
             ser = Serder(raw=tevt)
-            assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
-            assert ser.ked["ri"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+            assert ser.pre == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
+            assert ser.ked["ri"] == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
             assert ser.ked["t"] == "iss"
 
             ser = Serder(raw=kevt)
-            assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+            assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
             assert ser.ked["t"] == "ixn"
             seal = ser.ked["a"][0]
-            assert seal["i"] == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
+            assert seal["i"] == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
             assert seal["s"] == "0"
-            assert seal["d"] == 'E2IiG6Bt4Z4dSLKRcp6tTpdS4kNZq0QAEWu0Au4EdnUg'
+            assert seal["d"] == 'EXushvyjVgQgBOiWETWY_ci528w5yWBwPdy35eB-D6yU'
 
             issuer.revoke(creder=creder)
             kevt, tevt = events(issuer)
 
             ser = Serder(raw=tevt)
-            assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
+            assert ser.pre == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
             assert ser.ked["t"] == "rev"
-            assert ser.ked["ri"] == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+            assert ser.ked["ri"] == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
 
             ser = Serder(raw=kevt)
-            assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+            assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
             assert ser.ked["t"] == "ixn"
             seal = ser.ked["a"][0]
-            assert seal["i"] == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
+            assert seal["i"] == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
             assert seal["s"] == "1"
-            assert seal["d"] == 'E6wRBgyoP-Gq0_VR6s8QWos-cTKyhAbfJlkcoHkWaZDU'
+            assert seal["d"] == 'EY6zcYqOwQCCyAMZ2XPDFWlkKGkzVO8OnanLGnGv3Pr4'
 
     with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
         hby, hab = buildHab(db, kpr)
@@ -173,32 +173,32 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert ser.pre == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert ser.ked["t"] == "vcp"
         assert ser.ked["b"] == ["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU"]
         assert ser.ked["bt"] == "1"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert seal["i"] == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
 
         creder = credential(hab=hab, regk=issuer.regk)
         issuer.issue(creder=creder)
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert ser.pre == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert ser.ked["t"] == "bis"
         seal = ser.ked["ra"]
-        assert seal["i"] == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert seal["i"] == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert seal["i"] == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert seal["s"] == "0"
 
         issuer.rotate(adds=["B9DfgIp33muOuCI0L8db_TldMJXv892UmW8yfpUuKzkw",
@@ -207,33 +207,33 @@ def test_issuer(mockHelpingNowUTC):
 
         vrtser = Serder(raw=tevt)
         ser = Serder(raw=tevt)
-        assert ser.pre == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert ser.pre == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert ser.ked["t"] == "vrt"
         assert ser.ked["ba"] == ["B9DfgIp33muOuCI0L8db_TldMJXv892UmW8yfpUuKzkw",
                                  "BBC_BBLMeVwKFbfYSWU7aATS9itLSrGtIFQzCkfoKnjk"]
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert seal["i"] == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert seal["s"] == "1"
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert ser.pre == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert ser.ked["t"] == "brv"
         seal = ser.ked["ra"]
         # ensure the ra seal digest matches the vrt event digest
         assert seal["d"] == vrtser.saider.qb64
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "ixn"
         seal = ser.ked["a"][0]
-        assert seal["i"] == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert seal["i"] == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert seal["s"] == "1"
 
     with basing.openDB(name="bob") as db, keeping.openKS(name="bob") as kpr, viring.openReg() as reg:
@@ -244,38 +244,38 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "EkOHsPmFEtpOByvqk1r7FYBbi54kTeWNo97phizdlEnk"
+        assert ser.pre == "E_WBd2MgZlm36iyhmzMjNFWd_Xv6WsrybkGCjD_Es5JY"
         assert ser.ked["t"] == "vcp"
         assert ser.ked["c"] == ["NB"]
         assert ser.ked["bt"] == "0"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
         assert ser.ked["k"] == ["DKPE5eeJRzkRTMOoRGVd2m18o8fLqM2j9kaxLhV3x8AQ"]
-        assert ser.ked["n"] == "ELqHYQwWR0h2vP1_cxTsutU0wKJ_NrwBVKJCgPgWGgwc"
+        assert ser.ked["n"] == ['E-JoB6yM-Q9xRnC5Kn1_Pq68_O3um8FKQsZGzWAA1J4A']
 
         creder = credential(hab=hab, regk=issuer.regk)
         issuer.issue(creder=creder)
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
+        assert ser.pre == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
         assert ser.ked["t"] == "iss"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "Ez9cZdIoqLoQeOV-4XVb1JzI67NE-BC4j6Wmw2UX6Ajo"
+        assert ser.pre == "EoU5YLpjnfkWtPepbLoWQnkpT_st_MyPszLj_PxPJbiw"
         assert ser.ked["t"] == "rev"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
 
         with pytest.raises(ValueError):
@@ -290,9 +290,9 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert ser.pre == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert ser.ked["b"] == ["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU"]
-        assert ser.saider.qb64 == 'E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY'
+        assert ser.saider.qb64 == 'EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI'
         ser = Serder(raw=kevt)
         assert ser.ked["t"] == "rot"
 
@@ -302,14 +302,14 @@ def test_issuer(mockHelpingNowUTC):
 
         vrtser = Serder(raw=tevt)
         ser = Serder(raw=tevt)
-        assert ser.pre == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert ser.pre == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert ser.ked["t"] == "vrt"
         assert issuer.backers == ["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU",
                                   "B9DfgIp33muOuCI0L8db_TldMJXv892UmW8yfpUuKzkw",
                                   "BBC_BBLMeVwKFbfYSWU7aATS9itLSrGtIFQzCkfoKnjk"]
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
 
         creder = credential(hab=hab, regk=issuer.regk)
@@ -317,37 +317,37 @@ def test_issuer(mockHelpingNowUTC):
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert ser.pre == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert ser.ked["t"] == "bis"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
-        assert vrtser.saider.qb64 == 'EO4rxeZq_ZyfiYYaTKPi6LnwQ_EpLveZVT1d21a1Vlmw'
+        assert vrtser.saider.qb64 == 'EN1kFSB7XmRMp2TUFocy4NrJqqyUq38u_D8RfIo1bt0M'
 
         # rotate to no backers
         issuer.rotate(toad=2, cuts=["BwFbQvUaS4EirvZVPUav7R_KDHB8AKmSfXNpWnZU_YEU"])
         kevt, tevt = events(issuer)
 
         ser = Serder(raw=tevt)
-        assert ser.pre == "E7-tHhxEGQXtCOBKtKBAgaIjxUwAVp1JUuRiHZo3DAYY"
+        assert ser.pre == "EnDHbU-5I_3HMw8vXxLpoyXOKRcBTtoJb5QEfEovYnVI"
         assert ser.ked["t"] == "vrt"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
         vrtser = Serder(raw=tevt)
 
         issuer.revoke(creder=creder)
         kevt, tevt = events(issuer)
         ser = Serder(raw=tevt)
-        assert ser.pre == "E2s36o2exwLINJUGQyWN8jW8BgV-Fs-myTVNFQ0dIFFk"
+        assert ser.pre == "Ewr0AFofqVDZH6QXUJJuZVs263zRunNRVGTOdJj0hHL8"
         assert ser.ked["t"] == "brv"
 
         ser = Serder(raw=kevt)
-        assert ser.pre == "EhtDTO-ax8fziNSVsgTkQ9JRPsN4LAft2v0diSV_sdGw"
+        assert ser.pre == "Evzy4LumzatnQ1GB1LpIinFlqxzksir-EZ7dRGI0Br6A"
         assert ser.ked["t"] == "rot"
-        assert vrtser.saider.qb64 == 'EAUQwLvElrZD_j0e4Q6ovn50tzRrFknV7Rxbx5D1H_YE'
+        assert vrtser.saider.qb64 == 'E24XmL_Cie-NK_uPYKaZ0_HwAmwtNYLhnaHm9XbmLzdc'
 
     """ End Test """
 

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -1,8 +1,7 @@
-from keri.app import habbing, keeping
+from keri.app import habbing
 from keri.core import routing, parsing, coring
 from keri.core.eventing import Kevery
 
-from keri.db import basing
 from keri.vc import proving
 from keri.vdr import viring, issuing, eventing
 
@@ -15,12 +14,12 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC):
          habbing.openHby(name="bam", base="test") as bamHby:
 
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1,)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         reger = viring.Registry(name=bobHab.name, temp=True)
         issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
 
-        assert issuer.regk == "E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU"
+        assert issuer.regk == "ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4"
 
         # Gather up Bob's key event log
         msgs = bytearray()
@@ -36,10 +35,10 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC):
         tever = issuer.tevers[issuer.regk]
         tsn = tever.state()
 
-        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU",'
-                           b'"s":"0","d":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ii":"Et78eYkh8A3'
-                           b'H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8","dt":"2021-01-01T00:00:00.000000+00:00","'
-                           b'et":"vcp","a":{"s":1,"d":"E-H2udL7vQADRbeDID2ApJ8NKyQx-c7TUpCe7Oxriax8"},"bt'
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4",'
+                           b'"s":"0","d":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4","ii":"E7YbTIkWWyN'
+                           b'wOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EmNGNnOvmExjtktt8BOYdl4VImanADfUl1iRHlpVwgu8"},"bt'
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         rpy = bobHab.reply(route="/tsn/registry/" + bobHab.pre, data=tsn.ked)
@@ -55,7 +54,7 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC):
         assert cue['q']['ri'] == issuer.regk
 
         saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, bobHab.pre))
-        assert saider[0].qb64b == b'EkuNMOhl1lMQXbp4V7rNHAMhp4NGy4k1tlg4bXzD_m4c'
+        assert saider[0].qb64b == b'E9KUzPJ-8ajXljg7GX0e2JWzO0GYqHvb0eraRokvSG68'
 
         tmsgs = bytearray()
         cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
@@ -70,7 +69,7 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC):
         assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, bobHab.pre)) == []
         # check to make sure the tsn has been saved
         saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, bobHab.pre))
-        assert saider.qb64b == b'E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU'
+        assert saider.qb64b == b'ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4'
 
 
 def test_tsn_message_missing_anchor(mockHelpingNowUTC):
@@ -80,12 +79,12 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC):
          habbing.openHby(name="bam", base="test") as bamHby:
 
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1,)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         reger = viring.Registry(name=bobHab.name, temp=True)
         issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
 
-        assert issuer.regk == "E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU"
+        assert issuer.regk == "ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4"
 
         # pass key event log to Bam
         bamRtr = routing.Router()
@@ -95,10 +94,10 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC):
         tever = issuer.tevers[issuer.regk]
         tsn = tever.state()
 
-        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU",'
-                           b'"s":"0","d":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ii":"Et78eYkh8A3'
-                           b'H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8","dt":"2021-01-01T00:00:00.000000+00:00","'
-                           b'et":"vcp","a":{"s":1,"d":"E-H2udL7vQADRbeDID2ApJ8NKyQx-c7TUpCe7Oxriax8"},"bt'
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4",'
+                           b'"s":"0","d":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4","ii":"E7YbTIkWWyN'
+                           b'wOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EmNGNnOvmExjtktt8BOYdl4VImanADfUl1iRHlpVwgu8"},"bt'
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         rpy = bobHab.reply(route="/tsn/registry/" + bobHab.pre, data=tsn.ked)
@@ -109,7 +108,7 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC):
         parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
 
         saider = bamReger.txnsb.escrowdb.get(keys=("registry-mae", issuer.regk, bobHab.pre))
-        assert saider[0].qb64b == b'EkuNMOhl1lMQXbp4V7rNHAMhp4NGy4k1tlg4bXzD_m4c'
+        assert saider[0].qb64b == b'E9KUzPJ-8ajXljg7GX0e2JWzO0GYqHvb0eraRokvSG68'
         assert len(bamTvy.cues) == 1
         cue = bamTvy.cues.popleft()
         assert cue["kin"] == "query"
@@ -130,7 +129,7 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC):
         assert cue['q']['ri'] == issuer.regk
 
         saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, bobHab.pre))
-        assert saider[0].qb64b == b'EkuNMOhl1lMQXbp4V7rNHAMhp4NGy4k1tlg4bXzD_m4c'
+        assert saider[0].qb64b == b'E9KUzPJ-8ajXljg7GX0e2JWzO0GYqHvb0eraRokvSG68'
 
         tmsgs = bytearray()
         cloner = reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
@@ -146,7 +145,7 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC):
         assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, bobHab.pre)) == []
         # check to make sure the tsn has been saved
         saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, bobHab.pre))
-        assert saider.qb64b == b'E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU'
+        assert saider.qb64b == b'ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4'
 
 
 def test_tsn_from_witness(mockHelpingNowUTC):
@@ -167,12 +166,12 @@ def test_tsn_from_witness(mockHelpingNowUTC):
         assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
 
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1, wits=[wesHab.pre])
-        assert bobHab.pre == "ECJTKtR-GlybCmn1PCiVwIuGBjaOUXI09XWDdXkrJNj0"
+        assert bobHab.pre == "EGaV8sWx4qxaWgad0Teaj0VZLlblc8vFMpMUR1WhfYBs"
 
         reger = viring.Registry(name=bobHab.name, temp=True)
         issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
 
-        assert issuer.regk == "E83bZ5DV-FSe8WeldHfVBGmvJ1LBnV8RBXUyNzrTClZ8"
+        assert issuer.regk == "Em4Y6cd1oLJAfVnwtFWFHjoJl7M2mlNCMZGiy_8miPEY"
 
         # Create Bob's icp, pass to Wes.
         wesKvy = Kevery(db=wesHby.db, lax=False, local=False)
@@ -201,10 +200,10 @@ def test_tsn_from_witness(mockHelpingNowUTC):
         tever = wesReger.tevers[issuer.regk]
         tsn = tever.state()
 
-        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"E83bZ5DV-FSe8WeldHfVBGmvJ1LBnV8RBXUyNzrTClZ8",'
-                           b'"s":"0","d":"E83bZ5DV-FSe8WeldHfVBGmvJ1LBnV8RBXUyNzrTClZ8","ii":"ECJTKtR-Gly'
-                           b'bCmn1PCiVwIuGBjaOUXI09XWDdXkrJNj0","dt":"2021-01-01T00:00:00.000000+00:00","'
-                           b'et":"vcp","a":{"s":1,"d":"Ensje9wtQ6Pa5ed1QmYxrXMb9lFUnLy09nKHdcTioSdg"},"bt'
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"Em4Y6cd1oLJAfVnwtFWFHjoJl7M2mlNCMZGiy_8miPEY",'
+                           b'"s":"0","d":"Em4Y6cd1oLJAfVnwtFWFHjoJl7M2mlNCMZGiy_8miPEY","ii":"EGaV8sWx4qx'
+                           b'aWgad0Teaj0VZLlblc8vFMpMUR1WhfYBs","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EEF4A-_pz7m8zpRsCsfhdt6b9KzDf7y6V6uXPDDXgqr0"},"bt'
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         rpy = wesHab.reply(route="/tsn/registry/" + wesHab.pre, data=tsn.ked)
@@ -218,7 +217,7 @@ def test_tsn_from_witness(mockHelpingNowUTC):
         parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
 
         saider = bamReger.txnsb.escrowdb.get(keys=("registry-mae", issuer.regk, wesHab.pre))
-        assert saider[0].qb64b == b'Ee7FzyMw4Ys4NACg7Luv9p-wYHf9kfY-qwqayrd_Faqo'
+        assert saider[0].qb64b == b'EWa-XE_jF8gM26nPBMlAZF55w6QU47_OWE2S-OjgmUWs'
         assert len(bamTvy.cues) == 1
         cue = bamTvy.cues.popleft()
         assert cue["kin"] == "query"
@@ -243,7 +242,7 @@ def test_tsn_from_witness(mockHelpingNowUTC):
         assert cue['q']['ri'] == issuer.regk
 
         saider = bamReger.txnsb.escrowdb.get(keys=("registry-ooo", issuer.regk, wesHab.pre))
-        assert saider[0].qb64b == b'Ee7FzyMw4Ys4NACg7Luv9p-wYHf9kfY-qwqayrd_Faqo'
+        assert saider[0].qb64b == b'EWa-XE_jF8gM26nPBMlAZF55w6QU47_OWE2S-OjgmUWs'
 
         parsing.Parser().parse(ims=bytearray(tmsgs), tvy=bamTvy, rvy=bamRvy)
 
@@ -255,7 +254,7 @@ def test_tsn_from_witness(mockHelpingNowUTC):
         assert bamReger.txnsb.escrowdb.get(keys=(issuer.regk, wesHab.pre)) == []
         # check to make sure the tsn has been saved
         saider = bamReger.txnsb.saiderdb.get(keys=(issuer.regk, wesHab.pre))
-        assert saider.qb64b == b'E83bZ5DV-FSe8WeldHfVBGmvJ1LBnV8RBXUyNzrTClZ8'
+        assert saider.qb64b == b'Em4Y6cd1oLJAfVnwtFWFHjoJl7M2mlNCMZGiy_8miPEY'
 
 
 def test_tsn_from_no_one(mockHelpingNowUTC):
@@ -276,12 +275,12 @@ def test_tsn_from_no_one(mockHelpingNowUTC):
         assert wesHab.pre == "BFUOWBaJz-sB_6b-_u_P9W8hgBQ8Su9mAtN9cY2sVGiY"
 
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         reger = viring.Registry(name=bobHab.name, temp=True)
         issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
 
-        assert issuer.regk == "E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU"
+        assert issuer.regk == "ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4"
 
         # Create Bob's icp, pass to Wes.
         wesKvy = Kevery(db=wesHby.db, lax=False, local=False)
@@ -308,10 +307,10 @@ def test_tsn_from_no_one(mockHelpingNowUTC):
         tever = wesReger.tevers[issuer.regk]
         tsn = tever.state()
 
-        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU",'
-                           b'"s":"0","d":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ii":"Et78eYkh8A3'
-                           b'H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8","dt":"2021-01-01T00:00:00.000000+00:00","'
-                           b'et":"vcp","a":{"s":1,"d":"E-H2udL7vQADRbeDID2ApJ8NKyQx-c7TUpCe7Oxriax8"},"bt'
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4",'
+                           b'"s":"0","d":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4","ii":"E7YbTIkWWyN'
+                           b'wOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EmNGNnOvmExjtktt8BOYdl4VImanADfUl1iRHlpVwgu8"},"bt'
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         rpy = wesHab.reply(route="/tsn/registry/" + wesHab.pre, data=tsn.ked)
@@ -345,17 +344,16 @@ def test_credential_tsn_message(mockHelpingNowUTC):
     # Bob is the controller
     # Bam is verifying the key state for Bob with a stale key state in the way
 
-
     with habbing.openHby(name="bob", base="test") as bobHby, \
          habbing.openHby(name="bam", base="test") as bamHby:
 
         bobHab = bobHby.makeHab(name="bob", isith=1, icount=1,)
-        assert bobHab.pre == "Et78eYkh8A3H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8"
+        assert bobHab.pre == "E7YbTIkWWyNwOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0"
 
         reger = viring.Registry(name=bobHab.name, temp=True)
         issuer = issuing.Issuer(hab=bobHab, name=bobHab.name, reger=reger, noBackers=True, )
 
-        assert issuer.regk == "E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU"
+        assert issuer.regk == "ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4"
         assert len(issuer.cues) == 2
 
         # pass key event log to Bam
@@ -379,17 +377,17 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         tever = issuer.tevers[issuer.regk]
         tsn = tever.state()
 
-        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU",'
-                           b'"s":"0","d":"E_dyu0_yRduOU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ii":"Et78eYkh8A3'
-                           b'H9w6Q87EC5OcijiVEJT8KyNtEGdpPVWV8","dt":"2021-01-01T00:00:00.000000+00:00","'
-                           b'et":"vcp","a":{"s":1,"d":"E-H2udL7vQADRbeDID2ApJ8NKyQx-c7TUpCe7Oxriax8"},"bt'
+        assert tsn.raw == (b'{"v":"KERI10JSON000158_","i":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4",'
+                           b'"s":"0","d":"ENMQx5zunE2R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4","ii":"E7YbTIkWWyN'
+                           b'wOxZQTTnrs6qn8jFbu2A8zftQ33JYQFQ0","dt":"2021-01-01T00:00:00.000000+00:00","'
+                           b'et":"vcp","a":{"s":1,"d":"EmNGNnOvmExjtktt8BOYdl4VImanADfUl1iRHlpVwgu8"},"bt'
                            b'":"0","br":[],"ba":[],"b":[],"c":["NB"]}')
 
         ctsn = tever.vcState(vcpre=creder.said)
-        assert ctsn.raw == (b'{"v":"KERI10JSON000135_","i":"EU6Ihd0np3JU0p6HOiXkVMGpARyBjqZNeIIvKh_HYAPA",'
-                            b'"s":"0","d":"E1BchG9O1F4wCljhb62mfHVEe0VhLEw9ZH1iCyllH9zk","ri":"E_dyu0_yRdu'
-                            b'OU-KjhNvgCCmvBwoCPjdXozcvfglcrUvU","ra":{},"a":{"s":2,"d":"Ea05BQyfxAffAqq5n'
-                            b'5QR_eIHnCPyetHcz7vsIQqYI1T8"},"dt":"2021-01-01T00:00:00.000000+00:00","et":"'
+        assert ctsn.raw == (b'{"v":"KERI10JSON000135_","i":"EP_naalE6Jakf54yIHC7NNke_ySHqgIJOWxi-0cAY-V0",'
+                            b'"s":"0","d":"EijkKUqTvXqPv9JUsfSiADogSHnOSn_xtr_7tR9PeA38","ri":"ENMQx5zunE2'
+                            b'R4KG7NYUnNpMPRxMHJWwasV173b1n3NC4","ra":{},"a":{"s":2,"d":"EXETzzd9sSGjWdFnX'
+                            b'eMqUcsWAE7lHIHTfxoAZmnsq1Hg"},"dt":"2021-01-01T00:00:00.000000+00:00","et":"'
                             b'iss"}')
 
         rpy = bobHab.reply(route="/tsn/credential/" + bobHab.pre, data=ctsn.ked)
@@ -400,7 +398,7 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         parsing.Parser().parse(ims=bytearray(rpy), tvy=bamTvy, rvy=bamRvy)
 
         saider = bamReger.txnsb.escrowdb.get(keys=("credential-mre", creder.said, bobHab.pre))
-        assert saider[0].qb64b == b'EGqcQtozQ2FoVNJ5ytNQ6VWaVlCLgPr7lslb_7oiz9aI'
+        assert saider[0].qb64b == b'EQ-6RPvuIWvJMpS9Fsugdt3j2Az5iOAwqgjn7rR5eX4k'
         assert len(bamTvy.cues) == 1
         cue = bamTvy.cues.popleft()
         assert cue["kin"] == "telquery"
@@ -429,7 +427,7 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         assert cue['q']['ri'] == issuer.regk
 
         saider = bamReger.txnsb.escrowdb.get(keys=("credential-ooo", creder.said, bobHab.pre))
-        assert saider[0].qb64b == b'EGqcQtozQ2FoVNJ5ytNQ6VWaVlCLgPr7lslb_7oiz9aI'
+        assert saider[0].qb64b == b'EQ-6RPvuIWvJMpS9Fsugdt3j2Az5iOAwqgjn7rR5eX4k'
 
         vci = viring.nsKey([issuer.regk, creder.said])
         tmsgs = bytearray()
@@ -445,4 +443,4 @@ def test_credential_tsn_message(mockHelpingNowUTC):
         assert bamReger.txnsb.escrowdb.get(keys=(creder.said, bobHab.pre)) == []
         # check to make sure the tsn has been saved
         saider = bamReger.txnsb.saiderdb.get(keys=(creder.said, bobHab.pre))
-        assert saider.qb64b == b'E1BchG9O1F4wCljhb62mfHVEe0VhLEw9ZH1iCyllH9zk'
+        assert saider.qb64b == b'EijkKUqTvXqPv9JUsfSiADogSHnOSn_xtr_7tR9PeA38'

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -26,20 +26,20 @@ def test_verifier_query(mockHelpingNowUTC):
         msg = verfer.query(hab.pre, issuer.regk,
                            "Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4",
                            route="tels")
-        assert msg == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"Efp5Surn_KGO6S4G6ZnExhK8'
-                       b'3kCEIpVQA3QihDyeHG-Y","dt":"2021-01-01T00:00:00.000000+00:00","r'
+        assert msg == (b'{"v":"KERI10JSON0000fe_","t":"qry","d":"EdaoDw0LOorX185H3Mu8O8OZ'
+                       b'3rSHcuZn75AjFwhwgpUA","dt":"2021-01-01T00:00:00.000000+00:00","r'
                        b'":"tels","rr":"","q":{"i":"Eb8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-g'
-                       b'KXqgcX4","ri":"ERAY2VjFALVZAAuC3GDM-36qKD8ZhUaKF55MWtITBFnc"}}-V'
-                       b'Aj-HABEPmpiN6bEM8EI0Mctny-6AfglVOKnJje8-vqyKTlh0nc-AABAAfmxUPkuS'
-                       b'zu50ixd9C5NwXzI7Dm2IdtD_PKExpzz0CQRwa9d3fvuWG-iQKiPxPCMCDEOmDwx9'
-                       b'iBO55UL94q0CAQ')
+                       b'KXqgcX4","ri":"EAZj_M7DRVHIYEnvkCwo20w_ZrjKR_ScNxHXO25Qus9s"}}-V'
+                       b'Aj-HABECtWlHS2Wbx5M2Rg6nm69PCtzwb1veiRNvDpBGF9Z1Pc-AABAAktrAj01P'
+                       b'kZlEtu7VPC076cyCvlhXdL9gYcf5pcih5ehlV73947Qp0ZeyP8J3HjFc3KFI0Iwh'
+                       b'dvBVkQnHkFLlBw')
 
 
 def test_verifier():
     with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as (hby, hab), \
             habbing.openHab(name="recp", transferable=True, temp=True) as (recpHby, recp), \
             viring.openReg(temp=True) as reger:
-        assert hab.pre == "EtjehgJ3LiIcPUKIQy28zge56_B2lzdGGLwLpuRBkZ8w"
+        assert hab.pre == "ErO8qhYftaJsAbCb6HUrN4tUyrV9dMd2VEt7SdG0wh50"
 
         issuer = issuing.Issuer(hab=hab, reger=reger, noBackers=True, estOnly=True, temp=True)
         verifier = verifying.Verifier(hby=hby, reger=reger)
@@ -292,10 +292,10 @@ def test_verifier_chained_credential():
             viring.openReg(temp=True, name="ian") as ianreg, \
             viring.openReg(temp=True, name="vic") as vicreg:
 
-        assert ron.pre == "EoovZ8CJiavhb1hpjcmCjUUPglFR3AdRA9VUhXu-Px_4"
-        assert ian.pre == "EbgpwKmMagky9SvCGXrcsT0-YlbPnmAXqRSK1an7IzvI"
-        assert han.pre == "EmQqEDpWMGGt-zmXxe7vEbyWIZOm4XwUU0J177rUMhRw"
-        assert vic.pre == "E-1sk6rrObrEjysK7gsfbNyr4V4qFJsnrFiU5EDBO2Vo"
+        assert ron.pre == "EkaWvr-o2ktpq6nIYL-KlCd_hfVkhIxVRfBOOjETday8"
+        assert ian.pre == "EHcaV00uLjd7zXDt_FnH-gCNYG-HC2D2R1GsHDt6-eoc"
+        assert han.pre == "ErqUTGqxVQzG3oYuyKVi2zKQvtUqHHMz3t_BaMt9nbPo"
+        assert vic.pre == "EI4-27_xnAB2I7LXgIjKUl8APR4iZV_LY64Am5TyBilE"
 
         roniss = issuing.Issuer(hab=ron, reger=ronreg, noBackers=True, estOnly=True, temp=True)
         ronverfer = verifying.Verifier(hby=ronHby, reger=ronreg)


### PR DESCRIPTION
This PR includes:

* Partial rotation support added with support for weighted thresholds.

* New format for next and next threshold in est events in support of partial rotation.

* `n` field becomes an array of hash commitments to next public keys and `nt` becomes the next threshold.  `n` as an XOR digest has been removed.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>