### PR TITLE
Issue 314 invalid content type

### DIFF
--- a/src/keri/app/kiwiing.py
+++ b/src/keri/app/kiwiing.py
@@ -220,9 +220,7 @@ class IdentifierEnd(doing.DoDoer):
         """
         hab = self.hby.habByName(alias)
         if hab is None:
-            rep.status = falcon.HTTP_404
-            rep.content_type = f"no identifier for alias {alias}"
-            return
+            raise falcon.HTTPNotFound(description=f"no identifier for alias {alias}")
 
         info = self.info(hab)
 


### PR DESCRIPTION
Fix for issue #314

I'd like to suggest fixing this by raising HTTPNotFound exception

With this change the error looks like this

```
$  curl -i -s http://localhost:5620/ids/notfound
HTTP/1.1 404 Not Found
Content-Type: application/json
Vary: Accept
Content-Length: 77
Server: Ioflo WSGI Server
Date: Wed, 05 Oct 2022 15:49:19 GMT

{"title": "404 Not Found", "description": "no identifier for alias notfound"}
```

I can also apply this style of fix to other places where http errors are generated.