### PR TITLE
2 new command line tools and one new option

### DIFF
--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -1,0 +1,132 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri import kering
+from keri.app import agenting, indirecting, habbing, httping
+from keri.app.cli.common import displaying, existing
+from keri.core import coring
+from keri.kering import ConfigurationError
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Display mailbox status for an identifier and witness')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', default=None)
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--witness', '-w', help='The qualified b64 AID of the witness to poll', required=True)
+parser.add_argument("--verbose", "-V", help="print JSON of all current events", action="store_true")
+
+
+def handler(args):
+    """
+    Submit KERI identifier prefix to its witnesses for receipts.
+
+    Args:
+        args(Namespace): arguments object from command line
+    """
+
+    name = args.name
+    base = args.base
+    bran = args.bran
+    alias = args.alias
+    witness = args.witness
+    verbose = args.verbose
+
+    icpDoer = ReadDoer(name=name, base=base, alias=alias, bran=bran, witness=witness, verbose=verbose)
+
+    doers = [icpDoer]
+    return doers
+
+
+class ReadDoer(doing.DoDoer):
+    """ DoDoer for creating a new identifier prefix and Hab with an alias.
+    """
+
+    def __init__(self, name, base, alias, bran, witness, verbose):
+
+        hby = existing.setupHby(name=name, base=base, bran=bran)
+        self.hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
+        self.alias = alias
+        self.hby = hby
+        self.witness = witness
+        self.verbose = verbose
+
+        doers = [self.hbyDoer, doing.doify(self.readDo)]
+
+        super(ReadDoer, self).__init__(doers=doers)
+
+    def readDo(self, tymth, tock=0.0):
+        """
+        Parameters:
+            tymth (function): injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock (float): injected initial tock value
+
+        Returns:  doifiable Doist compatible generator method
+        """
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        hab = self.hby.habByName(name=self.alias)
+        topics = {"/receipt": 0, "/replay": 0, "/multisig": 0, "/credential": 0, "/delegate": 0, "/challenge": 0,
+                  "/oobi": 0}
+        try:
+            client, clientDoer = agenting.httpClient(hab, self.witness)
+        except kering.MissingEntryError as e:
+            raise ValueError(f"error connecting to witness {self.witness}: {e}")
+
+        self.extend([clientDoer])
+
+        print("Local Index per Topic")
+        witrec = hab.db.tops.get((hab.pre, self.witness))
+        for topic in witrec.topics:
+            print(f"   Topic {topic}:   {witrec.topics[topic]}")
+        print()
+
+        q = dict(pre=hab.pre, topics=topics)
+        if hab.mhab:
+            msg = hab.mhab.query(pre=hab.pre, src=self.witness, route="mbx", query=q)
+        else:
+            msg = hab.query(pre=hab.pre, src=self.witness, route="mbx", query=q)
+
+        httping.createCESRRequest(msg, client)
+
+        while client.requests:
+            yield self.tock
+
+        yield 1.0
+        print("Messages:")
+        while client.events:
+            evt = client.events.popleft()
+            if "id" not in evt or "data" not in evt or "name" not in evt:
+                print(f"bad mailbox event: {evt}")
+                continue
+            idx = evt["id"]
+            msg = evt["data"]
+            tpc = evt["name"]
+
+            if not self.verbose:
+                print(f"Topic {tpc}: {idx}: {msg[0:20]}")
+            else:
+                print(f"  Topic: {tpc}")
+                print(f"  Index: {idx}")
+                print(f"  {msg}")
+                print()
+
+        self.remove([self.hbyDoer, clientDoer])
+        return

--- a/src/keri/app/cli/commands/mailbox/update.py
+++ b/src/keri/app/cli/commands/mailbox/update.py
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app.cli.common import existing
+from keri.db import basing
+from keri.kering import ConfigurationError
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Update the index for a given topic for a witness')
+parser.set_defaults(handler=lambda args: handler(args), transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
+parser.add_argument("--config", "-c", help="directory override for configuration data")
+
+parser.add_argument("--witness", "-w", help="qualified b64 AID of witness to update", required=True)
+parser.add_argument("--topic", "-t", help="topic name to update", required=True)
+parser.add_argument("--index", "-i", help="new index for topic on witness", required=True)
+
+# Authentication for keystore
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--aeid', help='qualified base64 of non-transferable identifier prefix for  authentication '
+                                   'and encryption of secrets in keystore', default=None)
+
+
+def handler(args):
+    kwa = dict(args=args)
+    return [doing.doify(update, **kwa)]
+
+
+def update(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    alias = args.alias
+    base = args.base
+    bran = args.bran
+
+    witness = args.witness
+    topic = args.topic
+    idx = int(args.index)
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            hab = hby.habByName(name=alias)
+
+            if topic[0] != "/":
+                topic = "/" + topic
+
+            witrec = hab.db.tops.get((hab.pre, witness))
+            if witrec is None:
+                witrec = basing.TopicsRecord(topics=dict())
+
+            witrec.topics[topic] = int(idx)
+            hab.db.tops.pin((hab.pre, witness), witrec)
+
+    except ConfigurationError:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/cli/kli.py
+++ b/src/keri/app/cli/kli.py
@@ -26,9 +26,9 @@ def main():
         directing.runController(doers=doers, expire=0.0)
 
     except Exception as ex:
-        print(f"ERR: {ex}")
-        return -1
-        # raise ex
+        # print(f"ERR: {ex}")
+        # return -1
+        raise ex
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New utility to look at an AID's mailbox on a given witness

New utility to update current index for an AID's mailbox for a topic on a witness (use with care).

Additional `--force-` option to `kli submit` to force it to send all receipts to all witnesses even if it already has a full compliment.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>