### PR TITLE
New introduce rpy handler and updates to create HTTP server

### DIFF
--- a/src/keri/app/cli/commands/watcher/__init__.py
+++ b/src/keri/app/cli/commands/watcher/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.app.cli.commands.watcher Package
+"""
+

--- a/src/keri/app/cli/commands/watcher/add.py
+++ b/src/keri/app/cli/commands/watcher/add.py
@@ -1,0 +1,132 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app import connecting, habbing, forwarding
+from keri.app.cli.common import existing
+from keri.core import eventing, serdering
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Add AID or Alias to list of AIDs for a watcher to watch')
+parser.set_defaults(handler=lambda args: add(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
+                    required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument("--watcher", '-w', help="the watcher AID or alias to add to", required=True)
+parser.add_argument("--watched", '-W', help="the watched AID or alias to add")
+
+
+def add(args):
+    """ Command line handler for adding an aid to a watcher's list of AIds to watch
+
+    Parameters:
+        args(Namespace): parsed command line arguments
+
+    """
+
+    ed = AddDoer(name=args.name,
+                 alias=args.alias,
+                 base=args.base,
+                 bran=args.bran,
+                 watcher=args.watcher,
+                 watched=args.watched)
+    return [ed]
+
+
+class AddDoer(doing.DoDoer):
+
+    def __init__(self, name, alias, base, bran, watcher, watched):
+        self.hby = existing.setupHby(name=name, base=base, bran=bran)
+        self.hab = self.hby.habByName(alias)
+        self.org = connecting.Organizer(hby=self.hby)
+
+        if watcher in self.hby.kevers:
+            wat = watcher
+        else:
+            wat = self.org.find("alias", watcher)
+            if len(wat) != 1:
+                raise ValueError(f"invalid recipient {watcher}")
+            wat = wat[0]['id']
+
+        if not wat:
+            raise ValueError(f"unknown watcher {watcher}")
+
+        if watched in self.hby.kevers:
+            watd = watched
+        else:
+            watd = self.org.find("alias", watched)
+            if len(watd) != 1:
+                raise ValueError(f"invalid recipient {watched}")
+            watd = watd[0]['id']
+
+        if not watd:
+            raise ValueError(f"unknown watched {watched}")
+
+        self.watcher = wat
+        self.watched = watd
+
+        self.oobi = None
+        for (key,), obr in self.hby.db.roobi.getItemIter():
+            if obr.cid == watd:
+                self.oobi = key
+
+        if not self.oobi:
+            raise ValueError(f"no valid oobi for watched {self.watched}")
+
+        doers = [doing.doify(self.addDo)]
+
+        super(AddDoer, self).__init__(doers=doers)
+
+    def addDo(self, tymth, tock=0.0):
+        """ Grant credential by creating /ipex/grant exn message
+
+        Parameters:
+            tymth (function): injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock (float): injected initial tock value
+
+        Returns:  doifiable Doist compatible generator method
+
+        """
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        if isinstance(self.hab, habbing.GroupHab):
+            raise ValueError("watchers for multisig AIDs not currently supported")
+
+        postman = forwarding.StreamPoster(hby=self.hby, hab=self.hab, recp=self.watcher, topic="reply")
+        for msg in self.hab.db.clonePreIter(pre=self.hab.pre):
+            serder = serdering.SerderKERI(raw=msg)
+            postman.send(serder=serder, attachment=msg[serder.size:])
+
+        data = dict(cid=self.hab.pre,
+                    wid=self.watched,
+                    oobi=self.oobi)
+
+        route = "/watcher/aid/add"
+        msg = self.hab.reply(route=route, data=data)
+        rpy = serdering.SerderKERI(raw=msg)
+        postman.send(serder=rpy, attachment=msg[rpy.size:])
+
+        doer = doing.DoDoer(doers=postman.deliver())
+        self.extend([doer])
+
+        while not doer.done:
+            yield self.tock
+
+        print(f"Request to add {self.watched} to watcher {self.watcher} submitted.")

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -35,7 +35,10 @@ parser.add_argument("--witness", '-w', help="the witness AID or alias to authent
 
 
 def auth(args):
-    """ Command line list credential registries handler
+    """ Command line handler for authenticating  against a witness by retrieving the secret or a TOTP
+
+    Parameters:
+        args(Namespace): parsed command line arguments
 
     """
 
@@ -65,7 +68,7 @@ class AuthDoer(doing.DoDoer):
         if not wit:
             raise ValueError(f"unknown witness {witness}")
 
-        self.witness = witness
+        self.witness = wit
         self.clienter = httping.Clienter()
         doers = [doing.doify(self.authDo), self.clienter]
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -2077,7 +2077,7 @@ class BaseHab:
         """
         while cues:  # iteratively process each cue in cues
             msgs = bytearray()
-            cue = cues.pull() #cues.popleft()
+            cue = cues.pull()  # cues.popleft()
             cueKin = cue["kin"]  # type or kind of cue
 
             if cueKin in ("receipt",):  # cue to receipt a received event from other pre

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -248,7 +248,7 @@ class WitnessStart(doing.DoDoer):
 
         while True:
             while self.cues:
-                cue = self.cues.pull() # self.cues.popleft()
+                cue = self.cues.pull()  # self.cues.popleft()
                 cueKin = cue["kin"]
                 if cueKin == "stream":
                     self.queries.append(cue)

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -40,6 +40,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     Setup witness controller and doers
 
     """
+    host = "0.0.0.0"
     cues = decking.Deck()
     doers = []
 
@@ -87,7 +88,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     receiptEnd = ReceiptEnd(hab=hab, inbound=cues, aids=aids)
     app.add_route("/receipts", receiptEnd)
 
-    server = createHttpServer(httpPort, app, keypath, certpath, cafilepath)
+    server = createHttpServer(host, httpPort, app, keypath, certpath, cafilepath)
     if not server.reopen():
         raise RuntimeError(f"cannot create http server on port {httpPort}")
     httpServerDoer = http.ServerDoer(server=server)
@@ -112,10 +113,11 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     return doers
 
 
-def createHttpServer(port, app, keypath=None, certpath=None, cafilepath=None):
+def createHttpServer(host, port, app, keypath=None, certpath=None, cafilepath=None):
     """
     Create an HTTP or HTTPS server depending on whether TLS key material is present
     Parameters:
+        host(str)          : host to bind to for this server, or None for default of '0.0.0.0', all ifaces
         port (int)         : port to listen on for all HTTP(s) server instances
         app (falcon.App)   : application instance to pass to the http.Server instance
         keypath (string)   : the file path to the TLS private key
@@ -130,9 +132,9 @@ def createHttpServer(port, app, keypath=None, certpath=None, cafilepath=None):
                                 certpath=certpath,
                                 cafilepath=cafilepath,
                                 port=port)
-        server = http.Server(port=port, app=app, servant=servant)
+        server = http.Server(host=host, port=port, app=app, servant=servant)
     else:
-        server = http.Server(port=port, app=app)
+        server = http.Server(host=host, port=port, app=app)
     return server
 
 

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -13,18 +13,18 @@ from urllib.parse import urlparse
 import falcon
 from hio.base import doing
 from hio.help import decking
-from keri.core import coring
 
+from keri.core import coring
 from . import httping
-from .habbing import GroupHab
 from .. import help
 from .. import kering
-from ..app import forwarding, connecting
+from ..app import connecting
 from ..core import routing, eventing, parsing, scheming, serdering
 from ..db import basing
 from ..end import ending
 from ..end.ending import OOBI_RE, DOOBI_RE
 from ..help import helping
+from ..kering import Ilks, ValidationError, UnverifiedReplyError
 from ..peer import exchanging
 
 logger = help.ogler.getLogger()
@@ -276,7 +276,7 @@ class Oobiery:
 
     RetryDelay = 30
 
-    def __init__(self, hby, clienter=None, cues=None):
+    def __init__(self, hby, rvy, clienter=None, cues=None):
         """  DoDoer to handle the request and parsing of OOBIs
 
         Parameters:
@@ -286,6 +286,7 @@ class Oobiery:
         """
 
         self.hby = hby
+        self.rvy = rvy
         self.clienter = clienter or httping.Clienter()
         self.org = connecting.Organizer(hby=self.hby)
         rtr = routing.Router()
@@ -297,6 +298,86 @@ class Oobiery:
         self.cues = cues if cues is not None else decking.Deck()
         self.clients = dict()
         self.doers = [self.clienter, doing.doify(self.scoobiDo)]
+
+    def registerReplyRoutes(self, router):
+        """ Register the routes for processing messages embedded in `rpy` event messages
+
+        The Oobiery handles rpy messages with the /introduce route by processing the contained oobi
+
+        Parameters:
+            router(Router): reply message router
+
+        """
+        router.addRoute("/introduce", self)
+
+    def processReply(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
+        """
+        Process one reply message for route = /introduce
+        with either attached nontrans receipt couples in cigars or attached trans
+        indexed sig groups in tsgs.
+        Assumes already validated saider, dater, and route from serder.ked
+
+        Parameters:
+            serder (SerderKERI): instance of reply msg (SAD)
+            saider (Saider): instance  from said in serder (SAD)
+            route (str): reply route
+            cigars (list): of Cigar instances that contain nontrans signing couple
+                          signature in .raw and public key in .verfer
+            tsgs (list): tuples (quadruples) of form
+                (prefixer, seqner, diger, [sigers]) where:
+                prefixer is pre of trans endorser
+                seqner is sequence number of trans endorser's est evt for keys for sigs
+                diger is digest of trans endorser's est evt for keys for sigs
+                [sigers] is list of indexed sigs from trans endorser's keys from est evt
+
+        OobiRecord:
+            date: str = date time of reply message of the introduction
+
+        Reply Message:
+        {
+          "v" : "KERI10JSON00011c_",
+          "t" : "rpy",
+          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+          "dt": "2020-08-22T17:50:12.988921+00:00",
+          "r" : "/introduce",
+          "a" :
+          {
+             "cid": "ENcOes8_t2C7tck4X4j61fSm0sWkLbZrEZffq7mSn8On",
+             "oobi":  "http://localhost:5632/oobi/ENcOes8_t2C7tck4X4j61fSm0sWkLbZrEZffq7mSn8On/witness",
+          }
+        }
+
+        """
+        if route != "/introduce":
+            raise ValidationError(f"Usupported route={route} in {Ilks.rpy} "
+                                  f"msg={serder.ked}.")
+
+        data = serder.ked['a']
+        dt = serder.ked["dt"]
+
+        for k in ("cid", "oobi"):
+            if k not in data:
+                raise ValidationError(f"Missing element={k} from attributes in"
+                                      f" {Ilks.rpy} msg={serder.ked}.")
+
+        cider = coring.Prefixer(qb64=data["cid"])  # raises error if unsupported code
+        cid = cider.qb64  # controller authorizing eid at role
+        aid = cid  # authorizing attribution id
+
+        oobi = data["oobi"]
+        url = urlparse(oobi)
+        if url.scheme not in ("http", "https"):
+            raise ValidationError(f"Invalid url scheme for introduced OOBI scheme={url.scheme}")
+
+        # Process BADA RUN but with no previous reply message, always process introductions
+        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+                                        aid=aid, osaider=None, cigars=cigars,
+                                        tsgs=tsgs)
+        if not accepted:
+            raise UnverifiedReplyError(f"Unverified introduciton reply. {serder.ked}")
+
+        obr = basing.OobiRecord(cid=cid, date=help.toIso8601(dt))
+        self.hby.db.oobis.put(keys=(oobi,), val=obr)
 
     def scoobiDo(self, tymth=None, tock=0.0):
         """

--- a/src/keri/core/__init__.py
+++ b/src/keri/core/__init__.py
@@ -4,9 +4,6 @@ KERI
 keri.core Package
 """
 
-#__all__ = ["coring", "eventing", "parsing", "scheming"]
-
-
 # Constants etc
 from .coring import (Tiers, )
 

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4556,7 +4556,7 @@ class Kevery:
                     msgs.append(msg)
 
             if msgs:
-                self.cues.push(dict(kin="replay", src=src, msgs=msgs, dest=dest))
+                self.cues.push(dict(kin="replay", pre=pre, src=src, msgs=msgs, dest=dest))
 
         elif route == "ksn":
             pre = qry["i"]

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1162,15 +1162,6 @@ def reply(route="",
     serder._verify()  # raises error if fails verifications
     return serder
 
-    #_, sad = coring.Saider.saidify(sad=sad, kind=kind, label=label)
-
-    #saider = coring.Saider(qb64=sad[label])
-    #if not saider.verify(sad=sad, kind=kind, label=label, prefixed=True):
-        #raise ValidationError("Invalid said = {} for reply msg={}."
-                              #"".format(saider.qb64, sad))
-
-    #return Serder(ked=sad)  # return serialized Self-Addressed Data (SAD)
-
 
 def prod(route="",
           replyRoute="",
@@ -4115,7 +4106,6 @@ class Kevery:
         """
         pass
 
-
     def registerReplyRoutes(self, router):
         """ Register the routes for processing messages embedded in `rpy` event messages
 
@@ -4127,9 +4117,7 @@ class Kevery:
         router.addRoute("/loc/scheme", self, suffix="LocScheme")
         router.addRoute("/ksn/{aid}", self, suffix="KeyStateNotice")
 
-
-    def processReplyEndRole(self, *, serder, saider, route,
-                            cigars=None, tsgs=None, **kwargs):
+    def processReplyEndRole(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
         """
         Process one reply message for route = /end/role/add or /end/role/cut
         with either attached nontrans receipt couples in cigars or attached trans
@@ -4532,6 +4520,11 @@ class Kevery:
         # do signature validation and replay attack prevention logic here
         # src, dt, route
 
+        if source is None and cigars:
+            dest = cigars[0].verfer.qb64
+        else:
+            dest = source.qb64
+
         if route == "logs":
             pre = qry["i"]
             src = qry["src"]
@@ -4563,7 +4556,7 @@ class Kevery:
                     msgs.append(msg)
 
             if msgs:
-                self.cues.push(dict(kin="replay", src=src, msgs=msgs, dest=source.qb64))
+                self.cues.push(dict(kin="replay", src=src, msgs=msgs, dest=dest))
 
         elif route == "ksn":
             pre = qry["i"]
@@ -4585,7 +4578,7 @@ class Kevery:
 
             rserder = reply(route=f"/ksn/{src}", data=kever.state()._asdict())
             self.cues.push(dict(kin="reply", src=src, route="/ksn", serder=rserder,
-                                dest=source.qb64))
+                                dest=dest))
 
         elif route == "mbx":
             pre = qry["i"]

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1038,8 +1038,8 @@ class Parser:
                         rvy.processReply(serder, tsgs=tsgs)  # trans
 
                 except AttributeError as e:
-                    raise kering.ValidationError("No kevery to process so dropped msg"
-                                                 "= {}.".format(serder.pretty()))
+                    raise kering.ValidationError("No revery to process so dropped msg"
+                                                 "= {}.".format(serder.pretty())) from e
 
             elif ilk in (Ilks.qry,):  # query message
                 args = dict(serder=serder)
@@ -1059,9 +1059,9 @@ class Parser:
                 if route in ["logs", "ksn", "mbx"]:
                     try:
                         kvy.processQuery(**args)
-                    except AttributeError:
+                    except AttributeError as e:
                         raise kering.ValidationError("No kevery to process so dropped msg"
-                                                     "= {}.".format(serder.pretty()))
+                                                     "= {} from e = {}".format(serder.pretty(), e))
 
                 elif route in ["tels", "tsn"]:
                     try:

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1500,6 +1500,9 @@ class Baser(dbing.LMDBer):
             atc.extend(coring.Counter(code=coring.CtrDex.SealSourceCouples,
                                       count=1).qb64b)
             atc.extend(couple)
+        elif self.kevers[pre].delegated:
+            if coring.SerderKERI(raw=raw).estive:
+                raise kering.MissingEntryError("Missing delegator anchor seal for dig={}.".format(dig))
 
         # add trans endorsement quadruples to attachments not controller
         # may have been originally key event attachments or receipted endorsements

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -115,8 +115,6 @@ class Broker:
                     # still waiting on missing prior event to validate
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.exception("Kevery unescrow attempt failed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrow attempt failed: %s", ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -577,7 +577,7 @@ class OOBIEnd:
             rep.status = falcon.HTTP_NOT_FOUND
             return
 
-        if kever.delegated and kever.delegator not in self.hby.kevers:
+        if kever.delegated and kever.delpre not in self.hby.kevers:
             rep.status = falcon.HTTP_NOT_FOUND
             return
 

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -577,6 +577,10 @@ class OOBIEnd:
             rep.status = falcon.HTTP_NOT_FOUND
             return
 
+        if kever.delegated and kever.delegator not in self.hby.kevers:
+            rep.status = falcon.HTTP_NOT_FOUND
+            return
+
         owits = oset(kever.wits)
         if kever.prefixer.qb64 in self.hby.prefixes:  # One of our identifiers
             hab = self.hby.habs[kever.prefixer.qb64]

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -158,20 +158,21 @@ class MockServerTls:
 
 
 class MockHttpServer:
-    def __init__(self, port, app, servant=None):
+    def __init__(self, host, port, app, servant=None):
         self.servant = servant
 
 
 def test_createHttpServer(monkeypatch):
+    host = "0.0.0.0"
     port = 5632
     app = falcon.App()
-    server = indirecting.createHttpServer(port, app)
+    server = indirecting.createHttpServer(host, port, app)
     assert isinstance(server, http.Server)
 
     monkeypatch.setattr(hio.core.tcp, 'ServerTls', MockServerTls)
     monkeypatch.setattr(hio.core.http, 'Server', MockHttpServer)
 
-    server = indirecting.createHttpServer(port, app, keypath='keypath', certpath='certpath', cafilepath='cafilepath')
+    server = indirecting.createHttpServer(host, port, app, keypath='keypath', certpath='certpath', cafilepath='cafilepath')
 
     assert isinstance(server, MockHttpServer)
     assert isinstance(server.servant, MockServerTls)

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -445,7 +445,7 @@ def test_get_oobi():
         hab = hby.makeHab(name=name, delpre=delhab.pre)
 
         assert hab.pre == "EPERMS4wKU7ejhCdhI2qQR8snEx1cislR9C9bSEs0kS5"
-        assert hab.kever.delegator == delhab.pre
+        assert hab.kever.delpre == delhab.pre
 
         msgs.extend(hab.makeEndRole(eid=hab.pre,
                                     role=kering.Roles.controller,

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -438,6 +438,49 @@ def test_get_oobi():
         assert serder.ked['t'] == coring.Ilks.icp
         assert serder.ked['i'] == "EOaICQwhOy3wMwecjAuHQTbv_Cmuu1azTMnHi4QtUmEU"
 
+    delname = "delegator"
+    with habbing.openHby(name=name, base=base, salt=salt) as hby, \
+            habbing.openHby(name=delname, base=base, salt=salt) as delhby:
+        delhab = delhby.makeHab(name=delname)
+        hab = hby.makeHab(name=name, delpre=delhab.pre)
+
+        assert hab.pre == "EPERMS4wKU7ejhCdhI2qQR8snEx1cislR9C9bSEs0kS5"
+        assert hab.kever.delegator == delhab.pre
+
+        msgs.extend(hab.makeEndRole(eid=hab.pre,
+                                    role=kering.Roles.controller,
+                                    stamp=help.nowIso8601()))
+
+        msgs.extend(hab.makeLocScheme(url='http://127.0.0.1:5555',
+                                      scheme=kering.Schemes.http,
+                                      stamp=help.nowIso8601()))
+        hab.psr.parse(ims=msgs)
+
+        # must do it here to inject into Falcon endpoint resource instances
+        tymist = tyming.Tymist(tyme=0.0)
+
+        app = falcon.App()  # falcon.App instances are callable WSGI apps
+        ending.loadEnds(app, tymth=tymist.tymen(), hby=hby, default=hab.pre)
+
+        client = testing.TestClient(app=app)
+
+        # This should fail with 404 because we haven't been approved yet so we don't exist
+        rep = client.simulate_get('/oobi', )
+        assert rep.status == falcon.HTTP_NOT_FOUND
+
+        # Approve the delegation manually
+        delhab.interact(data=[dict(i=hab.pre, s="0", d=hab.pre)])
+        for msg in delhab.db.clonePreIter(pre=delhab.pre, fn=0):
+            hab.psr.parse(ims=msg)
+
+        rep = client.simulate_get('/oobi', )
+        assert rep.status == falcon.HTTP_OK
+
+        # We'll get the delegator first
+        serder = serdering.SerderKERI(raw=rep.text.encode("utf-8"))
+        assert serder.ked['t'] == coring.Ilks.icp
+        assert serder.ked['i'] == "EKL3to0Q059vtxKi7wWmaNFJ3NKE1nQsOPasRXqPzpjS"
+
     """Done Test"""
 
 


### PR DESCRIPTION
This PR includes:

* A handler tied into the Oobiery for processing `rpy` messages with a `/introduce` route.  The handler passes the provided OOBI to the Oobiery for resolution.
* The addition of host parameter for creating an HTTP server so it can be created on different network interfaces.
