### PR TITLE
Lock `libsodium` pwhash algo/params

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -410,9 +410,9 @@ def generateSigners(salt=None, count=8, transferable=True):
         seed = pysodium.crypto_pwhash(outlen=32,
                                       passwd=path,
                                       salt=salt,
-                                      opslimit=pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
-                                      memlimit=pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
-                                      alg=pysodium.crypto_pwhash_ALG_DEFAULT)
+                                      opslimit=2,  # pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+                                      memlimit=67108864,  # pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
+                                      alg=pysodium.crypto_pwhash_ALG_ARGON2ID13)
 
         signers.append(Signer(raw=seed, transferable=transferable))
 
@@ -2353,18 +2353,18 @@ class Salter(Matter):
         tier = tier if tier is not None else self.tier
 
         if temp:
-            opslimit = pysodium.crypto_pwhash_OPSLIMIT_MIN
-            memlimit = pysodium.crypto_pwhash_MEMLIMIT_MIN
+            opslimit = 1  # pysodium.crypto_pwhash_OPSLIMIT_MIN
+            memlimit = 8192  # pysodium.crypto_pwhash_MEMLIMIT_MIN
         else:
             if tier == Tiers.low:
-                opslimit = pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE
-                memlimit = pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE
+                opslimit = 2  # pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE
+                memlimit = 67108864  # pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE
             elif tier == Tiers.med:
-                opslimit = pysodium.crypto_pwhash_OPSLIMIT_MODERATE
-                memlimit = pysodium.crypto_pwhash_MEMLIMIT_MODERATE
+                opslimit = 3  # pysodium.crypto_pwhash_OPSLIMIT_MODERATE
+                memlimit = 268435456  # pysodium.crypto_pwhash_MEMLIMIT_MODERATE
             elif tier == Tiers.high:
-                opslimit = pysodium.crypto_pwhash_OPSLIMIT_SENSITIVE
-                memlimit = pysodium.crypto_pwhash_MEMLIMIT_SENSITIVE
+                opslimit = 4  # pysodium.crypto_pwhash_OPSLIMIT_SENSITIVE
+                memlimit = 1073741824  # pysodium.crypto_pwhash_MEMLIMIT_SENSITIVE
             else:
                 raise ValueError("Unsupported security tier = {}.".format(tier))
 
@@ -2374,7 +2374,7 @@ class Salter(Matter):
                                       salt=self.raw,
                                       opslimit=opslimit,
                                       memlimit=memlimit,
-                                      alg=pysodium.crypto_pwhash_ALG_DEFAULT)
+                                      alg=pysodium.crypto_pwhash_ALG_ARGON2ID13)
         return (seed)
 
     def signer(self, *, code=MtrDex.Ed25519_Seed, transferable=True, path="",

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -23,7 +23,7 @@ from keri.core import eventing
 from keri.core.coring import Ilkage, Ilks, Ids, Idents, Sadder
 from keri.core.coring import Seqner, NumDex, Number, Siger, Dater, Bexter
 from keri.core.coring import Serder, Tholder
-from keri.core.coring import Serialage, Serials, Vstrings
+from keri.core.coring import Serialage, Serials, Tiers, Vstrings
 from keri.core.coring import (Sizage, MtrDex, Matter, Xizage, IdrDex, IdxSigDex,
                               IdxCrtSigDex, IdxBthSigDex, Indexer,
                               CtrDex, Counter, sniff, ProDex)
@@ -4121,6 +4121,12 @@ def test_salter():
 
     with pytest.raises(ShortageError):
         salter = Salter(qb64='')
+
+    salter = Salter(raw=raw)
+    assert salter.stretch(temp=True) == b'\xd4@\xeb\xa6x\x86\xdf\x93\xd6C\xdc\xb8\xa6\x9b\x02\xafh\xc1m(L\xd6\xf6\x86YU>$[\xf9\xef\xc0'
+    assert salter.stretch(tier=Tiers.low) == b'\xf8e\x80\xbaX\x08\xb9\xba\xc6\x1e\x84\r\x1d\xac\xa7\\\x82Wc@`\x13\xfd\x024t\x8ct\xd3\x01\x19\xe9'
+    assert salter.stretch(tier=Tiers.med) == b',\xf3\x8c\xbb\xe9)\nSQ\xec\xad\x8c9?\xaf\xb8\xb0\xb3\xcdB\xda\xd8\xb6\xf7\r\xf6D}Z\xb9Y\x16'
+    assert salter.stretch(tier=Tiers.high) == b'(\xcd\xc4\xb85\xcd\xe8:\xfc\x00\x8b\xfd\xa6\tj.y\x98\x0b\x04\x1c\xe3hBc!I\xe49K\x16-'
 
     """ Done Test """
 

--- a/tests/core/test_crypto.py
+++ b/tests/core/test_crypto.py
@@ -46,9 +46,9 @@ def test_pysodium():
     sigseed = pysodium.crypto_pwhash(outlen=32,
                                     passwd="",
                                     salt=salt,
-                                    opslimit=pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
-                                    memlimit=pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
-                                    alg=pysodium.crypto_pwhash_ALG_DEFAULT)
+                                    opslimit=2,  # pysodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
+                                    memlimit=67108864,  # pysodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,
+                                    alg=pysodium.crypto_pwhash_ALG_ARGON2ID13)
 
     assert len(sigseed) == 32
     #  seed = (b'\xa9p\x89\x7f+\x0e\xc4\x9c\xf2\x01r\xafTI\xc0\xfa\xac\xd5\x99\xf8O\x8f=\x843\xa2\xb6e\x9fO\xff\xd0')


### PR DESCRIPTION
## Rationale

This PR locks the params we use for stretching keying material using libsodium. This will allow us to have more control over when the algorithm and params are updated, as they will be under ours. If the current Argon2 implementation is found to be flawed, it will likely be removed and the net effect will be the same. This just prevents libsodium from changing their defaults and breaking our implementation.

## Changes

Locks libsodium pwhash algorithm and params throughout.

## Testing

Created test vectors for all security tiers and verified they pass using the library constants and also the locked values.