### PR TITLE
Fixed TCP Arg help text in kli witness

### DIFF
--- a/src/keri/app/cli/commands/agent/vlei.py
+++ b/src/keri/app/cli/commands/agent/vlei.py
@@ -13,7 +13,7 @@ parser.add_argument('--config-file',
 
 
 def vlei(args):
-    print("\n******* Starting Agents for vLEI scenairo testing on ports:"
+    print("\n******* Starting Agents for vLEI scenario testing on ports:"
           "\n\n"
           "    RootGARs:  5620, 5621\n"
           "    ExtGARs:   5622, 5623\n"

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -28,7 +28,7 @@ parser.add_argument('-H', '--http',
 parser.add_argument('-T', '--tcp',
                     action='store',
                     default=5632,
-                    help="Local port number the HTTP server listens on. Default is 5632.")
+                    help="Local port number the TCP server listens on. Default is 5632.")
 parser.add_argument('-n', '--name',
                     action='store',
                     default="witness",


### PR DESCRIPTION
KLI --TCP arg had "HTTP" in the help text instead of "TCP".  Quick fix to avoid future confusion if anyone noticed.