### PR TITLE
Preparations for Indexer to support new rotation rules

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -3518,9 +3518,9 @@ class IndexerCodex:
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
     """
     Ed25519_Sig: str = 'A'  # Ed25519 signature.
-    ECDSA_256k1_Sig: str = 'B'  # ECDSA secp256k1 signature.
-    Ed448_Sig: str = '0A'  # Ed448 signature.
-    Label: str = '0B'  # Var len label L=N*4 <= 4095 char quadlets includes code
+    ECDSA_256k1_Sig: str = 'D'  # ECDSA secp256k1 signature.
+    Ed448_Sig: str = '0B'  # Ed448 signature.
+    TBD: str = '0Z'  # Test of Var len label L=N*4 <= 4095 char quadlets includes code
 
     def __iter__(self):
         return iter(astuple(self))  # enables inclusion test with "in"
@@ -3537,8 +3537,8 @@ class IndexedSigCodex:
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
     """
     Ed25519_Sig: str = 'A'  # Ed25519 signature.
-    ECDSA_256k1_Sig: str = 'B'  # ECDSA secp256k1 signature.
-    Ed448_Sig: str = '0A'  # Ed448 signature.
+    ECDSA_256k1_Sig: str = 'D'  # ECDSA secp256k1 signature.
+    Ed448_Sig: str = '0B'  # Ed448 signature.
 
     def __iter__(self):
         return iter(astuple(self))
@@ -3588,9 +3588,9 @@ class Indexer:
     # soft size, ss, should always be  > 0 for Indexer
     Sizes = {
         'A': Sizage(hs=1, ss=1, fs=88, ls=0),
-        'B': Sizage(hs=1, ss=1, fs=88, ls=0),
-        '0A': Sizage(hs=2, ss=2, fs=156, ls=0),
-        '0B': Sizage(hs=2, ss=2, fs=None, ls=0),
+        'D': Sizage(hs=1, ss=1, fs=88, ls=0),
+        '0B': Sizage(hs=2, ss=2, fs=156, ls=0),
+        '0Z': Sizage(hs=2, ss=2, fs=None, ls=0),
     }
     # Bards table maps to hard size, hs, of code from bytes holding sextets
     # converted from first code char. Used for ._bexfil.

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -953,8 +953,10 @@ def receipt(pre,
             kind=Serials.json
             ):
     """
-    Returns serder of event receipt message for non-transferable receipter prefix.
-    Utility function to automate creation of interaction events.
+    Returns serder of event receipt message. Used for both non-trans and trans
+    signers as determined by signature attachment type (cigar or siger)
+
+    Utility function to automate creation of receipts.
 
      Parameters:
         pre is qb64 str of prefix of event being receipted

--- a/tests/comply/test_direct_mode.py
+++ b/tests/comply/test_direct_mode.py
@@ -105,15 +105,10 @@ def test_direct_mode_with_manager():
                          s="{:x}".format(valKever.lastEst.s),
                          d=valKever.lastEst.d)
         coeK = valKevery.kevers[coepre]  # lookup coeKever from validator's .kevers
-        # create trans receipt
+        # create trans receipt by attaching siger to recipt msg
         reserder = receipt(pre=coeK.prefixer.qb64,
                            sn=coeK.sn,
                            said=coeK.serder.saider.qb64)
-        #reserder = chit(pre=coeK.prefixer.qb64,
-                        #sn=coeK.sn,
-                        #dig=coeK.serder.diger.qb64,
-                        #seal=seal)
-        # Validate receipt
 
         # sign controller's event not receipt
         # look up event to sign from validator's kever for coe
@@ -125,15 +120,17 @@ def test_direct_mode_with_manager():
         #assert counter.qb64 == '-AAB'
         sigers = valMgr.sign(ser=coeIcpRaw, verfers=valVerfers)  # return Siger if index
 
-        # process own validator receipt in validator's Kevery so have copy in own log
+        # attach signatures
         rmsg = messagize(reserder, sigers=sigers, seal=seal)
         assert len(rmsg) == 353
 
+        # process own validator receipt in validator's Kevery so have copy in own log
+        # also server to validate receipt
         parsing.Parser().parseOne(ims=bytearray(rmsg), kvy=valKevery)
-        # valKevery.processOne(ims=bytearray(rmsg))  # process copy of rmsg
 
         # attach receipt message to existing message with validators inception message
-        # simulate streaming. validator first sends it's inception event, then sends a receipt to controller
+        # simulate streaming. validator first sends it's inception event, then
+        # sends a receipt to controller
         vmsg.extend(rmsg)
 
         # Simulate sending validator's inception event and receipt of

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -25,7 +25,7 @@ from keri.core.coring import Seqner, NumDex, Number, Siger, Dater, Bexter
 from keri.core.coring import Serder, Tholder
 from keri.core.coring import Serialage, Serials, Vstrings
 from keri.core.coring import (Sizage, MtrDex, Matter,
-                              IdrDex, Indexer, CtrDex, Counter, sniff)
+                              IdrDex, IdxSigDex, Indexer, CtrDex, Counter, sniff)
 from keri.core.coring import (Verfer, Cigar, Signer, Salter, Saider, DigDex,
                               Diger, Prefixer, Nexter, Cipher, Encrypter, Decrypter)
 from keri.core.coring import versify, deversify, Rever, VERFULLSIZE, MINSNIFFSIZE
@@ -1517,17 +1517,28 @@ def test_indexer():
     """
     Test Indexer class
     """
+    assert Indexer.Codex == IdrDex
     assert dataclasses.asdict(IdrDex) == {
         'Ed25519_Sig': 'A',
-        'ECDSA_256k1_Sig': 'B',
-        'Ed448_Sig': '0A',
-        'Label': '0B'
+        'ECDSA_256k1_Sig': 'D',
+        'Ed448_Sig': '0B',
+        'TBD': '0Z'
     }
 
     assert IdrDex.Ed25519_Sig == 'A'  # Ed25519 signature.
-    assert IdrDex.ECDSA_256k1_Sig == 'B'  # ECDSA secp256k1 signature.
+    assert IdrDex.ECDSA_256k1_Sig == 'D'  # ECDSA secp256k1 signature.
+    assert IdrDex.Ed448_Sig == '0B'  # ECDSA secp256k1 signature.
 
-    assert Indexer.Codex == IdrDex
+
+    assert dataclasses.asdict(IdxSigDex) == {
+        'Ed25519_Sig': 'A',
+        'ECDSA_256k1_Sig': 'D',
+        'Ed448_Sig': '0B',
+    }
+
+    assert IdxSigDex.Ed25519_Sig == 'A'  # Ed25519 signature.
+    assert IdxSigDex.ECDSA_256k1_Sig == 'D'  # ECDSA secp256k1 signature.
+    assert IdxSigDex.Ed448_Sig == '0B'  # ECDSA secp256k1 signature.
 
     # first character of code with hard size of code
     assert Indexer.Hards == {
@@ -1543,9 +1554,9 @@ def test_indexer():
     # Codes table with sizes of code (hard) and full primitive material
     assert Indexer.Sizes == {
         'A': Sizage(hs=1, ss=1, fs=88, ls=0),
-        'B': Sizage(hs=1, ss=1, fs=88, ls=0),
-        '0A': Sizage(hs=2, ss=2, fs=156, ls=0),
-        '0B': Sizage(hs=2, ss=2, fs=None, ls=0)
+        'D': Sizage(hs=1, ss=1, fs=88, ls=0),
+        '0B': Sizage(hs=2, ss=2, fs=156, ls=0),
+        '0Z': Sizage(hs=2, ss=2, fs=None, ls=0)
     }
 
     assert Indexer.Sizes['A'].hs == 1  # hard size
@@ -1723,40 +1734,6 @@ def test_indexer():
     assert indexer.qb64b == qsig64b
     assert indexer.qb2 == qsig2b
 
-    #  Label Code (variable length)
-    label = b'Hello_World_Peep'
-    index = len(label) // 4
-    assert not len(label) % 4
-    assert index == 4
-    lraw = decodeB64(label)
-    assert len(lraw) == len(label) * 3 // 4
-    assert lraw == b'\x1d\xe9e\xa3\xf5\xa8\xaeW\x7f=\xe7\xa9'
-    ltext = encodeB64(lraw)
-    assert ltext == b'Hello_World_Peep' == label
-    qsc = IdrDex.Label + intToB64(index, l=2)
-    assert qsc == '0BAE'
-    qscb = qsc.encode("utf-8")
-    lq64b = qscb + label
-    assert lq64b == b"0BAEHello_World_Peep"
-    lq64 = lq64b.decode("utf-8")
-
-    indexer = Indexer(raw=lraw, code=IdrDex.Label, index=index)
-    assert indexer.raw == lraw
-    assert indexer.code == IdrDex.Label
-    assert indexer.index == index
-    assert indexer.qb64b == lq64b
-    assert indexer.qb64 == lq64
-    assert indexer.qb2 == b'\xd0\x10\x04\x1d\xe9e\xa3\xf5\xa8\xaeW\x7f=\xe7\xa9'
-
-    # index zero for empty label
-    indexer = Indexer(raw=lraw, code=IdrDex.Label, index=0)
-    assert indexer.raw == b''
-    assert indexer.code == IdrDex.Label
-    assert indexer.index == 0
-    assert indexer.qb64b == b'0BAA'
-    assert indexer.qb64 == '0BAA'
-    assert indexer.qb2 == b'\xd0\x10\x00'
-
     # Test ._bexfil
     indexer = Indexer(qb64=qsig64)  #
     raw = indexer.raw
@@ -1827,6 +1804,41 @@ def test_indexer():
     assert indexer.qb64b == qsig64b
     assert indexer.qb2 == qsig2b
     assert ims == extra
+
+    # Test of TBD Label Code (variable length)
+    label = b'Hello_World_Peep'
+    index = len(label) // 4
+    assert not len(label) % 4
+    assert index == 4
+    lraw = decodeB64(label)
+    assert len(lraw) == len(label) * 3 // 4
+    assert lraw == b'\x1d\xe9e\xa3\xf5\xa8\xaeW\x7f=\xe7\xa9'
+    ltext = encodeB64(lraw)
+    assert ltext == b'Hello_World_Peep' == label
+    qsc = IdrDex.TBD + intToB64(index, l=2)
+    assert qsc == '0ZAE'
+    qscb = qsc.encode("utf-8")
+    lq64b = qscb + label
+    assert lq64b == b"0ZAEHello_World_Peep"
+    lq64 = lq64b.decode("utf-8")
+
+    # label from raw
+    indexer = Indexer(raw=lraw, code=IdrDex.TBD, index=index)
+    assert indexer.raw == lraw
+    assert indexer.code == IdrDex.TBD
+    assert indexer.index == index
+    assert indexer.qb64b == lq64b
+    assert indexer.qb64 == lq64
+    assert indexer.qb2 == b'\xd1\x90\x04\x1d\xe9e\xa3\xf5\xa8\xaeW\x7f=\xe7\xa9'
+
+    # index zero for empty label
+    indexer = Indexer(raw=lraw, code=IdrDex.TBD, index=0)
+    assert indexer.raw == b''
+    assert indexer.code == IdrDex.TBD
+    assert indexer.index == 0
+    assert indexer.qb64b == b'0ZAA'
+    assert indexer.qb64 == '0ZAA'
+    assert indexer.qb2 == b'\xd1\x90\x00'
     """ Done Test """
 
 

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -1519,25 +1519,37 @@ def test_indexer():
     """
     assert Indexer.Codex == IdrDex
     assert dataclasses.asdict(IdrDex) == {
-        'Ed25519_Sig': 'A',
-        'ECDSA_256k1_Sig': 'D',
+        'Ed25519_Bth_Sig': 'A',
+        'Ed25519_Crt_Sig': 'B',
+        'Ed25519_Nxt_Sig': 'C',
+        'Follow_Otr_Idx': 'D',
+        'ECDSA_256k1_Sig': 'E',
         'Ed448_Sig': '0B',
         'TBD': '0Z'
     }
 
-    assert IdrDex.Ed25519_Sig == 'A'  # Ed25519 signature.
-    assert IdrDex.ECDSA_256k1_Sig == 'D'  # ECDSA secp256k1 signature.
+    assert IdrDex.Ed25519_Bth_Sig == 'A'  # Ed25519 signature.
+    assert IdrDex.Ed25519_Crt_Sig == 'B'  # Ed25519 signature idx current only.
+    assert IdrDex.Ed25519_Nxt_Sig == 'C'  # Ed25519 signature idx prior next only.
+    assert IdrDex.Follow_Otr_Idx == 'D'  # Ed25519 signature different idx current and prior next.
+    assert IdrDex.ECDSA_256k1_Sig == 'E'  # ECDSA secp256k1 signature.
     assert IdrDex.Ed448_Sig == '0B'  # ECDSA secp256k1 signature.
 
 
     assert dataclasses.asdict(IdxSigDex) == {
-        'Ed25519_Sig': 'A',
-        'ECDSA_256k1_Sig': 'D',
+        'Ed25519_Bth_Sig': 'A',
+        'Ed25519_Crt_Sig': 'B',
+        'Ed25519_Nxt_Sig': 'C',
+        'Follow_Otr_Idx': 'D',
+        'ECDSA_256k1_Sig': 'E',
         'Ed448_Sig': '0B',
     }
 
-    assert IdxSigDex.Ed25519_Sig == 'A'  # Ed25519 signature.
-    assert IdxSigDex.ECDSA_256k1_Sig == 'D'  # ECDSA secp256k1 signature.
+    assert IdxSigDex.Ed25519_Bth_Sig == 'A'  # Ed25519 Idx both signature.
+    assert IdxSigDex.Ed25519_Crt_Sig == 'B'  # Ed25519 signature idx current only.
+    assert IdxSigDex.Ed25519_Nxt_Sig == 'C'  # Ed25519 signature idx prior next only.
+    assert IdxSigDex.Follow_Otr_Idx == 'D'  # Ed25519 signature different idx current and prior next.
+    assert IdxSigDex.ECDSA_256k1_Sig == 'E'  # ECDSA secp256k1 signature.
     assert IdxSigDex.Ed448_Sig == '0B'  # ECDSA secp256k1 signature.
 
     # first character of code with hard size of code
@@ -1554,7 +1566,10 @@ def test_indexer():
     # Codes table with sizes of code (hard) and full primitive material
     assert Indexer.Sizes == {
         'A': Sizage(hs=1, ss=1, fs=88, ls=0),
-        'D': Sizage(hs=1, ss=1, fs=88, ls=0),
+        'B': Sizage(hs=1, ss=1, fs=88, ls=0),
+        'C': Sizage(hs=1, ss=1, fs=88, ls=0),
+        'D': Sizage(hs=1, ss=3, fs=4, ls=0),
+        'E': Sizage(hs=1, ss=1, fs=88, ls=0),
         '0B': Sizage(hs=2, ss=2, fs=156, ls=0),
         '0Z': Sizage(hs=2, ss=2, fs=None, ls=0)
     }
@@ -1598,7 +1613,7 @@ def test_indexer():
                      'ezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ')
 
     # replace prepad  with code "A" plus index 0 == "A"
-    qsc = IdrDex.Ed25519_Sig + intToB64(0, l=1)
+    qsc = IdrDex.Ed25519_Bth_Sig + intToB64(0, l=1)
     assert qsc == 'AA'
     qscb = qsc.encode("utf-8")
     qsig64 = qsc + sig64[ps:]  # replace prepad chars with clause
@@ -1615,15 +1630,15 @@ def test_indexer():
 
     indexer = Indexer(raw=sig)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 0
     assert indexer.qb64 == qsig64
     indexer._exfil(qsig64b)
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.raw == sig
     assert indexer.qb2 == qsig2b
     indexer._bexfil(qsig2b)
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.raw == sig
 
     # test wrong size of raw
@@ -1636,7 +1651,7 @@ def test_indexer():
 
     indexer = Indexer(qb64b=qsig64b)  # test with bytes not str
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 0
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1644,7 +1659,7 @@ def test_indexer():
 
     indexer = Indexer(qb64=qsig64)  # test with str not bytes
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 0
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1662,7 +1677,7 @@ def test_indexer():
 
     indexer = Indexer(qb2=qsig2b)  # test with qb2
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 0
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1681,7 +1696,7 @@ def test_indexer():
 
     # test with non-zero index=5
     # replace pad "==" with code "AF"
-    qsc = IdrDex.Ed25519_Sig + intToB64(5, l=1)
+    qsc = IdrDex.Ed25519_Bth_Sig + intToB64(5, l=1)
     assert qsc == 'AF'
     qscb = qsc.encode("utf-8")
     qsig64 = qsc + sig64[ps:]  # replace prepad chars with code
@@ -1696,31 +1711,31 @@ def test_indexer():
               b'\x8f@\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)'
               b'\xde\xca\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o"\x81&\t')
 
-    indexer = Indexer(raw=sig, code=IdrDex.Ed25519_Sig, index=5)
+    indexer = Indexer(raw=sig, code=IdrDex.Ed25519_Bth_Sig, index=5)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
     assert indexer.qb2 == qsig2b
     indexer._exfil(qsig64b)
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.raw == sig
     assert indexer.qb2 == qsig2b
     indexer._bexfil(qsig2b)
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.raw == sig
 
     indexer = Indexer(raw=sig)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 0  #default index is zero
     assert indexer.qb64 != qsig64
     assert indexer.qb2 != qsig2b
 
     indexer = Indexer(qb2=qsig2b)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1728,7 +1743,7 @@ def test_indexer():
 
     indexer = Indexer(qb64=qsig64)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1755,7 +1770,7 @@ def test_indexer():
     # strip ignored if qb64
     indexer = Indexer(qb64=qsig64)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1764,7 +1779,7 @@ def test_indexer():
     ims = bytearray(qsig64b)
     indexer = Indexer(qb64b=ims, strip=True)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1774,7 +1789,7 @@ def test_indexer():
     ims = bytearray(qsig2b)
     indexer = Indexer(qb2=ims, strip=True)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1786,7 +1801,7 @@ def test_indexer():
     ims = bytearray(qsig64b) + extra
     indexer = Indexer(qb64b=ims, strip=True)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -1798,7 +1813,7 @@ def test_indexer():
     ims = bytearray(qsig2b) + extra
     indexer = Indexer(qb2=ims, strip=True)
     assert indexer.raw == sig
-    assert indexer.code == IdrDex.Ed25519_Sig
+    assert indexer.code == IdrDex.Ed25519_Bth_Sig
     assert indexer.index == 5
     assert indexer.qb64 == qsig64
     assert indexer.qb64b == qsig64b
@@ -3227,7 +3242,7 @@ def test_signer():
     assert result == True
 
     sigmat = signer.sign(ser, index=0)
-    assert sigmat.code == IdrDex.Ed25519_Sig
+    assert sigmat.code == IdrDex.Ed25519_Bth_Sig
     assert len(sigmat.raw) == Indexer._rawSize(sigmat.code)
     assert sigmat.index == 0
     result = signer.verfer.verify(sigmat.raw, ser)
@@ -3253,7 +3268,7 @@ def test_signer():
     assert result == True
 
     sigmat = signer.sign(ser, index=0)
-    assert sigmat.code == IdrDex.Ed25519_Sig
+    assert sigmat.code == IdrDex.Ed25519_Bth_Sig
     assert len(sigmat.raw) == Indexer._rawSize(sigmat.code)
     assert sigmat.index == 0
     result = signer.verfer.verify(sigmat.raw, ser)
@@ -3276,7 +3291,7 @@ def test_signer():
     assert result == True
 
     sigmat = signer.sign(ser, index=1)
-    assert sigmat.code == IdrDex.Ed25519_Sig
+    assert sigmat.code == IdrDex.Ed25519_Bth_Sig
     assert len(sigmat.raw) == Indexer._rawSize(sigmat.code)
     assert sigmat.index == 1
     result = signer.verfer.verify(sigmat.raw, ser)
@@ -4093,19 +4108,19 @@ def test_siger():
                        b'cKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ')
 
     siger = Siger(qb64b=qsig64b)
-    assert siger.code == IdrDex.Ed25519_Sig
+    assert siger.code == IdrDex.Ed25519_Bth_Sig
     assert siger.index == 0
     assert siger.qb64 == qsig64
     assert siger.verfer == None
 
     siger = Siger(qb64=qsig64)
-    assert siger.code == IdrDex.Ed25519_Sig
+    assert siger.code == IdrDex.Ed25519_Bth_Sig
     assert siger.index == 0
     assert siger.qb64 == qsig64
     assert siger.verfer == None
 
     siger = Siger(qb64=qsig64b)  # also bytes
-    assert siger.code == IdrDex.Ed25519_Sig
+    assert siger.code == IdrDex.Ed25519_Bth_Sig
     assert siger.index == 0
     assert siger.qb64 == qsig64
     assert siger.verfer == None
@@ -5259,4 +5274,6 @@ def test_tholder():
 
 
 if __name__ == "__main__":
-    test_matter()
+    #test_matter()
+    ##test_counter()
+    test_indexer()

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -4123,7 +4123,7 @@ def test_process_manual():
     result = pysodium.crypto_sign_verify_detached(sig0raw, txsrdr.raw, aidmat.raw)
     assert not result  # None if verifies successfully else raises ValueError
 
-    txsigmat = Siger(raw=sig0raw, code=IdrDex.Ed25519_Sig, index=index)
+    txsigmat = Siger(raw=sig0raw, code=IdrDex.Ed25519_Bth_Sig, index=index)
     assert txsigmat.qb64 == ('AAClimpgQX2jFTbYlTebmxIVRpE1SzPCcHdyNm-EsBJAOUVXH'
                              'bdRBd6wbpePWsuEcWIK-k9kbX-PagPVG6lsKhcP')
     assert len(txsigmat.qb64) == 88

--- a/tests/db/test_subing.py
+++ b/tests/db/test_subing.py
@@ -812,7 +812,7 @@ def test_cesr_suber():
         sdb = subing.CesrSuber(db=db, subkey='pigs.', klas=coring.Siger)
         assert isinstance(sdb, subing.CesrSuber)
         assert issubclass(sdb.klas, coring.Siger)
-        sig0 = 'AAmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+        sig0 = 'AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
         val0 = coring.Siger(qb64=sig0)
         keys = ("zeta", "cat")
         assert sdb.put(keys=keys, val=val0)
@@ -950,7 +950,7 @@ def test_cat_suber():
         sdb = subing.CatCesrSuber(db=db, subkey='pigs.', klas=(coring.Siger, ))
         assert isinstance(sdb, subing.CatCesrSuber)
         assert issubclass(sdb.klas[0], coring.Siger)
-        sig0 = 'AAmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+        sig0 = 'AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
         val0 = coring.Siger(qb64=sig0)
         keys = ("zeta", "cat")
         assert sdb.put(keys=keys, val=[val0])
@@ -1157,7 +1157,7 @@ def test_cat__cesr_ioset_suber():
         sdb = subing.CatCesrIoSetSuber(db=db, subkey='pigs.', klas=(coring.Siger, ))
         assert isinstance(sdb, subing.CatCesrIoSetSuber)
         assert issubclass(sdb.klas[0], coring.Siger)
-        sig0 = 'AAmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+        sig0 = 'AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
         val0 = coring.Siger(qb64=sig0)
         keys = ("zeta", "cat")
         assert sdb.put(keys=keys, vals=[[val0]])
@@ -1294,7 +1294,7 @@ def test_cesr_dup_suber():
         sdb = subing.CesrDupSuber(db=db, subkey='pigs.', klas=coring.Siger)
         assert isinstance(sdb, subing.CesrDupSuber)
         assert issubclass(sdb.klas, coring.Siger)
-        sig0 = 'AAmdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
+        sig0 = 'AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ'
         val0 = coring.Siger(qb64=sig0)
         keys = ("zeta", "cat")
         assert sdb.put(keys=keys, vals=[val0])


### PR DESCRIPTION
Added checks for non-zeroed pad bits or lead bytes on init of Indexer. 
Added new indexed signature codes to support which list an indexed signature belonds (current or next or both)