### PR TITLE
Catching socket exception when creating witness http client

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -74,10 +74,13 @@ class Receiptor(doing.DoDoer):
         clients = dict()
         doers = []
         for wit in wits:
-            client, clientDoer = httpClient(hab, wit)
-            clients[wit] = client
-            doers.append(clientDoer)
-            self.extend([clientDoer])
+            try:
+                client, clientDoer = httpClient(hab, wit)
+                clients[wit] = client
+                doers.append(clientDoer)
+                self.extend([clientDoer])
+            except Exception as e:
+                logger.error(f"unable to create http client for witness {wit}: {e}")
 
         rcts = dict()
         for wit, client in clients.items():

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -12,6 +12,8 @@ from hio.core import http
 from hio.core.tcp import clienting
 from hio.help import decking, Hict
 
+from socket import gaierror
+
 from . import httping, forwarding
 from .. import help
 from .. import kering
@@ -79,7 +81,7 @@ class Receiptor(doing.DoDoer):
                 clients[wit] = client
                 doers.append(clientDoer)
                 self.extend([clientDoer])
-            except Exception as e:
+            except (kering.MissingEntryError, gaierror) as e:
                 logger.error(f"unable to create http client for witness {wit}: {e}")
 
         rcts = dict()


### PR DESCRIPTION
This PR is a fix for **KERIA** issue [#214](https://github.com/WebOfTrust/keria/issues/214) where a `socket.getaddrinfo` exception is raised in certain conditions causing the witness http client creation to fail.