### PR TITLE
Change JavaScript MIME type

### DIFF
--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -285,7 +285,7 @@ def test_get_static_sink():
     # get trial.js
     rep = client.simulate_get('/static/index.js')
     assert rep.status == falcon.HTTP_OK
-    assert rep.headers['content-type'] == 'application/javascript; charset=UTF-8'
+    assert rep.headers['content-type'] == 'text/javascript; charset=UTF-8'
     assert len(rep.text) > 0
     assert rep.text == '// vanilla index.js\n\nm.render(document.body, "Hello world")\n'
 


### PR DESCRIPTION
A minor fix for successful testing.

`text/javascript` is a recommended standard (both by IETF and by MDN). `application/javascript` is obsolete.