### PR TITLE
habery .__init__ creates its default .psr parser with local = True

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -221,7 +221,8 @@ class Habery:
         self.exc = exchanging.Exchanger(hby=self, handlers=[])
         self.kvy = eventing.Kevery(db=self.db, lax=False, local=True, rvy=self.rvy)
         self.kvy.registerReplyRoutes(router=self.rtr)
-        self.psr = parsing.Parser(framed=True, kvy=self.kvy, rvy=self.rvy, exc=self.exc)
+        self.psr = parsing.Parser(framed=True, kvy=self.kvy, rvy=self.rvy,
+                                  exc=self.exc, local=True)
         self.habs = {}  # empty .habs
         self.namespaces = {}  # empty .namespaces
         self._signator = None

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -537,6 +537,7 @@ class Baser(dbing.LMDBer):
         .mfes is named sub DB instance of CesrIoSetSuber for misfit escrows
             snKey
             DB is keyed by event controller prefix plus sn of serialized event
+            where sn is 32 char hex string with leading zeros
             Value is serialized qb64b dig (said) of event
             Misfit escrows are events with remote (nonlocal) sources that are
             inappropriate (i.e. would be dropped) unless they can be upgraded

--- a/src/keri/db/subing.py
+++ b/src/keri/db/subing.py
@@ -509,8 +509,8 @@ class IoSetSuber(SuberBase):
             val (Union[bytes, str]): serialization
 
         Returns:
-            result (bool): True means unique value among duplications,
-                              False means duplicte of same value already exists.
+            result (bool): True means unique value added among duplications,
+                            False means duplicate of same value already exists.
 
         """
         return (self.db.addIoSetVal(db=self.sdb,

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -504,6 +504,15 @@ class OutOfOrderTxnStateError(ValidationError):
         raise OutOfOrderTxnStateError("error message")
     """
 
+class MisfitEventSourceError(ValidationError):
+    """
+    Error referenced event missing from log so can't verify this txn state event
+    Usage:
+        raise MisfitEventSourceError("error message")
+    """
+
+
+
 
 # Stream Parsing and Extraction Errors
 class ExtractionError(KeriError):

--- a/tests/core/test_delegating.py
+++ b/tests/core/test_delegating.py
@@ -721,3 +721,4 @@ def test_delegation_supersede():
 
 if __name__ == "__main__":
     test_delegation()
+    test_delegation_supersede()

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -585,6 +585,19 @@ def test_missing_delegator_escrow():
     """End Test"""
 
 
+def test_misfit_escrow():
+    """
+    Test misfit escrow
+
+    """
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64  # init wes Salter
+
+    # stub for now
+
+    """End Test"""
+
+
+
 def test_out_of_order_escrow():
     """
     Test out of order escrow

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -4808,6 +4808,7 @@ def test_load_event(mockHelpingNowUTC):
         assert wanHab.pre == "BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP"
         msg = wanHab.makeOwnEvent(sn=0)
         parsing.Parser().parse(ims=msg, kvy=torKvy)
+        assert wanHab.pre in torKvy.kevers
 
         # Create Wil the witness, we'll use him later
         wilHab = wilHby.makeHab(name="wil", transferable=False)
@@ -4816,14 +4817,16 @@ def test_load_event(mockHelpingNowUTC):
         torHab = torHby.makeHab(name="tor", icount=1, isith='1', ncount=1, nsith='1', wits=[wanHab.pre], toad=1)
         assert torHab.pre == "EBOVJXs0trI76PRfvJB2fsZ56PrtyR6HrUT9LOBra8VP"
         torIcp = torHab.makeOwnEvent(sn=0)
+        assert torHab.pre in torHab.kvy.kevers
 
         # Try to load event before Wan has seen it
         with pytest.raises(ValueError):
             _ = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
 
-        parsing.Parser().parse(ims=bytearray(torIcp), kvy=wanKvy)
+        # tor events are locallyWitnessed by wan so must process as local
+        parsing.Parser().parse(ims=bytearray(torIcp), kvy=wanHab.kvy) # process as local
 
-        wanHab.processCues(wanKvy.cues)  # process cue returns rct msg
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
         evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.pre)
         assert evt == {'ked': {'a': [],
                                'b': ['BAbSj3jfaeJbpuqg0WtvHw31UoRZOnN_RZQYBwbAqteP'],
@@ -4857,8 +4860,8 @@ def test_load_event(mockHelpingNowUTC):
 
         # Anchor Tee's inception event in Tor's KEL
         ixn = torHab.interact(data=[dict(i=teeHab.pre, s='0', d=teeHab.kever.serder.said)])
-        parsing.Parser().parse(ims=bytearray(ixn), kvy=wanKvy)
-        wanHab.processCues(wanKvy.cues)  # process cue returns rct msg
+        parsing.Parser().parse(ims=bytearray(ixn), kvy=wanHab.kvy)  # give to wan must be local
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
 
         evt = eventing.loadEvent(wanHab.db, torHab.pre, torHab.kever.serder.said)
         assert evt == {'ked': {'a': [{'d': 'EDnrWpxagMvr5BBCwCOh3q5M9lvurboZ66vxR-GnIgQo',
@@ -4894,10 +4897,12 @@ def test_load_event(mockHelpingNowUTC):
         nrct = wilHab.receipt(serder=teeHab.kever.serder)
 
         # Now Wan should be ready for Tee's inception
-        parsing.Parser().parse(ims=bytearray(teeIcp), kvy=wanKvy)
-        parsing.Parser().parse(ims=bytearray(rct), kvy=wanKvy)
-        parsing.Parser().parse(ims=bytearray(nrct), kvy=wanKvy)
-        wanHab.processCues(wanKvy.cues)  # process cue returns rct msg
+        parsing.Parser().parse(ims=bytearray(teeIcp), kvy=wanHab.kvy)
+        parsing.Parser().parse(ims=bytearray(rct), kvy=wanHab.kvy)
+        parsing.Parser().parse(ims=bytearray(nrct), kvy=wanHab.kvy)
+        # ToDo XXXX fix it so cues are durable in db so can process cues from
+        # both and remote sources
+        wanHab.processCues(wanHab.kvy.cues)  # process cue returns rct msg
 
         # Endorse Tee's inception event with Wan's Hab just so we have non-trans receipts
 

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -224,6 +224,11 @@ def test_parser():
         kevery = Kevery(db=valDB)
 
         parser = parsing.Parser(kvy=kevery)
+        assert parser.kvy == kevery
+        assert parser.local == False
+        assert parser.framed == True
+        assert parser.pipeline == False
+        assert parser.ims == bytearray()
 
         parser.parse(ims=bytearray(msgs))  # make copy
         assert parser.ims == bytearray(b'')  # emptied
@@ -236,7 +241,7 @@ def test_parser():
         db_digs = [bytes(val).decode("utf-8") for val in kevery.db.getKelIter(pre)]
         assert db_digs == event_digs
 
-        parser = parsing.Parser()  # no kevery
+        parser = parsing.Parser()  # no kevery so drops all messages
         parser.parse(ims=msgs)
         assert parser.ims == bytearray(b'')
 


### PR DESCRIPTION
New local logic with event processing and misfit escrowing
But of unit tests now failing but reasons seem consistent with new logic