### PR TITLE
Update query cues to use hex string instead of int for sequence number.

### DIFF
--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -96,7 +96,7 @@ class SeqNoQuerier(doing.DoDoer):
         self.pre = pre
         self.sn = sn
         self.witq = agenting.WitnessInquisitor(hby=self.hby)
-        self.witq.query(src=self.hab.pre, pre=self.pre, sn=self.sn)
+        self.witq.query(src=self.hab.pre, pre=self.pre, sn="{:x}".format(self.sn))
         super(SeqNoQuerier, self).__init__(doers=[self.witq], **opts)
 
     def recur(self, tyme, deeds=None):

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2333,7 +2333,7 @@ class Kever:
                     if self.escrowPWEvent(serder=serder, wigers=wigers, sigers=sigers,
                                           seqner=delseqner, saider=delsaider):
                         # cue to query for witness receipts
-                        self.cues.push(dict(kin="query", q=dict(pre=serder.pre, sn=serder.sn)))
+                        self.cues.push(dict(kin="query", q=dict(pre=serder.pre, sn=serder.snh)))
                     raise MissingWitnessSignatureError(f"Failure satisfying toad={toader.num} "
                                                        f"on witness sigs="
                                                        f"{[siger.qb64 for siger in wigers]} "

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -81,7 +81,7 @@ class Exchanger:
 
                 if prefixer.qb64 not in self.kevers or self.kevers[prefixer.qb64].sn < seqner.sn:
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
-                        self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.sn)))
+                        self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                     raise MissingSignatureError(f"Unable to find sender {prefixer.qb64} in kevers"
                                                 f" for evt = {serder.ked}.")
 
@@ -91,7 +91,7 @@ class Exchanger:
 
                 if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
-                        self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.sn)))
+                        self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                     raise MissingSignatureError(f"Not enough signatures in  {indices}"
                                                 f" for evt = {serder.ked}.")
 


### PR DESCRIPTION
This PR fixes last few references to sequence number to use hex string in queries.