### PR TITLE
Fix I2I operator

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -196,7 +196,7 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op)
+                state = self.verifyChain(nodeSaid, op, creder.issuer)
                 if state is None:
                     self.escrowMCE(creder, sadsigers, sadcigars)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -380,7 +380,7 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True)
 
-    def verifyChain(self, nodeSaid, op):
+    def verifyChain(self, nodeSaid, op, issuer):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
@@ -408,8 +408,9 @@ class Verifier:
             if iss is None:
                 return None
 
-            if op == 'I2I' and nodeSaid not in [i.qb64 for i in iss]:
-                return None
+            if op == 'I2I':
+                if issuer != creder.subject['i'] or nodeSaid not in [i.qb64 for i in iss]:
+                    return None
 
             if op == "DI2I":
                 raise NotImplementedError()

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -408,9 +408,8 @@ class Verifier:
             if iss is None:
                 return None
 
-            if op == 'I2I':
-                if issuer != creder.subject['i'] or nodeSaid not in [i.qb64 for i in iss]:
-                    return None
+            if op == 'I2I' and issuer != creder.subject['i']:
+                return None
 
             if op == "DI2I":
                 raise NotImplementedError()


### PR DESCRIPTION
I thought that `nodeSaid not in [i.qb64 for i in iss]` was actually checking something it wasn't. Turns out the issuer == node issuee check needs to be explicit. I found this when implementing parity in Rust. I noticed our credential graph failed to pass there but was passing here. This should fix things.