### PR TITLE
fix(kli): Show help when called with no arguments

### DIFF
--- a/src/keri/app/cli/kli.py
+++ b/src/keri/app/cli/kli.py
@@ -17,6 +17,10 @@ def main():
     parser = multicommand.create_parser(commands)
     args = parser.parse_args()
 
+    if not hasattr(args, 'handler'):
+        parser.print_help()
+        return
+
     try:
         doers = args.handler(args)
         directing.runController(doers=doers, expire=0.0)


### PR DESCRIPTION
This MR prevents the exception when calling `kli` without any arguments and prints the help.

The snippet is taken straight from the [project docs](https://pypi.org/project/multicommand/).

**Before:**

```sh
kli
# Traceback (most recent call last):
#   File "/Users/tim.sterker/.asdf/installs/python/3.10.4/bin/kli", line 33, in <module>
#     sys.exit(load_entry_point('keri', 'console_scripts', 'kli')())
#   File "/Users/tim.sterker/projects/keripy/src/keri/app/cli/kli.py", line 27, in main
#     raise ex
#   File "/Users/tim.sterker/projects/keripy/src/keri/app/cli/kli.py", line 21, in main
#     doers = args.handler(args)
# AttributeError: 'Namespace' object has no attribute 'handler'
```

**After:**
```sh
kli
# usage: kli [-h] command ...
# [...]
```