### PR TITLE
Fix delete hab to use the right name.

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -679,7 +679,7 @@ class Habery:
         if not hab:
             return False
 
-        if not self.db.habs.rem(keys=self.name):
+        if not self.db.habs.rem(keys=(name,)):
             return False
 
         del self.habs[hab.pre]


### PR DESCRIPTION
This PR is a small fix to Habery.deleteHab to make it actually work.