### PR TITLE
Adds simple healthcheck

### DIFF
--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -23,7 +23,7 @@ from .. import help
 from .. import kering
 from ..app import habbing
 from ..core import coring
-from ..help import helping
+from ..help import helping, nowIso8601
 
 logger = help.ogler.getLogger()
 
@@ -645,6 +645,16 @@ def loadEnds(app, hby, *, tymth=None, default=None, static=False):
     app.add_route("/oobi/{aid}", end)
     app.add_route("/oobi/{aid}/{role}", end)
     app.add_route("/oobi/{aid}/{role}/{eid}", end)
+
+    # healthcheck endpoint
+    app.add_route("/health", HealthEnd())
+
+class HealthEnd:
+    """Health resource for determining that a container is live"""
+
+    def on_get(self, _req, resp):
+        resp.status = falcon.HTTP_OK
+        resp.media = {"message": f"Health is okay. Time is {nowIso8601()}"}
 
 
 def setup(name="who", temp=False, tymth=None, isith=None, count=1,

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -5,6 +5,7 @@ Test Falcon Module
 Includes Falcon ReST endpoints for testing purposes
 
 """
+import json
 import logging
 
 import falcon
@@ -398,6 +399,26 @@ def test_get_admin():
     assert rep.status == falcon.HTTP_OK
     assert rep.text == '\nKERI Admin\n\n'
     """Done Test"""
+
+def test_healthcheck():
+    name = 'zoe'
+    base = 'test'
+    with habbing.openHby(name=name, base=base) as hby:
+        hab = hby.makeHab(name=name)
+        # hab = setupTestHab(name='zoe')
+
+    # must do it here to inject into Falcon endpoint resource instances
+    tymist = tyming.Tymist(tyme=0.0)
+
+    myapp = falcon.App()  # falcon.App instances are callable WSGI apps
+    ending.loadEnds(myapp, tymth=tymist.tymen(), hby=hby)
+
+    client = testing.TestClient(app=myapp)
+    res = client.simulate_get('/health')
+    health = json.loads(res.content)
+    assert res.status == falcon.HTTP_OK
+    assert 'message' in health
+    assert health['message'].startswith('Health is okay')
 
 
 def test_get_oobi():


### PR DESCRIPTION
Adds a simple healthcheck endpoint at each of the ports that is allowed through the SignifyTS header check.

This is not a fully involved healthcheck that has useful statistics on the Habery, Habs, or other things related to the witness. That would be cool and will happen in a future evolution of the healthcheck. This endpoint is just to support a simple runtime status reporting that the application is running.

This is useful for Kubernetes readinessProbes and livenessProbes.