### PR TITLE
Unify CLI args for incept and rotate

### DIFF
--- a/scripts/demo/basic/clear.sh
+++ b/scripts/demo/basic/clear.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+rm -rfv ~/.keri && rm -rfv /usr/local/var/keri

--- a/scripts/demo/data/rotate-sample.json
+++ b/scripts/demo/data/rotate-sample.json
@@ -1,0 +1,10 @@
+{
+  "isith": "1",
+  "nsith": "1",
+  "ncount": 1,
+  "toad": 0,
+  "wits": [],
+  "witsCut": [],
+  "witsAdd": []
+}
+

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -3,17 +3,14 @@
 keri.kli.commands module
 
 """
-import sys
 import argparse
 from dataclasses import dataclass
-import json
-from json import JSONDecodeError
 
 from hio import help
 from hio.base import doing
 
 from keri.app import habbing, agenting, indirecting, configing, delegating, forwarding
-from keri.app.cli.common import existing
+from keri.app.cli.common import existing, incepting, config
 
 logger = help.ogler.getLogger()
 
@@ -26,13 +23,14 @@ parser.add_argument('--base', '-b', help='additional optional prefix to file loc
 parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
 parser.add_argument("--config", "-c", help="directory override for configuration data")
 
-parser.add_argument('--file', '-f', help='Filename to use to create the identifier', default="", required=True)
+parser.add_argument('--file', '-f', help='Filename to use to create the identifier', default="", required=False)
 
 # Authentication for keystore
 parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument('--aeid', help='qualified base64 of non-transferable identifier prefix for  authentication '
                                    'and encryption of secrets in keystore', default=None)
+incepting.addInceptingArgs(parser)
 
 
 @dataclass
@@ -60,29 +58,62 @@ def handler(args):
         args(Namespace): arguments object from command line
     """
 
-    try:
-        f = open(args.file)
-        config = json.load(f)
-
-        opts = InceptOptions(**config)
-    except FileNotFoundError:
-        print("config file", args.file, "not found")
-        sys.exit(-1)
-    except JSONDecodeError:
-        print("config file", args.file, "not valid JSON")
-        sys.exit(-1)
-
     name = args.name
     base = args.base
     bran = args.bran
     alias = args.alias
-    config = args.config
+    config_dir = args.config
 
-    kwa = opts.__dict__
-    icpDoer = InceptDoer(name=name, base=base, alias=alias, bran=bran, config=config, **kwa)
+    kwa = mergeArgsWithFile(args).__dict__
+
+    icpDoer = InceptDoer(name=name, base=base, alias=alias, bran=bran, config=config_dir, **kwa)
 
     doers = [icpDoer]
     return doers
+
+
+def emptyOptions():
+    """
+    Initializes an empty inception options to be used only when required values are passed in at the command line
+    """
+    return InceptOptions(
+        transferable=None, wits=None, icount=None, isith=None, ncount=None, nsith=None
+    )
+
+
+def mergeArgsWithFile(args):
+    """
+    Merge options specified with command line arguments with any specified config file
+    with command line arguments taking precedence.
+    """
+    required_args = ['transferable', 'wits', 'icount', 'isith', 'ncount', 'nsith', 'toad']
+    if args.file is None or args.file == '':
+        config.checkRequiredArgs(args, required_args)
+
+    incept_opts = config.loadFileOptions(args.file, InceptOptions) if args.file != '' else emptyOptions()
+
+    if args.transferable is not None:
+        incept_opts.transferable = args.transferable
+    if len(args.wits) > 0:
+        incept_opts.wits = args.wits
+    if args.icount is not None:
+        incept_opts.icount = int(args.icount)
+    if args.toad is not None:
+        incept_opts.toad = int(args.toad)
+    if args.icount is not None:
+        incept_opts.icount = int(args.icount)
+    if args.isith is not None:
+        incept_opts.isith = args.isith
+    if args.ncount is not None:
+        incept_opts.ncount = int(args.ncount)
+    if args.nsith is not None:
+        incept_opts.nsith = args.nsith
+    if args.est_only is not None:
+        incept_opts.estOnly = args.est_only
+    if args.data is not None:
+        incept_opts.data = config.parseData(args.data)
+
+    return incept_opts
 
 
 class InceptDoer(doing.DoDoer):

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -12,7 +12,7 @@ from hio.base import doing
 
 from keri import kering
 from keri.app import grouping, indirecting, habbing, forwarding
-from keri.app.cli.common import existing, displaying, rotating
+from keri.app.cli.common import existing, displaying, config
 from keri.core import coring
 
 logger = help.ogler.getLogger()
@@ -45,7 +45,7 @@ def interactGroupIdentifier(args):
 
     """
 
-    data = rotating.loadData(args)
+    data = config.parseData(args.data) if args.data is not None else None
     ixnDoer = GroupMultisigInteract(name=args.name, alias=args.alias, aids=args.aids, base=args.base, bran=args.bran,
                                     data=data)
 

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -11,7 +11,7 @@ from hio.base import doing
 
 from keri import kering
 from keri.app import grouping, indirecting, habbing, forwarding
-from keri.app.cli.common import rotating, existing, displaying
+from keri.app.cli.common import rotating, existing, displaying, config
 from keri.core import coring
 
 logger = help.ogler.getLogger()
@@ -48,7 +48,7 @@ def rotateGroupIdentifier(args):
 
     """
 
-    data = rotating.loadData(args)
+    data = config.parseData(args.data) if args.data is not None else None
 
     rotDoer = GroupMultisigRotate(name=args.name, base=args.base, alias=args.alias, smids=args.smids, rmids=args.rmids,
                                   bran=args.bran, wits=args.witnesses, cuts=args.cuts, adds=args.witness_add,

--- a/src/keri/app/cli/common/config.py
+++ b/src/keri/app/cli/common/config.py
@@ -5,7 +5,10 @@ keri.kli.common.config
 """
 import json
 from dataclasses import dataclass, asdict
+from json import JSONDecodeError
 from typing import Optional, List
+
+from keri import kering
 
 
 @dataclass
@@ -32,3 +35,66 @@ def loadConfig(file: str) -> Config:
         with open(file, "r") as f:
             cfg = Config(**json.loads(f.read()))
     return cfg
+
+
+def parseData(data_path):
+    """
+    Load JSON data from data path
+
+    Parameters:
+        data_path (str): path to file containing anchor/seal configuration data
+    """
+    try:
+        if data_path.startswith("@"):
+            f = open(data_path[1:], "r")
+            data = json.load(f)
+        else:
+            data = json.loads(data_path)
+    except json.JSONDecodeError:
+        raise kering.ConfigurationError("data supplied to anchor in a seal must be valid JSON")
+
+    if not isinstance(data, list):
+        data = [data]
+
+    return data
+
+
+def checkRequiredArgs(args, required_args):
+    """
+    Ensure required arguments are present or raise error.
+
+    Parameters:
+        args (Namespace)    : the command line arguments passed in
+        required_args (list): a list of strings of the names of required arguments
+    """
+    for required_arg in required_args:
+        try:
+            result = getattr(args, required_arg)
+            if result is None:
+                raise ValueError(f"Required arg {required_arg} not present when config file not specified")
+        except AttributeError as e:
+            print("all of", required_args, "must be present if not using a configuration file")
+            raise ValueError(f"Required arg {required_arg} not present when config file not specified") from e
+
+
+def loadFileOptions(file_path, options_class):
+    """
+    Load configuration JSON from the file_path and instantiate an options_class from it
+
+    Parameters:
+        file_path (str)      : the path to the configuration file to load
+        options_class (class): the type of class to instantiate from the parsed JSON of the file loaded
+    """
+    try:
+        f = open(file_path)
+        config = json.load(f)
+
+        options = options_class(**config)
+    except FileNotFoundError as e:
+        print("config file", file_path, "not found")
+        raise e
+    except JSONDecodeError as e:
+        print("config file", file_path, "not valid JSON")
+        raise e
+
+    return options

--- a/src/keri/app/cli/common/incepting.py
+++ b/src/keri/app/cli/common/incepting.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+"""
+keri.app..cli.common.incepting module
+
+"kli incept" command configuration options
+"""
+
+
+def addInceptingArgs(parser):
+    """
+    Add command line arguments for each of the properties in InceptOptions
+    """
+    parser.add_argument('--transferable', '-tf', type=bool, default=None,
+                        help='Whether the prefix is transferable or non-transferable')
+    parser.add_argument('--wits',         '-w', default=[], required=False, action="append", metavar="<prefix>",
+                        help='New set of witnesses, replaces all existing witnesses.  Can appear multiple times')
+    parser.add_argument('--toad',         '-t', default=None, required=False, type=int,
+                        help='int or str hex of witness threshold (threshold of acceptable duplicity)',)
+    parser.add_argument('--icount',       '-ic', default=None, required=False,
+                        help='incepting key count for number of keys used for inception')
+    parser.add_argument('--isith',        '-s', default=None, required=False,
+                        help='signing threshold for the inception event')
+    parser.add_argument('--ncount',       '-nc', default=None, required=False,
+                        help='next key count for number of next keys used on first rotation')
+    parser.add_argument('--nsith',        '-x', default=None, required=False,
+                        help='signing threshold for the next rotation event',)
+    parser.add_argument('--est-only',     '-e', type=bool, default=None,
+                        help='only allow establishment events in KEL for this prefix')
+    parser.add_argument('--data',         '-d', default=None, required=False, action="store",
+                        help='Anchor data, \'@\' allowed',)
+

--- a/src/keri/app/cli/common/rotating.py
+++ b/src/keri/app/cli/common/rotating.py
@@ -1,8 +1,3 @@
-import json
-
-from keri import kering
-
-
 def addRotationArgs(parser):
     parser.add_argument('--isith', '-i', help='signing threshold for the rotation event', default=None,
                         required=False)
@@ -19,27 +14,6 @@ def addRotationArgs(parser):
     parser.add_argument('--data', '-d', help='Anchor data, \'@\' allowed', default=None, action="store", required=False)
 
 
-def loadData(args):
-    """ Load data flag from command line namespace
 
-    Parameters:
-        args (Namespace): argparse command line namespace
 
-    """
-    if args.data is not None:
-        try:
-            if args.data.startswith("@"):
-                f = open(args.data[1:], "r")
-                data = json.load(f)
-            else:
-                data = json.loads(args.data)
-        except json.JSONDecodeError:
-            raise kering.ConfigurationError("data supplied must be value JSON to anchor in a seal")
 
-        if not isinstance(data, list):
-            data = [data]
-
-    else:
-        data = None
-
-    return data

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -451,6 +451,7 @@ class Habery:
             delpre (str): qb64 of delegator identifier prefix
             estOnly (str): eventing.TraitCodex.EstOnly means only establishment
                 events allowed in KEL for this Hab
+            data (list | None): seal dicts
         """
         hab = Hab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
                   rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,

--- a/tests/app/cli/rotate-sample.json
+++ b/tests/app/cli/rotate-sample.json
@@ -1,0 +1,10 @@
+{
+  "isith": "1",
+  "nsith": "1",
+  "ncount": 1,
+  "toad": 0,
+  "wits": [],
+  "witsCut": [],
+  "witsAdd": []
+}
+

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -247,3 +247,48 @@ def test_standalone_kli_commands(helpers, capsys):
                           '  "broken-chain-escrow": [],\n'
                           '  "missing-schema-escrow": []\n'
                           '}\n')
+
+
+def test_incept_and_rotate_opts(helpers, capsys):
+    """
+    Tests using the command line arguments for incept and the file argument for rotate
+    """
+    helpers.remove_test_dirs("test-opts")
+    assert os.path.isdir("/usr/local/var/keri/ks/test-opts") is False
+
+    parser = multicommand.create_parser(commands)
+    args = parser.parse_args(["init", "--name", "test-opts", "--nopasscode", "--salt", habbing.SALT])
+    assert args.handler is not None
+    doers = args.handler(args)
+
+    directing.runController(doers=doers)
+
+    with existing.existingHby("test-opts") as hby:
+        assert os.path.isdir(hby.db.path) is True
+
+    args = parser.parse_args(["incept", "--name", "test-opts", "--alias", "trans-args", "--transferable", "True"])
+    assert args.handler is not None
+    # Attempt to incept without required arg isith
+    with pytest.raises(ValueError):
+        args.handler(args)
+
+    # Incept with command line arguments
+    args = parser.parse_args(["incept", "--name", "test-opts", "--alias", "trans-args", "--transferable", "True",
+                              "--isith", "1", "--icount", "1", "--nsith", "1", "--ncount", "1", "--toad", "0"])
+    assert args.handler is not None
+    doers = args.handler(args)
+
+    directing.runController(doers=doers)
+
+    # Rotate with file
+    args = parser.parse_args(["rotate", "--name", "test-opts", "--alias", "trans-args",
+                              "--file",
+                              os.path.join(TEST_DIR, "rotate-sample.json")])
+    assert args.handler is not None
+    doers = args.handler(args)
+
+    directing.runController(doers=doers)
+
+
+
+


### PR DESCRIPTION
This adds in the support for using a configuration file (JSON) to configure a rotation event as well as support for using command line arguments to configure an inception event for all relevant configuration properties of each type of event.

The --file argument is no longer required for "incept" nor is it required for "rotate" though there are a minimum set of required attributes checked for "incept" that maps to the existing sample configuration "transferable-sample.json" file.

There are a few code cleanups like the `config.parse_data` for the "data" attribute parsing and the moving of parsing the file options to `config.load_file_options`.

This addresses #274 