### PR TITLE
Fix all broken kli commands and sample scripts

### DIFF
--- a/scripts/demo/basic/challenge.sh
+++ b/scripts/demo/basic/challenge.sh
@@ -3,7 +3,7 @@
 kli init --name cha1 --nopasscode --config-dir "${KERI_SCRIPT_DIR}" --config-file demo-witness-oobis
 kli incept --name cha1 --alias cha1 --file ${KERI_DEMO_SCRIPT_DIR}/data/challenge-sample.json
 kli ends add --name cha1 --alias cha1 --eid BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM --role mailbox
-exit 0
+
 kli init --name cha2 --nopasscode --config-dir "${KERI_SCRIPT_DIR}" --config-file pool2-witness-oobis
 kli incept --name cha2 --alias cha2 --file ${KERI_DEMO_SCRIPT_DIR}/data/challenge-sample-pool2.json
 kli ends add --name cha2 --alias cha2 --eid BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM --role mailbox

--- a/scripts/demo/credentials/multisig-issuer.sh
+++ b/scripts/demo/credentials/multisig-issuer.sh
@@ -86,6 +86,8 @@ wait $PID_LIST
 
 SAID=$(kli vc list --name multisig1 --alias multisig --issued --said)
 
+kli oobi resolve --name holder --oobi-alias multisig --oobi http://127.0.0.1:5642/oobi/EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2/witness
+
 kli ipex grant --name multisig1 --alias multisig --said "${SAID}" --recipient ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k --time "${TIME}" &
 pid=$!
 PID_LIST+=" $pid"
@@ -95,8 +97,6 @@ pid=$!
 PID_LIST+=" $pid"
 
 wait $PID_LIST
-
-kli oobi resolve --name holder --oobi-alias multisig --oobi http://127.0.0.1:5642/oobi/EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2/witness
 
 echo "Polling for holder's IPEX message..."
 SAID=$(kli ipex list --name holder --alias holder --poll --said)

--- a/src/keri/app/cli/commands/ipex/grant.py
+++ b/src/keri/app/cli/commands/ipex/grant.py
@@ -108,11 +108,11 @@ class GrantDoer(doing.DoDoer):
 
         iss = self.rgy.reger.cloneTvtAt(creder.said)
 
-        iserder = serdering.SerderKERI(raw=bytes(iss)) # coring.Serder(raw=bytes(iss))
+        iserder = serdering.SerderKERI(raw=bytes(iss))  # coring.Serder(raw=bytes(iss))
         seqner = coring.Seqner(sn=iserder.sn)
 
-        serder = self.hby.db.findAnchoringSealEvent(creder.ked['i'],
-                                                seal=dict(i=iserder.pre, s=seqner.snh, d=iserder.said))
+        serder = self.hby.db.findAnchoringSealEvent(creder.sad['i'],
+                                                    seal=dict(i=iserder.pre, s=seqner.snh, d=iserder.said))
         anc = self.hby.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
 
         exn, atc = protocoling.ipexGrantExn(hab=self.hab, recp=recp, message=self.message, acdc=acdc, iss=iss, anc=anc,
@@ -122,7 +122,9 @@ class GrantDoer(doing.DoDoer):
 
         parsing.Parser().parseOne(ims=bytes(msg), exc=self.exc)
 
+        sender = self.hab
         if isinstance(self.hab, habbing.GroupHab):
+            sender = self.hab.mhab
             wexn, watc = grouping.multisigExn(self.hab, exn=msg)
 
             smids = self.hab.db.signingMembers(pre=self.hab.pre)
@@ -140,7 +142,7 @@ class GrantDoer(doing.DoDoer):
 
         if self.exc.lead(self.hab, said=exn.said):
             print(f"Sending message {exn.said} to {recp}")
-            postman = forwarding.StreamPoster(hby=self.hby, hab=self.hab, recp=recp, topic="credential")
+            postman = forwarding.StreamPoster(hby=self.hby, hab=sender, recp=recp, topic="credential")
 
             sources = self.rgy.reger.sources(self.hby.db, creder)
             credentialing.sendArtifacts(self.hby, self.rgy.reger, postman, creder, recp)

--- a/src/keri/app/cli/commands/ipex/list.py
+++ b/src/keri/app/cli/commands/ipex/list.py
@@ -82,7 +82,7 @@ class ListDoer(doing.DoDoer):
         self.vry = verifying.Verifier(hby=self.hby, reger=self.rgy.reger)
         self.exc = exchanging.Exchanger(hby=self.hby, handlers=[])
         protocoling.loadHandlers(self.hby, self.exc, self.notifier)
-        self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=['/replay', 'reply', '/credential'],
+        self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=['/replay', '/reply', '/credential'],
                                                exc=self.exc, verifier=self.vry)
 
         self.doers = [self.mbx]

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -450,7 +450,7 @@ class ConfirmDoer(doing.DoDoer):
 
         if approve:
             # Create and parse the event with "their" signatures
-            rserder = serdering.SerderKERI(ked=rpy)
+            rserder = serdering.SerderKERI(sad=rpy)
             anc = bytearray(rserder.raw) + pathed["rpy"]
             self.psr.parseOne(ims=bytes(anc))
 
@@ -512,7 +512,7 @@ class ConfirmDoer(doing.DoDoer):
             # Create and parse the event with "their" signatures
             registryName = input("Name for Registry: ")
             anc = embeds["anc"]
-            aserder = serdering.SerderKERI(ked=anc)
+            aserder = serdering.SerderKERI(sad=anc)
             anc = bytearray(aserder.raw) + pathed["anc"]
             self.psr.parseOne(ims=bytes(anc))
 
@@ -522,7 +522,7 @@ class ConfirmDoer(doing.DoDoer):
             self.psr.parseOne(ims=bytes(anc))
 
             vcp = embeds["vcp"]
-            vserder = serdering.SerderKERI(ked=vcp)
+            vserder = serdering.SerderKERI(sad=vcp)
             try:
                 self.rgy.tvy.processEvent(serder=vserder)
             except kering.MissingAnchorError:
@@ -606,7 +606,7 @@ class ConfirmDoer(doing.DoDoer):
         if approve:
             # Create and parse the event with "their" signatures
             anc = embeds["anc"]
-            aserder = serdering.SerderKERI(ked=anc)
+            aserder = serdering.SerderKERI(sad=anc)
             anc = bytearray(aserder.raw) + pathed["anc"]
             self.psr.parseOne(ims=bytes(anc))
 
@@ -616,7 +616,7 @@ class ConfirmDoer(doing.DoDoer):
             self.psr.parseOne(ims=bytes(anc))
 
             iss = embeds["iss"]
-            iserder = serdering.SerderKERI(ked=iss)
+            iserder = serdering.SerderKERI(sad=iss)
             try:
                 self.rgy.tvy.processEvent(serder=iserder)
             except kering.MissingAnchorError:
@@ -690,8 +690,8 @@ class ConfirmDoer(doing.DoDoer):
         print(f"    Type: {schemer.sed['title']}")
         print(f"    Issued By: {hab.name} ({hab.pre})")
 
-        if "i" in creder.subject:
-            isse = creder.subject['i']
+        if "i" in creder.attrib:
+            isse = creder.attrib['i']
             contact = self.org.get(isse)
             if contact is not None and "alias" in contact:
                 print(f"    Issued To: {contact['alias']} ({isse})")
@@ -704,7 +704,7 @@ class ConfirmDoer(doing.DoDoer):
         if approve:
             # Create and parse the event with "their" signatures
             anc = embeds["anc"]
-            aserder = serdering.SerderKERI(ked=anc)
+            aserder = serdering.SerderKERI(sad=anc)
             anc = bytearray(aserder.raw) + pathed["anc"]
             self.psr.parseOne(ims=bytes(anc))
 
@@ -714,7 +714,7 @@ class ConfirmDoer(doing.DoDoer):
             self.psr.parseOne(ims=bytes(anc))
 
             rev = embeds["rev"]
-            rserder = serdering.SerderKERI(ked=rev)
+            rserder = serdering.SerderKERI(sad=rev)
             try:
                 self.rgy.tvy.processEvent(serder=rserder)
             except kering.MissingAnchorError:
@@ -738,8 +738,8 @@ class ConfirmDoer(doing.DoDoer):
                 yield self.tock
 
             print(f"Credential {creder.said} revoked.")
-            if hab.witnesser() and 'i' in creder.subject:
-                recp = creder.subject['i']
+            if hab.witnesser() and 'i' in creder.attrib:
+                recp = creder.attrib['i']
                 msgs = []
                 for msg in self.hby.db.clonePreIter(pre=creder.issuer):
                     serder = serdering.SerderKERI(raw=msg)
@@ -798,7 +798,7 @@ class ConfirmDoer(doing.DoDoer):
         approve = yn in ('', 'y', 'Y')
 
         if approve:
-            eserder = serdering.SerderKERI(ked=eexn)
+            eserder = serdering.SerderKERI(sad=eexn)
             anc = bytearray(eserder.raw) + pathed["exn"]
             self.psr.parseOne(ims=bytes(anc))
 

--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -5,13 +5,11 @@ from hio import help
 from hio.base import doing
 
 from keri import kering
-from keri.core import serdering
 from keri.app import indirecting, habbing, grouping, connecting, forwarding, signing, notifying
 from keri.app.cli.common import existing
 from keri.core import coring, eventing, serdering
 from keri.help import helping
 from keri.peer import exchanging
-from keri.vc import proving
 from keri.vdr import credentialing, verifying
 
 logger = help.ogler.getLogger()
@@ -206,7 +204,7 @@ class CredentialIssuer(doing.DoDoer):
         registry = self.rgy.registryByName(self.registryName)
         hab = registry.hab
 
-        dt = self.creder.subject["dt"] if "dt" in self.creder.subject else helping.nowIso8601()
+        dt = self.creder.attrib["dt"] if "dt" in self.creder.attrib else helping.nowIso8601()
         iserder = registry.issue(said=self.creder.said, dt=dt)
 
         vcid = iserder.ked["i"]
@@ -220,7 +218,7 @@ class CredentialIssuer(doing.DoDoer):
         else:
             anc = hab.interact(data=[rseal])
 
-        aserder = serdering.SerderACDC(raw=anc)  # coring.Serder(raw=anc)
+        aserder = serdering.SerderKERI(raw=anc)  # coring.Serder(raw=anc)
         self.credentialer.issue(self.creder, iserder)
         self.registrar.issue(self.creder, iserder, aserder)
 

--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -11,7 +11,7 @@ from hio import help
 from hio.base import doing
 
 from keri.app.cli.common import existing
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.vdr import credentialing
 
 logger = help.ogler.getLogger()
@@ -43,7 +43,7 @@ def export_credentials(args):
     """
     tels = args.tels
     kels = args.kels
-    chains = args.edge if args.edge is not None else {}
+    chains = args.chains if args.chains is not None else {}
 
     if args.full:
         tels = kels = chains = True

--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -3,6 +3,7 @@
 keri.app.storing module
 
 """
+from dataclasses import asdict
 
 from hio.base import doing
 from keri.app import agenting
@@ -43,8 +44,7 @@ class KeyStateNoticer(doing.DoDoer):
             match cue['kin']:
                 case "keyStateSaved":
                     kcue = cue
-                    serder = kcue['ksn']  # key state notice dict
-                    ksn = serder.ked['a']
+                    ksn = kcue['ksn']  # key state notice dict
                     match ksn["i"]:
                         case self.pre:
                             if kever.sn < int(ksn["s"], 16):

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1120,7 +1120,7 @@ class Parser:
                     if tsgs:
                         exc.processEvent(tsgs=tsgs, **args)
 
-                except AttributeError as e:
+                except AttributeError:
                     raise kering.ValidationError("No Exchange to process so dropped msg"
                                                  "= {}.".format(serder.pretty()))
 

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -46,7 +46,7 @@ def test_querying():
         hby.kvy.cues.clear()
         ksr = subHab.kever.state()
         rpy = eventing.reply(route="/ksn", data=ksr._asdict())
-        cue = dict(kin="keyStateSaved", ksn=rpy)
+        cue = dict(kin="keyStateSaved", ksn=ksr._asdict())
         hby.kvy.cues.append(cue)
 
         doist.recur(deeds=deeds)
@@ -65,7 +65,7 @@ def test_querying():
         rot = subHab.rotate()
         ksr = subHab.kever.state()
         rpy = eventing.reply(route="/ksn", data=ksr._asdict())
-        cue = dict(kin="keyStateSaved", ksn=rpy)
+        cue = dict(kin="keyStateSaved", ksn=ksr._asdict())
         hby.kvy.cues.append(cue)
         deeds = doist.enter(doers=[qdoer])
         doist.recur(deeds=deeds)


### PR DESCRIPTION
This PR fixes broken kli commands from the serdering changes and get scripts in scripts/demo/credentials and scripts/demo/vLEI working again.

This closes #666 #665 and #664 