### PR TITLE
Added version support for new Serder. Added prelim surport for both ACDC and KERI protocols

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -3075,17 +3075,21 @@ class PreCodex:
     Only provide defined codes.
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
     """
-    Ed25519N:    str = 'B'  # Ed25519 verification key non-transferable, basic derivation.
-    Ed25519:     str = 'D'  # Ed25519 verification key basic derivation
-    Blake3_256:  str = 'E'  # Blake3 256 bit digest self-addressing derivation.
-    Blake2b_256: str = 'F'  # Blake2b 256 bit digest self-addressing derivation.
-    Blake2s_256: str = 'G'  # Blake2s 256 bit digest self-addressing derivation.
-    SHA3_256:    str = 'H'  # SHA3 256 bit digest self-addressing derivation.
-    SHA2_256:    str = 'I'  # SHA2 256 bit digest self-addressing derivation.
-    Blake3_512:  str = '0D'  # Blake3 512 bit digest self-addressing derivation.
-    Blake2b_512: str = '0E'  # Blake2b 512 bit digest self-addressing derivation.
-    SHA3_512:    str = '0F'  # SHA3 512 bit digest self-addressing derivation.
-    SHA2_512:    str = '0G'  # SHA2 512 bit digest self-addressing derivation.
+    Ed25519N:      str = 'B'  # Ed25519 verification key non-transferable, basic derivation.
+    Ed25519:       str = 'D'  # Ed25519 verification key basic derivation
+    Blake3_256:    str = 'E'  # Blake3 256 bit digest self-addressing derivation.
+    Blake2b_256:   str = 'F'  # Blake2b 256 bit digest self-addressing derivation.
+    Blake2s_256:   str = 'G'  # Blake2s 256 bit digest self-addressing derivation.
+    SHA3_256:      str = 'H'  # SHA3 256 bit digest self-addressing derivation.
+    SHA2_256:      str = 'I'  # SHA2 256 bit digest self-addressing derivation.
+    Blake3_512:    str = '0D'  # Blake3 512 bit digest self-addressing derivation.
+    Blake2b_512:   str = '0E'  # Blake2b 512 bit digest self-addressing derivation.
+    SHA3_512:      str = '0F'  # SHA3 512 bit digest self-addressing derivation.
+    SHA2_512:      str = '0G'  # SHA2 512 bit digest self-addressing derivation.
+    ECDSA_256k1N:  str = '1AAA'  # ECDSA secp256k1 verification key non-transferable, basic derivation.
+    ECDSA_256k1:   str = '1AAB'  # ECDSA public verification or encryption key, basic derivation
+    ECDSA_256r1N:  str = "1AAI"  # ECDSA secp256r1 verification key non-transferable, basic derivation.
+    ECDSA_256r1:   str = "1AAJ"  # ECDSA secp256r1 verification or encryption key, basic derivation
 
     def __iter__(self):
         return iter(astuple(self))

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -136,6 +136,11 @@ class Serder:
         DigDex.SHA2_512: Digestage(klas=hashlib.sha512, size=None, length=None),
     }
 
+    Proto = Protos.keri  # default protocol type
+    Vrsn = Version  # default protocol version for protocol type
+    Kind = Serials.json  # default serialization kind
+    Code = DigDex.Blake3_256  # default said field code
+
     # Protocol specific field labels dict, keyed by ilk (packet type string).
     # value of each entry is Labelage instance that provides saidive field labels,
     # codes, and all field labels
@@ -143,15 +148,7 @@ class Serder:
     # Override in sub class that is protocol specific
     Labels = {None: Labelage(saids=['d'], codes=[DigDex.Blake3_256], fields=['v','d'])}
 
-    Proto = Protos.keri  # default protocol type
-    Vrsn = Version  # default protocol version for protocol type
-    Kind = Serials.json  # default serialization kind
-    Code = DigDex.Blake3_256  # default said field code
 
-
-    # add list of codes to Labelage so makify can use those as the defaults
-    # passed in list to .makify will override. None is passed in list means use
-    # the default
 
 
     def __init__(self, *, raw=b'', sad=None, strip=False, version=Version,
@@ -414,7 +411,7 @@ class Serder:
                     # in sad must have valid CESR. Otherwise override in subclass
 
             if code in DigDex:  # if digestive then fill with dummy
-                sad[label] = self.Dummy * len(value)
+                sad[label] = self.Dummy * Matter.Sizes[code].fs
 
             labCodes[label] = code
 

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -13,12 +13,12 @@ import blake3
 import hashlib
 
 from .. import kering
-from ..kering import (ValidationError,  MissingFieldError, InvalidValueError,
+from ..kering import (ValidationError,  MissingFieldError,
                       ShortageError, VersionError, ProtocolError, KindError,
                       DeserializeError, FieldError, SerializeError)
 
 from ..core import coring
-from .coring import Rever, versify, deversify, Version, Versionage
+from .coring import Rever, versify, deversify, Version, Versionage, Ilks
 from .coring import Protos, Serials, MtrDex, DigDex, PreDex
 from .coring import Matter, Diger, Saider, Digestage
 
@@ -97,23 +97,27 @@ class Serder:
         ._proto (str):  Protocolage value as protocol type identifier
         ._version is Versionage instance of event version
         ._kind is serialization kind string value (see namedtuple coring.Serials)
-          supported kinds are 'json', 'cbor', 'msgpack', 'binary'
+            supported kinds are 'json', 'cbor', 'msgpack', 'binary'
         ._size is int of number of bytes in serialed event only
         ._saider (Saider): instance for this Sadder's SAID
 
-
     Methods:
+        verify()
+        _verify()
+        makify()
+        compare()
         pretty(size: int | None ) -> str: Prettified JSON of this SAD
+
+    ClassMethods:
+        _inhale()
+        _exhale()
+
+    StaticMethods:
+        loads()
+        dumps()
 
     Note:
         loads and jumps of json use str whereas cbor and msgpack use bytes
-
-    ToDo:
-        verify
-            add fields check for required fields
-        saidify
-
-        Errors for extraction versus verification
 
     """
 
@@ -146,7 +150,9 @@ class Serder:
     # codes, and all field labels
     # A key of None is default when no ilk required
     # Override in sub class that is protocol specific
-    Labels = {None: Labelage(saids=['d'], codes=[DigDex.Blake3_256], fields=['v','d'])}
+    Labels = {None: Labelage(saids=['d'],
+                             codes=[DigDex.Blake3_256],
+                             fields=['v','d'])}
 
 
 
@@ -657,26 +663,6 @@ class Serder:
         return raw
 
 
-    def pretty(self, *, size=None):
-        """Utility method to pretty print .sad as JSON str.
-        Returns:
-            pretty (str):  JSON of .sad with pretty formatting
-
-        Pararmeters:
-            size (int | None): size limit. None means not limit.
-                Enables protection against syslog error when
-                exceeding UDP MTU (max trans unit) for syslog applications.
-                Guaranteed IPv4 MTU is 576, and IPv6 MTU is 1280.
-                Most broadband routers have an UDP MTU set to 1454.
-                Must include not just payload but UDP/IP header in
-                MTU calculation. So must leave room for either UDP/IpV4 or
-                the bigger UDP/IPv6 header.
-                Except for old IoT hardware, modern implementations all
-                support IPv6 so 1024 is usually a safe value for payload.
-        """
-        return json.dumps(self.sad, indent=1)[:size]
-
-
     def compare(self, said=None):
         """Utility method to allow comparison of own .said digest of .raw
         with some other purported said of .raw
@@ -697,6 +683,27 @@ class Serder:
 
         else:
             raise ValidationError(f"Uncomparable saids.")
+
+
+
+    def pretty(self, *, size=None):
+        """Utility method to pretty print .sad as JSON str.
+        Returns:
+            pretty (str):  JSON of .sad with pretty formatting
+
+        Pararmeters:
+            size (int | None): size limit. None means not limit.
+                Enables protection against syslog error when
+                exceeding UDP MTU (max trans unit) for syslog applications.
+                Guaranteed IPv4 MTU is 576, and IPv6 MTU is 1280.
+                Most broadband routers have an UDP MTU set to 1454.
+                Must include not just payload but UDP/IP header in
+                MTU calculation. So must leave room for either UDP/IpV4 or
+                the bigger UDP/IPv6 header.
+                Except for old IoT hardware, modern implementations all
+                support IPv6 so 1024 is usually a safe value for payload.
+        """
+        return json.dumps(self.sad, indent=1)[:size]
 
 
     @property
@@ -791,3 +798,18 @@ class Serder:
         """
         return self.sad.get('t')  # returns None if 't' not in sad
 
+
+
+class SerderKERI(Serder):
+    """SerderKERI is Serder subclass with Labels for KERI packet types (ilks) and
+       properties for exposing field values of KERI messages
+
+       See docs for Serder
+    """
+
+    # Protocol specific field labels dict, keyed by ilk (packet type string).
+    # value of each entry is Labelage instance that provides saidive field labels,
+    # codes, and all field labels
+    # A key of None is default when no ilk required
+    Labels = {Ilks.icp: Labelage(saids=['d'], codes=[DigDex.Blake3_256], fields=['v','d']),
+             }

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -316,9 +316,9 @@ class Serder:
             raise ValidationError(f"Invalid packet type (ilk) = {self.ilk} for"
                                   f"protocol = {self.proto}.")
 
-
+        labels = self.Labels[self.proto][self.ilk]  # get labelage
         # ensure required fields are in sad
-        fields = self.Labels[self.proto][self.ilk].fields  # all field labels
+        fields = labels.fields  # all field labels
         keys = list(self.sad)  # get list of keys of self.sad
         for key in list(keys):  # make copy to mutate
             if key not in fields:
@@ -330,7 +330,7 @@ class Serder:
 
         # said field labels are not order dependent with respect to all fields
         # in sad so use set() to test inclusion
-        saids = self.Labels[self.proto][self.ilk].saids  # saidive field labels
+        saids = labels.saids  # saidive field labels
         if not (set(saids) <= set(fields)):
             raise MissingFieldError(f"Missing required said fields = {saids}"
                                     f" in sad = {self.sad}.")
@@ -468,15 +468,17 @@ class Serder:
             raise SerializeError(f"Invalid packet type (ilk) = {ilk} for"
                                   f"protocol = {proto}.")
 
+        labels = self.Labels[proto][ilk]  # get Labelage
+
         if not sad:  # empty or None so create
-            sad = {label: "" for label in self.Labels[proto][ilk].fields}
+            sad = {label: "" for label in labels.fields}
             if 't' in sad:  # packet type (ilk) requried so set value to ilk
                 sad['t'] = ilk
 
 
 
         # ensure required fields are in sad
-        fields = self.Labels[proto][ilk].fields  # all field labels
+        fields = labels.fields  # all field labels
         keys = list(sad)  # get list of keys of self.sad
         for key in list(keys):  # make copy to mutate
             if key not in fields:
@@ -488,7 +490,7 @@ class Serder:
 
         # said field labels are not order dependent with respect to all fields
         # in sad so use set() to test inclusion
-        saids = self.Labels[proto][ilk].saids
+        saids = labels.saids
         if not (set(saids) <= set(fields)):
             raise SerializeError(f"Missing one or more required said fields = {saids}"
                                           f" in sad = {sad}.")
@@ -509,7 +511,7 @@ class Serder:
                     code = None
 
             if code is None:  # default from .Labels
-                code = self.Labels[proto][ilk].codes[i]
+                code = labels.codes[i]
 
             labCodes[label] = code
 

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -140,6 +140,9 @@ class Serder:
         DigDex.SHA2_512: Digestage(klas=hashlib.sha512, size=None, length=None),
     }
 
+    #override in subclass to enforce specific protocol
+    Protocol = None  # required protocol, None means any in Protos is ok
+
     Proto = Protos.keri  # default protocol type
     Vrsn = Version  # default protocol version for protocol type
     Kind = Serials.json  # default serialization kind
@@ -290,6 +293,10 @@ class Serder:
             raise ValidationError(f"Invalid packet type (ilk) = {self.ilk} for"
                                   f"protocol = {self.proto}.")
 
+        if self.Protocol and self.proto != self.Protocol:
+            raise SerializeError(f"Expected protocol = {self.Protocol}, got "
+                                 f"{self.proto} instead.")
+
         # ensure required fields are in sad
         fields = self.Labels[self.ilk].fields  # all field labels
         keys = list(self.sad)  # get list of keys of self.sad
@@ -404,6 +411,10 @@ class Serder:
 
         if proto not in Protos:
             raise SerializeError(f"Invalid protocol type = {proto}.")
+
+        if self.Protocol and proto != self.Protocol:
+            raise SerializeError(f"Expected protocol = {self.Protocol}, got "
+                                 f"{proto} instead.")
 
         if version is not None and vrsn != version:
             raise SerializeError(f"Expected version = {version}, got "
@@ -819,6 +830,9 @@ class SerderKERI(Serder):
 
        See docs for Serder
     """
+    #override in subclass to enforce specific protocol
+    Protocol = Protos.keri  # required protocol, None means any in Protos is ok
+    Proto = Protos.keri  # default protocol type
 
     # Protocol specific field labels dict, keyed by ilk (packet type string).
     # value of each entry is Labelage instance that provides saidive field labels,

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -16,10 +16,10 @@ from .. import kering
 from ..kering import (ValidationError,  MissingFieldError,
                       ShortageError, VersionError, ProtocolError, KindError,
                       DeserializeError, FieldError, SerializeError)
-
+from ..kering import Versionage, Version, VERRAWSIZE, VERFMT, VERFULLSIZE
+from ..kering import Protos, Serials, Rever, versify, deversify, Ilks
 from ..core import coring
-from .coring import Rever, versify, deversify, Version, Versionage, Ilks
-from .coring import Protos, Serials, MtrDex, DigDex, PreDex
+from .coring import MtrDex, DigDex, PreDex
 from .coring import Matter, Diger, Saider, Digestage
 
 from .. import help
@@ -122,7 +122,7 @@ class Serder:
     """
 
     MaxVSOffset = 12
-    InhaleSize = MaxVSOffset + coring.VERFULLSIZE  # min buffer size to inhale
+    InhaleSize = MaxVSOffset + VERFULLSIZE  # min buffer size to inhale
 
     Dummy = "#"  # dummy spaceholder char for said. Must not be a valid Base64 char
 
@@ -523,7 +523,7 @@ class Serder:
             raise SerializeError(f"Missing requires version string field 'v'"
                                           f" in sad = {sad}.")
 
-        sad['v'] = self.Dummy * coring.VERFULLSIZE  # ensure size of vs
+        sad['v'] = self.Dummy * VERFULLSIZE  # ensure size of vs
 
         raw = self.dumps(sad, kind)  # get size of fully dummied sad
         size = len(raw)

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -20,6 +20,7 @@ Protos = Protocolage(keri="KERI", acdc="ACDC")
 
 Versionage = namedtuple("Versionage", "major minor")
 Version = Versionage(major=1, minor=0)  # KERI Protocol Version
+Vrsn_1_0 = Versionage(major=1, minor=0)  # KERI Protocol Version Specific
 
 VERRAWSIZE = 6  # hex characters in raw serialization size in version string
 # "{:0{}x}".format(300, 6)  # make num char in hex a variable

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -3,15 +3,121 @@
 Generic Constants and Classes
 """
 import sys
+import re
 from collections import namedtuple
 
 
 FALSEY = (False, 0, None, "?0", "no", "false", "False", "off")
 TRUTHY = (True, 1, "?1", "yes" "true", "True", 'on')
 
-Versionage = namedtuple("Versionage", "major minor")
+# Serialization Kinds
+Serialage = namedtuple("Serialage", 'json mgpk cbor')
+Serials = Serialage(json='JSON', mgpk='MGPK', cbor='CBOR')
 
+# Protocol Types
+Protocolage = namedtuple("Protocolage", "keri acdc")
+Protos = Protocolage(keri="KERI", acdc="ACDC")
+
+Versionage = namedtuple("Versionage", "major minor")
 Version = Versionage(major=1, minor=0)  # KERI Protocol Version
+
+VERRAWSIZE = 6  # hex characters in raw serialization size in version string
+# "{:0{}x}".format(300, 6)  # make num char in hex a variable
+# '00012c'
+VERFMT = "{}{:x}{:x}{}{:0{}x}_"  # version format string
+VERFULLSIZE = 17  # number of characters in full version string
+
+VEREX = b'(?P<proto>[A-Z]{4})(?P<major>[0-9a-f])(?P<minor>[0-9a-f])(?P<kind>[A-Z]{4})(?P<size>[0-9a-f]{6})_'
+Rever = re.compile(VEREX)  # compile is faster
+
+
+def versify(proto=Protos.keri, version=Version, kind=Serials.json, size=0):
+    """
+    Returns version string
+    """
+    if proto not in Protos:
+        raise ValueError("Invalid message identifier = {}".format(proto))
+    #version = version if version else Version
+    if kind not in Serials:
+        raise ValueError("Invalid serialization kind = {}".format(kind))
+
+    return VERFMT.format(proto, version[0], version[1], kind, size, VERRAWSIZE)
+
+
+def deversify(vs, version=None):
+    """
+    Returns:  tuple(proto, kind, version, size) Where:
+        proto (str): value is protocol type identifier one of Protos (Protocolage)
+                   acdc='ACDC', keri='KERI'
+        kind (str): value is serialization kind, one of Serials
+                   json='JSON', mgpk='MGPK', cbor='CBOR'
+        vrsn (tuple):  version tuple of type Versionage
+        size  (int): raw size in bytes
+
+    Parameters:
+      vs (str): version string to extract from
+      version (Versionage | None): supported version. None means do not check
+            for supported version.
+
+    Uses regex match to extract:
+        protocol type
+        protocol version tuple
+        serialization kind
+        serialization size
+    """
+    match = Rever.match(vs.encode("utf-8"))  # match takes bytes
+    if match:
+        proto, major, minor, kind, size = match.group("proto",
+                                                      "major",
+                                                      "minor",
+                                                      "kind",
+                                                      "size")
+        proto = proto.decode("utf-8")
+        vrsn = Versionage(major=int(major, 16), minor=int(minor, 16))
+        kind = kind.decode("utf-8")
+
+        if proto not in Protos:
+            raise ValueError("Invalid message identifier = {}".format(proto))
+        if version is not None and vrsn != version:
+            raise ValueError(f"Expected version = {version}, got "
+                               f"{vrsn.major}.{vrsn.minor}.")
+        if kind not in Serials:
+            raise ValueError("Invalid serialization kind = {}".format(kind))
+        size = int(size, 16)
+        return proto, vrsn, kind, size
+
+    raise ValueError("Invalid version string = {}".format(vs))
+
+"""
+ilk is short for packet or message type for a given protocol
+    icp = incept, inception
+    rot = rotate, rotation
+    ixn = interact, interaction
+    dip = delcept, delegated inception
+    drt = deltate, delegated rotation
+    rct = receipt
+    ksn = state, key state notice
+    qry = query
+    rpy = reply
+    exn = exchange
+    exp = expose, sealed data exposition
+    vcp = vdr incept, verifiable data registry inception
+    vrt = vdr rotate, verifiable data registry rotation
+    iss = vc issue, verifiable credential issuance
+    rev = vc revoke, verifiable credential revocation
+    bis = backed vc issue, registry-backed transaction event log credential issuance
+    brv = backed vc revoke, registry-backed transaction event log credential revocation
+"""
+
+# KERI protocol packet (message) types
+Ilkage = namedtuple("Ilkage", ('icp rot ixn dip drt rct ksn qry rpy exn '
+                               'pro bar vcp vrt iss rev bis brv '))
+
+Ilks = Ilkage(icp='icp', rot='rot', ixn='ixn', dip='dip', drt='drt', rct='rct',
+              ksn='ksn', qry='qry', rpy='rpy', exn='exn', pro='pro', bar='bar',
+              vcp='vcp', vrt='vrt', iss='iss', rev='rev', bis='bis', brv='brv')
+
+
 
 SEPARATOR = "\r\n\r\n"
 SEPARATOR_BYTES = SEPARATOR.encode("utf-8")

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -411,16 +411,21 @@ def test_serder():
     assert serder.said == said
     assert serder.ilk == coring.Ilks.icp
 
-    #serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])  # test makify
-    #assert serder.raw == rawJSON
-    #assert serder.sad == sad
-    #assert serder.proto == coring.Protos.acdc
-    #assert serder.version == coring.Versionage(major=1, minor=0)
-    #assert serder.size == 90
-    #assert serder.kind == coring.Serials.json
-    #assert serder.said == saider.qb64
-    #assert serder.saidb == saider.qb64b
-    #assert serder.ilk == None
+    serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])  # test makify
+    assert serder.sad == {'v': 'KERI10JSON00009f_',
+                        't': 'icp',
+                        'd': 'EFmPBVkCqAbAOO8JHr4WJDvR-lcb14SzW1tQ5C53S3-T',
+                        'i': '',
+                        's': '',
+                        'kt': '',
+                        'k': '',
+                        'nt': '',
+                        'n': '',
+                        'bt': '',
+                        'b': '',
+                        'c': '',
+                        'a': ''}
+
 
 
 

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -14,7 +14,7 @@ import pytest
 
 from keri import kering
 from keri.core import coring
-from keri.core.serdering import Serder, Serdery
+from keri.core.serdering import Labelage, Serder, Serdery
 
 
 
@@ -24,6 +24,18 @@ def test_serder():
     """
 
     # Test Serder
+
+    assert Serder.Labels == {'KERI':
+                             {'icp': Labelage(saids=['d', 'i'],
+                                              codes=['E', 'E'],
+                                              fields=['v', 't', 'd', 'i', 's',
+                                                      'kt', 'k', 'nt', 'n', 'bt', 'b', 'c', 'a'])},
+                            'ACDC':
+                              {None: Labelage(saids=['d'],
+                                              codes=['E'],
+                                              fields=['v', 'd', 'i', 's'])}}
+
+    assert Serder.Ilks == {'KERI': 'icp', 'ACDC': None}
 
     assert Serder.Labels[coring.Protos.acdc][None].saids == ['d']
     assert Serder.Labels[coring.Protos.acdc][None].codes == [coring.DigDex.Blake3_256]
@@ -37,7 +49,7 @@ def test_serder():
     with pytest.raises(ValueError):
         serder = Serder()
 
-
+    # Test ACDC JSON bootstrap with Saider.saidify
     sad = dict(v=coring.versify(proto=coring.Protos.acdc,
                                 version=coring.Version,
                                 kind=coring.Serials.json),
@@ -51,6 +63,7 @@ def test_serder():
                    's': ''}
 
     assert saider.qb64 == sad["d"]
+    saidAcdcJson = sad["d"]  # save for later
 
     serder = Serder(sad=sad)
     assert serder.raw == (b'{"v":"ACDC10JSON00005a_",'
@@ -142,7 +155,7 @@ def test_serder():
     with pytest.raises(kering.ValidationError):
         serder = Serder(raw=badraw, verify=True)
 
-    # Test CBOR
+    # Test ACDC CBOR bootstrap with Saider.saidify
     sad = dict(v=coring.versify(proto=coring.Protos.acdc,
                                 version=coring.Version,
                                 kind=coring.Serials.cbor),
@@ -227,7 +240,7 @@ def test_serder():
     assert serder.ilk == None
 
 
-    # Test MGPK
+    # Test ACDC MGPK bootstrap with Saider.saidify
     sad = dict(v=coring.versify(proto=coring.Protos.acdc,
                                 version=coring.Version,
                                 kind=coring.Serials.mgpk),
@@ -310,6 +323,105 @@ def test_serder():
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
+
+    # test ACDC JSON with makify defaults for self bootstrap of ACDC
+    serder = Serder(makify=True, proto=coring.Protos.acdc)  # make defaults for ACDC
+    assert serder.sad == {'v': 'ACDC10JSON00005a_',
+                          'd': 'EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT',
+                          'i': '',
+                          's': ''}
+    assert serder.raw == rawJSON
+    assert serder.proto == coring.Protos.acdc
+    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.size == 90
+    assert serder.kind == coring.Serials.json
+    assert serder.said == saidAcdcJson
+    assert serder.ilk == None
+
+    # Test KERI JSON with makify defaults for self bootstrap
+    serder = Serder(makify=True)  # make with defaults
+    assert serder.sad == {
+                            'v': 'KERI10JSON0000cb_',
+                            't': 'icp',
+                            'd': 'EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J',
+                            'i': 'EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J',
+                            's': '',
+                            'kt': '',
+                            'k': '',
+                            'nt': '',
+                            'n': '',
+                            'bt': '',
+                            'b': '',
+                            'c': '',
+                            'a': ''
+                         }
+    assert serder.raw == (b'{"v":"KERI10JSON0000cb_","t":"icp","d":"EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KG'
+                          b'f87Bc70J","i":"EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J","s":"","kt":"",'
+                          b'"k":"","nt":"","n":"","bt":"","b":"","c":"","a":""}')
+    assert serder.proto == coring.Protos.keri
+    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.size == 203
+    assert serder.kind == coring.Serials.json
+    assert serder.said == 'EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J'
+    assert serder.sad['i'] == serder.said
+    assert serder.ilk == coring.Ilks.icp
+    assert serder.pretty() == ('{\n'
+                        ' "v": "KERI10JSON0000cb_",\n'
+                        ' "t": "icp",\n'
+                        ' "d": "EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J",\n'
+                        ' "i": "EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J",\n'
+                        ' "s": "",\n'
+                        ' "kt": "",\n'
+                        ' "k": "",\n'
+                        ' "nt": "",\n'
+                        ' "n": "",\n'
+                        ' "bt": "",\n'
+                        ' "b": "",\n'
+                        ' "c": "",\n'
+                        ' "a": ""\n'
+                        '}')
+    assert serder.compare(said=serder.said)
+    assert not serder.compare(said='EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pE')
+
+    sad = serder.sad  # save for later
+    raw = serder.raw  # save for later
+    size = serder.size # save for later
+    said = serder.said  # save for later
+
+
+    serder = Serder(sad=sad)
+    assert serder.raw == raw
+    assert serder.sad == sad
+    assert serder.proto == coring.Protos.keri
+    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.size == size
+    assert serder.kind == coring.Serials.json
+    assert serder.said == said
+    assert serder.ilk == coring.Ilks.icp
+
+
+
+    serder = Serder(raw=raw)
+    assert serder.raw == raw
+    assert serder.sad == sad
+    assert serder.proto == coring.Protos.keri
+    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.size == size
+    assert serder.kind == coring.Serials.json
+    assert serder.said == said
+    assert serder.ilk == coring.Ilks.icp
+
+    #serder = Serder(sad=sad, makify=True, codes=[coring.DigDex.Blake3_256])  # test makify
+    #assert serder.raw == rawJSON
+    #assert serder.sad == sad
+    #assert serder.proto == coring.Protos.acdc
+    #assert serder.version == coring.Versionage(major=1, minor=0)
+    #assert serder.size == 90
+    #assert serder.kind == coring.Serials.json
+    #assert serder.said == saider.qb64
+    #assert serder.saidb == saider.qb64b
+    #assert serder.ilk == None
+
 
 
     # ToDo: create malicious raw values to test verify more thoroughly

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -37,22 +37,22 @@ def test_serder():
 
     assert Serder.Ilks == {'KERI': 'icp', 'ACDC': None}
 
-    assert Serder.Labels[coring.Protos.acdc][None].saids == ['d']
-    assert Serder.Labels[coring.Protos.acdc][None].codes == [coring.DigDex.Blake3_256]
-    assert Serder.Labels[coring.Protos.acdc][None].fields == ['v', 'd', 'i', 's']
+    assert Serder.Labels[kering.Protos.acdc][None].saids == ['d']
+    assert Serder.Labels[kering.Protos.acdc][None].codes == [coring.DigDex.Blake3_256]
+    assert Serder.Labels[kering.Protos.acdc][None].fields == ['v', 'd', 'i', 's']
 
     # said field labels must be subset of all field labels
-    assert (set(Serder.Labels[coring.Protos.acdc][None].saids) <=
-            set(Serder.Labels[coring.Protos.acdc][None].fields))
+    assert (set(Serder.Labels[kering.Protos.acdc][None].saids) <=
+            set(Serder.Labels[kering.Protos.acdc][None].fields))
 
 
     with pytest.raises(ValueError):
         serder = Serder()
 
     # Test ACDC JSON bootstrap with Saider.saidify
-    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
-                                version=coring.Version,
-                                kind=coring.Serials.json),
+    sad = dict(v=kering.versify(proto=kering.Protos.acdc,
+                                version=kering.Version,
+                                kind=kering.Serials.json),
                d="",
                i="",
                s="")
@@ -70,10 +70,10 @@ def test_serder():
                           b'"d":"EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT",'
                           b'"i":"","s":""}')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -96,10 +96,10 @@ def test_serder():
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -107,10 +107,10 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -118,10 +118,10 @@ def test_serder():
     serder = Serder(sad=sad, makify=True, codes=[coring.DigDex.Blake3_256])  # test makify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -129,10 +129,10 @@ def test_serder():
     serder = Serder(raw=rawJSON)
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -140,10 +140,10 @@ def test_serder():
     serder = Serder(raw=rawJSON, verify=False)  # test without verify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -156,9 +156,9 @@ def test_serder():
         serder = Serder(raw=badraw, verify=True)
 
     # Test ACDC CBOR bootstrap with Saider.saidify
-    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
-                                version=coring.Version,
-                                kind=coring.Serials.cbor),
+    sad = dict(v=kering.versify(proto=kering.Protos.acdc,
+                                version=kering.Version,
+                                kind=kering.Serials.cbor),
                d="",
                i="",
                s="")
@@ -174,10 +174,10 @@ def test_serder():
     assert serder.raw == (b'\xa4avqACDC10CBOR00004b_adx,EGahYhEMb_Sz0L1UwhrUv'
                           b'byxyzoi_G85-pD9jRjhnqgUai`as`')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.cbor
+    assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -198,10 +198,10 @@ def test_serder():
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.cbor
+    assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -209,10 +209,10 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.cbor
+    assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -220,10 +220,10 @@ def test_serder():
     serder = Serder(raw=rawCBOR)
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.cbor
+    assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -231,19 +231,19 @@ def test_serder():
     serder = Serder(raw=rawCBOR, verify=False)  # test without verify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.cbor
+    assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
 
 
     # Test ACDC MGPK bootstrap with Saider.saidify
-    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
-                                version=coring.Version,
-                                kind=coring.Serials.mgpk),
+    sad = dict(v=kering.versify(proto=kering.Protos.acdc,
+                                version=kering.Version,
+                                kind=kering.Serials.mgpk),
                d="",
                i="",
                s="")
@@ -259,10 +259,10 @@ def test_serder():
     assert serder.raw == (b'\x84\xa1v\xb1ACDC10MGPK00004b_\xa1d\xd9,EGV5wdF1n'
                           b'RbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC\xa1i\xa0\xa1s\xa0')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.mgpk
+    assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -283,10 +283,10 @@ def test_serder():
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.mgpk
+    assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -294,10 +294,10 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.mgpk
+    assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -305,10 +305,10 @@ def test_serder():
     serder = Serder(raw=rawMGPK)
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.mgpk
+    assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
@@ -316,25 +316,25 @@ def test_serder():
     serder = Serder(raw=rawMGPK, verify=False)  # test not verify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 75
-    assert serder.kind == coring.Serials.mgpk
+    assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
 
     # test ACDC JSON with makify defaults for self bootstrap of ACDC
-    serder = Serder(makify=True, proto=coring.Protos.acdc)  # make defaults for ACDC
+    serder = Serder(makify=True, proto=kering.Protos.acdc)  # make defaults for ACDC
     assert serder.sad == {'v': 'ACDC10JSON00005a_',
                           'd': 'EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT',
                           'i': '',
                           's': ''}
     assert serder.raw == rawJSON
-    assert serder.proto == coring.Protos.acdc
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.acdc
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 90
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == saidAcdcJson
     assert serder.ilk == None
 
@@ -358,13 +358,13 @@ def test_serder():
     assert serder.raw == (b'{"v":"KERI10JSON0000cb_","t":"icp","d":"EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KG'
                           b'f87Bc70J","i":"EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J","s":"","kt":"",'
                           b'"k":"","nt":"","n":"","bt":"","b":"","c":"","a":""}')
-    assert serder.proto == coring.Protos.keri
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.keri
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == 203
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == 'EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J'
     assert serder.sad['i'] == serder.said
-    assert serder.ilk == coring.Ilks.icp
+    assert serder.ilk == kering.Ilks.icp
     assert serder.pretty() == ('{\n'
                         ' "v": "KERI10JSON0000cb_",\n'
                         ' "t": "icp",\n'
@@ -392,24 +392,24 @@ def test_serder():
     serder = Serder(sad=sad)
     assert serder.raw == raw
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.keri
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == size
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == said
-    assert serder.ilk == coring.Ilks.icp
+    assert serder.ilk == kering.Ilks.icp
 
 
 
     serder = Serder(raw=raw)
     assert serder.raw == raw
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
-    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.proto == kering.Protos.keri
+    assert serder.version == kering.Versionage(major=1, minor=0)
     assert serder.size == size
-    assert serder.kind == coring.Serials.json
+    assert serder.kind == kering.Serials.json
     assert serder.said == said
-    assert serder.ilk == coring.Ilks.icp
+    assert serder.ilk == kering.Ilks.icp
 
     # Test with non-digestive code for 'i' saidive field no sad
     serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])
@@ -460,6 +460,13 @@ def test_serder():
                         'c': [],
                         'a': []}
     assert serder.sad['i'] == pre
+
+    sad = serder.sad  # save for later
+
+    serder = Serder(sad=sad)  # test verify
+    assert serder.sad == sad
+
+
 
 
     # ToDo: create malicious raw values to test verify more thoroughly

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -235,40 +235,44 @@ def test_serder():
                i="",
                s="")
     saider, sad = coring.Saider.saidify(sad=sad)
-    assert sad == {'v': 'KERI10MGPK000045_',
-                   'd': 'EHORCaFv9ThskIBG0qSr3edk7oQ9x-xT8-FgsUIADb5E'}
+    assert sad == {'v': 'ACDC10MGPK00004b_',
+                    'd': 'EGV5wdF1nRbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC',
+                    'i': '',
+                    's': ''}
 
     assert saider.qb64 == sad["d"]
 
     serder = Serder(sad=sad)
-    assert serder.raw == (b'\x82\xa1v\xb1KERI10MGPK000045_\xa1d\xd9,EHORCaFv9'
-                          b'ThskIBG0qSr3edk7oQ9x-xT8-FgsUIADb5E')
+    assert serder.raw == (b'\x84\xa1v\xb1ACDC10MGPK00004b_\xa1d\xd9,EGV5wdF1n'
+                          b'RbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC\xa1i\xa0\xa1s\xa0')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
     assert serder.pretty() == ('{\n'
-                               ' "v": "KERI10MGPK000045_",\n'
-                               ' "d": "EHORCaFv9ThskIBG0qSr3edk7oQ9x-xT8-FgsUIADb5E"\n'
-                               '}')
+                                ' "v": "ACDC10MGPK00004b_",\n'
+                                ' "d": "EGV5wdF1nRbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC",\n'
+                                ' "i": "",\n'
+                                ' "s": ""\n'
+                                '}')
     assert serder.compare(said=saider.qb64)
     assert serder.compare(said=saider.qb64b)
     assert not serder.compare(said='EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8e')
 
     rawMGPK = serder.raw  # save for later tests
-    assert rawMGPK == (b'\x82\xa1v\xb1KERI10MGPK000045_\xa1d\xd9,EHORCaFv9'
-                          b'ThskIBG0qSr3edk7oQ9x-xT8-FgsUIADb5E')
+    assert rawMGPK == (b'\x84\xa1v\xb1ACDC10MGPK00004b_\xa1d\xd9,EGV5wdF1n'
+                          b'RbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC\xa1i\xa0\xa1s\xa0')
 
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -277,9 +281,9 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -288,9 +292,9 @@ def test_serder():
     serder = Serder(raw=rawMGPK)
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -299,9 +303,9 @@ def test_serder():
     serder = Serder(raw=rawMGPK, verify=False)  # test not verify
     assert serder.raw == rawMGPK
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.mgpk
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -89,6 +89,17 @@ def test_serder():
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
 
+    serder = Serder(sad=sad, makify=True, codes=[coring.DigDex.Blake3_256])  # test makify
+    assert serder.raw == rawJSON
+    assert serder.sad == sad
+    assert serder.proto == coring.Protos.keri
+    assert serder.version == coring.Versionage(major=1, minor=0)
+    assert serder.size == 76
+    assert serder.kind == coring.Serials.json
+    assert serder.said == saider.qb64
+    assert serder.saidb == saider.qb64b
+    assert serder.ilk == None
+
     serder = Serder(raw=rawJSON)
     assert serder.raw == rawJSON
     assert serder.sad == sad

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -411,7 +411,8 @@ def test_serder():
     assert serder.said == said
     assert serder.ilk == coring.Ilks.icp
 
-    serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])  # test makify
+    # Test with non-digestive code for 'i' saidive field no sad
+    serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])
     assert serder.sad == {'v': 'KERI10JSON00009f_',
                         't': 'icp',
                         'd': 'EFmPBVkCqAbAOO8JHr4WJDvR-lcb14SzW1tQ5C53S3-T',
@@ -426,7 +427,39 @@ def test_serder():
                         'c': '',
                         'a': ''}
 
+    # test makify with preloaded non-digestive 'i' value in sad
+    pre = 'DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx'
+    sad = {
+            'v': '',
+            't': 'icp',
+            'd': '',
+            'i': pre,
+            's': '',
+            'kt': '',
+            'k': [],
+            'nt': '',
+            'n': [],
+            'bt': '',
+            'b': [],
+            'c': [],
+            'a': []
+          }
 
+    serder = Serder(sad=sad, makify=True)
+    assert serder.sad == {'v': 'KERI10JSON0000cb_',
+                        't': 'icp',
+                        'd': 'EF0LlW8szMeZNqCJJUrDhSxQQkGnBHkuvbNa0ar2C4hJ',
+                        'i': 'DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx',
+                        's': '',
+                        'kt': '',
+                        'k': [],
+                        'nt': '',
+                        'n': [],
+                        'bt': '',
+                        'b': [],
+                        'c': [],
+                        'a': []}
+    assert serder.sad['i'] == pre
 
 
     # ToDo: create malicious raw values to test verify more thoroughly

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -411,7 +411,7 @@ def test_serder():
     assert serder.said == said
     assert serder.ilk == coring.Ilks.icp
 
-    #serder = Serder(sad=sad, makify=True, codes=[coring.DigDex.Blake3_256])  # test makify
+    #serder = Serder(makify=True, codes=[None, coring.PreDex.Ed25519])  # test makify
     #assert serder.raw == rawJSON
     #assert serder.sad == sad
     #assert serder.proto == coring.Protos.acdc

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -25,54 +25,67 @@ def test_serder():
 
     # Test Serder
 
-    assert Serder.Labels[None].saids == ['d']
-    assert Serder.Labels[None].fields == ['v', 'd']
+    assert Serder.Labels[coring.Protos.acdc][None].saids == ['d']
+    assert Serder.Labels[coring.Protos.acdc][None].codes == [coring.DigDex.Blake3_256]
+    assert Serder.Labels[coring.Protos.acdc][None].fields == ['v', 'd', 'i', 's']
 
     # said field labels must be subset of all field labels
-    assert set(Serder.Labels[None].saids) <= set(Serder.Labels[None].fields)
+    assert (set(Serder.Labels[coring.Protos.acdc][None].saids) <=
+            set(Serder.Labels[coring.Protos.acdc][None].fields))
 
 
     with pytest.raises(ValueError):
         serder = Serder()
 
-    sad = dict(v=coring.Vstrings.json, #
-               d="")
+
+    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
+                                version=coring.Version,
+                                kind=coring.Serials.json),
+               d="",
+               i="",
+               s="")
     saider, sad = coring.Saider.saidify(sad=sad)
-    assert sad == {'v': 'KERI10JSON00004c_',
-                   'd': 'EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8d'}
+    assert sad == {'v': 'ACDC10JSON00005a_',
+                   'd': 'EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT',
+                   'i': '',
+                   's': ''}
 
     assert saider.qb64 == sad["d"]
 
     serder = Serder(sad=sad)
-    assert serder.raw == (b'{"v":"KERI10JSON00004c_",'
-                          b'"d":"EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8d"}')
+    assert serder.raw == (b'{"v":"ACDC10JSON00005a_",'
+                          b'"d":"EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT",'
+                          b'"i":"","s":""}')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
     assert serder.pretty() == ('{\n'
-                                ' "v": "KERI10JSON00004c_",\n'
-                                ' "d": "EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8d"\n'
-                                '}')
+                               ' "v": "ACDC10JSON00005a_",\n'
+                               ' "d": "EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT",\n'
+                               ' "i": "",\n'
+                               ' "s": ""\n'
+                               '}')
 
     assert serder.compare(said=saider.qb64)
     assert serder.compare(said=saider.qb64b)
-    assert not serder.compare(said='EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8e')
+    assert not serder.compare(said='EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pE')
 
     rawJSON = serder.raw  # save for later tests
-    assert rawJSON == (b'{"v":"KERI10JSON00004c_",'
-                              b'"d":"EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8d"}')
+    assert rawJSON == (b'{"v":"ACDC10JSON00005a_",'
+                       b'"d":"EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pT",'
+                       b'"i":"","s":""}')
 
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -81,9 +94,9 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -92,9 +105,9 @@ def test_serder():
     serder = Serder(sad=sad, makify=True, codes=[coring.DigDex.Blake3_256])  # test makify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -103,9 +116,9 @@ def test_serder():
     serder = Serder(raw=rawJSON)
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -114,56 +127,67 @@ def test_serder():
     serder = Serder(raw=rawJSON, verify=False)  # test without verify
     assert serder.raw == rawJSON
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 76
+    assert serder.size == 90
     assert serder.kind == coring.Serials.json
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
 
     # test verify bad digest value
-    badraw = (b'{"v":"KERI10JSON00004c_",'
-                          b'"d":"EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8g"}')
+    badraw = (b'{"v":"ACDC10JSON00005a_",'
+              b'"d":"EMk7BvrqO_2sYjpI_-BmSELOFNie-muw4XTi3iYCz6pE",'
+              b'"i":"","s":""}')
     with pytest.raises(kering.ValidationError):
         serder = Serder(raw=badraw, verify=True)
 
     # Test CBOR
-    sad = dict(v=coring.Vstrings.cbor, #
-               d="")
+    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
+                                version=coring.Version,
+                                kind=coring.Serials.cbor),
+               d="",
+               i="",
+               s="")
     saider, sad = coring.Saider.saidify(sad=sad)
-    assert sad == {'v': 'KERI10CBOR000045_',
-                   'd': 'EK2_0ouKrN9hXmQvtfenA455EYZ4QENydBdrwtbPZuxa'}
+    assert sad == {'v': 'ACDC10CBOR00004b_',
+                    'd': 'EGahYhEMb_Sz0L1UwhrUvbyxyzoi_G85-pD9jRjhnqgU',
+                    'i': '',
+                    's': ''}
 
     assert saider.qb64 == sad["d"]
 
     serder = Serder(sad=sad)
-    assert serder.raw == b'\xa2avqKERI10CBOR000045_adx,EK2_0ouKrN9hXmQvtfenA455EYZ4QENydBdrwtbPZuxa'
+    assert serder.raw == (b'\xa4avqACDC10CBOR00004b_adx,EGahYhEMb_Sz0L1UwhrUv'
+                          b'byxyzoi_G85-pD9jRjhnqgUai`as`')
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
     assert serder.ilk == None
     assert serder.pretty() == ('{\n'
-                                ' "v": "KERI10CBOR000045_",\n'
-                                ' "d": "EK2_0ouKrN9hXmQvtfenA455EYZ4QENydBdrwtbPZuxa"\n'
+                                ' "v": "ACDC10CBOR00004b_",\n'
+                                ' "d": "EGahYhEMb_Sz0L1UwhrUvbyxyzoi_G85-pD9jRjhnqgU",\n'
+                                ' "i": "",\n'
+                                ' "s": ""\n'
                                 '}')
     assert serder.compare(said=saider.qb64)
     assert serder.compare(said=saider.qb64b)
     assert not serder.compare(said='EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8e')
 
     rawCBOR = serder.raw  # save for later tests
-    assert rawCBOR == b'\xa2avqKERI10CBOR000045_adx,EK2_0ouKrN9hXmQvtfenA455EYZ4QENydBdrwtbPZuxa'
+    assert rawCBOR == (b'\xa4avqACDC10CBOR00004b_adx,EGahYhEMb_Sz0L1UwhrUv'
+                          b'byxyzoi_G85-pD9jRjhnqgUai`as`')
 
     serder = Serder(sad=sad, verify=False)  # test not verify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -172,9 +196,9 @@ def test_serder():
     serder = Serder(sad=sad, makify=True)  # test makify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -183,9 +207,9 @@ def test_serder():
     serder = Serder(raw=rawCBOR)
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -194,9 +218,9 @@ def test_serder():
     serder = Serder(raw=rawCBOR, verify=False)  # test without verify
     assert serder.raw == rawCBOR
     assert serder.sad == sad
-    assert serder.proto == coring.Protos.keri
+    assert serder.proto == coring.Protos.acdc
     assert serder.version == coring.Versionage(major=1, minor=0)
-    assert serder.size == 69
+    assert serder.size == 75
     assert serder.kind == coring.Serials.cbor
     assert serder.said == saider.qb64
     assert serder.saidb == saider.qb64b
@@ -204,8 +228,12 @@ def test_serder():
 
 
     # Test MGPK
-    sad = dict(v=coring.Vstrings.mgpk, #
-               d="")
+    sad = dict(v=coring.versify(proto=coring.Protos.acdc,
+                                version=coring.Version,
+                                kind=coring.Serials.mgpk),
+               d="",
+               i="",
+               s="")
     saider, sad = coring.Saider.saidify(sad=sad)
     assert sad == {'v': 'KERI10MGPK000045_',
                    'd': 'EHORCaFv9ThskIBG0qSr3edk7oQ9x-xT8-FgsUIADb5E'}

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -13,7 +13,9 @@ import msgpack
 import pytest
 
 from keri import kering
+
 from keri.core import coring
+
 from keri.core.serdering import Labelage, Serder, Serdery
 
 
@@ -25,25 +27,38 @@ def test_serder():
 
     # Test Serder
 
-    assert Serder.Labels == {'KERI':
-                             {'icp': Labelage(saids=['d', 'i'],
-                                              codes=['E', 'E'],
-                                              fields=['v', 't', 'd', 'i', 's',
-                                                      'kt', 'k', 'nt', 'n', 'bt', 'b', 'c', 'a'])},
+    assert Serder.Labels == {
+                            'KERI':
+                            {
+                                kering.Vrsn_1_0:
+                                {
+                                    'icp': Labelage(saids=['d', 'i'],
+                                        codes=['E', 'E'],
+                                        fields=['v', 't', 'd', 'i', 's', 'kt',
+                                                'k', 'nt', 'n', 'bt', 'b', 'c', 'a']),
+                                },
+                            },
                             'ACDC':
-                              {None: Labelage(saids=['d'],
-                                              codes=['E'],
-                                              fields=['v', 'd', 'i', 's'])}}
+                            {
+                                kering.Vrsn_1_0:
+                                {
+                                    None: Labelage(saids=['d'],
+                                        codes=['E'],
+                                        fields=['v', 'd', 'i', 's']),
+                                },
+                            },
+                            }
+
 
     assert Serder.Ilks == {'KERI': 'icp', 'ACDC': None}
 
-    assert Serder.Labels[kering.Protos.acdc][None].saids == ['d']
-    assert Serder.Labels[kering.Protos.acdc][None].codes == [coring.DigDex.Blake3_256]
-    assert Serder.Labels[kering.Protos.acdc][None].fields == ['v', 'd', 'i', 's']
+    assert Serder.Labels[kering.Protos.acdc][kering.Vrsn_1_0][None].saids == ['d']
+    assert Serder.Labels[kering.Protos.acdc][kering.Vrsn_1_0][None].codes == [coring.DigDex.Blake3_256]
+    assert Serder.Labels[kering.Protos.acdc][kering.Vrsn_1_0][None].fields == ['v', 'd', 'i', 's']
 
     # said field labels must be subset of all field labels
-    assert (set(Serder.Labels[kering.Protos.acdc][None].saids) <=
-            set(Serder.Labels[kering.Protos.acdc][None].fields))
+    assert (set(Serder.Labels[kering.Protos.acdc][kering.Vrsn_1_0][None].saids) <=
+            set(Serder.Labels[kering.Protos.acdc][kering.Vrsn_1_0][None].fields))
 
 
     with pytest.raises(ValueError):
@@ -71,7 +86,7 @@ def test_serder():
                           b'"i":"","s":""}')
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -97,7 +112,7 @@ def test_serder():
     assert serder.raw == rawJSON
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -108,7 +123,7 @@ def test_serder():
     assert serder.raw == rawJSON
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -119,7 +134,7 @@ def test_serder():
     assert serder.raw == rawJSON
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -130,7 +145,7 @@ def test_serder():
     assert serder.raw == rawJSON
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -141,7 +156,7 @@ def test_serder():
     assert serder.raw == rawJSON
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saider.qb64
@@ -175,7 +190,7 @@ def test_serder():
                           b'byxyzoi_G85-pD9jRjhnqgUai`as`')
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
@@ -199,7 +214,7 @@ def test_serder():
     assert serder.raw == rawCBOR
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
@@ -210,7 +225,7 @@ def test_serder():
     assert serder.raw == rawCBOR
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
@@ -221,7 +236,7 @@ def test_serder():
     assert serder.raw == rawCBOR
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
@@ -232,7 +247,7 @@ def test_serder():
     assert serder.raw == rawCBOR
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.cbor
     assert serder.said == saider.qb64
@@ -260,7 +275,7 @@ def test_serder():
                           b'RbSXatBgZDpAxlGL6BuATjpUYBuk0AQW7GC\xa1i\xa0\xa1s\xa0')
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
@@ -284,7 +299,7 @@ def test_serder():
     assert serder.raw == rawMGPK
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
@@ -295,7 +310,7 @@ def test_serder():
     assert serder.raw == rawMGPK
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
@@ -306,7 +321,7 @@ def test_serder():
     assert serder.raw == rawMGPK
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
@@ -317,7 +332,7 @@ def test_serder():
     assert serder.raw == rawMGPK
     assert serder.sad == sad
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 75
     assert serder.kind == kering.Serials.mgpk
     assert serder.said == saider.qb64
@@ -332,7 +347,7 @@ def test_serder():
                           's': ''}
     assert serder.raw == rawJSON
     assert serder.proto == kering.Protos.acdc
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 90
     assert serder.kind == kering.Serials.json
     assert serder.said == saidAcdcJson
@@ -359,7 +374,7 @@ def test_serder():
                           b'f87Bc70J","i":"EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J","s":"","kt":"",'
                           b'"k":"","nt":"","n":"","bt":"","b":"","c":"","a":""}')
     assert serder.proto == kering.Protos.keri
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == 203
     assert serder.kind == kering.Serials.json
     assert serder.said == 'EDGnGYIa5obfFUhxcAuUmM4fJyeRYj2ti3KGf87Bc70J'
@@ -393,7 +408,7 @@ def test_serder():
     assert serder.raw == raw
     assert serder.sad == sad
     assert serder.proto == kering.Protos.keri
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == size
     assert serder.kind == kering.Serials.json
     assert serder.said == said
@@ -405,7 +420,7 @@ def test_serder():
     assert serder.raw == raw
     assert serder.sad == sad
     assert serder.proto == kering.Protos.keri
-    assert serder.version == kering.Versionage(major=1, minor=0)
+    assert serder.vrsn == kering.Vrsn_1_0
     assert serder.size == size
     assert serder.kind == kering.Serials.json
     assert serder.said == said


### PR DESCRIPTION
The core functionality of new Serder is largely complete. 

Most of what remains is fleshing out the .Labels table to include
all the packet types for KERI. ACDC currently only has one default packet type so that is done.
Also still need to add the subclasses with protocol specific and (when necessary) packet type speciific properties.
Also still need to add protocol and packet type specific additional verifications to ._verify augmentation.

Did some refatoring. Moved the versioning stuff from coring to kering  see of better spot.