### PR TITLE
Fix for failing Reply End Roles escrows

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4285,7 +4285,8 @@ class Kevery:
         aid = cid  # authorizing attribution id
         keys = (aid, role, eid)
         osaider = self.db.eans.get(keys=keys)  # get old said if any
-        if osaider is not None and osaider.qb64b == saider.qb64b: osaider = None
+        if osaider is not None and osaider.qb64b == saider.qb64b: 
+            osaider = None
         # BADA Logic
         accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
                                         aid=aid, osaider=osaider, cigars=cigars,

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4285,6 +4285,7 @@ class Kevery:
         aid = cid  # authorizing attribution id
         keys = (aid, role, eid)
         osaider = self.db.eans.get(keys=keys)  # get old said if any
+        if osaider is not None and osaider.qb64b == saider.qb64b: osaider = None
         # BADA Logic
         accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
                                         aid=aid, osaider=osaider, cigars=cigars,


### PR DESCRIPTION
Sometimes when escrowing reply end roles, a race condition causes that the updated `end` in the db is interpreted as an old end, and then the validation failed because the datetime of the new message has not increased. When that happens, the escrow of the reply message can not be confirmed and fails until timeouts. 
In this PR I'm adding a validation to make sure that the end retrieved from the DB is actually an old end and not the same that we are trying to authorize.