### PR TITLE
allow the rotate command to add witness poller for any new witnesses.

### DIFF
--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -16,8 +16,7 @@ from keri.core import coring
 logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='Initialize a prefix')
-parser.set_defaults(handler=lambda args: handler(args),
-                    transferable=True)
+parser.set_defaults(handler=lambda args: handler(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -176,7 +176,6 @@ class RotateDoer(doing.DoDoer):
             self.adds = set(self.wits) - set(ewits)
             if self.endpoint:
                 for wit in self.adds:
-                    print(f"catching up {wit}")
                     yield from receiptor.catchup(hab.pre, wit)
 
         hab.rotate(isith=self.isith, nsith=self.nsith, ncount=self.count, toad=self.toad,
@@ -193,6 +192,10 @@ class RotateDoer(doing.DoDoer):
             if self.endpoint:
                 yield from receiptor.receipt(hab.pre, sn=hab.kever.sn)
             else:
+                for wit in self.adds:
+                    self.mbx.addPoller(hab, witness=wit)
+                    
+                print("Waiting for witness receipts...")
                 witDoer = agenting.WitnessReceiptor(hby=self.hby)
                 self.extend(doers=[witDoer])
                 yield self.tock

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -395,7 +395,7 @@ class Habery:
 
         self.reconfigure()  # post hab load reconfiguration
 
-    def makeHab(self, name, ns=None, **kwa):
+    def makeHab(self, name, ns=None, cf=None, **kwa):
         """Make new Hab with name, pre is generated from **kwa
 
         Parameters: (Passthrough to hab.make)
@@ -418,7 +418,8 @@ class Habery:
         if ns is not None and "." in ns:
             raise kering.ConfigurationError("Hab namespace names are not allowed to contain the '.' character")
 
-        hab = Hab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+        cf = cf if cf is not None else self.cf
+        hab = Hab(ks=self.ks, db=self.db, cf=cf, mgr=self.mgr,
                   rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                   name=name, ns=ns, temp=self.temp)
 

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -140,7 +140,7 @@ class Respondant(doing.DoDoer):
 
     """
 
-    def __init__(self, hby, reps=None, cues=None, mbx=None, **kwa):
+    def __init__(self, hby, reps=None, cues=None, mbx=None, aids=None, **kwa):
         """
         Creates Respondant that uses local environment to find the destination KEL and stores
         peer to peer messages in mbx, the mailboxer
@@ -154,6 +154,7 @@ class Respondant(doing.DoDoer):
         self.cues = cues if cues is not None else decking.Deck()
 
         self.hby = hby
+        self.aids = aids
         self.mbx = mbx if mbx is not None else Mailboxer(name=self.hby.name)
         self.postman = forwarding.Poster(hby=self.hby, mbx=self.mbx)
 
@@ -225,6 +226,11 @@ class Respondant(doing.DoDoer):
                     serder = cue["serder"]  # Serder of received event for other pre
                     cuedKed = serder.ked
                     cuedPrefixer = coring.Prefixer(qb64=cuedKed["i"])
+
+                    # If respondant configured with list of acceptable AIDs to witness for, check them here
+                    if self.aids is not None and cuedPrefixer.qb64 not in self.aids:
+                        continue
+
                     if cuedPrefixer.qb64 in self.hby.kevers:
                         kever = self.hby.kevers[cuedPrefixer.qb64]
                         owits = oset(kever.wits)


### PR DESCRIPTION
This PR includes a bug fix that prevented `kli rotate` from getting receipts from newly added witnesses.  The system was not adding a poller for the new witness so it could not get receipts.  Now it can.