### PR TITLE
Revert "Use image python:3.10-alpine; Fix docker COPY build failure"

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,5 +1,5 @@
 # Builder layer
-FROM python:3.10-alpine as builder
+FROM python:3.10.13-alpine3.18 as builder
 
 # Install compilation dependencies
 RUN apk --no-cache add \
@@ -24,8 +24,7 @@ RUN pip install --upgrade pip && \
     mkdir /keripy/src
 
 # Copy Python dependency files in
-COPY requirements.txt setup.py ./
-
+COPY requirements.txt setup.py .
 # Set up Rust environment and install Python dependencies
 # Must source the Cargo environment for the blake3 library to see
 # the Rust intallation during requirements install


### PR DESCRIPTION
Reverts WebOfTrust/keripy#671

I didn't mean to merge this into development.