### PR TITLE
This hotfix adds fixes for rotation from kli and witness arg for logging

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -9,7 +9,6 @@ kli incept --name delegate --alias delegate --proxy proxy --file ${KERI_DEMO_SCR
 pid=$!
 PID_LIST+=" $pid"
 
-# In other console run the following:
 sleep 2
 kli delegate confirm --name delegator --alias delegator -Y &
 pid=$!
@@ -18,3 +17,16 @@ PID_LIST+=" $pid"
 wait $PID_LIST
 
 kli status --name delegate --alias delegate
+
+echo "Now rotating delegate..."
+kli rotate --name delegate --alias delegate --proxy proxy &
+pid=$!
+PID_LIST="$pid"
+
+sleep 2
+echo "Checking for delegate rotate..."
+kli delegate confirm --name delegator --alias delegator -Y &
+pid=$!
+PID_LIST+=" $pid"
+
+wait $PID_LIST

--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -41,6 +41,12 @@ printf "\n************************************\n"
 isSuccess
 
 printf "\n************************************\n"
+printf "Running delegate.sh"
+printf "\n************************************\n"
+"${script_dir}/basic/delegate.sh"
+isSuccess
+
+printf "\n************************************\n"
 printf "Running multisig.sh"
 printf "\n************************************\n"
 "${script_dir}/basic/multisig.sh"

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -187,13 +187,21 @@ class ConfirmDoer(doing.DoDoer):
                         print(f'\tDelegate {eserder.pre} {typ} Anchored at Seq. No.  {hab.kever.sner.num}')
 
                         # wait for confirmation of fully commited event
-                        wits = [werfer.qb64 for werfer in eserder.berfers]
-                        self.witq.query(src=hab.pre, pre=eserder.pre, sn=eserder.sn, wits=wits)
+                        if eserder.pre in self.hby.kevers:
+                            self.witq.query(src=hab.pre, pre=eserder.pre, sn=eserder.sn)
 
-                        while eserder.pre not in self.hby.kevers:
-                            yield self.tock
+                            while eserder.sn < self.hby.kevers[eserder.pre].sn:
+                                yield self.tock
 
-                        print(f"Delegate {eserder.pre} {typ} event committed.")
+                            print(f"Delegate {eserder.pre} {typ} event committed.")
+                        else:  # It should be an inception event then...
+                            wits = [werfer.qb64 for werfer in eserder.berfers]
+                            self.witq.query(src=hab.pre, pre=eserder.pre, sn=eserder.sn, wits=wits)
+
+                            while eserder.pre not in self.hby.kevers:
+                                yield self.tock
+
+                            print(f"Delegate {eserder.pre} {typ} event committed.")
 
                         self.remove(self.toRemove)
                         return True

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -26,6 +26,8 @@ parser.add_argument('--next-count', '-C', help='Count of pre-rotated keys (signi
                     default=None, type=int, required=False)
 parser.add_argument("--receipt-endpoint", help="Attempt to connect to witness receipt endpoint for witness receipts.",
                     dest="endpoint", action='store_true')
+parser.add_argument("--proxy", help="alias for delegation communication proxy", default="")
+
 rotating.addRotationArgs(parser)
 
 
@@ -58,7 +60,7 @@ def rotate(args):
                          cuts=opts.witsCut, adds=opts.witsAdd,
                          isith=opts.isith, nsith=opts.nsith,
                          count=opts.ncount, toad=opts.toad,
-                         data=opts.data)
+                         data=opts.data, proxy=args.proxy)
 
     doers = [rotDoer]
 
@@ -113,7 +115,7 @@ class RotateDoer(doing.DoDoer):
     """
 
     def __init__(self, name, base, bran, alias, endpoint=False, isith=None, nsith=None, count=None,
-                 toad=None, wits=None, cuts=None, adds=None, data: list = None):
+                 toad=None, wits=None, cuts=None, adds=None, data: list = None, proxy=None):
         """
         Returns DoDoer with all registered Doers needed to perform rotation.
 
@@ -126,6 +128,8 @@ class RotateDoer(doing.DoDoer):
             cuts is list of qb64 pre of witnesses to be removed from witness list
             adds is list of qb64 pre of witnesses to be added to witness list
             data is list of dicts of committed data such as seals
+            proxy is optional name of proxy Hab to use to send messages to delegator
+
        """
 
         self.alias = alias
@@ -135,6 +139,7 @@ class RotateDoer(doing.DoDoer):
         self.toad = toad
         self.data = data
         self.endpoint = endpoint
+        self.proxy = proxy
 
         self.wits = wits if wits is not None else []
         self.cuts = cuts if cuts is not None else []
@@ -144,7 +149,7 @@ class RotateDoer(doing.DoDoer):
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
         self.swain = delegating.Sealer(hby=self.hby)
         self.postman = forwarding.Poster(hby=self.hby)
-        self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=["/receipt"])
+        self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=['/receipt', "/replay", "/reply"])
         doers = [self.hbyDoer, self.mbx, self.swain, self.postman, doing.doify(self.rotateDo)]
 
         super(RotateDoer, self).__init__(doers=doers)
@@ -183,7 +188,7 @@ class RotateDoer(doing.DoDoer):
                    data=self.data)
 
         if hab.kever.delegator:
-            self.swain.delegation(pre=hab.pre, sn=hab.kever.sn)
+            self.swain.delegation(pre=hab.pre, sn=hab.kever.sn, proxy=self.hby.habByName(self.proxy))
             print("Waiting for delegation approval...")
             while not self.swain.complete(hab.kever.prefixer, coring.Seqner(sn=hab.kever.sn)):
                 yield self.tock

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -47,12 +47,13 @@ parser.add_argument('--config-file',
 parser.add_argument("--keypath", action="store", required=False, default=None)
 parser.add_argument("--certpath", action="store", required=False, default=None)
 parser.add_argument("--cafilepath", action="store", required=False, default=None)
+parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
+                    help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 
 
 def launch(args):
-    help.ogler.level = logging.CRITICAL
-    help.ogler.reopen(name=args.name, temp=True, clear=True)
-
+    help.ogler.level = logging.getLevelName(args.loglevel)
+    help.ogler.reopen(name=args.name, temp=True, clear=True)  # need to configure for logging persistent file
     logger = help.ogler.getLogger()
 
     logger.info("\n******* Starting Witness for %s listening: http/%s, tcp/%s "

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -47,7 +47,7 @@ class Sealer(doing.DoDoer):
         self.proxy = proxy
 
         super(Sealer, self).__init__(doers=[self.witq, self.witDoer, self.postman, doing.doify(self.escrowDo)],
-                                        **kwa)
+                                     **kwa)
 
     def delegation(self, pre, sn=None, proxy=None):
         if pre not in self.hby.habs:
@@ -69,10 +69,10 @@ class Sealer(doing.DoDoer):
         if isinstance(hab, GroupHab):
             phab = hab.mhab
             smids = hab.smids
-        elif hab.kever.sn > 0:
-            phab = hab
         elif proxy is not None:
             phab = proxy
+        elif hab.kever.sn > 0:
+            phab = hab
         elif self.proxy is not None:
             phab = self.proxy
         else:


### PR DESCRIPTION
This PR includes:

- Update to `delegate confirm` and `rotate` kli commands to fix delegation approval of rotation from command line.
- Pull in changes from PR #688 that add log level as a command line argument for `witness start` kli command.