### PR TITLE
removed "expose", exp, message. Replaced now with pair of messages

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -52,11 +52,11 @@ bis = backed vc issue, registry-backed transaction event log credential issuance
 brv = backed vc revoke, registry-backed transaction event log credential revocation
 """
 
-Ilkage = namedtuple("Ilkage", ('icp rot ixn dip drt rct ksn qry rpy exn exp '
-                               'vcp vrt iss rev bis brv '))
+Ilkage = namedtuple("Ilkage", ('icp rot ixn dip drt rct ksn qry rpy exn '
+                               'prd bre vcp vrt iss rev bis brv '))
 
 Ilks = Ilkage(icp='icp', rot='rot', ixn='ixn', dip='dip', drt='drt', rct='rct',
-              ksn='ksn', qry='qry', rpy='rpy', exn='exn', exp='exp',
+              ksn='ksn', qry='qry', rpy='rpy', exn='exn', prd='prd', bre='bre',
               vcp='vcp', vrt='vrt', iss='iss', rev='rev', bis='bis', brv='brv')
 
 Serialage = namedtuple("Serialage", 'json mgpk cbor')

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1392,16 +1392,16 @@ def reply(route="",
     return Serder(ked=sad)  # return serialized Self-Addressed Data (SAD)
 
 
-def expose(route="",
+def bare(route="",
            data=None,
            version=Version,
            kind=Serials.json):
     """
-    Returns serder of exposure 'exp' message.
-    Utility function to automate creation of exposure messages for disclosure of
-    sealed data associated with anchored seals in a KEL. Reference to anchoring
-    seal is provided as an attachment to exposure message.
-    Exposure 'exp' message is a SAD item with an associated derived SAID in its
+    Returns serder of bare 'bre' message.
+    Utility function to automate creation of unhiding (bareing) messages for
+    disclosure of sealed data associated with anchored seals in a KEL.
+    Reference to anchoring seal is provided as an attachment to bare message.
+    Bare 'bre' message is a SAD item with an associated derived SAID in its
     'd' field.
 
      Parameters:
@@ -1413,7 +1413,7 @@ def expose(route="",
 
     {
       "v" : "KERI10JSON00011c_",
-      "t" : "exp",
+      "t" : "bre",
       "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
       "r" : "sealed/processor",
       "a" :
@@ -1431,7 +1431,7 @@ def expose(route="",
         data = {}
 
     sad = dict(v=vs,  # version string
-               t=Ilks.exp,
+               t=Ilks.bre,
                d="",
                r=route if route is not None else "",  # route
                a=data if data else {},  # attributes

--- a/tests/core/test_bare.py
+++ b/tests/core/test_bare.py
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 """
-tests.core.test_expose module
+tests.core.test_bare module
 
-Test expose messages
+Test bare message
 routes:
 
 """
@@ -18,13 +18,13 @@ from keri import help
 logger = help.ogler.getLogger()
 
 
-def test_expose():
+def test_bare():
     """
-    Test expose message 'exp'
+    Test bare message 'bre'
 
     {
       "v" : "KERI10JSON00011c_",
-      "t" : "exp",
+      "t" : "bre",
       "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
       "r" : "logs/processor",
       "a" :
@@ -87,17 +87,18 @@ def test_expose():
                )
 
 
-    serderE = eventing.expose(route="/to/the/moon",
+    serderE = eventing.bare(route="/to/the/moon",
                              data=data,
                             )
 
-    assert serderE.raw == (b'{"v":"KERI10JSON0000f9_","t":"exp","d":"EWcQzVYR26plzL6foNKGD2T4MnNMwjuVy8hh'
-                        b'Ke25a_Z0","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqW'
-                        b'VK9ZBNZk0","role":"watcher","eid":"EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ'
-                        b'5CM","name":"besty"}}')
+    assert serderE.raw == (b'{"v":"KERI10JSON0000f9_","t":"bre","d":"EB_Xo7dILS8QB5Y1-KeB3qHUwbpVW2-gEe9D'
+                           b'jd-OG-cw","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrALTyejaJaGAVhNpSCtqyerPqW'
+                           b'VK9ZBNZk0","role":"watcher","eid":"EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ'
+                           b'5CM","name":"besty"}}')
 
 
-    assert serderE.ked["d"] == 'EWcQzVYR26plzL6foNKGD2T4MnNMwjuVy8hhKe25a_Z0'
+
+    assert serderE.ked["d"] == "EB_Xo7dILS8QB5Y1-KeB3qHUwbpVW2-gEe9Djd-OG-cw"
 
     # create SealEvent for endorsers est evt whose keys use to sign
 
@@ -111,17 +112,17 @@ def test_expose():
                      s='0',
                      d='EMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z')
     msg = messagize(serderE, sigers=[sigerC], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"exp","d":"EWcQzVYR26plzL6foNKGD2T4'
-                    b'MnNMwjuVy8hhKe25a_Z0","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
-                    b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
-                    b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-FABD3p'
-                    b'YGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk00AAAAAAAAAAAAAAAAAAAAAA'
-                    b'AEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAt_KQsGz2VO83a'
-                    b'tmF-1yfwJ676NnzrS9z6g-qytJrEumx78lcNLZr77IVOUotfO-yP1vrQnEcOgbW9'
-                    b'YVsyIr5Bw')
+    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"bre","d":"EB_Xo7dILS8QB5Y1-KeB3qHU'
+                   b'wbpVW2-gEe9Djd-OG-cw","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
+                   b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
+                   b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-FABD3p'
+                   b'YGFaqnrALTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk00AAAAAAAAAAAAAAAAAAAAAA'
+                   b'AEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAARJ66zuChkViyH'
+                   b'IghE_ODT5NXyhWHXH7kfo23q85BnjT8tJ9RSOErXifLY6RHRiv3yYf7ooX5eENPy'
+                   b'Ut5luaeCA')
 
-    # create endorsed rpy with trans endorser
-    # create trans key pair for endorder
+    # create endorsed bre with trans endorser
+    # create trans key pair for endorser
     signerE = salter.signer(path="E", temp=True)
     assert signerE.verfer.code == MtrDex.Ed25519  # transferable
     preE = signerE.verfer.qb64  # use public key verfer.qb64 as pre
@@ -135,16 +136,17 @@ def test_expose():
                      s='0',
                      d='EMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z')
     msg = messagize(serderE, sigers=[sigerE], seal=seal)
-    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"exp","d":"EWcQzVYR26plzL6foNKGD2T4'
-                b'MnNMwjuVy8hhKe25a_Z0","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
-                b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
-                b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-FABDyv'
-                b'CLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAA'
-                b'AEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAw0Jer1I2BUxYX'
-                b'YEJ_GpiddpoXBsTp9qs3RXR8QrcL_Nt9YYlTvbc8yjqV-9r0UDAU_K6l-tGXwrp3'
-                b'k0koeYDDw')
+    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"bre","d":"EB_Xo7dILS8QB5Y1-KeB3qHU'
+                   b'wbpVW2-gEe9Djd-OG-cw","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
+                   b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
+                   b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-FABDyv'
+                   b'CLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0AAAAAAAAAAAAAAAAAAAAAA'
+                   b'AEMuNWHss_H_kH4cG7Li1jn2DXfrEaqN7zhqTEhkeDZ2z-AABAAYsvGuxuEjx8uy'
+                   b'-QtgZrwXMrkdcix7nUdx_qCXM-Oy23D44m_xHbtTGdHXtNJAKZ1H-jnaNDnYNmjk'
+                   b'c8NOd4ZAA')
 
-    # create endorsed rpy with nontrans endorser
+
+    # create endorsed bre with nontrans endorser
     # create nontrans key pair for endorder
     signerE = salter.signer(path="E", transferable=False, temp=True)
     assert signerE.verfer.code == MtrDex.Ed25519N  # non-transferable
@@ -154,19 +156,20 @@ def test_expose():
     cigarE = signerE.sign(ser=serderE.raw)  # no index so Cigar
     assert signerE.verfer.verify(sig=cigarE.raw, ser=serderE.raw)
     msg = messagize(serderE, cigars=[cigarE])
-    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"exp","d":"EWcQzVYR26plzL6foNKGD2T4'
-                b'MnNMwjuVy8hhKe25a_Z0","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
-                b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
-                b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-CABByv'
-                b'CLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0Bw0Jer1I2BUxYXYEJ_Gpid'
-                b'dpoXBsTp9qs3RXR8QrcL_Nt9YYlTvbc8yjqV-9r0UDAU_K6l-tGXwrp3k0koeYDDw')
+    assert msg == (b'{"v":"KERI10JSON0000f9_","t":"bre","d":"EB_Xo7dILS8QB5Y1-KeB3qHU'
+                   b'wbpVW2-gEe9Djd-OG-cw","r":"/to/the/moon","a":{"cid":"D3pYGFaqnrA'
+                   b'LTyejaJaGAVhNpSCtqyerPqWVK9ZBNZk0","role":"watcher","eid":"EAoTN'
+                   b'ZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM","name":"besty"}}-CABByv'
+                   b'CLRr5luWmp7keDvDuLP0kIqcyBYq79b3Dho1QvrjI0BYsvGuxuEjx8uy-QtgZrwX'
+                   b'Mrkdcix7nUdx_qCXM-Oy23D44m_xHbtTGdHXtNJAKZ1H-jnaNDnYNmjkc8NOd4ZAA')
+
 
     """Done Test"""
 
 
 
 if __name__ == "__main__":
-    test_expose()
+    test_bare()
     # pytest.main(['-vv', 'test_reply.py::test_reply'])
 
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -42,7 +42,8 @@ def test_ilks():
     """
     assert Ilks == Ilkage(icp='icp', rot='rot', ixn='ixn', dip='dip', drt='drt',
                           rct='rct', ksn='ksn', qry='qry', rpy='rpy',
-                          exn='exn', exp='exp', vcp='vcp', vrt='vrt',
+                          exn='exn', prd='prd', bre='bre',
+                          vcp='vcp', vrt='vrt',
                           iss='iss', rev='rev', bis='bis', brv='brv', )
 
     assert isinstance(Ilks, Ilkage)
@@ -70,8 +71,13 @@ def test_ilks():
     assert Ilks.rpy == 'rpy'
     assert 'exn' in Ilks
     assert Ilks.exn == 'exn'
-    assert 'exp' in Ilks
-    assert Ilks.exp == 'exp'
+
+
+    assert 'prd' in Ilks
+    assert Ilks.prd == 'prd'
+    assert 'bre' in Ilks
+    assert Ilks.bre == 'bre'
+
 
     assert 'vcp' in Ilks
     assert Ilks.vcp == 'vcp'


### PR DESCRIPTION
bare, bre and prod, prd messages for
Use prod to initiate request for bare response
use bare in unintiated respose

data that is anchored in KEL via a digest seal of some type.
So uses the BADA logic for anchored data.