### PR TITLE
Hab class refactor

### DIFF
--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -110,7 +110,7 @@ class RespondDoer(doing.DoDoer):
         ims = hab.endorse(serder=exn, last=True, pipelined=False)
         del ims[:exn.size]
 
-        senderHab = hab.mhab if hab.mhab else hab
+        senderHab = hab.mhab if hab.group else hab
         self.postman.send(src=senderHab.pre, dest=recp, topic="challenge", serder=exn, attachment=ims)
         while not self.postman.cues:
             yield self.tock

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -118,7 +118,7 @@ class ConfirmDoer(doing.DoDoer):
                     if not approve:
                         continue
 
-                    if hab.mhab:
+                    if hab.group:
                         aids = hab.smids
                         seqner = coring.Seqner(sn=eserder.sn)
                         anchor = dict(i=eserder.ked["i"], s=seqner.snh, d=eserder.said)

--- a/src/keri/app/cli/commands/delegate/request.py
+++ b/src/keri/app/cli/commands/delegate/request.py
@@ -89,7 +89,7 @@ class RequestDoer(doing.DoDoer):
         del evt[:srdr.size]
         delpre = hab.kever.delegator  # get the delegator identifier
 
-        if hab.mhab:
+        if hab.group:
             phab = hab.mhab
         else:
             phab = self.hby.habByName(f"{self.alias}-proxy")

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -5,11 +5,9 @@ keri.kli.commands module
 """
 import sys
 import argparse
-from typing import Union
 from dataclasses import dataclass
 import json
 from json import JSONDecodeError
-from ordered_set import OrderedSet as oset
 
 from hio import help
 from hio.base import doing
@@ -157,4 +155,3 @@ class InceptDoer(doing.DoDoer):
         self.remove(toRemove)
 
         return
-

--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -99,7 +99,7 @@ class ReadDoer(doing.DoDoer):
         print()
 
         q = dict(pre=hab.pre, topics=topics)
-        if hab.mhab:
+        if hab.group:
             msg = hab.mhab.query(pre=hab.pre, src=self.witness, route="mbx", query=q)
         else:
             msg = hab.query(pre=hab.pre, src=self.witness, route="mbx", query=q)

--- a/src/keri/app/cli/commands/multisig/continue.py
+++ b/src/keri/app/cli/commands/multisig/continue.py
@@ -62,7 +62,7 @@ class ContinueDoer(doing.DoDoer):
             raise ValueError(f"no escrowed events for {self.alias} ({hab.pre})")
 
         (seqner, saider) = esc[0]
-        src = hab.mhab.pre if hab.mhab else hab.pre
+        src = hab.mhab.pre if hab.group else hab.pre
         anchor = dict(i=hab.pre, s=seqner.snh, d=saider.qb64)
         self.witq.query(src=src, pre=hab.kever.delegator, anchor=anchor)
 

--- a/src/keri/app/cli/commands/vc/present.py
+++ b/src/keri/app/cli/commands/vc/present.py
@@ -98,7 +98,7 @@ class PresentDoer(doing.DoDoer):
             credentialing.sendCredential(self.hby, hab=self.hab, reger=self.rgy.reger, postman=self.postman,
                                          creder=creder, recp=recp)
 
-        if self.hab.mhab:
+        if self.hab.group:
             senderHab = self.hab.mhab
         else:
             senderHab = self.hab

--- a/src/keri/app/cli/common/displaying.py
+++ b/src/keri/app/cli/common/displaying.py
@@ -40,7 +40,7 @@ def printIdentifier(hby, pre, label="Identifier"):
                 print(f"{terming.Colors.FAIL}{terming.Symbols.FAILED} Not Anchored{terming.Colors.ENDC}")
             print()
 
-        if hab.mhab:
+        if hab.group:
             print("Group Identifier")
             sys.stdout.write(f"    Local Indentifier:  {hab.mhab.pre} ")
             if hab.accepted:
@@ -60,7 +60,7 @@ def printIdentifier(hby, pre, label="Identifier"):
         print("{}: {}".format(label, hab.pre))
         print("Seq No:\t{}".format(0))
 
-        if hab.mhab:
+        if hab.group:
             print("Group Identifier")
             sys.stdout.write(f"    Local Indentifier:  {hab.mhab.pre} ")
             if hab.accepted:

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -85,8 +85,10 @@ class Boatswain(doing.DoDoer):
                 srdr = coring.Serder(raw=evt)
                 del evt[:srdr.size]
 
-                if hab.mhab:
+                smids = []
+                if hab.group:
                     phab = hab.mhab
+                    smids = hab.smids
                 elif srdr.ked["t"] == coring.Ilks.dip:  # are we incepting a new event?
                     phab = self.proxy(alias, hab.kever)  # create a proxy identifier for comms
                     if phab.kever.wits:
@@ -109,8 +111,7 @@ class Boatswain(doing.DoDoer):
                     phab = self.hby.habByName(f"{alias}-proxy")
 
                 # Send exn message for notification purposes
-                # ToDo: NRR should this be fixed to include rmids as parameter?
-                exn, atc = delegateRequestExn(phab, delpre=delpre, ked=srdr.ked, aids=hab.smids)
+                exn, atc = delegateRequestExn(phab, delpre=delpre, ked=srdr.ked, aids=smids)
                 # exn of /oobis of all multisig participants to rootgar
                 self.postman.send(src=phab.pre, dest=hab.kever.delegator, topic="delegate", serder=exn, attachment=atc)
                 self.postman.send(src=phab.pre, dest=delpre, topic="delegate", serder=srdr, attachment=evt)

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -127,7 +127,7 @@ class Postman(doing.DoDoer):
         ser = coring.Serder(raw=icp)
         del icp[:ser.size]
 
-        sender = hab.mhab.pre if hab.mhab is not None else hab.pre
+        sender = hab.mhab.pre if hab.group is not None else hab.pre
         self.send(src=sender, dest=hab.kever.delegator, topic="delegate", serder=ser, attachment=icp)
         while True:
             if self.cues:

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -875,7 +875,6 @@ class Hab:
         self.inited = False
         self.delpre = None  # assigned laster if delegated
 
-
     def make(self, *, secrecies=None, iridx=0, code=coring.MtrDex.Blake3_256,
              transferable=True, isith=None, icount=1, nsith=None, ncount=None,
              toad=None, wits=None, delpre=None, estOnly=False, DnD=False,
@@ -1040,7 +1039,6 @@ class Hab:
             self.reconfigure()  # should we do this for new Habs not loaded from db
 
         self.inited = True
-
 
     def reconfigure(self):
         """Apply configuration from config file managed by .cf. to this Hab.

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -805,7 +805,7 @@ class Poller(doing.DoDoer):
                 else:
                     topics[topic] = 0
 
-            if self.hab.mhab:
+            if self.hab.group:
                 msg = self.hab.mhab.query(pre=self.pre, src=self.witness, route="mbx", query=q)
             else:
                 msg = self.hab.query(pre=self.pre, src=self.witness, route="mbx", query=q)

--- a/src/keri/app/kiwiing.py
+++ b/src/keri/app/kiwiing.py
@@ -235,7 +235,7 @@ class IdentifierEnd(doing.DoDoer):
             prefix=hab.pre,
         )
 
-        if hab.mhab:
+        if hab.group:
             data["group"] = dict(
                 pid=hab.mhab.pre,
                 aids=hab.smids,
@@ -690,7 +690,7 @@ class IdentifierEnd(doing.DoDoer):
             pre = cue["pre"]
             hab = self.hby.habs[pre]
 
-            if hab.mhab:  # Skip if group, they are handled elsewhere
+            if hab.group:  # Skip if group, they are handled elsewhere
                 yield self.tock
                 continue
 
@@ -809,7 +809,7 @@ class KeyStateEnd:
         evts = []
         if pre in self.hby.habs:
             hab = self.hby.habs[pre]
-            if hab.mhab:
+            if hab.group:
                 evts = self.counselor.pendingEvents(pre)
         res["pending"] = evts
 
@@ -2797,7 +2797,7 @@ class ChallengeEnd(doing.DoDoer):
         ims = hab.endorse(serder=exn, last=True, pipelined=False)
         del ims[:exn.size]
 
-        senderHab = hab.mhab if hab.mhab else hab
+        senderHab = hab.mhab if hab.group else hab
         self.postman.send(src=senderHab.pre, dest=recpt, topic="challenge", serder=exn, attachment=ims)
 
         rep.status = falcon.HTTP_202

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -250,14 +250,14 @@ class OobiResource(doing.DoDoer):
             rep.text = f"Unknown identifier {alias}"
             return
 
-        if hab.mhab is None:
+        if not hab.group:
             rep.status = falcon.HTTP_400
             rep.text = f"Identifer for {alias} is not a group hab, not supported"
             return
 
         oobis = body["oobis"]
         both = list(set(hab.smids + (hab.rmids or [])))
-        for mid in both: #hab.smids
+        for mid in both:  # hab.smids
             if mid == hab.mhab.pre:
                 continue
 

--- a/src/keri/app/signing.py
+++ b/src/keri/app/signing.py
@@ -109,7 +109,7 @@ def transSeal(hab):
     """
     # create SealEvent or SealLast for endorser's est evt whose keys are
     # used to sign
-    if not hab.mhab:  # not a group use own kever
+    if not hab.group:  # not a group use own kever
         indices = None  # use default order
     else:  # group so use gid kever
         indices = [hab.smids.index(hab.mhab.pre)]  # use group order*

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -372,7 +372,6 @@ class Registrar(doing.DoDoer):
 
         super(Registrar, self).__init__(doers=doers)
 
-
     def incept(self, name, pre, conf=None, smids=None, rmids=None):
         """
 
@@ -398,7 +397,7 @@ class Registrar(doing.DoDoer):
         rseq = coring.Seqner(sn=0)
         rseal = SealEvent(registry.regk, "0", registry.regd)
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
-        if hab.mhab is None:
+        if not hab.group:
             if estOnly:
                 hab.rotate(data=[rseal])
             else:
@@ -449,7 +448,7 @@ class Registrar(doing.DoDoer):
         rseal = SealEvent(vcid, rseq.snh, iserder.said)
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
 
-        if hab.mhab is None:  # not a multisig group
+        if not hab.group:  # not a multisig group
             if registry.estOnly:
                 hab.rotate(data=[rseal])
             else:
@@ -503,7 +502,7 @@ class Registrar(doing.DoDoer):
         rseal = SealEvent(vcid, rseq.snh, rserder.said)
         rseal = dict(i=rseal.i, s=rseal.s, d=rseal.d)
 
-        if hab.mhab is None:
+        if not hab.group:
             if registry.estOnly:
                 hab.rotate(data=[rseal])
             else:
@@ -748,8 +747,9 @@ class Credentialer(doing.DoDoer):
         regk = creder.crd["ri"]
         registry = self.rgy.regs[regk]
         hab = registry.hab
-        smids = smids if smids is not None else hab.smids
-        rmids = rmids if rmids is not None else hab.rmids
+        if hab.group:
+            smids = smids if smids is not None else hab.smids
+            rmids = rmids if rmids is not None else hab.rmids
 
         dt = creder.subject["dt"] if "dt" in creder.subject else None
 
@@ -757,7 +757,7 @@ class Credentialer(doing.DoDoer):
                                          dt=dt, smids=smids, rmids=rmids)
 
         rseq = coring.Seqner(sn=seq)
-        if hab.mhab:
+        if hab.group:
             craw = signing.ratify(hab=hab, serder=creder)
             atc = bytearray(craw[creder.size:])
             others = list(oset(smids + (rmids or [])))
@@ -816,7 +816,7 @@ class Credentialer(doing.DoDoer):
                 recp = creder.subject["i"]
 
                 hab = self.hby.habs[issr]
-                if hab.mhab:
+                if hab.group:
                     sender = hab.mhab.pre
                 else:
                     sender = issr
@@ -968,7 +968,7 @@ def sendCredential(hby, hab, reger, postman, creder, recp):
     Returns:
 
     """
-    if hab.mhab:
+    if hab.group:
         sender = hab.mhab.pre
     else:
         sender = hab.pre

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -11,7 +11,6 @@ from keri import kering
 from keri.app import habbing, delegating, indirecting, agenting, notifying
 from keri.core import eventing, parsing, coring
 from keri.db import dbing
-from keri.end import ending
 from keri.peer import exchanging
 
 


### PR DESCRIPTION
Extract BaseHab and create Hab and GroupHab as instances specific for single and group respectively.

Lays the foundation for an EdgeHab in support of Signify