### PR TITLE
Remove debug code that broken `kli multisig join` for inception.

### DIFF
--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -146,9 +146,6 @@ class ConfirmDoer(doing.DoDoer):
         """ Incept group multisig
 
         """
-        if True:
-            return True
-
         smids = attrs["smids"]  # change body mids for group member ids
         rmids = attrs["rmids"] if "rmids" in attrs else None
         ked = attrs["ked"]


### PR DESCRIPTION
This PR fixes kli multisig join by removing debug code that short-circuited inception. Closes https://github.com/WebOfTrust/keripy/issues/697