### PR TITLE
Add support for processing a multi OOBI (MOOBI) in the form of a rpy message

### DIFF
--- a/src/keri/app/cli/commands/saidify.py
+++ b/src/keri/app/cli/commands/saidify.py
@@ -41,4 +41,4 @@ def saidify(tock=0.0, **opts):
         _, out = coring.Saider.saidify(sad=sad, label=args.label)
 
     with open(args.file, 'w') as f:
-        json.dump(out, f, indent=2)
+        json.dump(out, f)

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -129,6 +129,7 @@ class OobiRecord:
     role: str = None
     date: str = None
     state: str = None
+    urls: list = None
 
 
 @dataclass
@@ -894,7 +895,13 @@ class Baser(dbing.LMDBer):
 
         # Well known OOBIs that are to be used for mfa against a resolved OOBI.
         self.woobi = koming.Komer(db=self,
-                                  subkey='wknwn.',
+                                  subkey='woobi.',
+                                  schema=OobiRecord,
+                                  sep=">")  # Use seperator not a allowed in URLs so no splitting occurs.
+
+        # Well known OOBIs that are to be used for mfa against a resolved OOBI.
+        self.moobi = koming.Komer(db=self,
+                                  subkey='moobi.',
                                   schema=OobiRecord,
                                   sep=">")  # Use seperator not a allowed in URLs so no splitting occurs.
 

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -1715,7 +1715,7 @@ def test_clean_baser():
         state = natHab.db.states.get(keys=natHab.pre)  # Serder instance
         assert state.sn == 6
         assert state.ked["f"] == '6'
-        assert natHab.db.env.stat()['entries'] == 67
+        assert natHab.db.env.stat()['entries'] == 68
 
         # test reopenDB with reuse  (because temp)
         with basing.reopenDB(db=natHab.db, reuse=True):
@@ -1724,7 +1724,7 @@ def test_clean_baser():
             assert ldig == natHab.kever.serder.saidb
             serder = coring.Serder(raw=bytes(natHab.db.getEvt(dbing.dgKey(natHab.pre,ldig))))
             assert serder.said == natHab.kever.serder.said
-            assert natHab.db.env.stat()['entries'] == 67
+            assert natHab.db.env.stat()['entries'] == 68
 
             # verify name pre kom in db
             data = natHab.db.habs.get(keys=natHab.name)


### PR DESCRIPTION
Add support for processing a multi OOBI (MOOBI) in the form of a rpy message, processing each URL embedded in the MOOBI and not marking the URL for the MOOBI as resolved until all embedded URLs are complete.

Also enhanced the Oobiery tests by serving real OOBIs (and now MOOBI) from an enpoint and actually resolving them.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>