### PR TITLE
One more reference to the deprecated `subject` field in SerderACDC.

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,5 +1,5 @@
 # Builder layer
-FROM python:3.10.13-alpine3.18 as builder
+FROM python:3.10-alpine as builder
 
 # Install compilation dependencies
 RUN apk --no-cache add \
@@ -24,7 +24,7 @@ RUN pip install --upgrade pip && \
     mkdir /keripy/src
 
 # Copy Python dependency files in
-COPY requirements.txt setup.py .
+COPY requirements.txt setup.py ./
 # Set up Rust environment and install Python dependencies
 # Must source the Cargo environment for the blake3 library to see
 # the Rust intallation during requirements install

--- a/src/keri/app/cli/commands/ipex/grant.py
+++ b/src/keri/app/cli/commands/ipex/grant.py
@@ -94,7 +94,7 @@ class GrantDoer(doing.DoDoer):
         acdc = signing.serialize(creder, prefixer, seqner, saider)
 
         if self.recp is None:
-            recp = creder.subject['i'] if 'i' in creder.subject else None
+            recp = creder.attrib['i'] if 'i' in creder.attrib else None
         elif self.recp in self.hby.kevers:
             recp = self.recp
         else:


### PR DESCRIPTION
This PR fixes the kli grant command by removing the last reference to `creder.subject`, changing it to the new `creder.attrib`