### PR TITLE
make status msg accurate

### DIFF
--- a/src/keri/app/cli/commands/vc/issue.py
+++ b/src/keri/app/cli/commands/vc/issue.py
@@ -160,7 +160,7 @@ class CredentialIssuer(doing.DoDoer):
                                                        rules=rules,
                                                        data=data,
                                                        private=private)
-                print(f"Writing credential {self.creder.said} to credential.json")
+                print(f"Writing credential {self.creder.said} to {out}")
                 f = open(out, mode="w")
                 json.dump(self.creder.crd, f)
                 f.close()


### PR DESCRIPTION
Status message for kli vc issue assumed that filename would always be credential.json; this changes it to report (accurately) what the actual output filename will be.