### PR TITLE
Update `local watch` and `multisig update` commands to query correctly for the right mailboxes to work with replies

### DIFF
--- a/src/keri/app/cli/commands/local/watch.py
+++ b/src/keri/app/cli/commands/local/watch.py
@@ -58,7 +58,7 @@ class WatchDoer(doing.DoDoer):
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
         self.cues = help.decking.Deck()
 
-        self.mbd = indirecting.MailboxDirector(hby=self.hby, topics=["/replay", "/receipt", "reply"])
+        self.mbd = indirecting.MailboxDirector(hby=self.hby, topics=["/replay", "/receipt", "/reply"])
         self.postman = forwarding.Poster(hby=self.hby)
         doers.extend([self.hbyDoer, self.mbd, self.postman, doing.doify(self.cueDo)])
 

--- a/src/keri/app/cli/commands/multisig/update.py
+++ b/src/keri/app/cli/commands/multisig/update.py
@@ -62,7 +62,7 @@ class UpdateDoer(doing.DoDoer):
         self.said = said
         self.cues = help.decking.Deck()
 
-        self.mbd = indirecting.MailboxDirector(hby=self.hby, topics=["/replay", "/receipt"])
+        self.mbd = indirecting.MailboxDirector(hby=self.hby, topics=["/replay", "/receipt", "/reply"])
         self.witq = agenting.WitnessInquisitor(hby=self.hby)
         doers.extend([self.hbyDoer, self.mbd, self.witq])
 


### PR DESCRIPTION
This was broken with the update to correctly forward all messages from witnesses.