### PR TITLE
ensure creder.attrib is not a string before treating it like a dict

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -300,7 +300,7 @@ class Verifier:
         self.reger.issus.add(keys=issuer, val=saider)
         self.reger.schms.add(keys=schema, val=saider)
 
-        if 'i' in creder.attrib:
+        if not isinstance(creder.attrib, str) and 'i' in creder.attrib:
             subject = creder.attrib["i"].encode("utf-8")
             self.reger.subjs.add(keys=subject, val=saider)
 


### PR DESCRIPTION
This allows saving most compact variants of ACDCs. I haven't thoroughly tested it but the change seems safe to me, hopefully existing coverage will tell me if I'm wrong.

## before
```
keri: Parser msg non-extraction error: string indices must be integers, not 'str'
Traceback (most recent call last):
  File "/Users/jason/github.com/WebOfTrust/keripy/src/keri/core/parsing.py", line 420, in allParsator
    done = yield from self.msgParsator(ims=ims,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/github.com/WebOfTrust/keripy/src/keri/core/parsing.py", line 1115, in msgParsator
    vry.processCredential(creder=serder, prefixer=prefixer, seqner=seqner, saider=saider)
  File "/Users/jason/github.com/WebOfTrust/keripy/src/keri/vdr/verifying.py", line 180, in processCredential
    self.saveCredential(creder, prefixer, seqner, saider)
  File "/Users/jason/github.com/WebOfTrust/keripy/src/keri/vdr/verifying.py", line 305, in saveCredential
    subject = creder.attrib["i"].encode("utf-8")
              ~~~~~~~~~~~~~^^^^^
TypeError: string indices must be integers, not 'str'
```