### PR TITLE
Final round of changes to support presentation of credentials and revocations.

### DIFF
--- a/scripts/demo/credentials/single-issuer.sh
+++ b/scripts/demo/credentials/single-issuer.sh
@@ -6,14 +6,18 @@ kli incept --name issuer --alias issuer --file ${KERI_DEMO_SCRIPT_DIR}/data/glei
 kli init --name holder --salt 0ACDEyMzQ1Njc4OWxtbm9qWc --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
 kli incept --name holder --alias holder --file ${KERI_DEMO_SCRIPT_DIR}/data/gleif-sample.json
 
-kli oobi resolve --name issuer --oobi-alias holder --oobi http://127.0.0.1:5642/oobi/EeWTHzoGK_dNn71CmJh-4iILvqHGXcqEoKGF4VUc6ZXI/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name holder --oobi-alias issuer --oobi http://127.0.0.1:5642/oobi/Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name issuer --oobi-alias issuer --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-kli oobi resolve --name holder --oobi-alias holder --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
+kli oobi resolve --name issuer --oobi-alias holder --oobi http://127.0.0.1:5642/oobi/ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name holder --oobi-alias issuer --oobi http://127.0.0.1:5642/oobi/EKxICWTx5Ph4EKq5xie2znZf7amggUn4Sd-2-46MIQTg/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name issuer --oobi-alias issuer --oobi http://127.0.0.1:7723/oobi/ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz
+kli oobi resolve --name holder --oobi-alias holder --oobi http://127.0.0.1:7723/oobi/ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz
 
 kli vc registry incept --name issuer --alias issuer --registry-name vLEI
 
-kli vc issue --name issuer --alias issuer --registry-name vLEI --schema EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw --recipient EeWTHzoGK_dNn71CmJh-4iILvqHGXcqEoKGF4VUc6ZXI --data @${KERI_DEMO_SCRIPT_DIR}/data/credential-data.json
+kli vc issue --name issuer --alias issuer --registry-name vLEI --schema ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz --recipient ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k --data @${KERI_DEMO_SCRIPT_DIR}/data/credential-data.json
+sleep 2
+kli vc list --name holder --alias holder --poll
+SAID=`kli vc list --name holder --alias holder --said --schema ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz`
 
+kli vc revoke --name issuer --alias issuer --registry-name vLEI --said ${SAID}
 sleep 2
 kli vc list --name holder --alias holder --poll

--- a/scripts/demo/data/ecr-auth-data.json
+++ b/scripts/demo/data/ecr-auth-data.json
@@ -1,5 +1,5 @@
 {
-  "AID": "Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE",
+  "AID": "EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe",
   "LEI": "5493001KJTIIGC8Y1R17",
   "personLegalName": "John Smith",
   "engagementContextRole": "Auditor"

--- a/scripts/demo/data/ecr-auth-edges-filter.jq
+++ b/scripts/demo/data/ecr-auth-edges-filter.jq
@@ -1,1 +1,1 @@
-{d: "", le: {n: ., s: "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"}}
+{d: "", le: {n: ., s: "EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ"}}

--- a/scripts/demo/data/ecr-auth-rules.json
+++ b/scripts/demo/data/ecr-auth-rules.json
@@ -5,5 +5,8 @@
   },
   "issuanceDisclaimer": {
     "l": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or individual named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+  },
+  "privacyDisclaimer": {
+    "l": "Privacy Considerations are applicable to QVI ECR AUTH vLEI Credentials.  It is the sole responsibility of QVIs as Issuees of QVI ECR AUTH vLEI Credentials to present these Credentials in a privacy-preserving manner using the mechanisms provided in the Issuance and Presentation Exchange (IPEX) protocol specification and the Authentic Chained Data Container (ACDC) specification.  https://github.com/WebOfTrust/IETF-IPEX and https://github.com/trustoverip/tswg-acdc-specification."
   }
 }

--- a/scripts/demo/data/ecr-edges-filter.jq
+++ b/scripts/demo/data/ecr-edges-filter.jq
@@ -1,14 +1,8 @@
 {
   "d": "",
-  "o": "AND",
   "auth": {
     "n": .[1],
-    "s": "ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
-    "o": "NI2I"
-  },
-  "qvi": {
-    "n": .[0],
-    "s": "EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw",
+    "s": "ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "o": "I2I"
   }
 }

--- a/scripts/demo/data/ecr-rules.json
+++ b/scripts/demo/data/ecr-rules.json
@@ -5,5 +5,8 @@
   },
   "issuanceDisclaimer": {
     "l": "All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or individual named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework."
+  },
+  "privacyDisclaimer": {
+    "l": "It is the sole responsibility of Holders as Issuees of an ECR vLEI Credential to present that Credential in a privacy-preserving manner using the mechanisms provided in the Issuance and Presentation Exchange (IPEX) protocol specification and the Authentic Chained Data Container (ACDC) specification. https://github.com/WebOfTrust/IETF-IPEX and https://github.com/trustoverip/tswg-acdc-specification."
   }
 }

--- a/scripts/demo/data/legal-entity-edges-filter.jq
+++ b/scripts/demo/data/legal-entity-edges-filter.jq
@@ -1,1 +1,1 @@
-{d: "", qvi: {n: ., s: "EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"}}
+{d: "", qvi: {n: ., s: "ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz"}}

--- a/scripts/demo/data/oor-auth-data.json
+++ b/scripts/demo/data/oor-auth-data.json
@@ -1,5 +1,5 @@
 {
-  "AID": "Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE",
+  "AID": "EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe",
   "LEI": "5493001KJTIIGC8Y1R17",
   "personLegalName": "John Smith",
   "officialRole": "Chief Executive Officer"

--- a/scripts/demo/data/oor-auth-edges-filter.jq
+++ b/scripts/demo/data/oor-auth-edges-filter.jq
@@ -1,1 +1,1 @@
-{d: "", le: {n: ., s: "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"}}
+{d: "", le: {n: ., s: "EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ"}}

--- a/scripts/demo/data/oor-edges-filter.jq
+++ b/scripts/demo/data/oor-edges-filter.jq
@@ -1,14 +1,8 @@
 {
   "d": "",
-  "o": "AND",
   "auth": {
     "n": .[1],
-    "s": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "o": "NI2I"
-  },
-  "qvi": {
-    "n": .[0],
-    "s": "EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw",
+    "s": "EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
     "o": "I2I"
   }
 }

--- a/scripts/demo/data/xbrl-edges-filter.jq
+++ b/scripts/demo/data/xbrl-edges-filter.jq
@@ -2,6 +2,6 @@
   "d": "",
   "oor": {
     "n": .,
-    "s": "EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4"
+    "s": "EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm"
   },
 }

--- a/scripts/demo/vLEI/issue-xbrl-attestation-agent.sh
+++ b/scripts/demo/vLEI/issue-xbrl-attestation-agent.sh
@@ -85,7 +85,7 @@ QVI_SAID=$(curl -s -X GET "http://localhost:5626/credentials/qvi?type=received" 
 echo $QVI_SAID | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/legal-entity-edges-filter.jq  > /tmp/legal-entity-edges.json
 LE_EDGES=`cat /tmp/legal-entity-edges.json`
 RULES=`cat ${KERI_DEMO_SCRIPT_DIR}/data/rules.json`
-curl -s -X POST "http://localhost:5626/credentials/qvi" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"LEI\":\"5493001KJTIIGC8Y1R17\"},\"recipient\":\"EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws\",\"registry\":\"vLEI-qvi\",\"schema\":\"EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs\",\"source\":$LE_EDGES,\"rules\":$RULES}" | jq
+curl -s -X POST "http://localhost:5626/credentials/qvi" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"LEI\":\"5493001KJTIIGC8Y1R17\"},\"recipient\":\"EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws\",\"registry\":\"vLEI-qvi\",\"schema\":\"EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ\",\"source\":$LE_EDGES,\"rules\":$RULES}" | jq
 
 sleep 8
 echo "LE retrieves Credentials..."
@@ -98,7 +98,7 @@ LE_SAID=$(curl -s -X GET "http://localhost:5628/credentials/legal-entity?type=re
 echo $LE_SAID | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/oor-auth-edges-filter.jq > /tmp/oor-auth-edges.json
 OOR_AUTH_EDGES=`cat /tmp/oor-auth-edges.json`
 
-curl -s -X POST "http://localhost:5628/credentials/legal-entity" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"AID\": \"Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE\", \"LEI\":\"6383001AJTYIGC8Y1X37\", \"personLegalName\": \"John Smith\", \"officialRole\": \"Chief Executive Officer\"},\"recipient\":\"EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM\",\"registry\":\"vLEI-legal-entity\",\"schema\":\"EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI\",\"source\":$OOR_AUTH_EDGES,\"rules\":$RULES}" | jq
+curl -s -X POST "http://localhost:5628/credentials/legal-entity" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"AID\": \"Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE\", \"LEI\":\"6383001AJTYIGC8Y1X37\", \"personLegalName\": \"John Smith\", \"officialRole\": \"Chief Executive Officer\"},\"recipient\":\"EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM\",\"registry\":\"vLEI-legal-entity\",\"schema\":\"EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy\",\"source\":$OOR_AUTH_EDGES,\"rules\":$RULES}" | jq
 sleep 8
 echo "QVI retrieves Credentials..."
 curl -s -X GET "http://localhost:5626/credentials/qvi?type=received" -H "accept: application/json" | jq
@@ -106,11 +106,11 @@ sleep 3
 
 # Issue OOR credential from QVI to Person
 echo 'qvi issues OOR credential to person'
-AUTH_SAID=$(curl -s -X GET "http://localhost:5626/credentials/qvi?type=received&schema=EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI" -H "accept: application/json" -H "Content-Type: application/json" | jq '.[0] | .sad.d')
+AUTH_SAID=$(curl -s -X GET "http://localhost:5626/credentials/qvi?type=received&schema=EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy" -H "accept: application/json" -H "Content-Type: application/json" | jq '.[0] | .sad.d')
 echo "[$QVI_SAID, $AUTH_SAID]" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/oor-edges-filter.jq > /tmp/oor-edges.json
 OOR_EDGES=`cat /tmp/oor-edges.json`
 
-curl -s -X POST "http://localhost:5626/credentials/qvi" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"LEI\":\"6383001AJTYIGC8Y1X37\", \"personLegalName\": \"John Smith\", \"officialRole\": \"Chief Executive Officer\"},\"recipient\":\"Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE\",\"registry\":\"vLEI-qvi\",\"schema\":\"EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4\",\"source\":$OOR_EDGES,\"rules\":$RULES}" | jq
+curl -s -X POST "http://localhost:5626/credentials/qvi" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"credentialData\":{\"LEI\":\"6383001AJTYIGC8Y1X37\", \"personLegalName\": \"John Smith\", \"officialRole\": \"Chief Executive Officer\"},\"recipient\":\"Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE\",\"registry\":\"vLEI-qvi\",\"schema\":\"EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm\",\"source\":$OOR_EDGES,\"rules\":$RULES}" | jq
 sleep 8
 echo "Person retrieves Credentials..."
 curl -s -X GET "http://localhost:5630/credentials/person?type=received" -H "accept: application/json" | jq

--- a/scripts/demo/vLEI/issue-xbrl-attestation.sh
+++ b/scripts/demo/vLEI/issue-xbrl-attestation.sh
@@ -6,75 +6,45 @@
 #   > vLEI-server -s ./schema/acdc -c ./samples/acdc/ -o ./samples/oobis/
 #
 
-# EWN6BzdXo6IByOsuh_fYanK300iEOrQKf6msmbIeC4Y0
-kli init --name external --salt 0ACDEyMzQ1Njc4OWxtbm9GhI --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
+# EHOuGiHMxJShXHgSb6k_9pqxmRb8H-LT0R2hQouHp8pW
+kli init --name external --salt 0ACDEyMzQ1Njc4OWxtbm9GhI --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis-schema
 kli incept --name external --alias external --file ${KERI_DEMO_SCRIPT_DIR}/data/gleif-sample.json
 
-# EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM
-kli init --name qvi --salt 0ACDEyMzQ1Njc4OWxtbm9aBc --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
+# EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX
+kli init --name qvi --salt 0ACDEyMzQ1Njc4OWxtbm9aBc --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis-schema
 kli incept --name qvi --alias qvi --file ${KERI_DEMO_SCRIPT_DIR}/data/gleif-sample.json
 
-# EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws
-kli init --name legal-entity --salt 0ACDEyMzQ1Njc4OWxtbm9AbC --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
+# EIitNxxiNFXC1HDcPygyfyv3KUlBfS_Zf-ZYOvwjpTuz
+kli init --name legal-entity --salt 0ACDEyMzQ1Njc4OWxtbm9AbC --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis-schema
 kli incept --name legal-entity --alias legal-entity --file ${KERI_DEMO_SCRIPT_DIR}/data/gleif-sample.json
 
-# Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE
+# EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe
 # Passcode: DoB2-6Fj4x-9Lbo-AFWJr-a17O
-kli init --name person --salt 0ACDEyMzQ1Njc4OWxtbm9dEf --passcode DoB26Fj4x9LboAFWJra17O --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
+kli init --name person --salt 0ACDEyMzQ1Njc4OWxtbm9dEf --passcode DoB26Fj4x9LboAFWJra17O --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis-schema
 kli incept --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --file ${KERI_DEMO_SCRIPT_DIR}/data/gleif-sample.json
 
 echo 'resolving external'
-kli oobi resolve --name qvi --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EWN6BzdXo6IByOsuh_fYanK300iEOrQKf6msmbIeC4Y0/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name legal-entity --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EWN6BzdXo6IByOsuh_fYanK300iEOrQKf6msmbIeC4Y0/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EWN6BzdXo6IByOsuh_fYanK300iEOrQKf6msmbIeC4Y0/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name qvi --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EHOuGiHMxJShXHgSb6k_9pqxmRb8H-LT0R2hQouHp8pW/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name legal-entity --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EHOuGiHMxJShXHgSb6k_9pqxmRb8H-LT0R2hQouHp8pW/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias external --oobi http://127.0.0.1:5642/oobi/EHOuGiHMxJShXHgSb6k_9pqxmRb8H-LT0R2hQouHp8pW/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 echo 'resolving qvi'
-kli oobi resolve --name external --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name legal-entity --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name external --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name legal-entity --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias qvi --oobi http://127.0.0.1:5642/oobi/EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 echo 'resolving legal-entity'
-kli oobi resolve --name external --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name qvi --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name external --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EIitNxxiNFXC1HDcPygyfyv3KUlBfS_Zf-ZYOvwjpTuz/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name qvi --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EIitNxxiNFXC1HDcPygyfyv3KUlBfS_Zf-ZYOvwjpTuz/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias legal-entity --oobi http://127.0.0.1:5642/oobi/EIitNxxiNFXC1HDcPygyfyv3KUlBfS_Zf-ZYOvwjpTuz/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 echo 'resolving person'
-kli oobi resolve --name external --oobi-alias person --oobi http://127.0.0.1:5642/oobi/Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name qvi --oobi-alias person --oobi http://127.0.0.1:5642/oobi/Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name legal-entity --oobi-alias person --oobi http://127.0.0.1:5642/oobi/Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name external --oobi-alias person --oobi http://127.0.0.1:5642/oobi/EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name qvi --oobi-alias person --oobi http://127.0.0.1:5642/oobi/EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name legal-entity --oobi-alias person --oobi http://127.0.0.1:5642/oobi/EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
-echo 'resolving QVI vLEI Schema EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-echo 'resolving Legal Entity vLEI Schema EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
-echo 'resolving OOR Authorization vLEI Schema EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI
-echo 'resolving OOR vLEI Schema EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4
-echo 'resolving ECR Authorization vLEI Schema ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s
-echo 'resolving ECR vLEI Schema EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg
-echo 'resolving iXBRL Data Attestation Schema EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0'
-kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0
-kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0
-kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0
-kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0
+echo 'resolving iXBRL Data Attestation Schema EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u'
+kli oobi resolve --name external --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u
+kli oobi resolve --name qvi --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u
+kli oobi resolve --name legal-entity --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u
+kli oobi resolve --name person --passcode DoB26Fj4x9LboAFWJra17O --oobi-alias credential --oobi http://127.0.0.1:7723/oobi/EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u
 
 kli vc registry incept --name external --alias external --registry-name vLEI-external
 kli vc registry incept --name qvi --alias qvi --registry-name vLEI-qvi
@@ -82,49 +52,49 @@ kli vc registry incept --name legal-entity --alias legal-entity --registry-name 
 kli vc registry incept --name person  --passcode DoB26Fj4x9LboAFWJra17O --alias person --registry-name vLEI-person
 
 # Issue QVI credential vLEI from GLEIF External to QVI
-kli vc issue --name external --alias external --registry-name vLEI-external --schema EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw --recipient EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM --data @${KERI_DEMO_SCRIPT_DIR}/data/qvi-data.json
+kli vc issue --name external --alias external --registry-name vLEI-external --schema ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz --recipient EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX --data @${KERI_DEMO_SCRIPT_DIR}/data/qvi-data.json
 kli vc list --name qvi --alias qvi --poll
 
 # Issue LE credential from QVI to Legal Entity - have to create the edges first
-QVI_SAID=`kli vc list --name qvi --alias qvi --said --schema EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw`
+QVI_SAID=`kli vc list --name qvi --alias qvi --said --schema ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz`
 echo \"$QVI_SAID\" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/legal-entity-edges-filter.jq  > /tmp/legal-entity-edges.json
 kli saidify --file /tmp/legal-entity-edges.json
-kli vc issue --name qvi --alias qvi --registry-name vLEI-qvi --schema EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs --recipient EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws --data @${KERI_DEMO_SCRIPT_DIR}/data/legal-entity-data.json --edges @/tmp/legal-entity-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
+kli vc issue --name qvi --alias qvi --registry-name vLEI-qvi --schema EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ --recipient EIitNxxiNFXC1HDcPygyfyv3KUlBfS_Zf-ZYOvwjpTuz --data @${KERI_DEMO_SCRIPT_DIR}/data/legal-entity-data.json --edges @/tmp/legal-entity-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
 kli vc list --name legal-entity --alias legal-entity --poll
 
 # Issue ECR Authorization credential from Legal Entity to QVI - have to create the edges first
 LE_SAID=`kli vc list --name legal-entity --alias legal-entity --said`
 echo \"$LE_SAID\" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/ecr-auth-edges-filter.jq > /tmp/ecr-auth-edges.json
 kli saidify --file /tmp/ecr-auth-edges.json
-kli vc issue --name legal-entity --alias legal-entity --registry-name vLEI-legal-entity --schema ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s --recipient EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM --data @${KERI_DEMO_SCRIPT_DIR}/data/ecr-auth-data.json --edges @/tmp/ecr-auth-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
+kli vc issue --name legal-entity --alias legal-entity --registry-name vLEI-legal-entity --schema ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta --recipient EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX --data @${KERI_DEMO_SCRIPT_DIR}/data/ecr-auth-data.json --edges @/tmp/ecr-auth-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/ecr-auth-rules.json
 kli vc list --name qvi --alias qvi --poll
 
 # Issue ECR credential from QVI to Person
-AUTH_SAID=`kli vc list --name qvi --alias qvi --said --schema ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s`
+AUTH_SAID=`kli vc list --name qvi --alias qvi --said --schema ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta`
 echo "[\"$QVI_SAID\", \"$AUTH_SAID\"]" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/ecr-edges-filter.jq > /tmp/ecr-edges.json
 kli saidify --file /tmp/ecr-edges.json
-kli vc issue --name qvi --alias qvi --registry-name vLEI-qvi --schema EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg --recipient Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE --data @${KERI_DEMO_SCRIPT_DIR}/data/ecr-data.json --edges @/tmp/ecr-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
+kli vc issue --name qvi --alias qvi --private --registry-name vLEI-qvi --schema EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY --recipient EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe --data @${KERI_DEMO_SCRIPT_DIR}/data/ecr-data.json --edges @/tmp/ecr-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/ecr-rules.json
 kli vc list --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --poll
 
 # Issue OOR Authorization credential from Legal Entity to QVI - have to create the edges first
 echo \"$LE_SAID\" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/oor-auth-edges-filter.jq > /tmp/oor-auth-edges.json
 kli saidify --file /tmp/oor-auth-edges.json
-kli vc issue --name legal-entity --alias legal-entity --registry-name vLEI-legal-entity --schema EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI --recipient EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM --data @${KERI_DEMO_SCRIPT_DIR}/data/oor-auth-data.json --edges @/tmp/oor-auth-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
+kli vc issue --name legal-entity --alias legal-entity --registry-name vLEI-legal-entity --schema EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy --recipient EHMnCf8_nIemuPx-cUHaDQq8zSnQIFAurdEpwHpNbnvX --data @${KERI_DEMO_SCRIPT_DIR}/data/oor-auth-data.json --edges @/tmp/oor-auth-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
 kli vc list --name qvi --alias qvi --poll
 
 # Issue OOR credential from QVI to Person
-AUTH_SAID=`kli vc list --name qvi --alias qvi --said --schema EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI`
+AUTH_SAID=`kli vc list --name qvi --alias qvi --said --schema EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy`
 echo "[\"$QVI_SAID\", \"$AUTH_SAID\"]" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/oor-edges-filter.jq > /tmp/oor-edges.json
 kli saidify --file /tmp/oor-edges.json
-kli vc issue --name qvi --alias qvi --registry-name vLEI-qvi --schema EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4 --recipient Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE --data @${KERI_DEMO_SCRIPT_DIR}/data/oor-data.json --edges @/tmp/oor-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
+kli vc issue --name qvi --alias qvi --registry-name vLEI-qvi --schema EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm --recipient EKE7b7owCvObR6dBTrU7w38_oATL9Tcrp_-xjPn05zYe --data @${KERI_DEMO_SCRIPT_DIR}/data/oor-data.json --edges @/tmp/oor-edges.json --rules @${KERI_DEMO_SCRIPT_DIR}/data/rules.json
 kli vc list --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --poll
 
 # Issue iXBRL data attestation from Person
-OOR_SAID=`kli vc list --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --said --schema EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4`
+OOR_SAID=`kli vc list --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --said --schema EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm`
 echo \"$OOR_SAID\" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/xbrl-edges-filter.jq > /tmp/xbrl-edges.json
 kli saidify --file /tmp/xbrl-edges.json
 NOW=`date -u +"%Y-%m-%dT%H:%M:%S+00:00"`
 echo \"$NOW\" | jq -f ${KERI_DEMO_SCRIPT_DIR}/data/xbrl-data.jq > /tmp/xbrl-data.json
 kli saidify --file /tmp/xbrl-data.json
-kli vc issue --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --registry-name vLEI-person --schema EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0 --data @/tmp/xbrl-data.json --edges @/tmp/xbrl-edges.json
+kli vc issue --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --registry-name vLEI-person --schema EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u --data @/tmp/xbrl-data.json --edges @/tmp/xbrl-edges.json
 kli vc list --name person --alias person --passcode DoB26Fj4x9LboAFWJra17O --issued

--- a/scripts/demo/vLEI/qar.sh
+++ b/scripts/demo/vLEI/qar.sh
@@ -70,8 +70,8 @@ kli oobi generate --name intgar2 --alias intgar2 --role witness
 
 kli oobi resolve --name intgar1 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
 kli oobi resolve --name intgar2 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw
-kli oobi resolve --name intgar1 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
-kli oobi resolve --name intgar2 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs
+kli oobi resolve --name intgar1 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ
+kli oobi resolve --name intgar2 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ
 
 # kli vc list --name intgar1 --alias "GLEIF Internal" --poll
 # kli vc list --name intgar2 --alias "GLEIF Internal" --poll

--- a/scripts/keri/cf/demo-witness-oobis-schema.json
+++ b/scripts/keri/cf/demo-witness-oobis-schema.json
@@ -6,12 +6,12 @@
     "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller"
   ],
   "durls": [
-    "http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
-    "http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0",
-    "http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
-    "http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
-    "http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
-    "http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
+    "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
+    "http://127.0.0.1:7723/oobi/EJEMDhCDi8gLqtaXrb36DRLHMfC1c08PqirQvdPPSG5u",
+    "http://127.0.0.1:7723/oobi/EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
+    "http://127.0.0.1:7723/oobi/EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY",
+    "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
+    "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
+    "http://127.0.0.1:7723/oobi/ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz"
   ]
 }

--- a/scripts/keri/cf/vlei-gar-oobis-schema.json
+++ b/scripts/keri/cf/vlei-gar-oobis-schema.json
@@ -7,12 +7,12 @@
     "http://127.0.0.1:7723/.well-known/keri/oobi/gleif-root?name=GLEIF%20Root"
   ],
   "durls": [
-    "http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+    "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
     "http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0",
-    "http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
-    "http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
-    "http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
+    "http://127.0.0.1:7723/oobi/EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY",
+    "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
+    "http://127.0.0.1:7723/oobi/EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
+    "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
   ]
 }

--- a/scripts/keri/cf/vlei-lar-oobis-schema.json
+++ b/scripts/keri/cf/vlei-lar-oobis-schema.json
@@ -7,12 +7,12 @@
     "http://127.0.0.1:7723/.well-known/keri/oobi/gleif-root?name=GLEIF%20Root"
   ],
   "durls": [
-    "http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+    "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
     "http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0",
-    "http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
-    "http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
-    "http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
+    "http://127.0.0.1:7723/oobi/EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY",
+    "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
+    "http://127.0.0.1:7723/oobi/EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
+    "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
   ]
 }

--- a/scripts/keri/cf/vlei-qar-oobis-schema.json
+++ b/scripts/keri/cf/vlei-qar-oobis-schema.json
@@ -7,12 +7,12 @@
     "http://127.0.0.1:7723/.well-known/keri/oobi/gleif-external?name=GLEIF%20External"
   ],
   "durls": [
-    "http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+    "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
     "http://127.0.0.1:7723/oobi/EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0",
-    "http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
-    "http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
-    "http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
+    "http://127.0.0.1:7723/oobi/EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY",
+    "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
+    "http://127.0.0.1:7723/oobi/EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
+    "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
   ]
 }

--- a/scripts/keri/cf/vlei-root-oobis-schema.json
+++ b/scripts/keri/cf/vlei-root-oobis-schema.json
@@ -8,12 +8,12 @@
     "http://127.0.0.1:7723/.well-known/keri/oobi/gleif-internal?name=GLEIF%20Internal"
   ],
   "durls": [
-    "http://127.0.0.1:7723/oobi/EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+    "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
     "http://127.0.0.1:7723/oobi/Ec7NSIUfktTAofFOSaXhnKHdOqoILdSLvvMtin9uQk_s",
-    "http://127.0.0.1:7723/oobi/EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
-    "http://127.0.0.1:7723/oobi/EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
-    "http://127.0.0.1:7723/oobi/EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
-    "http://127.0.0.1:7723/oobi/ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
+    "http://127.0.0.1:7723/oobi/EOhcE9MV90LRygJuYN1N0c5XXNFkzwFxUBfQ24v7qeEY",
+    "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
+    "http://127.0.0.1:7723/oobi/EDqjl80uP0r_SNSp-yImpLGglTEbOwgO77wsOPjyRVKy",
+    "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "http://127.0.0.1:7723/oobi/EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
   ]
 }

--- a/src/keri/app/cli/commands/vc/issue.py
+++ b/src/keri/app/cli/commands/vc/issue.py
@@ -32,6 +32,8 @@ parser.add_argument('--credential', help='Full credential, \'@\' allowed', defau
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")
 parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
+parser.add_argument("--private", help="flag to indicate if this credential needs privacy preserving features",
+                    action="store_true")
 parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 
@@ -92,7 +94,8 @@ def issueCredential(args):
                                  data=data,
                                  edges=edges,
                                  rules=rules,
-                                 credential=credential)
+                                 credential=credential,
+                                 private=args.private)
 
     doers = [issueDoer]
     return doers

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -14,7 +14,6 @@ from hio.core import http
 from hio.core.tcp import serving
 from hio.help import decking
 
-
 from . import directing, storing, httping, forwarding, agenting, oobiing
 from .. import help, kering
 from ..core import eventing, parsing, routing
@@ -493,7 +492,8 @@ class MailboxDirector(doing.DoDoer):
 
     """
 
-    def __init__(self, hby, topics, ims=None, verifier=None, kvy=None, exc=None, rep=None, cues=None, rvy=None, **kwa):
+    def __init__(self, hby, topics, ims=None, verifier=None, kvy=None, exc=None, rep=None, cues=None, rvy=None,
+                 tvy=None, **kwa):
         """
         Initialize instance.
 
@@ -539,12 +539,12 @@ class MailboxDirector(doing.DoDoer):
         self.kvy.registerReplyRoutes(self.rtr)
 
         if self.verifier is not None:
-            self.tevery = Tevery(reger=self.verifier.reger,
-                                 db=self.hby.db, rvy=self.rvy,
-                                 lax=True, local=False, cues=self.cues)
-            self.tevery.registerReplyRoutes(self.rtr)
+            self.tvy = tvy if tvy is not None else Tevery(reger=self.verifier.reger,
+                                                          db=self.hby.db, rvy=self.rvy,
+                                                          lax=True, local=False, cues=self.cues)
+            self.tvy.registerReplyRoutes(self.rtr)
         else:
-            self.tevery = None
+            self.tvy = None
 
         if self.exchanger is not None:
             doers.extend([doing.doify(self.exchangerDo)])
@@ -552,7 +552,7 @@ class MailboxDirector(doing.DoDoer):
         self.parser = parsing.Parser(ims=self.ims,
                                      framed=True,
                                      kvy=self.kvy,
-                                     tvy=self.tevery,
+                                     tvy=self.tvy,
                                      exc=self.exchanger,
                                      rvy=self.rvy,
                                      vry=self.verifier)
@@ -688,8 +688,8 @@ class MailboxDirector(doing.DoDoer):
         while True:
             self.kvy.processEscrows()
             self.rvy.processEscrowReply()
-            if self.tevery is not None:
-                self.tevery.processEscrows()
+            if self.tvy is not None:
+                self.tvy.processEscrows()
             if self.verifier is not None:
                 self.verifier.processEscrows()
 
@@ -946,7 +946,6 @@ class QryRpyMailboxIterable:
 
 
 class MailboxIterable:
-
     TimeoutMBX = 30000000
 
     def __init__(self, mbx, pre, topics, retry=5000):

--- a/tests/app/test_kiwiing.py
+++ b/tests/app/test_kiwiing.py
@@ -1510,7 +1510,7 @@ def test_presentation_ends(seeder, mockCoringRandomNonce, mockHelpingNowIso8601)
         raw = json.dumps(body).encode("utf-8")
         response = client.simulate_post("/credentials/pal/presentations", body=raw)
         assert response.status == falcon.HTTP_202
-        assert len(presentEnd.postman.evts) == 7
+        assert len(presentEnd.postman.evts) == 10
 
         # Bad alias
         body = dict(


### PR DESCRIPTION
Updating the KLI revoke command to work and added `--send` parameter to specify AIDs or alias of recipients for the events of the revocation.

Updated issue-xbrl-attestation.sh to work with final version of vLEI credential schema.

Updates single-issuer.sh to work with new schema and to include a revocation command.

Added --private flag to the issue command for adding the needed nonces to a credential to enable privacy preserving presentations.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>