### PR TITLE
Fix reference to .saider in challenge response and add test

### DIFF
--- a/src/keri/app/challenging.py
+++ b/src/keri/app/challenging.py
@@ -4,8 +4,7 @@ keri.vc.challenging module
 
 """
 
-from hio.base import doing
-from hio.help import decking
+from keri.core import coring
 
 
 def loadHandlers(db, signaler, exc):
@@ -55,4 +54,4 @@ class ChallengeHandler:
         self.signaler.push(msg, topic="/challenge")
 
         # Log signer against event to track successful challenges with signed response
-        self.db.reps.add(keys=(signer,), val=serder.saider)
+        self.db.reps.add(keys=(signer,), val=coring.Saider(qb64=serder.said))

--- a/tests/app/test_challenging.py
+++ b/tests/app/test_challenging.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.challenging module
+
+"""
+
+from keri.app import habbing, challenging, signaling
+from keri.peer import exchanging
+
+
+def test_challenge_handler():
+    with habbing.openHab(name="test", temp=True) as (hby, hab):
+
+        signaler = signaling.Signaler()
+        handler = challenging.ChallengeHandler(db=hab.db, signaler=signaler)
+
+        payload = dict(i=hab.pre, words=["the", "test", "words", "that", "are", "not", "sufficient"])
+        exn, _ = exchanging.exchange(route="/challenge/response", payload=payload, sender=hab.pre)
+
+        handler.handle(serder=exn)
+
+        assert len(signaler.signals) == 1
+        saids = hab.db.reps.get(keys=(hab.pre,))
+
+        assert len(saids) == 1
+        assert saids[0].qb64 == exn.said


### PR DESCRIPTION
This PR fixes challenge response after being broken by the CESR updates.  Also added tests since this lost coverage when KIWI was deleted.