### PR TITLE
Update rotate command to not barf with no toad is specified.

### DIFF
--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -13,9 +13,22 @@ sleep 3
 # Ensure we kill the witnesses on exit
 trap 'kill -HUP $wits' EXIT
 
+function isSuccess() {
+    ret=$?
+    if [ $ret -ne 0 ]; then
+       echo "Error $ret"
+       exit $ret
+    fi
+}
+
 # Test scripts
 "${script_dir}/basic/demo-script.sh"
+isSuccess
 "${script_dir}/basic/demo-witness-script.sh"
+isSuccess
 "${script_dir}/basic/multisig.sh"
+isSuccess
 "${script_dir}/basic/multisig-delegate-delegator.sh"
+isSuccess
 "${script_dir}/basic/challenge.sh"
+isSuccess

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -32,10 +32,10 @@ class RotateOptions:
     Configurable options for a rotation performed at the command line.
     Each of the defaults is depended on by the option merge_args_with_file function.
     """
-    isith: int | str | list
-    ncount: int
+    isith: int | str | list | None
+    ncount: int | None
     nsith: int | str | list = '0'
-    toad: int = 0
+    toad: int = None
     wits: list = None
     witsCut: list = None
     witsAdd: list = None


### PR DESCRIPTION
Also fixes test_scripts.sh to actually fail when one of the sub-scripts is broken by a PR.