### PR TITLE
Allow data at inception

### DIFF
--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -51,6 +51,7 @@ class InceptOptions:
     toad: int = 0
     delpre: str = None
     estOnly: bool = False
+    data: list = None
 
 
 def handler(args):

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -876,7 +876,7 @@ class Hab:
     def make(self, *, secrecies=None, iridx=0, code=coring.MtrDex.Blake3_256,
              transferable=True, isith=None, icount=1, nsith=None, ncount=None,
              toad=None, wits=None, delpre=None, estOnly=False, DnD=False,
-             merfers=None, migers=None, mindices=None, hidden=False):
+             merfers=None, migers=None, mindices=None, hidden=False, data=None):
         """
         Finish setting up or making Hab from parameters includes inception.
         Assumes injected dependencies were already setup.
@@ -917,6 +917,7 @@ class Hab:
                 (csi, npi)
 
             hidden (bool): A hidden Hab is not included in the list of Habs.
+            data (list | None): seal dicts
 
         ToDo: NRR
         HabitatRecord needs to also store indices for each mid midex tuple(csi, pni)
@@ -993,7 +994,8 @@ class Hab:
                                      toad=toad,
                                      wits=wits,
                                      cnfg=cnfg,
-                                     code=code)
+                                     code=code,
+                                     data=data)
 
         self.pre = serder.ked["i"]  # new pre
 

--- a/src/keri/app/kiwiing.py
+++ b/src/keri/app/kiwiing.py
@@ -476,6 +476,7 @@ class IdentifierEnd(doing.DoDoer):
         ncount = int(body.get("ncount")) if "ncount" in body else 1
         estOnly = int(body.get("estOnly")) if "estOnly" in body else False
         DnD = int(body.get("DnD")) if "DnD" in body else False
+        data = body.get("data") if "data" in body else None
 
         kwa = dict(
             transferable=transferable,
@@ -487,6 +488,7 @@ class IdentifierEnd(doing.DoDoer):
             ncount=ncount,
             estOnly=estOnly,
             DnD=DnD,
+            data=data,
         )
         if "delpre" in body:
             kwa["delpre"] = body["delpre"]


### PR DESCRIPTION
Allows inception with data. Tested from `kli incept` and from API `ids/{alias}`.