### PR TITLE
Use image python:3.10-alpine; Fix docker COPY build failure

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,5 +1,5 @@
 # Builder layer
-FROM python:3.10.13-alpine3.18 as builder
+FROM python:3.10-alpine as builder
 
 # Install compilation dependencies
 RUN apk --no-cache add \
@@ -24,7 +24,8 @@ RUN pip install --upgrade pip && \
     mkdir /keripy/src
 
 # Copy Python dependency files in
-COPY requirements.txt setup.py .
+COPY requirements.txt setup.py ./
+
 # Set up Rust environment and install Python dependencies
 # Must source the Cargo environment for the blake3 library to see
 # the Rust intallation during requirements install


### PR DESCRIPTION
By using a less specific base image we can be right more often while doing less maintenance grunt-work on our Docker image. By using 3.10 instead of 3.10.13, our code will still be correct when 3.10.14 is released. Similarly, by using "alpine" instead of "alpine 3.18", we are still presently using the latest stable version of Alpine 3 (3.18) while being upgraded automatically to the latest stable version when it becomes available.

Reference:

- https://hub.docker.com/layers/library/python/3.10-alpine/images/sha256-4b062a3861ac865436439499d9a03e055871a0f465833987d23b67364a35a38f?context=repo
- https://github.com/docker-library/python/blob/b34fc81375758e84dec797e9210a079b4889352e/3.10/alpine3.18/Dockerfile#L24

Also, fix docker build bug with COPY:

> Step 9/17 : COPY requirements.txt setup.py .
> When using COPY with more than one source file, the destination must be a directory and end with a /
