### PR TITLE
Correct the KLI description for TOAD

### DIFF
--- a/src/keri/app/cli/common/incepting.py
+++ b/src/keri/app/cli/common/incepting.py
@@ -15,7 +15,7 @@ def addInceptingArgs(parser):
     parser.add_argument('--wits',         '-w', default=[], required=False, action="append", metavar="<prefix>",
                         help='New set of witnesses, replaces all existing witnesses.  Can appear multiple times')
     parser.add_argument('--toad',         '-t', default=None, required=False, type=int,
-                        help='int or str hex of witness threshold (threshold of acceptable duplicity)',)
+                        help='int or str hex of witness threshold (threshold of accountable duplicity)',)
     parser.add_argument('--icount',       '-ic', default=None, required=False,
                         help='incepting key count for number of keys used for inception')
     parser.add_argument('--isith',        '-s', default=None, required=False,


### PR DESCRIPTION
TOAD is threshold of accountable duplicity, not threshold of acceptable duplicity.