### PR TITLE
Explicit use of hex str or int sequence numbers

### DIFF
--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -22,15 +22,38 @@ function isSuccess() {
 }
 
 # Test scripts
+printf "\n************************************\n"
+printf "Running demo-script.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/demo-script.sh"
 isSuccess
+
+printf "\n************************************\n"
+printf "Running demo-witness-script.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/demo-witness-script.sh"
 isSuccess
+
+printf "\n************************************\n"
+printf "Running demo-witness-async-script.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/demo-witness-async-script.sh"
 isSuccess
+
+printf "\n************************************\n"
+printf "Running multisig.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/multisig.sh"
 isSuccess
+
+printf "\n************************************\n"
+printf "Running multisig-delegate-delegator.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/multisig-delegate-delegator.sh"
 isSuccess
+
+printf "\n************************************\n"
+rintf "Running challenge.sh"
+printf "\n************************************\n"
 "${script_dir}/basic/challenge.sh"
 isSuccess

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -506,7 +506,7 @@ class WitnessInquisitor(doing.DoDoer):
 
             yield self.tock
 
-    def query(self, pre, r="logs", sn=0, src=None, hab=None, anchor=None, wits=None, **kwa):
+    def query(self, pre, r="logs", sn='0', src=None, hab=None, anchor=None, wits=None, **kwa):
         """ Create, sign and return a `qry` message against the attester for the prefix
 
         Parameters:
@@ -514,7 +514,7 @@ class WitnessInquisitor(doing.DoDoer):
             hab (Hab): Hab to use instead of src if provided
             pre (str): qb64 identifier prefix being queried for
             r (str): query route
-            sn (int): optional specific sequence number to query for
+            sn (str): optional specific hex str of sequence number to query for
             anchor (Seal): anchored Seal to search for
             wits (list) witnesses to query
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1400,7 +1400,7 @@ class BaseHab:
                 seal = eventing.SealLast(i=kever.prefixer.qb64)
             else:
                 seal = eventing.SealEvent(i=kever.prefixer.qb64,
-                                          s=hex(kever.lastEst.s),
+                                          s="{:x}".format(kever.lastEst.s),
                                           d=kever.lastEst.d)
 
             sigers = self.sign(ser=serder.raw,

--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -39,7 +39,7 @@ class KeyStateNoticer(doing.DoDoer):
             return super(KeyStateNoticer, self).recur(tyme, deeds)
 
         if self.cues:
-            cue = self.cues.pull() # self.cues.popleft()
+            cue = self.cues.pull()
             match cue['kin']:
                 case "keyStateSaved":
                     kcue = cue

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4104,7 +4104,7 @@ class Kevery:
             pre = qry["i"]
             src = qry["src"]
             anchor = qry["a"] if "a" in qry else None
-            sn = qry["s"] if "s" in qry else None
+            sn = int(qry["s"], 16) if "s" in qry else None
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -630,6 +630,16 @@ class Registrar(doing.DoDoer):
         return ixn, prefixer, seqner, saider
 
     def complete(self, pre, sn=0):
+        """ Determine if registry event (inception, issuance, revocation, etc.) is finished validation
+
+        Parameters:
+            pre (str): qb64 identifier of registry event
+            sn (int): integer sequence number of regsitry event
+
+        Returns:
+            bool: True means event has completed and is commited to database
+        """
+
         seqner = coring.Seqner(sn=sn)
         said = self.rgy.reger.ctel.get(keys=(pre, seqner.qb64))
         return said is not None and self.witPub.sent(said=pre)

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -334,7 +334,7 @@ def backerIssue(
     isn = 0
     ilk = Ilks.bis
 
-    seal = SealEvent(regk, regsn, regd)
+    seal = SealEvent(regk, "{:x}".format(regsn), regd)
 
     ked = dict(v=vs,  # version string
                t=ilk,
@@ -389,7 +389,7 @@ def backerRevoke(
     isn = 1
     ilk = Ilks.brv
 
-    seal = SealEvent(regk, regsn, regd)
+    seal = SealEvent(regk, "{:x}".format(regsn), regd)
 
     ked = dict(v=vs,
                t=ilk,
@@ -1567,7 +1567,6 @@ class Tevery:
         regk = self.registryKey(serder)
         pre = serder.pre
         ked = serder.ked
-        said = serder.said
         sn = ked["s"]
         ilk = ked["t"]
 
@@ -1908,7 +1907,7 @@ class Tevery:
         ra = vsr.ra
 
         if 's' in ra:
-            regsn = ra["s"]
+            regsn = int(ra["s"], 16)
         else:
             regsn = 0
 

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -37,7 +37,7 @@ def test_querying():
         assert msg["src"] == inqHab.pre
         assert msg["pre"] == subHab.pre
         assert msg["r"] == "ksn"
-        assert msg["q"] == {'s': 0}
+        assert msg["q"] == {'s': '0'}
         assert msg["wits"] is None
 
         doist.recur(deeds=deeds)

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -1261,7 +1261,7 @@ def test_unverified_trans_receipt_escrow():
         # create receipt(s) of rotation message with rotation message of receipter
         # create chit receipt(s) of interaction message
         seal = eventing.SealEvent(i=rpre,
-                                  s= rsrdr.ked["s"],
+                                  s=rsrdr.ked["s"],
                                   d=rsrdr.said)
         reserder = eventing.receipt(pre=pre, sn=2, said=rotdig)
         # sign event not receipt

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -304,19 +304,19 @@ def test_backer_issue_revoke(mockHelpingNowUTC):
     dig = "EC2L3ycqK9645aEeQKP941xojSiuiHsw4Y6yTW-PmsBg"
 
     serder = backerIssue(vcdig=vcdig, regk=regk, regsn=sn, regd=regd)
-    assert serder.raw == (b'{"v":"KERI10JSON000160_","t":"bis","d":"EM2zBvc6fL7BvcRT-OhPR7dgja5p4Kc1G3l3'
-                        b'5Plb0CYk","i":"DAtNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","ii":"EE3Xv6CWw'
-                        b'EMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":"0","ra":{"i":"EE3Xv6CWwEMpW-99rhPD'
-                        b'9IHFCR2LN5ienLVI8yG5faBw","s":3,"d":"EBpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-PL'
-                        b'MZ1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+    assert serder.raw == (b'{"v":"KERI10JSON000162_","t":"bis","d":"EK9X5Ih5z68pKA-dHMuEZXt_2avkzM8i1_gD'
+                          b'KlFBGDM7","i":"DAtNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","ii":"EE3Xv6CWw'
+                          b'EMpW-99rhPD9IHFCR2LN5ienLVI8yG5faBw","s":"0","ra":{"i":"EE3Xv6CWwEMpW-99rhPD'
+                          b'9IHFCR2LN5ienLVI8yG5faBw","s":"3","d":"EBpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-'
+                          b'PLMZ1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
 
     serder = backerRevoke(vcdig=vcdig, regk=regk, regsn=sn, regd=regd, dig=dig)
-    assert serder.raw == (b'{"v":"KERI10JSON00015f_","t":"brv","d":"EAIZZ8ujQQl4XGMh8XPzxokkzqrWh8M6Ftxq'
-                        b'kezbVtDu","i":"DAtNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","s":"1","p":"EC'
-                        b'2L3ycqK9645aEeQKP941xojSiuiHsw4Y6yTW-PmsBg","ra":{"i":"EE3Xv6CWwEMpW-99rhPD9'
-                        b'IHFCR2LN5ienLVI8yG5faBw","s":3,"d":"EBpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-PLM'
-                        b'Z1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+    assert serder.raw == (b'{"v":"KERI10JSON000161_","t":"brv","d":"EMBHVoEIM4GfoLtelLD6erwNLyO39PUyEAcC'
+                          b'-N77OGoq","i":"DAtNTPnDFBnmlO6J44LXCrzZTAmpe-82b7BmQGtL4QhM","s":"1","p":"EC'
+                          b'2L3ycqK9645aEeQKP941xojSiuiHsw4Y6yTW-PmsBg","ra":{"i":"EE3Xv6CWwEMpW-99rhPD9'
+                          b'IHFCR2LN5ienLVI8yG5faBw","s":"3","d":"EBpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-P'
+                          b'LMZ1H4"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
     """ End Test """
 
@@ -685,11 +685,11 @@ def test_tever_backers(mockHelpingNowUTC, mockCoringRandomNonce):
 
         vci = vcdig
         dgkey = dgKey(pre=vci, dig=bis.said)
-        assert bytes(reg.getTvt(dgkey)) == (b'{"v":"KERI10JSON000160_","t":"bis","d":"EJkHLOtyOkkQYkgyZPeVq-QjvdtMYtqnpKoL'
-                    b'LklRpdir","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","ii":"EBgdJt_AS'
-                    b'Weq7HjOmut2E8vQL8P1c9VTPDA0Pdh4KsZX","s":"0","ra":{"i":"EBgdJt_ASWeq7HjOmut2'
-                    b'E8vQL8P1c9VTPDA0Pdh4KsZX","s":1,"d":"EEc1UURU3liIomWOFeDVqCo-3QbZHFZCUorx8Md'
-                    b'ZFZvy"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
+        assert bytes(reg.getTvt(dgkey)) == (b'{"v":"KERI10JSON000162_","t":"bis","d":"EN01O_jV46iSPtJMFXLNB83OWHtUl0wEDnMT'
+                                            b'eHSWXJwf","i":"EEBp64Aw2rsjdJpAR0e2qCq3jX7q7gLld3LjAwZgaLXU","ii":"EBgdJt_AS'
+                                            b'Weq7HjOmut2E8vQL8P1c9VTPDA0Pdh4KsZX","s":"0","ra":{"i":"EBgdJt_ASWeq7HjOmut2'
+                                            b'E8vQL8P1c9VTPDA0Pdh4KsZX","s":"1","d":"EEc1UURU3liIomWOFeDVqCo-3QbZHFZCUorx8'
+                                            b'MdZFZvy"},"dt":"2021-01-01T00:00:00.000000+00:00"}')
 
 
 def test_tevery():


### PR DESCRIPTION
This PR updates all uses of sequence number to ensure we are explicit about passing around hex string for Seals and all parameters unless a mathematical comparison operation is required, then use an int and declare that in doc strings