### PR TITLE
Fix Counselor to accept a partial rotation of a group multisig AID correctly.

### DIFF
--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -251,17 +251,19 @@ class Counselor(doing.DoDoer):
             gkever = ghab.kever  # group hab's Kever instance key state
 
             merfers = []  # local verfers of group signing keys
+            indices = []  # weights of the local signers who have already rotated
             migers = list(gkever.nexter.digers)  # local participants next digers
             for aid in rec.smids:
                 pkever = self.hby.kevers[aid]
                 idx = ghab.smids.index(aid)
                 if pkever.nexter.digs[0] != gkever.nexter.digs[idx]:
+                    indices.append(idx)
                     merfers.append(pkever.verfers[0])
                     migers[idx] = pkever.nexter.digers[0]
                 else:
                     break
 
-            if len(merfers) != len(rec.smids):
+            if not gkever.tholder.satisfy(indices):
                 continue
 
             rot = ghab.rotate(isith=rec.isith, nsith=rec.nsith,

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -91,7 +91,7 @@ def test_counselor():
         counselor.postman.evts.popleft()
 
         # Partial rotation
-        smids = [hab1.pre, hab2.pre]
+        smids = [hab1.pre, hab2.pre, hab3.pre]
         rmids = None  # need to fix
         counselor.rotate(ghab=ghab, smids=smids, rmids=rmids,
                          nsith='2', toad=0, cuts=list(), adds=list())
@@ -104,7 +104,7 @@ def test_counselor():
         counselor.processEscrows()  # process escrows to get witness-less event to next step
         rec = hby1.db.glwe.get(keys=(ghab.pre,))
         assert rec is None
-        assert len(counselor.postman.evts) == 1
+        assert len(counselor.postman.evts) == 2
         evt = counselor.postman.evts.popleft()
         assert evt["src"] == hab1.pre
         assert evt["dest"] == hab2.pre
@@ -155,7 +155,7 @@ def test_counselor():
                        b'YvFai31ajkT7qpwKFuCSQboCFIJ9T8iP462ltRgL-FbNb-YbybQFamTa23vqn7ve'
                        b'Es4w9C1UK')
 
-        # Create group rotation from second participany
+        # Create group rotation from second participant
 
         parsing.Parser().parse(ims=bytearray(msg), kvy=kev1)  # parse second signed group inception
         kev1.processEscrows()  # Run escrows for Kevery1 so he processes all sigs together


### PR DESCRIPTION
Fix Counselor to accept a partial rotation of a group multisig AID when a threshold satisfying number of members have rotated their local AIDs, regardless of the initial list provided.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>