### PR TITLE
Issue 313 crash when witness missing

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -593,7 +593,7 @@ def httpClient(hab, wit):
     """
     urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http)
     if not urls:
-        logger.error(f"unable to query witness {wit}, no http endpoint")
+        raise kering.MissingEntryError(f"unable to query witness {wit}, no http endpoint")
 
     up = urlparse(urls[kering.Schemes.http])
     client = http.clienting.Client(hostname=up.hostname, port=up.port)

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -782,8 +782,13 @@ class Poller(doing.DoDoer):
             witrec = basing.TopicsRecord(topics=dict())
 
         while self.retry > 0:
-            self.retry = 0
-            client, clientDoer = agenting.httpClient(self.hab, self.witness)
+            self.retry -= 1
+            try:
+                client, clientDoer = agenting.httpClient(self.hab, self.witness)
+            except kering.MissingEntryError as e:
+                traceback.print_exception(e, file=sys.stderr)
+                yield self.tock
+                continue
             self.extend([clientDoer])
 
             topics = dict()

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -7,6 +7,8 @@ simple indirect mode demo support classes
 """
 import falcon
 import time
+import sys
+import traceback
 from ordered_set import OrderedSet as oset
 
 from hio.base import doing
@@ -786,7 +788,7 @@ class Poller(doing.DoDoer):
             try:
                 client, clientDoer = agenting.httpClient(self.hab, self.witness)
             except kering.MissingEntryError as e:
-                traceback.print_exception(e, file=sys.stderr)
+                traceback.print_exception(e, file=sys.stderr) # logging
                 yield self.tock
                 continue
             self.extend([clientDoer])


### PR DESCRIPTION
Fix for issue #313 

The code was not handling "not urls" case which caused KeyError from following statement. Added raise MissingEntryError. Handling this error in indirecting.py by letting the while loop retry the operation.

agenting.httpClient is invoked from some other places in code. I have not improved error handling in those places.