### PR TITLE
Multistage dockerfile example

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.10.4-alpine3.16
+FROM python:3.10.4-alpine3.16 as builder
 
 RUN apk update
 RUN apk add bash
@@ -13,10 +13,29 @@ RUN apk add libsodium-dev
 # Setup Rust for blake3 dependency build
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
-COPY . /keripy
+WORKDIR /keripy
+
+RUN python -m venv venv
+
+ENV PATH=/keripy/venv/bin:${PATH}
+
+RUN pip install --upgrade pip
+
+COPY requirements.txt setup.py .
+COPY src/ src/
+RUN . ${HOME}/.cargo/env && pip install -r requirements.txt
+
+FROM python:3.10.4-alpine3.16
+
+RUN apk add alpine-sdk
+RUN apk add libsodium-dev
+
+ENV PATH=/keripy/venv/bin:${PATH}
+
+COPY --from=builder /keripy /keripy
+
 WORKDIR /keripy
 
 # Install KERIpy dependencies
 # Must source the Cargo environment for the blake3 library to see the Rust intallation during requirements install
-RUN source "$HOME/.cargo/env" && pip install -r requirements.txt
-
+ENTRYPOINT [ "kli" ]


### PR DESCRIPTION
This is a slight elaboration on Jason's initial work.

Moving the COPY src/ src/ from the build stage to the runtime stage enables near instantaneous builds for source-only updates. 

The `RUN mkdir /keripy/src` in the build layer enables the setup.py and requirements.txt to be able to fully execute.

Building from scratch, or with no cache, a `linux/amd64` image on my Mac takes about 25 minutes. This Dockerfile enables me to have a build that is less than 5 seconds when there are source only changes. However, dependency changes still require a full rebuild.