### PR TITLE
Add witness TLS support

### DIFF
--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -44,6 +44,9 @@ parser.add_argument('--config-file',
                     action='store',
                     default=None,
                     help="configuration filename override")
+parser.add_argument("--keypath", action="store", required=False, default=None)
+parser.add_argument("--certpath", action="store", required=False, default=None)
+parser.add_argument("--cafilepath", action="store", required=False, default=None)
 
 
 def launch(args):
@@ -62,14 +65,17 @@ def launch(args):
                tcp=int(args.tcp),
                http=int(args.http),
                configDir=args.configDir,
-               configFile=args.configFile)
+               configFile=args.configFile,
+               keypath=args.keypath,
+               certpath=args.certpath,
+               cafilepath=args.cafilepath)
 
     logger.info("\n******* Ended Witness for %s listening: http/%s, tcp/%s"
                 ".******\n\n", args.name, args.http, args.tcp)
 
 
 def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http=5632, expire=0.0,
-               configDir="", configFile=""):
+               configDir="", configFile="", keypath=None, certpath=None, cafilepath=None):
     """
     Setup and run one witness
     """
@@ -96,6 +102,9 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
     doers.extend(indirecting.setupWitness(alias=alias,
                                           hby=hby,
                                           tcpPort=tcp,
-                                          httpPort=http))
+                                          httpPort=http,
+                                          keypath=keypath,
+                                          certpath=certpath,
+                                          cafilepath=cafilepath))
 
     directing.runController(doers=doers, expire=expire)

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -5,7 +5,9 @@ tests.app.indirecting module
 """
 import json
 
+import falcon
 import pytest
+from hio.core import tcp, http
 from hio.help import decking
 
 from keri.app import indirecting, storing, habbing
@@ -147,6 +149,14 @@ def test_qrymailbox_iter():
         mb.iter.TimeoutMBX = 0  # Force the iter to timeout
         with pytest.raises(StopIteration):
             next(mbi)
+
+
+def test_createHttpServer():
+    port = 5632
+    app = falcon.App()
+    server = indirecting.createHttpServer(port, app)
+    assert isinstance(server, http.Server)
+
 
 
 if __name__ == "__main__":

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -6,6 +6,7 @@ tests.app.indirecting module
 import json
 
 import falcon
+import hio
 import pytest
 from hio.core import tcp, http
 from hio.help import decking
@@ -151,11 +152,30 @@ def test_qrymailbox_iter():
             next(mbi)
 
 
-def test_createHttpServer():
+class MockServerTls:
+    def __init__(self,  certify, keypath, certpath, cafilepath, port):
+        pass
+
+
+class MockHttpServer:
+    def __init__(self, port, app, servant=None):
+        self.servant = servant
+
+
+def test_createHttpServer(monkeypatch):
     port = 5632
     app = falcon.App()
     server = indirecting.createHttpServer(port, app)
     assert isinstance(server, http.Server)
+
+    monkeypatch.setattr(hio.core.tcp, 'ServerTls', MockServerTls)
+    monkeypatch.setattr(hio.core.http, 'Server', MockHttpServer)
+
+    server = indirecting.createHttpServer(port, app, keypath='keypath', certpath='certpath', cafilepath='cafilepath')
+
+    assert isinstance(server, MockHttpServer)
+    assert isinstance(server.servant, MockServerTls)
+
 
 
 


### PR DESCRIPTION
Adds the same args from `kli agent start` to `kli witness start`.

If the base function `createHttpServer` is accepted into KERIpy then we can change my PR to KERIA to use that function rather than duplicate it.

This is missing a positive test for creating a `tcp.ServerTls` instance. I just need to figure out how to generate self-signed TLS certs on the fly or add a test set of TLS certs+key to the test fixtures.