### PR TITLE
Delegated event propagation to delegator (and two bug fixes)

### DIFF
--- a/scripts/keri/cf/demo-witness-oobis-schema.json
+++ b/scripts/keri/cf/demo-witness-oobis-schema.json
@@ -3,7 +3,8 @@
   "iurls": [
     "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
     "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller",
-    "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller"
+    "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller",
+    "http://20.121.171.161:7723/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG?name=GLEIF%20Root"
   ],
   "durls": [
     "http://127.0.0.1:7723/oobi/EIL-RWno8cEnkGTi9cr7-PFg_IXTPx9fZ0r9snFFZ0nm",
@@ -13,5 +14,12 @@
     "http://127.0.0.1:7723/oobi/EK0jwjJbtYLIynGtmXXLO5MGJ7BDuX2vr2_MhM9QjAxZ",
     "http://127.0.0.1:7723/oobi/ED_PcIn1wFDe0GB0W7Bk9I4Q_c9bQJZCM2w7Ex9Plsta",
     "http://127.0.0.1:7723/oobi/ELqriXX1-lbV9zgXP4BXxqJlpZTgFchll3cyjaCyVKiz"
+  ],
+  "murls": [
+    "https://www.gleif.org/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG",
+    "https://github.io/WebOfTrust/vLEI/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG",
+    "https://github.io/GLEIF-IT/vLEI/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG",
+    "https://www.first-roc-member.com/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG",
+    "https://www.another-roc-member.com/.well-known/keri/oobi/EL0QKj5uCRRAawr91sVWCVvKM1XNMQ3WJGo_g0O9s-BG"
   ]
 }

--- a/src/keri/app/cli/commands/multisig/incept.py
+++ b/src/keri/app/cli/commands/multisig/incept.py
@@ -13,7 +13,7 @@ import sys
 from hio.base import doing
 
 from keri import help, kering
-from keri.app import indirecting, grouping, habbing
+from keri.app import indirecting, grouping, habbing, forwarding
 from keri.app.cli.common import existing, displaying
 from keri.core import coring
 
@@ -88,8 +88,9 @@ class GroupMultisigIncept(doing.DoDoer):
 
         self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=topics)
         self.counselor = grouping.Counselor(hby=self.hby)
+        self.postman = forwarding.Postman(hby=self.hby)
 
-        doers = [self.hbyDoer, self.mbx, self.counselor]
+        doers = [self.hbyDoer, self.mbx, self.counselor, self.postman]
         self.toRemove = list(doers)
 
         doers.extend([doing.doify(self.inceptDo)])
@@ -137,6 +138,9 @@ class GroupMultisigIncept(doing.DoDoer):
                 break
 
             yield self.tock
+
+        if ghab.kever.delegator:
+            yield from self.postman.sendEvent(hab=ghab, fn=ghab.kever.sn)
 
         print()
         displaying.printIdentifier(self.hby, ghab.pre)

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -10,7 +10,7 @@ from hio import help
 from hio.base import doing
 
 from keri import kering
-from keri.app import grouping, indirecting, habbing
+from keri.app import grouping, indirecting, habbing, forwarding
 from keri.app.cli.common import rotating, existing, displaying
 from keri.core import coring
 
@@ -81,8 +81,9 @@ class GroupMultisigRotate(doing.DoDoer):
 
         mbd = indirecting.MailboxDirector(hby=self.hby, topics=['/receipt', '/multisig'])
         self.counselor = grouping.Counselor(hby=self.hby)
+        self.postman = forwarding.Postman(hby=self.hby)
 
-        doers = [mbd, self.hbyDoer, self.counselor]
+        doers = [mbd, self.hbyDoer, self.counselor, self.postman]
         self.toRemove = list(doers)
 
         doers.extend([doing.doify(self.rotateDo)])
@@ -120,12 +121,16 @@ class GroupMultisigRotate(doing.DoDoer):
         self.counselor.rotate(ghab=ghab, aids=self.aids, sith=self.sith, toad=self.toad,
                               cuts=list(self.cuts), adds=list(self.adds),
                               data=self.data)
+
         while True:
             saider = self.hby.db.cgms.get(keys=(ghab.pre, seqner.qb64))
             if saider is not None:
                 break
 
             yield self.tock
+
+        if ghab.kever.delegator:
+            yield from self.postman.sendEvent(hab=ghab, fn=ghab.kever.sn)
 
         print()
         displaying.printIdentifier(self.hby, ghab.pre)

--- a/src/keri/app/cli/commands/query.py
+++ b/src/keri/app/cli/commands/query.py
@@ -51,7 +51,7 @@ class QueryDoer(doing.DoDoer):
         self.cues = help.decking.Deck()
 
         self.mbd = indirecting.MailboxDirector(hby=self.hby, topics=["/replay", "/receipt"])
-        self.witq = agenting.WitnessInquisitor(hhby=self.hby)
+        self.witq = agenting.WitnessInquisitor(hby=self.hby)
         doers.extend([self.hbyDoer, self.mbd, self.witq, doing.doify(self.cueDo)])
 
         self.toRemove = list(doers)

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -9,7 +9,7 @@ from hio.base import doing
 
 from keri import kering
 from keri.app.cli.common import rotating, existing
-from ... import habbing, agenting, indirecting, directing, delegating
+from ... import habbing, agenting, indirecting, directing, delegating, forwarding
 
 parser = argparse.ArgumentParser(description='Rotate keys')
 parser.set_defaults(handler=lambda args: rotate(args))
@@ -75,8 +75,9 @@ class RotateDoer(doing.DoDoer):
         self.hby = existing.setupHby(name=name, base=base, bran=bran)
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
         self.swain = delegating.Boatswain(hby=self.hby)
+        self.postman = forwarding.Postman(hby=self.hby)
         self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=["/receipt"])
-        doers = [self.hbyDoer, self.mbx, self.swain, doing.doify(self.rotateDo)]
+        doers = [self.hbyDoer, self.mbx, self.swain, self.postman, doing.doify(self.rotateDo)]
 
         super(RotateDoer, self).__init__(doers=doers)
 
@@ -122,12 +123,15 @@ class RotateDoer(doing.DoDoer):
             while not witDoer.cues:
                 _ = yield self.tock
 
+        if hab.kever.delegator:
+            yield from self.postman.sendEvent(hab=hab, fn=hab.kever.sn)
+
         print(f'Prefix  {hab.pre}')
         print(f'New Sequence No.  {hab.kever.sn}')
         for idx, verfer in enumerate(hab.kever.verfers):
             print(f'\tPublic key {idx + 1}:  {verfer.qb64}')
 
-        toRemove = [self.hbyDoer, witDoer, self.swain, self.mbx]
+        toRemove = [self.hbyDoer, witDoer, self.swain, self.mbx, self.postman]
         self.remove(toRemove)
 
         return

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -5,8 +5,6 @@ keri.app.delegating module
 
 module for enveloping and forwarding KERI message
 """
-import json
-from urllib import parse
 
 from hio import help
 from hio.base import doing
@@ -14,8 +12,7 @@ from hio.help import decking
 
 from . import agenting, forwarding
 from ..core import coring
-from ..db import dbing, basing
-from ..help import helping
+from ..db import dbing
 from ..peer import exchanging
 
 logger = help.ogler.getLogger()
@@ -114,7 +111,6 @@ class Boatswain(doing.DoDoer):
                 # Send exn message for notification purposes
                 exn, atc = delegateRequestExn(phab, delpre=delpre, ked=srdr.ked, aids=hab.gaids)
                 # exn of /oobis of all multisig participants to rootgar
-                # self.postman.send(src=phab.pre, dest=hab.kever.delegator, topic="oobis", serder=exn, attachment=atc)
                 self.postman.send(src=phab.pre, dest=hab.kever.delegator, topic="delegate", serder=exn, attachment=atc)
                 self.postman.send(src=phab.pre, dest=delpre, topic="delegate", serder=srdr, attachment=evt)
 

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -126,7 +126,9 @@ class Postman(doing.DoDoer):
         icp = self.hby.db.cloneEvtMsg(pre=hab.pre, fn=fn, dig=hab.kever.serder.saidb)
         ser = coring.Serder(raw=icp)
         del icp[:ser.size]
-        self.send(src=hab.pre, dest=hab.kever.delegator, topic="delegate", serder=ser, attachment=icp)
+
+        sender = hab.lhab.pre if hab.lhab is not None else hab.pre
+        self.send(src=sender, dest=hab.kever.delegator, topic="delegate", serder=ser, attachment=icp)
         while True:
             if self.cues:
                 cue = self.cues.popleft()

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -65,7 +65,6 @@ class Counselor(doing.DoDoer):
         print(f"Waiting for other signatures for {seqner.sn}...")
         return self.hby.db.gpse.add(keys=(prefixer.qb64,), val=(seqner, saider))
 
-
     def rotate(self, ghab, aids, sith, toad, cuts=None, adds=None, data=None):
         """ Begin processing of escrowed group multisig identifier
 
@@ -98,8 +97,8 @@ class Counselor(doing.DoDoer):
         pkever = ghab.lhab.kever
         pnkey = pkever.nexter.digs[0]
 
-        rec = basing.RotateRecord(aids=aids, sn=kever.sn+1, sith=sith, toad=toad,
-                    cuts=cuts, adds=adds, data=data, date=helping.nowIso8601())
+        rec = basing.RotateRecord(aids=aids, sn=kever.sn + 1, sith=sith, toad=toad,
+                                  cuts=cuts, adds=adds, data=data, date=helping.nowIso8601())
         if pnkey in kever.nexter.digs:  # local already participate in last event, rotate
             ghab.lhab.rotate()
             print(f"Rotating local identifier, waiting for witness receipts")
@@ -607,7 +606,6 @@ class MultisigRotateHandler(doing.DoDoer):
 
 
 def multisigRotateExn(ghab, aids, isith, toad, cuts, adds, data):
-
     exn = exchanging.exchange(route=MultisigRotateHandler.resource, modifiers=dict(),
                               payload=dict(gid=ghab.pre,
                                            aids=aids,

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -751,7 +751,7 @@ class Baser(dbing.LMDBer):
         self.gpwe = subing.CatCesrIoSetSuber(db=self, subkey='gdwe.',
                                              klas=(coring.Seqner, coring.Saider))
 
-        # group partial witness escrow
+        # completed group multisig
         self.cgms = subing.CesrSuber(db=self, subkey='cgms.',
                                      klas=coring.Saider)
 


### PR DESCRIPTION
This PR includes:

* Add to all delegated commands (kli and agent) a call to send the committed delegated event back to the delegator with all witness receipts at the end of the process.  Also ensure the sending Hab is not a multisig group.

* Fix agent to accept `private` flag for indicating a credential with support for privacy preserving presentation

* Fix agent to allow for empty edges section.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>