### PR TITLE
Non deterministic prefixes in witnesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ config/
 
 # keripy virtualenv
 keripy/
+
+# ctags
+.tags

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -50,8 +50,6 @@ parser.add_argument("--cafilepath", action="store", required=False, default=None
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 
-print("FUCK ME")
-
 
 def launch(args):
     help.ogler.level = logging.getLevelName(args.loglevel)

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -50,6 +50,8 @@ parser.add_argument("--cafilepath", action="store", required=False, default=None
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 
+print("FUCK ME")
+
 
 def launch(args):
     help.ogler.level = logging.getLevelName(args.loglevel)

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -68,7 +68,7 @@ def openHby(*, name="test", base="", temp=True, salt=None, **kwa):
 
     """
     habery = None
-    salt = salt if not None else coring.Salter(raw=b'0123456789abcdef').qb64
+    salt = salt if salt is not None else coring.Salter().qb64
     try:
         habery = Habery(name=name, base=base, temp=temp, salt=salt, **kwa)
         yield habery
@@ -79,7 +79,7 @@ def openHby(*, name="test", base="", temp=True, salt=None, **kwa):
 
 
 @contextmanager
-def openHab(name="test", base="", salt=b'0123456789abcdef', temp=True, cf=None, **kwa):
+def openHab(name="test", base="", salt=None, temp=True, cf=None, **kwa):
     """
     Context manager wrapper for Hab instance.
     Defaults to temporary resources
@@ -297,7 +297,7 @@ class Habery:
                 aeid = signer.verfer.qb64  # lest it remove encryption
 
         if salt is None:  # salt for signing keys not aeid seed
-            salt = coring.Salter(raw=b'0123456789abcdef').qb64
+            salt = coring.Salter().qb64
         else:
             salt = coring.Salter(qb64=salt).qb64
 

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -116,7 +116,7 @@ def sealer_test_do(tymth=None, tock=0.0, **opts):
 
 
 def test_delegation_request(mockHelpingNowUTC):
-    with habbing.openHab(name="test", temp=True) as (hby, hab):
+    with habbing.openHab(name="test", temp=True, salt=b'0123456789abcdef') as (hby, hab):
 
         delpre = "EArzbTSWjccrTdNRsFUUfwaJ2dpYxu9_5jI2PJ-TRri0"
         serder = eventing.delcept(keys=["DUEFuPeaDH2TySI-wX7CY_uW5FF41LRu3a59jxg1_pMs"], delpre=delpre,

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -632,7 +632,7 @@ def openMultiSig(prefix="test", salt=b'0123456789abcdef', temp=True, **kwa):
 
 
 def test_multisig_incept(mockHelpingNowUTC):
-    with habbing.openHab(name="test", temp=True) as (hby, hab):
+    with habbing.openHab(name="test", temp=True, salt=b'0123456789abcdef') as (hby, hab):
         aids = [hab.pre, "EfrzbTSWjccrTdNRsFUUfwaJ2dpYxu9_5jI2PJ-TRri0"]
         exn, atc = grouping.multisigInceptExn(hab=hab, smids=aids, rmids=aids,
                                               icp=hab.makeOwnEvent(sn=hab.kever.sn))
@@ -715,7 +715,7 @@ def test_multisig_registry_incept(mockHelpingNowUTC, mockCoringRandomNonce):
 
 
 def test_multisig_incept_handler(mockHelpingNowUTC):
-    with habbing.openHab(name="test0", temp=True) as (hby, hab):
+    with habbing.openHab(name="test0", temp=True, salt=b'0123456789abcdef') as (hby, hab):
         aids = [hab.pre, "EfrzbTSWjccrTdNRsFUUfwaJ2dpYxu9_5jI2PJ-TRri0"]
         exn, atc = grouping.multisigInceptExn(hab=hab, smids=aids, rmids=aids,
                                               icp=hab.makeOwnEvent(sn=hab.kever.sn))

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -24,7 +24,7 @@ def test_habery():
     """
     # test default
     default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
-    hby = habbing.Habery(temp=True)
+    hby = habbing.Habery(temp=True, salt=default_salt)
     assert hby.name == "test"
     assert hby.base == ""
     assert hby.temp
@@ -76,7 +76,7 @@ def test_habery():
     seed4bran = 'ALQVu9AjGW3JrIzX0UHm2awGCbDXcsLzy-vAE649Fz1j'
     aeid4seed = 'BHRYV_5a1AlibCrXFG_KDD9rC6aXx9cb0sR968NL80VI'
 
-    hby = habbing.Habery(bran=bran, temp=True)
+    hby = habbing.Habery(bran=bran, temp=True, salt=default_salt)
     assert hby.name == "test"
     assert hby.base == ""
     assert hby.temp
@@ -126,7 +126,7 @@ def test_habery():
 
     # setup habery
     hby = habbing.Habery(name=name, base=base, ks=ks, db=db, cf=cf, temp=temp,
-                         bran=bran)
+                         bran=bran, salt=default_salt)
     hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
 
     assert hby.name == "main"
@@ -180,7 +180,7 @@ def test_habery():
     temp = True
 
     # setup habery with resources
-    hby = habbing.Habery(name=name, base=base, temp=temp, bran=bran, free=True)
+    hby = habbing.Habery(name=name, base=base, temp=temp, bran=bran, free=True, salt=default_salt)
     hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
 
     conf = hby.cf.get()
@@ -234,7 +234,7 @@ def test_habery():
     assert not os.path.exists(hby.db.path)
     assert not os.path.exists(hby.ks.path)
 
-    with habbing.openHby() as hby:
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         assert hby.name == "test"
         assert hby.base == ""
         assert hby.temp
@@ -281,7 +281,7 @@ def test_habery():
     assert not os.path.exists(hby.ks.path)
 
     bran = "MyPasscodeARealSecret"
-    with habbing.openHby(bran=bran) as hby:
+    with habbing.openHby(bran=bran, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         assert hby.name == "test"
         assert hby.base == ""
         assert hby.temp
@@ -342,7 +342,7 @@ def test_make_load_hab_with_habery():
     name = "sue"
     suePre = 'ELF1S0jZkyQx8YtHaPLu-qyFmrkcykAiEW8twS-KPSO1'  # with temp=True
 
-    with habbing.openHby() as hby:  # default is temp=True on openHab
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:  # default is temp=True on openHab
         hab = hby.makeHab(name=name)
         assert isinstance(hab, habbing.Hab)
         assert hab.pre in hby.habs
@@ -386,7 +386,7 @@ def test_make_load_hab_with_habery():
     suePre = 'EAxe215BJ4Iy9r0mfoMEGVmHW8A4Avk3RYBC1A1_DZam'  # with temp=False
     bobPre = 'ENya5E5pvc6MVCe75huDK0QQhE4_64J55vCn4aKdXhR9'  # with temp=False
 
-    with habbing.openHby(base=base, temp=False) as hby:  # default is temp=True
+    with habbing.openHby(base=base, temp=False, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:  # default is temp=True
         assert hby.cf.path.endswith("keri/cf/hold/test.json")
         assert hby.db.path.endswith("keri/db/hold/test")
         assert hby.ks.path.endswith('keri/ks/hold/test')
@@ -560,7 +560,7 @@ def test_habery_reinitialization():
 
 
 def test_habery_signatory():
-    with habbing.openHby() as hby:
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         signer = hby.signator
 
         assert signer is not None
@@ -714,7 +714,7 @@ def test_habery_reconfigure(mockHelpingNowUTC):
 
 
 def test_namespaced_habs():
-    with habbing.openHby() as hby:
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name="test")
         assert hab.pre == "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3"
 
@@ -797,7 +797,7 @@ def test_namespaced_habs():
 
 
 def test_make_other_event():
-    with habbing.openHby() as hby:
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name="test")
         assert hab.pre == "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3"
 
@@ -867,9 +867,9 @@ def test_hab_by_pre():
 
 
 def test_postman_endsfor():
-    with habbing.openHby(name="test", temp=True) as hby, \
-            habbing.openHby(name="wes", salt=coring.Salter(raw=b'wess-the-witness').qb64, temp=True) as wesHby, \
-            habbing.openHab(name="agent", temp=True) as (agentHby, agentHab):
+    with habbing.openHby(name="test", temp=True, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby, \
+            habbing.openHby(name="wes", temp=True, salt=coring.Salter(raw=b'wess-the-witness').qb64) as wesHby, \
+            habbing.openHab(name="agent", temp=True, salt=b'0123456789abcdef') as (agentHby, agentHab):
 
         wesHab = wesHby.makeHab(name='wes', isith="1", icount=1, transferable=False)
         assert not wesHab.kever.prefixer.transferable

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -66,7 +66,7 @@ class MockClient:
 
 
 def test_create_cesr_request(mockHelpingNowUTC):
-    with habbing.openHab(name="test", transferable=True, temp=True) as (hby, hab):
+    with habbing.openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef') as (hby, hab):
         wit = "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"
         regery = credentialing.Regery(hby=hby, name="test", temp=True)
         issuer = regery.makeRegistry(prefix=hab.pre, name="test")
@@ -114,7 +114,7 @@ def test_create_cesr_request(mockHelpingNowUTC):
 
 
 def test_stream_cesr_request(mockHelpingNowUTC):
-    with habbing.openHab(name="test", transferable=True, temp=True) as (hby, hab):
+    with habbing.openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef') as (hby, hab):
         wit = "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"
         regery = credentialing.Regery(hby=hby, name="test", temp=True)
         issuer = regery.makeRegistry(prefix=hab.pre, name="test")

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -101,7 +101,7 @@ def test_mailbox_multiple_iter():
 
 
 def test_qrymailbox_iter():
-    with habbing.openHab(name="test", transferable=True, temp=True) as (hby, hab):
+    with habbing.openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef') as (hby, hab):
         assert hab.pre == 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3'
         icp = hab.makeOwnInception()
         icpSrdr = serdering.SerderKERI(raw=icp)

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -25,7 +25,7 @@ from tests.app import openMultiSig
 def test_oobi_share(mockHelpingNowUTC):
     oobi = "http://127.0.0.1:5642/oobi/Egw3N07Ajdkjvv4LB2Mhx2qxl6TOCFdWNJU6cYR_ImFg/witness" \
            "/BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo?name=Phil"
-    with habbing.openHab(name="test", temp=True) as (hby, hab):
+    with habbing.openHab(name="test", temp=True, salt=b'0123456789abcdef') as (hby, hab):
         exc = exchanging.Exchanger(hby=hby, handlers=[])
         notifier = notifying.Notifier(hby=hby)
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -4726,7 +4726,7 @@ def test_reload_kever(mockHelpingNowUTC):
     Test reload Kever from keystate state message
     """
 
-    with habbing.openHby(name="nat", base="test") as natHby:
+    with habbing.openHby(name="nat", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as natHby:
         # setup Nat's habitat using default salt multisig already incepts
         natHab = natHby.makeHab(name="nat", isith='2', icount=3)
         assert natHab.name == 'nat'
@@ -4795,10 +4795,10 @@ def test_reload_kever(mockHelpingNowUTC):
 
 
 def test_load_event(mockHelpingNowUTC):
-    with habbing.openHby(name="tor", base="test") as torHby, \
-         habbing.openHby(name="wil", base="test") as wilHby, \
-         habbing.openHby(name="wan", base="test") as wanHby, \
-         habbing.openHby(name="tee", base="test") as teeHby:
+    with habbing.openHby(name="tor", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as torHby, \
+         habbing.openHby(name="wil", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wilHby, \
+         habbing.openHby(name="wan", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wanHby, \
+         habbing.openHby(name="tee", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as teeHby:
 
         wanKvy = Kevery(db=wanHby.db, lax=False, local=False)
         torKvy = Kevery(db=torHby.db, lax=False, local=False)

--- a/tests/core/test_kevery.py
+++ b/tests/core/test_kevery.py
@@ -246,7 +246,7 @@ def test_witness_state():
     """
 
     # with basing.openDB(name="controller") as bobDB, keeping.openKS(name="controller") as bobKS:
-    with habbing.openHby(name="controller", base="test") as hby:
+    with habbing.openHby(name="controller", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
 
         wits = [
             "BAMUu4hpUYY4FKd4LtsvpMN6claZKF2AUmXIgXiAI9ZQ",
@@ -336,11 +336,11 @@ def test_stale_event_receipts():
     Bam is verifying the key events with receipts from Bob
     """
     # openHby default temp=True
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-            habbing.openHby(name="bam", base="test") as bamHby,
-            habbing.openHby(name="wes", base="test") as wesHby,
-            habbing.openHby(name="wan", base="test") as wanHby,
-            habbing.openHby(name="wil", base="test") as wilHby):
+    with (habbing.openHby(name="bob", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as bobHby,
+            habbing.openHby(name="bam", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as bamHby,
+            habbing.openHby(name="wes", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wesHby,
+            habbing.openHby(name="wan", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wanHby,
+            habbing.openHby(name="wil", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as wilHby):
 
         # setup Wes's habitat nontrans
         wesHab = wesHby.makeHab(name="wes", isith='1', icount=1, transferable=False,)

--- a/tests/core/test_keystate.py
+++ b/tests/core/test_keystate.py
@@ -26,7 +26,7 @@ def test_keystate(mockHelpingNowUTC):
             "t": "ksn",
             "p": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
             "d": "EtgNGVxYd6W0LViISr7RSn6ul8Yn92uyj2kiWzt51mHc",
-           "f": "1",
+            "f": "1",
             "dt": "2021-11-04T12:55:14.480038+00:00",
             "et": "ixn",
             "kt": "1",

--- a/tests/core/test_keystate.py
+++ b/tests/core/test_keystate.py
@@ -26,7 +26,7 @@ def test_keystate(mockHelpingNowUTC):
             "t": "ksn",
             "p": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
             "d": "EtgNGVxYd6W0LViISr7RSn6ul8Yn92uyj2kiWzt51mHc",
-            "f": "1",
+           "f": "1",
             "dt": "2021-11-04T12:55:14.480038+00:00",
             "et": "ixn",
             "kt": "1",
@@ -57,13 +57,15 @@ def test_keystate(mockHelpingNowUTC):
     salt = salter.qb64
     assert salt == '0AAFqo8tU5rp-lWcApybCEh1'
 
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+
     # Bob is the controller
     # Wes is his witness
     # Bam is verifying the key state for Bob from Wes
 
     # default for openHby temp = True
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-         habbing.openHby(name="bam", base="test") as bamHby,
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+         habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby,
          habbing.openHby(name="wes", base="test", salt=salt) as wesHby):
 
         # setup Wes's habitat nontrans
@@ -124,8 +126,8 @@ def test_keystate(mockHelpingNowUTC):
     # Bam is verifying the key state for Bob from Wes
     # Wes is Bam's watcher
 
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-         habbing.openHby(name="bam", base="test") as bamHby,
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+         habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby,
          habbing.openHby(name="wes", base="test",  salt=salt) as wesHby):
 
         # setup Wes's habitat nontrans
@@ -192,8 +194,8 @@ def test_keystate(mockHelpingNowUTC):
     # Bam is verifying the key state for Bob from Wes
     # Wes is no one
 
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-         habbing.openHby(name="bam", base="test") as bamHby,
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+         habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby,
          habbing.openHby(name="wes", base="test",  salt=salt) as wesHby):
 
         # setup Wes's habitat nontrans
@@ -234,8 +236,8 @@ def test_keystate(mockHelpingNowUTC):
     # Bob is the controller
     # Bam is verifying the key state for Bob with a stale key state in the way
 
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-         habbing.openHby(name="bam", base="test") as bamHby):
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+         habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         bobHab = bobHby.makeHab(name="bob", isith='1', icount=1, transferable=True)
         assert bobHab.pre == bobpre

--- a/tests/core/test_parsing_pathed.py
+++ b/tests/core/test_parsing_pathed.py
@@ -28,7 +28,7 @@ def test_pathed_material(mockHelpingNowUTC):
             self.atcs.append(attachments)
 
     with (habbing.openHby(name="pal", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby,
-          habbing.openHby(name="deb", base="test") as debHby):
+          habbing.openHby(name="deb", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as debHby):
         sith = ["1/2", "1/2", "1/2"]  # weighted signing threshold
         palHab = hby.makeHab(name="pal")
         debHab = debHby.makeHab(name="deb", isith=sith, icount=3)

--- a/tests/core/test_replay.py
+++ b/tests/core/test_replay.py
@@ -25,10 +25,11 @@ def test_replay():
     Compare replay of Deb's events with receipts by both Deb and Cam to confirm identical
     """
     artSalt = coring.Salter(raw=b'abcdef0123456789').qb64
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
 
-    with (habbing.openHby(name="deb", base="test") as debHby,
-         habbing.openHby(name="cam", base="test") as camHby,
-         habbing.openHby(name="bev", base="test") as bevHby,
+    with (habbing.openHby(name="deb", base="test", salt=default_salt) as debHby,
+         habbing.openHby(name="cam", base="test", salt=default_salt) as camHby,
+         habbing.openHby(name="bev", base="test", salt=default_salt) as bevHby,
          habbing.openHby(name="art", base="test", salt=artSalt) as artHby):
 
         # setup Deb's habitat using default salt multisig already incepts
@@ -493,11 +494,11 @@ def test_replay_all():
 
     """
     artSalt = coring.Salter(raw=b'abcdef0123456789').qb64
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
 
-
-    with (habbing.openHby(name="deb", base="test") as debHby,
-         habbing.openHby(name="cam", base="test") as camHby,
-         habbing.openHby(name="bev", base="test") as bevHby,
+    with (habbing.openHby(name="deb", base="test", salt=default_salt) as debHby,
+         habbing.openHby(name="cam", base="test", salt=default_salt) as camHby,
+         habbing.openHby(name="bev", base="test", salt=default_salt) as bevHby,
          habbing.openHby(name="art", base="test", salt=artSalt) as artHby):
 
         # setup Deb's habitat using default salt multisig already incepts

--- a/tests/core/test_witness.py
+++ b/tests/core/test_witness.py
@@ -576,9 +576,10 @@ def test_out_of_order_witnessed_events():
     # Wes is his witness
     # Bam is verifying the key state for Bob from Wes
 
-    with habbing.openHby(name="wes", base="test") as wesHby, \
-         habbing.openHby(name="bob", base="test") as bobHby, \
-         habbing.openHby(name="bam", base="test") as bamHby:
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    with habbing.openHby(name="wes", base="test", salt=default_salt) as wesHby, \
+         habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby, \
+         habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby:
 
         # setup Wes's habitat nontrans
         wesHab = wesHby.makeHab(name='wes', isith='1', icount=1, transferable=False)

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -1707,7 +1707,7 @@ def test_clean_baser():
     """
     name = "nat"
     # with basing.openDB(name="nat") as natDB, keeping.openKS(name="nat") as natKS:
-    with habbing.openHby(name=name) as hby:  # default is temp=True
+    with habbing.openHby(name=name, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:  # default is temp=True
         natHab = hby.makeHab(name=name, isith='2', icount=3)  # default Hab
         # setup Nat's habitat using default salt multisig already incepts
         #natHab = habbing.Habitat(name='nat', ks=natKS, db=natDB,

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -417,12 +417,12 @@ def test_indirect_mode_sam_cam_wit_demo():
     camSigners = coring.Salter(raw=raw).signers(count=8, path="cam", temp=True)
     camSecrecies = [[signer.qb64] for signer in camSigners]
 
-    with (habbing.openHby(name="cam", base="test") as camHby,
-          habbing.openHby(name="sam", base="test") as samHby,
-          habbing.openHby(name="wit", base="test") as witHby):
+    with (habbing.openHby(name="cam", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as camHby,
+          habbing.openHby(name="sam", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as samHby,
+          habbing.openHby(name="wit", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as witHby):
 
         samPort = 5620  # sam's TCP listening port for server
-        witPort = 5621  # wit' TCP listneing port for server
+        witPort = 5621  # wit' TCP listening port for server
 
         # setup the witness
         witHab = witHby.makeHab(name="Wit",

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -59,7 +59,7 @@ def test_signature_designature():
     # db = basing.Baser(name=name, temp=temp, reopen=reopen)
 
     # Setup Habery and Hab
-    with habbing.openHby(name=name, base=base) as hby:
+    with habbing.openHby(name=name, base=base, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         # hby = habbing.Habery(name=name, base=base, temp=temp, free=True)
         hab = hby.makeHab(name=name, icount=3)
         print()
@@ -313,7 +313,7 @@ def test_seid_api():
     # Setup Habery and Hab
     name = 'zoe'
     base = 'test'
-    with habbing.openHby(name=name, base=base) as hby:
+    with habbing.openHby(name=name, base=base, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name=name)
         # hab = setupTestHab(name='zoe')
         # must do it here to inject into Falcon endpoint resource instances
@@ -382,7 +382,7 @@ def test_get_admin():
     # Setup Habery and Hab
     name = 'zoe'
     base = 'test'
-    with habbing.openHby(name=name, base=base) as hby:
+    with habbing.openHby(name=name, base=base, salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name=name)
         # hab = setupTestHab(name='zoe')
 
@@ -439,7 +439,7 @@ def test_get_oobi():
 
 def test_siginput(mockHelpingNowUTC):
     print()
-    with habbing.openHab(name="test", base="test", temp=True) as (hby, hab):
+    with habbing.openHab(name="test", base="test", temp=True, salt=b'0123456789abcdef') as (hby, hab):
         headers = Hict([
             ("Content-Type", "application/json"),
             ("Content-Length", "256"),

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -76,7 +76,7 @@ def test_exchanger():
 
 
 def test_hab_exchange(mockHelpingNowUTC):
-    with habbing.openHby() as hby:
+    with habbing.openHby(salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name="test")
         assert hab.pre == "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3"
 

--- a/tests/vc/test_protocoling.py
+++ b/tests/vc/test_protocoling.py
@@ -21,7 +21,9 @@ def test_ipex(seeder, mockCoringRandomNonce, mockHelpingNowIso8601, mockHelpingN
     wanSalt = coring.Salter(raw=b'wann-the-witness').qb64
     assert wanSalt == '0AB3YW5uLXRoZS13aXRuZXNz'
 
-    with (habbing.openHby(name="red", base="test") as redHby,
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+
+    with (habbing.openHby(name="red", base="test", salt=default_salt) as redHby,
           habbing.openHby(name="sid", base="test", salt=sidSalt) as sidHby):
         seeder.seedSchema(redHby.db)
         seeder.seedSchema(sidHby.db)

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -12,8 +12,10 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC, mockCoringRandomNonce):
     # Bob is the controller
     # Bam is verifying the key state for Bob with a stale key state in the way
 
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-          habbing.openHby(name="bam", base="test") as bamHby):
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+          habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         bobHab = bobHby.makeHab(name="bob", isith='1', icount=1,)
         assert bobHab.pre == 'EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH'
@@ -90,8 +92,9 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC, mockCoringRandomNonce):
 def test_tsn_message_missing_anchor(mockHelpingNowUTC, mockCoringRandomNonce):
     # Bob is the controller
     # Bam is verifying the key state for Bob with a stale key state in the way
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-          habbing.openHby(name="bam", base="test") as bamHby):
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+          habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         bobHab = bobHby.makeHab(name="bob", isith='1', icount=1,)
         assert bobHab.pre == 'EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH'
@@ -182,9 +185,10 @@ def test_tsn_from_witness(mockHelpingNowUTC, mockCoringRandomNonce):
     # Wes is his witness
     # Bam is verifying the key state for Bob from Wes
     # Habery.makeHab uses name as stem path for salt so different pre
-    with (habbing.openHby(name="wes", base="test") as wesHby,
-          habbing.openHby(name="bob", base="test") as bobHby,
-          habbing.openHby(name="bam", base="test") as bamHby):
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    with (habbing.openHby(name="wes", base="test", salt=default_salt) as wesHby,
+          habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+          habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         # setup Wes's habitat nontrans
         wesHab = wesHby.makeHab(name="wes", isith='1', icount=1,transferable=False,)
@@ -305,9 +309,10 @@ def test_tsn_from_no_one(mockHelpingNowUTC, mockCoringRandomNonce):
     #salt = salter.qb64
     #assert salt == '0AAFqo8tU5rp-lWcApybCEh1'
     # Habery.makeHab uses name as stem path for salt so different pre
-    with (habbing.openHby(name="wes", base="test") as wesHby,
-          habbing.openHby(name="bob", base="test") as bobHby,
-          habbing.openHby(name="bam", base="test") as bamHby):
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    with (habbing.openHby(name="wes", base="test", salt=default_salt) as wesHby,
+          habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+          habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         # setup Wes's habitat nontrans
         wesHab = wesHby.makeHab(name="wes", isith='1', icount=1,transferable=False,)
@@ -397,8 +402,9 @@ def test_credential_tsn_message(mockHelpingNowUTC, mockCoringRandomNonce, mockHe
     # Bob is the controller
     # Bam is verifying the key state for Bob with a stale key state in the way
 
-    with (habbing.openHby(name="bob", base="test") as bobHby,
-          habbing.openHby(name="bam", base="test") as bamHby):
+    default_salt = coring.Salter(raw=b'0123456789abcdef').qb64
+    with (habbing.openHby(name="bob", base="test", salt=default_salt) as bobHby,
+          habbing.openHby(name="bam", base="test", salt=default_salt) as bamHby):
 
         bobHab = bobHby.makeHab(name="bob", isith='1', icount=1,)
         assert bobHab.pre == 'EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH'
@@ -524,9 +530,7 @@ def test_credential_tsn_message(mockHelpingNowUTC, mockCoringRandomNonce, mockHe
 
 
 def test_tever_reload(mockHelpingNowUTC, mockCoringRandomNonce, mockHelpingNowIso8601):
-
-    with habbing.openHby(name="bob", base="test") as hby:
-
+    with habbing.openHby(name="bob", base="test", salt=coring.Salter(raw=b'0123456789abcdef').qb64) as hby:
         bobHab = hby.makeHab(name="bob", isith='1', icount=1,)
         assert bobHab.pre == 'EA_SbBUZYwqLVlAAn14d6QUBQCSReJlZ755JqTgmRhXH'
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -17,7 +17,7 @@ from keri.vdr import verifying, credentialing, eventing
 
 
 def test_verifier_query(mockHelpingNowUTC, mockCoringRandomNonce):
-    with habbing.openHab(name="test", transferable=True, temp=True) as (hby, hab):
+    with habbing.openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef') as (hby, hab):
         regery = credentialing.Regery(hby=hby, name="test", temp=True)
         issuer = regery.makeRegistry(prefix=hab.pre, name="test")
 
@@ -310,8 +310,8 @@ def test_verifier_chained_credential(seeder):
 
     with habbing.openHab(name="ron", temp=True, salt=b'0123456789abcdef') as (ronHby, ron), \
             habbing.openHab(name="ian", temp=True, salt=b'0123456789abcdef') as (ianHby, ian), \
-            habbing.openHab(name="han", transferable=True, temp=True) as (hanHby, han), \
-            habbing.openHab(name="vic", transferable=True, temp=True) as (vicHby, vic):
+            habbing.openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef') as (hanHby, han), \
+            habbing.openHab(name="vic", transferable=True, temp=True, salt=b'0123456789abcdef') as (vicHby, vic):
         seeder.seedSchema(db=ronHby.db)
         seeder.seedSchema(db=ianHby.db)
         seeder.seedSchema(db=hanHby.db)


### PR DESCRIPTION
Removed hardcoded salts as default behavior of openHby and openHab.

Also fixed a bug that hadn't been caught yet wherein whatever was passed to openHby was always used and a default salt was never created. Adjusted to match the intention of the code and no tests seemed to break from it so it must have been getting caught further down the stack.