### PR TITLE
Updated build-witness-demo command.  No gleif/keri-1.1.0 on dockerhub…

### DIFF
--- a/images/witness.demo.dockerfile
+++ b/images/witness.demo.dockerfile
@@ -1,4 +1,4 @@
-FROM gleif/keri:1.1.0
+FROM gleif/keri:latest
 
 SHELL ["/bin/bash", "-c"]
 EXPOSE 5632


### PR DESCRIPTION
… but latest probably fulfills the same requirement