### PR TITLE
Allow untargeted ACDCs before end of chain

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -401,6 +401,9 @@ class Verifier:
             op = 'I2I' if 'i' in creder.subject else 'NI2I'
 
         if op != 'NI2I':
+            if 'i' not in creder.subject:
+                return None
+
             iss = self.reger.subjs.get(keys=creder.subject['i'])
             if iss is None:
                 return None

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -395,9 +395,10 @@ class Verifier:
             return None
 
         creder = self.reger.creds.get(keys=nodeSaid)
-        iss = self.reger.subjs.get(keys=creder.subject['i'])
-        if iss is None:
-            return None
+        if 'i' in creder.subject:
+            iss = self.reger.subjs.get(keys=creder.subject['i'])
+            if iss is None:
+                return None
 
         if creder.status not in self.tevers:
             return None

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -195,7 +195,8 @@ class Verifier:
                 if label in ('d', 'o'):  # SAID or Operator of this edge block
                     continue
                 nodeSaid = node["n"]
-                state = self.verifyChain(nodeSaid)
+                op = node['o'] if 'o' in node else None
+                state = self.verifyChain(nodeSaid, op, creder.issuer)
                 if state is None:
                     self.escrowMCE(creder, sadsigers, sadcigars)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -379,7 +380,7 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True)
 
-    def verifyChain(self, nodeSaid):
+    def verifyChain(self, nodeSaid, op, issuer):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
@@ -395,10 +396,23 @@ class Verifier:
             return None
 
         creder = self.reger.creds.get(keys=nodeSaid)
-        if 'i' in creder.subject:
+
+        if op not in ['I2I', 'DI2I', 'NI2I']:
+            if 'i' in creder.subject:
+                op = 'I2I'
+            else:
+                op = 'NI2I'
+
+        if op != 'NI2I':
             iss = self.reger.subjs.get(keys=creder.subject['i'])
             if iss is None:
                 return None
+
+            if op == 'I2I' and issuer != creder.subject['i']:
+                return None
+
+            if op == "DI2I":
+                raise NotImplementedError()
 
         if creder.status not in self.tevers:
             return None

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -196,7 +196,7 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.issuer)
+                state = self.verifyChain(nodeSaid, op)
                 if state is None:
                     self.escrowMCE(creder, sadsigers, sadcigars)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -380,7 +380,7 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True)
 
-    def verifyChain(self, nodeSaid, op, issuer):
+    def verifyChain(self, nodeSaid, op):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
@@ -405,7 +405,7 @@ class Verifier:
             if iss is None:
                 return None
 
-            if op == 'I2I' and issuer != creder.subject['i']:
+            if op == 'I2I' and nodeSaid not in [i.qb64 for i in iss]:
                 return None
 
             if op == "DI2I":

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -398,10 +398,7 @@ class Verifier:
         creder = self.reger.creds.get(keys=nodeSaid)
 
         if op not in ['I2I', 'DI2I', 'NI2I']:
-            if 'i' in creder.subject:
-                op = 'I2I'
-            else:
-                op = 'NI2I'
+            op = 'I2I' if 'i' in creder.subject else 'NI2I'
 
         if op != 'NI2I':
             iss = self.reger.subjs.get(keys=creder.subject['i'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,35 @@ class DbSeed:
 
     @staticmethod
     def seedSchema(db):
+        # EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz
+        sad = {'$id': '',
+               '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Optional Issuee',
+               'description': 'A credential with an optional issuee',
+               'credentialType': 'UntargetedAttestation',
+               'properties': {'v': {'type': 'string'}, 'd': {'type': 'string'}, 'i': {'type': 'string'},
+                              'ri': {'description': 'credential status registry', 'type': 'string'},
+                              's': {'description': 'schema SAID', 'type': 'string'}, 'a': {'properties': {
+                                                                                               'd': {'type': 'string'},
+                                                                                               'i': {'type': 'string'},
+                                                                                               'dt': {
+                                                                                                   'format':
+                                                                                                       'date-time',
+                                                                                                   'type': 'string'},
+                                                                                               'claim': {
+                                                                                                   'type': 'string'}},
+                                                                                           'additionalProperties':
+                                                                                               False,
+                                                                                           'required': ['dt',
+                                                                                                        'claim'],
+                                                                                           'type': 'object'},
+                              'e': {'description': 'edges block', 'type': 'object'},
+                              'r': {'type': 'object', 'description': 'rules block'}}, 'additionalProperties': False,
+               'required': ['i', 'ri', 's', 'd', 'e', 'r'], 'type': 'object'}
+
+        _, sad = coring.Saider.saidify(sad, label=coring.Saids.dollar)
+        schemer = scheming.Schemer(sed=sad)
+        db.schema.pin(schemer.said, schemer)
+
         # OLD: "E1MCiPag0EWlqeJGzDA9xxr1bUSUR4fZXtqHDrwdXgbk"
         sad = {'$id': '',
                '$schema': 'http://json-schema.org/draft-07/schema#', 'title': 'Legal Entity vLEI Credential',

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -491,7 +491,6 @@ def test_verifier_chained_credential(seeder):
         assert saider[0].qb64 == vLeiCreder.said
 
         # test operators
-        ianverfer = verifying.Verifier(hby=ianHby, reger=ianreg.reger)
 
         untargetedSubject = dict(
             d="",
@@ -524,11 +523,10 @@ def test_verifier_chained_credential(seeder):
             missing = True
 
         assert missing is True
-        assert len(ianverfer.cues) == 1
+        assert len(ianverfer.cues) == 3
         cue = ianverfer.cues.popleft()
-        assert cue["kin"] == "telquery"
-        q = cue["q"]
-        assert q["ri"] == ianiss.regk
+        assert cue["kin"] == "saved"
+        cue["creder"] = untargetedCreder.raw
 
         iss = ianiss.issue(said=untargetedCreder.said)
         rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
@@ -565,12 +563,30 @@ def test_verifier_chained_credential(seeder):
 
         chainedSadsigers, chainedSadcigars = signing.signPaths(hab=ian, serder=chainedCreder, paths=[[]])
 
+        missing = False
         try:
             ianverfer.processCredential(chainedCreder, sadsigers=chainedSadsigers, sadcigars=chainedSadcigars)
-        except KeyError:
-            # this verifies that the operator I2I is respected for chains
-            pass
+        except kering.MissingRegistryError:
+            missing = True
 
+        assert missing is True
+        assert len(ianverfer.cues) == 4
+        cue = ianverfer.cues.popleft()
+        assert cue["kin"] == "saved"
+        cue["creder"] = chainedCreder.raw
+
+        iss = ianiss.issue(said=chainedCreder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal])
+        seqner = coring.Seqner(sn=ian.kever.sn)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said, seqner=seqner, saider=ian.kever.serder.saider)
+        ianreg.processEscrows()
+
+        # Now that the credential has been issued, process escrows and it will find the TEL event
+        try:
+            ianverfer.processCredential(chainedCreder, sadsigers=chainedSadsigers, sadcigars=chainedSadcigars)
+        except kering.MissingChainError:
+            pass
 
         # Now lets get Ron's credential into Vic's Tevers and Database
         vickvy = ceventing.Kevery(db=vic.db, lax=False, local=False)

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -582,7 +582,7 @@ def test_verifier_chained_credential(seeder):
         ianiss.anchorMsg(pre=iss.pre, regd=iss.said, seqner=seqner, saider=ian.kever.serder.saider)
         ianreg.processEscrows()
 
-        # Now that the credential has been issued, process escrows and it will find the TEL event
+        # Ensure that when specifying I2I it is enforced
         try:
             ianverfer.processCredential(chainedCreder, sadsigers=chainedSadsigers, sadcigars=chainedSadcigars)
         except kering.MissingChainError:

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -295,6 +295,7 @@ def test_verifier(seeder):
 def test_verifier_chained_credential(seeder):
     qviSchema = "EFgnk_c08WmZGgv9_mpldibRuqFMTQN-rAgtD-TCOwbs"
     vLeiSchema = "ED892b40P_GcESs3wOcc2zFvL_GVi2Ybzp9isNTZKqP0"
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
     with habbing.openHab(name="ron", temp=True, salt=b'0123456789abcdef') as (ronHby, ron), \
             habbing.openHab(name="ian", temp=True, salt=b'0123456789abcdef') as (ianHby, ian), \
@@ -488,6 +489,88 @@ def test_verifier_chained_credential(seeder):
         assert saider[0].qb64 == vLeiCreder.said
         saider = ianreg.reger.schms.get(vLeiSchema)
         assert saider[0].qb64 == vLeiCreder.said
+
+        # test operators
+        ianverfer = verifying.Verifier(hby=ianHby, reger=ianreg.reger)
+
+        untargetedSubject = dict(
+            d="",
+            dt=helping.nowIso8601(),
+            claim="An outrageous claim.",
+        )
+        _, d = scheming.Saider.saidify(sad=untargetedSubject, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        chainSad = dict(
+            d='',
+            targetedEdge=dict(
+                n=vLeiCreder.said,
+            ),
+        )
+        _, chain = scheming.Saider.saidify(sad=chainSad, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        untargetedCreder = proving.credential(issuer=ian.pre,
+                                        schema=optionalIssueeSchema,
+                                        data=d,
+                                        status=ianiss.regk,
+                                        source=chain,
+                                        rules={})
+
+        untargetedSadsigers, untargetedSadcigars = signing.signPaths(hab=ian, serder=untargetedCreder, paths=[[]])
+
+        missing = False
+        try:
+            ianverfer.processCredential(untargetedCreder, sadsigers=untargetedSadsigers, sadcigars=untargetedSadcigars)
+        except kering.MissingRegistryError:
+            missing = True
+
+        assert missing is True
+        assert len(ianverfer.cues) == 1
+        cue = ianverfer.cues.popleft()
+        assert cue["kin"] == "telquery"
+        q = cue["q"]
+        assert q["ri"] == ianiss.regk
+
+        iss = ianiss.issue(said=untargetedCreder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal])
+        seqner = coring.Seqner(sn=ian.kever.sn)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said, seqner=seqner, saider=ian.kever.serder.saider)
+        ianreg.processEscrows()
+
+        # Now that the credential has been issued, process escrows and it will find the TEL event
+        ianverfer.processEscrows()
+
+        chainedSubject = dict(
+            d="",
+            dt=helping.nowIso8601(),
+            claim="An outrageous claim.",
+        )
+        _, d = scheming.Saider.saidify(sad=chainedSubject, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        chainSad = dict(
+            d='',
+            untargetedButI2I=dict(
+                n=untargetedCreder.said,
+                o="I2I"
+            ),
+        )
+        _, chain = scheming.Saider.saidify(sad=chainSad, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        chainedCreder = proving.credential(issuer=ian.pre,
+                                        schema=optionalIssueeSchema,
+                                        data=d,
+                                        status=ianiss.regk,
+                                        source=chain,
+                                        rules={})
+
+        chainedSadsigers, chainedSadcigars = signing.signPaths(hab=ian, serder=chainedCreder, paths=[[]])
+
+        try:
+            ianverfer.processCredential(chainedCreder, sadsigers=chainedSadsigers, sadcigars=chainedSadcigars)
+        except KeyError:
+            # this verifies that the operator I2I is respected for chains
+            pass
+
 
         # Now lets get Ron's credential into Vic's Tevers and Database
         vickvy = ceventing.Kevery(db=vic.db, lax=False, local=False)


### PR DESCRIPTION
I think this could could be changed - I seems like it might be unintentional.

When I use this branch I can verify complex ACDC graphs we produce that have attestations in places other than the end of a chain. `development` is breaking my integration tests, and I'm hoping this was just an oversight.

If it makes sense please merge!