### PR TITLE
Fix failing EndRole escrow

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4198,6 +4198,8 @@ class Kevery:
         aid = cid  # authorizing attribution id
         keys = (aid, role, eid)
         osaider = self.db.eans.get(keys=keys)  # get old said if any
+        if osaider is not None and osaider.qb64b == saider.qb64b: # check idempotent
+            osaider = None
         # BADA Logic
         accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
                                         aid=aid, osaider=osaider, cigars=cigars,


### PR DESCRIPTION
This is the same as closed (but not merged)  PR #738.
We are fixing a problem that happens when escrowing replay messages that authorize the EndRole of a multisig, where the EndRole got accepted but the same replay message keeps being escrowed and rejected because the date timestamp is not increasing. Since the authorization event is the same, we are validating that the compared messages are idempotent.