### PR TITLE
Remove package level salt

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -23,11 +23,8 @@ from ..kering import MissingSignatureError, Roles
 
 logger = help.ogler.getLogger()
 
-SALT = coring.Salter(raw=b'0123456789abcdef').qb64  # '0AAwMTIzNDU2Nzg5YWJjZGVm'
-
-
 @contextmanager
-def openHby(*, name="test", base="", temp=True, salt=SALT, **kwa):
+def openHby(*, name="test", base="", temp=True, salt=None, **kwa):
     """
     Context manager wrapper for Habery instance.
     Context 'with' statements call .close on exit of 'with' block
@@ -72,6 +69,7 @@ def openHby(*, name="test", base="", temp=True, salt=SALT, **kwa):
 
     """
     habery = None
+    salt = salt if not None else coring.Salter(raw=b'0123456789abcdef').qb64
     try:
         habery = Habery(name=name, base=base, temp=temp, salt=salt, **kwa)
         yield habery
@@ -296,7 +294,7 @@ class Habery:
                 aeid = signer.verfer.qb64  # lest it remove encryption
 
         if salt is None:  # salt for signing keys not aeid seed
-            salt = SALT
+            salt = coring.Salter(raw=b'0123456789abcdef').qb64
         else:
             salt = coring.Salter(qb64=salt).qb64
 

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -17,7 +17,8 @@ def test_standalone_kli_commands(helpers, capsys):
     assert os.path.isdir("/usr/local/var/keri/ks/test") is False
 
     parser = multicommand.create_parser(commands)
-    args = parser.parse_args(["init", "--name", "test", "--nopasscode", "--salt", habbing.SALT])
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    args = parser.parse_args(["init", "--name", "test", "--nopasscode", "--salt", salt])
     assert args.handler is not None
     doers = args.handler(args)
 
@@ -257,7 +258,8 @@ def test_incept_and_rotate_opts(helpers, capsys):
     assert os.path.isdir("/usr/local/var/keri/ks/test-opts") is False
 
     parser = multicommand.create_parser(commands)
-    args = parser.parse_args(["init", "--name", "test-opts", "--nopasscode", "--salt", habbing.SALT])
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    args = parser.parse_args(["init", "--name", "test-opts", "--nopasscode", "--salt", salt])
     assert args.handler is not None
     doers = args.handler(args)
 

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -26,6 +26,7 @@ def test_habery():
     Test Habery class
     """
     # test default
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
     hby = habbing.Habery(temp=True)
     assert hby.name == "test"
     assert hby.base == ""
@@ -54,7 +55,7 @@ def test_habery():
 
     assert hby.mgr.seed == ""
     assert hby.mgr.aeid == ""
-    assert hby.mgr.salt == habbing.SALT
+    assert hby.mgr.salt == default_salt
     assert hby.mgr.pidx == 1
     assert hby.mgr.algo == keeping.Algos.salty
     assert hby.mgr.tier == coring.Tiers.low
@@ -87,7 +88,7 @@ def test_habery():
 
     assert hby.mgr.seed == seed4bran
     assert hby.mgr.aeid == aeid4seed
-    assert hby.mgr.salt == habbing.SALT
+    assert hby.mgr.salt == default_salt
     assert hby.mgr.pidx == 1
     assert hby.mgr.algo == keeping.Algos.salty
     assert hby.mgr.tier == coring.Tiers.low
@@ -154,7 +155,7 @@ def test_habery():
     assert hby.mgr is not None
     assert hby.mgr.seed == seed4bran
     assert hby.mgr.aeid == aeid4seed
-    assert hby.mgr.salt == habbing.SALT
+    assert hby.mgr.salt == default_salt
     assert hby.mgr.pidx == 1
     assert hby.mgr.algo == keeping.Algos.salty
     assert hby.mgr.tier == coring.Tiers.low
@@ -215,7 +216,7 @@ def test_habery():
     assert hby.mgr is not None
     assert hby.mgr.seed == seed4bran
     assert hby.mgr.aeid == aeid4seed
-    assert hby.mgr.salt == habbing.SALT
+    assert hby.mgr.salt == default_salt
     assert hby.mgr.pidx == 1
     assert hby.mgr.algo == keeping.Algos.salty
     assert hby.mgr.tier == coring.Tiers.low
@@ -263,7 +264,7 @@ def test_habery():
 
         assert hby.mgr.seed == ""
         assert hby.mgr.aeid == ""
-        assert hby.mgr.salt == habbing.SALT
+        assert hby.mgr.salt == default_salt
         assert hby.mgr.pidx == 1
         assert hby.mgr.algo == keeping.Algos.salty
         assert hby.mgr.tier == coring.Tiers.low
@@ -312,7 +313,7 @@ def test_habery():
         # test bran to seed
         assert hby.mgr.seed == seed4bran
         assert hby.mgr.aeid == aeid4seed
-        assert hby.mgr.salt == habbing.SALT
+        assert hby.mgr.salt == default_salt
         assert hby.mgr.pidx == 1
         assert hby.mgr.algo == keeping.Algos.salty
         assert hby.mgr.tier == coring.Tiers.low
@@ -606,7 +607,7 @@ def test_habery_reconfigure(mockHelpingNowUTC):
     # salt = salter.qb64
     # assert salt == '0ABaqPLVOa6fpVnAKcmwhIdQ'
 
-    salt = habbing.SALT
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64
 
     cname = "tam"  # controller name
     cbase = "main"  # controller base shared


### PR DESCRIPTION
In some places, we inline a "default" salt; in others, we use this package-level salt.

Given I think we should discourage the use of any default salt (seems like a bad security practice) I opted to move the creation of the salt to where it is used.

This came up as I was testing Signifypy and mocking the keripy library.

As a note: I have started another branch https://github.com/m00sey/keripy/tree/remove-default-salt to investigate what removing a default salt and requiring one be provided, would look like and the impact on keripy.