### PR TITLE
Writing logs into file is configurable from cli argument

### DIFF
--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -49,11 +49,15 @@ parser.add_argument("--certpath", action="store", required=False, default=None)
 parser.add_argument("--cafilepath", action="store", required=False, default=None)
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument("--logfile", action="store", required=False, default=None,
+                    help="path of the log file. If not defined, logs will not be written to the file.")
 
 
 def launch(args):
     help.ogler.level = logging.getLevelName(args.loglevel)
-    help.ogler.reopen(name=args.name, temp=True, clear=True)  # need to configure for logging persistent file
+    if(args.logfile != None):
+        help.ogler.headDirPath = args.logfile
+        help.ogler.reopen(name=args.name, temp=False, clear=True)
     logger = help.ogler.getLogger()
 
     logger.info("\n******* Starting Witness for %s listening: http/%s, tcp/%s "


### PR DESCRIPTION
As keripy is mostly running inside a docker container, so writing logs into the console makes sense, and we can utilize the docker daemons log rotation feature. Recently we saw keripy also writing logs into a temporary file (in `/tmp` directory) inside the container. And it doesn't rotate the log. So the storage is getting full. And there is no way to modify this behavior without changing the code. I hope this CLI argument will make life easier. 