### PR TITLE
Updated rotation apis and parameters to support both an isith and nsith for current and next thresholds

### DIFF
--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -32,8 +32,11 @@ def rotate(args):
 
     """
     data = rotating.loadData(args)
-    rotDoer = RotateDoer(name=args.name, base=args.base, alias=args.alias, bran=args.bran, wits=args.witnesses,
-                         cuts=args.cuts, adds=args.witness_add, sith=args.sith, count=args.next_count, toad=args.toad,
+    rotDoer = RotateDoer(name=args.name, base=args.base, alias=args.alias,
+                         bran=args.bran, wits=args.witnesses,
+                         cuts=args.cuts, adds=args.witness_add,
+                         isith=args.isith, nsith=args.nsith,
+                         count=args.next_count, toad=args.toad,
                          data=data)
 
     doers = [rotDoer]
@@ -47,14 +50,15 @@ class RotateDoer(doing.DoDoer):
     to all appropriate witnesses
     """
 
-    def __init__(self, name, base, bran, alias, sith=None, count=None,
+    def __init__(self, name, base, bran, alias, isith=None, nsith=None, count=None,
                  toad=None, wits=None, cuts=None, adds=None, data: list = None):
         """
         Returns DoDoer with all registered Doers needed to perform rotation.
 
         Parameters:
             name is human readable str of identifier
-            sith is next signing threshold as int or str hex or list of str weights
+            isith is next signing threshold as int or str hex or list of str weights
+            nsith is next signing threshold as int or str hex or list of str weights
             count is int next number of signing keys
             toad is int or str hex of witness threshold after cuts and adds
             cuts is list of qb64 pre of witnesses to be removed from witness list
@@ -63,7 +67,8 @@ class RotateDoer(doing.DoDoer):
        """
 
         self.alias = alias
-        self.sith = sith
+        self.isith = isith
+        self.nsith = nsith
         self.count = count
         self.toad = toad
         self.data = data
@@ -104,7 +109,7 @@ class RotateDoer(doing.DoDoer):
             self.cuts = set(ewits) - set(self.wits)
             self.adds = set(self.wits) - set(ewits)
 
-        hab.rotate(sith=self.sith, count=self.count, toad=self.toad,
+        hab.rotate(isith=self.isith, nsith=self.nsith, count=self.count, toad=self.toad,
                    cuts=list(self.cuts), adds=list(self.adds),
                    data=self.data)
 

--- a/src/keri/app/cli/common/rotating.py
+++ b/src/keri/app/cli/common/rotating.py
@@ -4,7 +4,7 @@ from keri import kering
 
 
 def addRotationArgs(parser):
-    parser.add_argument('--sith', '-s', help='signing threshold for the rotation event', default=None,
+    parser.add_argument('--isith', '-s', help='signing threshold for the rotation event', default=None,
                         required=False)
     parser.add_argument('--nsith', '-x', help='signing threshold for the next rotation event', default=None,
                         required=False)

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -65,7 +65,10 @@ class Counselor(doing.DoDoer):
         print(f"Waiting for other signatures for {seqner.sn}...")
         return self.hby.db.gpse.add(keys=(prefixer.qb64,), val=(seqner, saider))
 
-    def rotate(self, ghab, aids, sith, toad, cuts=None, adds=None, data=None):
+
+
+    def rotate(self, ghab, aids, isith=None, nsith=None,
+               toad=None, cuts=None, adds=None, data=None):
         """ Begin processing of escrowed group multisig identifier
 
         Escrow identifier for multisigs, witness receipts and delegation anchor
@@ -73,7 +76,10 @@ class Counselor(doing.DoDoer):
         Parameters:
             ghab (Hab): group identifier Hab
             aids (list): qb64 identifier prefixes of participants
-            sith (Optional[int,str])next signing threshold as int or str hex or list of str weights
+            isith (Optional[int,str]) currentsigning threshold as int or str hex
+                 or list of str weights
+            nsith (Optional[int,str])next signing threshold as int or str hex
+                 or list of str weights
             toad (int) or str hex of witness threshold after cuts and adds
             cuts (list) of qb64 pre of witnesses to be removed from witness list
             adds (list) of qb64 pre of witnesses to be added to witness list
@@ -97,8 +103,10 @@ class Counselor(doing.DoDoer):
         pkever = ghab.lhab.kever
         pnkey = pkever.nexter.digs[0]
 
-        rec = basing.RotateRecord(aids=aids, sn=kever.sn + 1, sith=sith, toad=toad,
-                                  cuts=cuts, adds=adds, data=data, date=helping.nowIso8601())
+
+        rec = basing.RotateRecord(aids=aids, sn=kever.sn+1, isith=isith, nsith=nsith,
+            toad=toad, cuts=cuts, adds=adds, data=data, date=helping.nowIso8601())
+
         if pnkey in kever.nexter.digs:  # local already participate in last event, rotate
             ghab.lhab.rotate()
             print(f"Rotating local identifier, waiting for witness receipts")
@@ -229,22 +237,23 @@ class Counselor(doing.DoDoer):
             ghab = self.hby.habs[pre]
             gkever = ghab.kever
 
-            keys = []
-            ndigs = list(gkever.nexter.digers)
+            gverfers = []  # verfers of group signing keys
+            ndigers = list(gkever.nexter.digers)
             for aid in rec.aids:
                 pkever = self.hby.kevers[aid]
                 idx = ghab.gaids.index(aid)
                 if pkever.nexter.digs[0] != gkever.nexter.digs[idx]:
-                    keys.append(pkever.verfers[0])
-                    ndigs[idx] = pkever.nexter.digers[0]
+                    gverfers.append(pkever.verfers[0])
+                    ndigers[idx] = pkever.nexter.digers[0]
                 else:
                     break
 
-            if len(keys) != len(rec.aids):
+            if len(gverfers) != len(rec.aids):
                 continue
 
-            rot = ghab.rotate(sith=rec.sith, toad=rec.toad, cuts=rec.cuts, adds=rec.adds, data=rec.data,
-                              mskeys=keys, msdigers=ndigs)
+            rot = ghab.rotate(isith=rec.isith, nsith=rec.nsith,
+                              toad=rec.toad, cuts=rec.cuts, adds=rec.adds, data=rec.data,
+                              gverfers=gverfers, gdigers=ndigers)
             serder = coring.Serder(raw=rot)
             del rot[:serder.size]
 
@@ -370,7 +379,8 @@ class Counselor(doing.DoDoer):
             data = dict(
                 aids=rec.aids,
                 sn=rec.sn,
-                sith=rec.sith,
+                isith=rec.isith,
+                nsith=rec.nsith,
                 timestamp=rec.date,
                 toad=rec.toad,
                 cuts=rec.cuts,
@@ -382,7 +392,8 @@ class Counselor(doing.DoDoer):
             data = dict(
                 aids=rec.aids,
                 sn=rec.sn,
-                sith=rec.sith,
+                isith=rec.isith,
+                nsith=rec.nsith,
                 timestamp=rec.date,
                 toad=rec.toad,
                 cuts=rec.cuts,

--- a/src/keri/app/kiwiing.py
+++ b/src/keri/app/kiwiing.py
@@ -594,7 +594,7 @@ class IdentifierEnd(doing.DoDoer):
             adds = set(wits) - set(ewits)
 
         try:
-            rot = hab.rotate(sith=isith, count=count, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
+            rot = hab.rotate(isith=isith, count=count, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
             self.cues.append(dict(pre=hab.pre))
 
             serder = coring.Serder(raw=rot)
@@ -2370,7 +2370,7 @@ class MultisigEventEnd(MultisigEndBase):
 
         sn = ghab.kever.sn
         # begin the rotation process
-        self.counselor.rotate(ghab=ghab, aids=aids, sith=isith, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
+        self.counselor.rotate(ghab=ghab, aids=aids, isith=isith, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
 
         # Create `exn` peer to peer message to notify other participants UI
         exn, atc = grouping.multisigRotateExn(ghab, aids, isith, toad, cuts, adds, data)
@@ -2486,7 +2486,7 @@ class MultisigEventEnd(MultisigEndBase):
             adds = set(wits) - set(ewits)
 
         sn = ghab.kever.sn
-        self.counselor.rotate(ghab=ghab, aids=aids, sith=isith, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
+        self.counselor.rotate(ghab=ghab, aids=aids, isith=isith, toad=toad, cuts=list(cuts), adds=list(adds), data=data)
 
         # cue up an event to send notification when complete
         self.evts.append(dict(r="/rot/complete", i=ghab.pre, s=sn))

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -146,7 +146,8 @@ class HabitatRecord:  # baser.habs
 class RotateRecord:
     aids: list
     sn: Optional[int]
-    sith: Optional[str|list]
+    isith: Optional[str|list]
+    nsith: Optional[str|list]
     toad: Optional[int]
     cuts: Optional[list]
     adds: Optional[list]

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -65,7 +65,8 @@ class Regery:
             if hab is None:
                 raise kering.ConfigurationError(f"Unknown prefix {pre} for creating Registry {name}")
 
-            reg = Registry(hab=hab, reger=self.reger, tvy=self.tvy, psr=self.psr, name=name, regk=regk, cues=self.cues)
+            reg = Registry(hab=hab, reger=self.reger, tvy=self.tvy, psr=self.psr,
+                           name=name, regk=regk, cues=self.cues)
 
             reg.inited = True
             self.regs[regk] = reg

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -102,7 +102,7 @@ def test_standalone_kli_commands(helpers, capsys):
              }
         ]
 
-    rotate_args = ["rotate", "--name", "test", "--alias", "trans", "--next-count", "3", "--sith", "2"]
+    rotate_args = ["rotate", "--name", "test", "--alias", "trans", "--next-count", "3", "--nsith", "2"]
     args = parser.parse_args(rotate_args)
     assert args.handler is not None
     doers = args.handler(args)

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -88,11 +88,11 @@ def test_counselor():
 
         # Partial rotation
         aids = [hab1.pre, hab2.pre]
-        counselor.rotate(ghab=ghab, aids=aids, sith='2', toad=0, cuts=list(), adds=list())
+        counselor.rotate(ghab=ghab, aids=aids, nsith='2', toad=0, cuts=list(), adds=list())
         rec = hby1.db.glwe.get(keys=(ghab.pre,))
         assert rec is not None
         assert rec.aids == aids
-        assert rec.sith == '2'
+        assert rec.nsith == '2'
         assert rec.toad == 0
 
         counselor.processEscrows()  # process escrows to get witness-less event to next step
@@ -460,7 +460,8 @@ def test_pending_events():
         rec = basing.RotateRecord(
             aids=[hab.pre],
             sn=0,
-            sith=["1/2, 1/2, 1/2"],
+            isith=["1/2, 1/2, 1/2"],
+            nsith=["1/2, 1/2, 1/2"],
             toad=3,
             cuts=[],
             adds=[],
@@ -475,7 +476,8 @@ def test_pending_events():
                            'aids': ['EFPnKh_K7OrV7giJWjUVM7QIZftaCdPQnTQBOGIviMrj'],
                            'cuts': [],
                            'data': [{'a': 1}],
-                           'sith': ['1/2, 1/2, 1/2'],
+                           'isith': ['1/2, 1/2, 1/2'],
+                           'nsith': ['1/2, 1/2, 1/2'],
                            'sn': 0,
                            'timestamp': '2021-06-09T17:35:54.169967+00:00',
                            'toad': 3}
@@ -483,7 +485,8 @@ def test_pending_events():
         rec = basing.RotateRecord(
             aids=[hab.pre],
             sn=3,
-            sith="1",
+            isith=['1/2, 1/2, 1/2'],
+            nsith="1",
             toad=1,
             cuts=[],
             adds=[],
@@ -497,7 +500,8 @@ def test_pending_events():
                            'aids': ['EFPnKh_K7OrV7giJWjUVM7QIZftaCdPQnTQBOGIviMrj'],
                            'cuts': [],
                            'data': [],
-                           'sith': '1',
+                           'isith': ['1/2, 1/2, 1/2'],
+                           'nsith': '1',
                            'sn': 3,
                            'timestamp': '2021-06-09T17:35:54.169967+00:00',
                            'toad': 1}

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -255,7 +255,7 @@ def test_partial_signed_escrow():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"],["1/1", "1/1"]]
-        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, isith=sith, nsith=nxtsith, temp=True)
         assert nst == [['1/2', '1/2', '1/2'], ['1', '1']]  # normalized nxtsith
 
         srdr = eventing.rotate(pre=kvr.prefixer.qb64,
@@ -286,7 +286,11 @@ def test_partial_signed_escrow():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"],["1/1", "1/1"]]
-        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = mgr.rotate(pre=pre,
+                                               count=5,
+                                               isith=sith,
+                                               nsith=nxtsith,
+                                               temp=True)
         assert cst == nst == [['1/2', '1/2', '1/2'], ['1', '1']]  # normalized nxtsith
 
         srdr = eventing.rotate(pre=kvr.prefixer.qb64,
@@ -657,7 +661,7 @@ def test_out_of_order_escrow():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"],["1/1", "1/1"]]
-        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5,isith=sith, nsith=nxtsith, temp=True)
         assert cst == sith
         assert nst == [['1/2', '1/2', '1/2'], ['1', '1']] # normalized nxtsith
 
@@ -1251,7 +1255,7 @@ def test_unverified_trans_receipt_escrow():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"],["1/1", "1/1"]]
-        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = mgr.rotate(pre=pre, count=5, isith=sith, nsith=nxtsith, temp=True)
         assert cst == sith
         assert nst == [['1/2', '1/2', '1/2'], ['1', '1']]  # normalized nxtsith
 

--- a/tests/core/test_weighted_threshold.py
+++ b/tests/core/test_weighted_threshold.py
@@ -111,7 +111,7 @@ def test_weighted():
         # Create rotation event for Wes
         # get current keys as verfers and next digests as digers
         nxtsith = ["1/2", "1/2", "1/2"]  # 2 of 3 but with weighted threshold
-        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=3, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=3, nsith=nxtsith, temp=True)
         assert nst == nxtsith
 
         wesSrdr = eventing.rotate(pre=wesK.prefixer.qb64,
@@ -158,7 +158,7 @@ def test_weighted():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"], ["1", "1"]]
-        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=5, isith=sith, nsith=nxtsith, temp=True)
         assert cst == sith
         assert nst == nxtsith
 
@@ -206,7 +206,7 @@ def test_weighted():
         sith = nxtsith  # rotate so nxtsith is now current sith and need new nextsith
         #  2 of first 3 and 1 of last 2
         nxtsith = [["1/2", "1/2", "1/2"], ["1/1", "1/1"]]
-        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=5, sith=nxtsith, temp=True)
+        verfers, digers, cst, nst = wesMgr.rotate(pre=wesPre, count=5, isith=sith, nsith=nxtsith, temp=True)
         assert cst == nst == [['1/2', '1/2', '1/2'], ['1', '1']] # normalized nxtsith
 
         wesSrdr = eventing.rotate(pre=wesK.prefixer.qb64,


### PR DESCRIPTION
New rotation rules will require that current signing threshold isith is not the same as the prior next signing threshold 
so rotations must support both independently. The default is for isith to be the prior next when not provided so mostly backwards compatible. The old sith which was the new next threshold is now nsith for next threshold.