### PR TITLE
690 Fix SyntaxWarning: invalid escape sequence

### DIFF
--- a/src/keri/help/helping.py
+++ b/src/keri/help/helping.py
@@ -264,7 +264,7 @@ B64IdxByChr = {char: index for index, char in B64ChrByIdx.items()}
 B64_CHARS = tuple(B64ChrByIdx.values())  # tuple of characters in Base64
 
 
-B64REX = b'^[0-9A-Za-z_-]*\Z'   # [A-Za-z0-9\-\_]
+B64REX = rb'^[0-9A-Za-z_-]*\Z'   # [A-Za-z0-9\-\_]
 Reb64 = re.compile(B64REX)  # compile is faster
 # to use if Reb64.match(bext):
 


### PR DESCRIPTION
Use a raw byte string for the regex so that \Z is properly interpreted as an anchor representing the end of the input, not an escape sequence for the character \Z (which doesn't exist). The hyphen was already moved to the end of the character class so we don't need to worry about escaping that.