### PR TITLE
Hab.sign now supports dual index for new rotation rules that is backwards compatible with old.

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1018,22 +1018,22 @@ class Hab:
             self.prefixes.add(self.pre)
 
         # create inception event
-        if self.mhab:  # Group multisig member. Sign with single sig of mhab
-            # convention use indices from mhab's first current signing key if
-            # participating
-            # mid index tuple (csi, pni)
-            csi = keys.index(self.mhab.kever.verfers[0].qb64)  # first key of mhab
-            # inception so no prior next so pni could be None but for backwards
-            # compatibility set to same as csi since inception event validation
-            # ignores pni index since not required. In future should set to None
-            pni = csi
-            sigers = self.mhab.mgr.sign(ser=serder.raw,
-                                        verfers=[self.mhab.kever.verfers[0]],
-                                        indices=[csi],
-                                        ondices=[pni])
+        #if self.mhab:  # Group multisig member. Sign with single sig of mhab
+            ## convention use indices from mhab's first current signing key if
+            ## participating
+            ## mid index tuple (csi, pni)
+            #csi = keys.index(self.mhab.kever.verfers[0].qb64)  # first key of mhab
+            ## inception so no prior next so pni could be None but for backwards
+            ## compatibility set to same as csi since inception event validation
+            ## ignores pni index since not required. In future should set to None
+            #pni = csi
+            #sigers = self.mhab.mgr.sign(ser=serder.raw,
+                                        #verfers=[self.mhab.kever.verfers[0]],
+                                        #indices=[csi],
+                                        #ondices=[pni])
 
-        else:
-            sigers = self.sign(ser=serder.raw, verfers=verfers)
+        #else:
+        sigers = self.sign(ser=serder.raw, verfers=verfers)
 
         # during delegation initialization of a habitat we ignore the MissingDelegationError and
         # MissingSignatureError
@@ -1256,20 +1256,20 @@ class Hab:
                                      adds=adds,
                                      data=data)
 
-        if self.mhab:  # Group multisig member. Sign with single sig of mhab
-            # convention use indices from mhab's first current signing key if
-            # participating and first prior next dig if participating. One or
-            # the other or both must be participant
-            # mid index tuple (csi, pni)
-            csi = keys.index(self.mhab.kever.verfers[0].qb64)  # always use first key of mhab
-            pni = csi # self.mhab.kever.nexter.digs[0] #always use first dig of mhab
-            sigers = self.mhab.mgr.sign(ser=serder.raw,
-                                        verfers=[self.mhab.kever.verfers[0]],
-                                        indices=[csi],
-                                        ondices=[pni])
+        #if self.mhab:  # Group multisig member. Sign with single sig of mhab
+            ## convention use indices from mhab's first current signing key if
+            ## participating and first prior next dig if participating. One or
+            ## the other or both must be participant
+            ## mid index tuple (csi, pni)
+            #csi = keys.index(self.mhab.kever.verfers[0].qb64)  # always use first key of mhab
+            #pni = csi # self.mhab.kever.nexter.digs[0] #always use first dig of mhab
+            #sigers = self.mhab.mgr.sign(ser=serder.raw,
+                                        #verfers=[self.mhab.kever.verfers[0]],
+                                        #indices=[csi],
+                                        #ondices=[pni])
 
-        else:
-            sigers = self.sign(ser=serder.raw, verfers=verfers)
+        #else:
+        sigers = self.sign(ser=serder.raw, verfers=verfers)
 
         # update own key event verifier state
         msg = eventing.messagize(serder, sigers=sigers)

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1319,28 +1319,31 @@ class Hab:
             verfers = self.kever.verfers
 
         if self.mhab:  # Group multisig member. Sign with single sig of mhab.
-            # Convention is to always use always use first key of mhab.kever and
-            # first dig mhab prior nexter.digs. Assumes that prior next and
-            # current key after rotation of mhab always match, that is the
-            # prior next dig is the digest of current key at same index in
-            # both lists. Key or both key and prior dig might be participants
-            # in group hab's rotation. Recall that can't participate as prior dig
-            # unless exposed as participant in curren (after rotation) key.
-            # If mhab.kever.verfer[0] key in new group verfers then
-            # participating in group as new key at index csi. If in addition
-            # mhab .prior  nexter.digs[0] in group.kever.digers (which is prior
-            # next for group) then also participating as group prior next at index
-            # pni else pni is None.
+            # Convention is to always use first key of mhab.kever.verfers and
+            # first dig of mhab's prior nexter.digs. Assumes that index in
+            # prior next and current key after rotation of mhab always match in
+            # their respective lists. that is the prior next dig at index i
+            # is the digest of current key at index i in both lists.
 
             keys = [verfer.qb64 for verfer in verfers]  # group hab's keys
             merfer = self.mhab.kever.verfers[0]  # always use first key of mhab
             try:
                 csi = keys.index(merfer.qb64) # find mhab key index in group hab keys
             except ValueError as ex:
-                raise ValueError(f"Member hab={mhab.pre} not a participant in "
-                                 "this group hab={self.pre} event.") from ex
+                raise ValueError(f"Member hab={self.mhab.pre} not a participant in "
+                                 f"event for this group hab={self.pre}.") from ex
 
-            if rotated:  # rotation so uses other index of dual index
+            if rotated:  # rotation so uses the other index from dual indices
+                # Either the verfer key or both the verfer key and prior dig
+                # might be participants in group hab's rotation.
+                # Each prior dig participant must also be exposed as participant
+                # in current (after rotation) key list.
+                # If mhab.kever.verfer[0] key is in group's new verfers (after rot)
+                # then mhab participates in group as new key at index csi.
+                # If in addition mhab prior dig at nexter.digs[0] is in group's
+                # kever.digers (which will be prior next for group after rotation)
+                # then mhab participates as group prior next at index pni.
+                # else pni is None which means mhab only participates as new key.
                 # get nexter of .mhab's prior Next est event
                 mexter = self.mhab.kever.fetchPriorNexter()
                 if mexter is not None:

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1353,9 +1353,15 @@ class Hab:
             keys = [verfer.qb64 for verfer in verfers]  # group hab's keys
             merfer = self.mhab.kever.verfers[0]  # always use first key of mhab
             csi = keys.index(merfer.qb64) # find mhab key index in group hab keys
-            if rotated:  # rotation so use dual index
-                #always use first prior dig of mhab
-                # get prior Next keys by looking up from self.mhab.kever.lastEst
+
+            if rotated:  # rotation uses dual index
+                # get .mhab's prior Next digs
+                #nexter = self.mhab.kever.fetchPriorNexter()
+                #if nexter is not None:
+                    #miger = nexter.digers[0]  #always use first prior dig of mhab
+                    #pni = digs.index(miger.qb64)  # find mhab dig index in group hab digs
+                #else:
+                    #pni = None  # not part of prior next
                 pni = csi
             else:  # not a rotation so either both same or current signing keys only
                 pni = csi  # backwards compatible is both same

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -1228,6 +1228,7 @@ class Manager:
                 one of pubs or verfers is required. If both then verfers is ignored.
             verfers (list[Verfer] | None): Verfer instances of public keys
                 one of pubs or verfers is required. If both then verfers is ignored.
+                If not pubs then gets public key from verfer.qb64
             indexed (bool):
                 True means use use indexed signatures and return
                 list of Siger instances.

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2506,6 +2506,37 @@ class Kever:
                 )
 
 
+    def fetchPriorNexter(self) -> (Nexter | None):
+        """ Returns either the most recent prior Nexter before .lastEst or None
+
+        Starts searching at sn = .lastEst.s - 1
+
+        Returns the Nexter instance at the most recent prior Nexter to the
+        current nexter of the given sequence number (sn) otherwise returns None.
+        Walks backwards to the more recent prior establishment event before the
+        .sn if any.
+        If sn represents an interaction event (ixn) then the result will be the
+        current valid nexter. If sn represents an establishment event then
+        the result will be the prior nexter to the current one.
+
+        Parameters:
+
+        Returns:
+            Nexter instance or None if no prior est event to current .lastEst
+
+        """
+        pre = self.prefixer.qb64
+        sn = self.lastEst.s - 1
+        for digb in self.db.getKelBackIter(pre, sn):
+            dgkey = dgKey(pre, digb)
+            raw = self.db.getEvt(dgkey)
+            serder = coring.Serder(raw=bytes(raw))
+            if serder.est:  # establishment event
+                return serder.nexter
+
+        return None
+
+
 class Kevery:
     """
     Kevery (Key Event Message Processing Facility) processes an incoming

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1944,8 +1944,8 @@ class Baser(dbing.LMDBer):
     def getKelBackIter(self, pre, fn):
         """
         Returns iterator of all dup vals in insertion order for all entries
-        with same prefix across all sequence numbers without gaps. Stops if
-        encounters gap.
+        with same prefix across all sequence numbers without gaps in decreasing
+        order starting with first sequence number fn. Stops if encounters gap.
         Assumes that key is combination of prefix and sequence number given
         by .snKey().
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -1976,6 +1976,9 @@ def test_keyeventsequence_0():
         assert kever.estOnly is False
         assert kever.transferable is True
 
+        nexter = kever.fetchPriorNexter()
+        assert nexter is None
+
         # Event 1 Rotation Transferable
         # compute nxt digest from keys2
         keys2 = [signers[2].verfer.qb64]
@@ -2003,6 +2006,10 @@ def test_keyeventsequence_0():
         assert [verfer.qb64 for verfer in kever.verfers] == keys1
         assert kever.nexter.digs == nxt2
 
+        nexter = kever.fetchPriorNexter()
+        assert nexter is not None
+        assert nexter.digs == nxt1  # digs from inception before rotation
+
         # Event 2 Rotation Transferable
         # compute nxt digest from keys3
         keys3 = [signers[3].verfer.qb64]
@@ -2028,6 +2035,10 @@ def test_keyeventsequence_0():
         assert [verfer.qb64 for verfer in kever.verfers] == keys2
         assert kever.nexter.digs == nxt3
 
+        nexter = kever.fetchPriorNexter()
+        assert nexter is not None
+        assert nexter.digs == nxt2  # digs from rotation before rotation
+
         # Event 3 Interaction
         serder3 = interact(pre=pre, dig=serder2.said, sn=3)
         event_digs.append(serder3.said)
@@ -2047,6 +2058,10 @@ def test_keyeventsequence_0():
         assert [verfer.qb64 for verfer in kever.verfers] == keys2  # no change
         assert kever.nexter.digs == nxt3  # no change
 
+        nexter = kever.fetchPriorNexter()
+        assert nexter is not None
+        assert nexter.digs == nxt2  # digs from rot before rot before ixn
+
         # Event 4 Interaction
         serder4 = interact(pre=pre, dig=serder3.said, sn=4)
         event_digs.append(serder4.said)
@@ -2065,6 +2080,10 @@ def test_keyeventsequence_0():
         assert kever.ilk == Ilks.ixn
         assert [verfer.qb64 for verfer in kever.verfers] == keys2  # no change
         assert kever.nexter.digs == nxt3  # no change
+
+        nexter = kever.fetchPriorNexter()
+        assert nexter is not None
+        assert nexter.digs == nxt2  # digs from rot before rot before ixn ixn
 
         # Event 5 Rotation Transferable
         # compute nxt digest from keys4
@@ -2090,6 +2109,10 @@ def test_keyeventsequence_0():
         assert kever.ilk == Ilks.rot
         assert [verfer.qb64 for verfer in kever.verfers] == keys3
         assert kever.nexter.digs == nxt4
+
+        nexter = kever.fetchPriorNexter()
+        assert nexter is not None
+        assert nexter.digs == nxt3  # digs from rot before ixn ixn before rot
 
         # Event 6 Interaction
         serder6 = interact(pre=pre, dig=serder5.said, sn=6)
@@ -4389,4 +4412,5 @@ def test_load_event(mockHelpingNowUTC):
 
 if __name__ == "__main__":
     # pytest.main(['-vv', 'test_eventing.py::test_keyeventfuncs'])
-    test_process_manual()
+    #test_process_manual()
+    test_keyeventsequence_0()


### PR DESCRIPTION
No code or tests use the new dual index where the current and prior next are different.  but the new logic does not break the old code. Next work is to update the validation logic to use the dual index when used.