### PR TITLE
Version bump to 1.0 for KERIpy main branch, docker image, PyPi release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 .PHONY: build-keri
 build-keri:
-	@docker build --no-cache -f images/keripy.dockerfile --tag gleif/keri:0.6.8 .
+	@docker build --no-cache -f images/keripy.dockerfile --tag gleif/keri:1.0.0 .
 
 .PHONY: build-witness-demo
 build-witness-demo:
-	@docker build --no-cache -f images/witness.demo.dockerfile --tag gleif/keri-witness-demo:0.6.8 .
+	@docker build --no-cache -f images/witness.demo.dockerfile --tag gleif/keri-witness-demo:1.0.0 .

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then you can run
 
 to get a version string similar to the following: 
 
-`0.6.7`
+`1.0.0`
 
 ### Local installation - Docker build
 Run `make build-keri` to build your docker image.

--- a/images/witness.demo.dockerfile
+++ b/images/witness.demo.dockerfile
@@ -1,4 +1,4 @@
-FROM gleif/keri:0.6.7
+FROM gleif/keri:1.0.0
 
 SHELL ["/bin/bash", "-c"]
 EXPOSE 5632

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from os.path import splitext
 from setuptools import find_packages, setup
 setup(
     name='keri',
-    version='0.6.9',  # also change in src/keri/__init__.py
+    version='1.0.0',  # also change in src/keri/__init__.py
     license='Apache Software License 2.0',
     description='Key Event Receipt Infrastructure',
     long_description="KERI Decentralized Key Management Infrastructure",

--- a/src/keri/__init__.py
+++ b/src/keri/__init__.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-__version__ = '0.6.9'  # also change in setup.py
+__version__ = '1.0.0'  # also change in setup.py
 
 


### PR DESCRIPTION
This is the precursor PR for merging development to main.