### PR TITLE
refactor sniff to be in kering instead of Parser class method. This i…

### DIFF
--- a/src/keri/app/httping.py
+++ b/src/keri/app/httping.py
@@ -168,7 +168,7 @@ def streamCESRRequests(client, ims, dest, path=None):
     """
     path = path if path is not None else "/"
 
-    cold = parsing.Parser.sniff(ims)  # check for spurious counters at front of stream
+    cold = kering.sniff(ims)  # check for spurious counters at front of stream
     if cold in (parsing.Colds.txt, parsing.Colds.bny):  # not message error out to flush stream
         # replace with pipelining here once CESR message format supported.
         raise kering.ColdStartError("Expecting message counter tritet={}"


### PR DESCRIPTION
…s to support new Streamer class for SPAC wrapping that needs to use sniff without circular import.