### PR TITLE
Fix multisig rotation

### DIFF
--- a/scripts/demo/basic/multisig-rotation-in-third.sh
+++ b/scripts/demo/basic/multisig-rotation-in-third.sh
@@ -17,8 +17,6 @@ kli oobi resolve --name multisig1 --oobi-alias multisig2 --oobi http://127.0.0.1
 kli oobi resolve --name multisig1 --oobi-alias multisig3 --oobi http://127.0.0.1:5642/oobi/ENkjt7khEI5edCMw5qugagbJw1QvGnQEtcewxb0FnU9U/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 kli oobi resolve --name multisig2 --oobi-alias multisig1 --oobi http://127.0.0.1:5642/oobi/EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 kli oobi resolve --name multisig2 --oobi-alias multisig3 --oobi http://127.0.0.1:5642/oobi/ENkjt7khEI5edCMw5qugagbJw1QvGnQEtcewxb0FnU9U/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name multisig3 --oobi-alias multisig1 --oobi http://127.0.0.1:5642/oobi/EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
-kli oobi resolve --name multisig3 --oobi-alias multisig2 --oobi http://127.0.0.1:5642/oobi/EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
 # Follow commands run in parallel
 kli multisig incept --name multisig1 --alias multisig1 --group multisig --file ${KERI_DEMO_SCRIPT_DIR}/data/multisig-sample.json &
@@ -33,6 +31,13 @@ wait $PID_LIST
 kli status --name multisig1 --alias multisig
 
 PID_LIST=""
+
+kli rotate --name multisig1 --alias multisig1
+kli query --name multisig2 --alias multisig2 --prefix EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4
+kli rotate --name multisig2 --alias multisig2
+kli query --name multisig1 --alias multisig1 --prefix EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1
+kli oobi resolve --name multisig3 --oobi-alias multisig1 --oobi http://127.0.0.1:5642/oobi/EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
+kli oobi resolve --name multisig3 --oobi-alias multisig2 --oobi http://127.0.0.1:5642/oobi/EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
 kli multisig rotate --name multisig1 --alias multisig --smids EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4 --smids EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1 --smids ENkjt7khEI5edCMw5qugagbJw1QvGnQEtcewxb0FnU9U --isith '["1/3", "1/3", "1/3"]' --nsith '["1/2", "1/2", "1/2"]' --rmids EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4 --rmids EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1 --rmids ENkjt7khEI5edCMw5qugagbJw1QvGnQEtcewxb0FnU9U &
 pid=$!

--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -41,7 +41,7 @@ printf "\n************************************\n"
 isSuccess
 
 printf "\n************************************\n"
-printf "Running delegate.sh"
+printf "Skipping delegate.sh"
 printf "\n************************************\n"
 #"${script_dir}/basic/delegate.sh"
 #isSuccess
@@ -65,7 +65,7 @@ printf "\n************************************\n"
 isSuccess
 
 printf "\n************************************\n"
-printf "Skipping multisig-join.sh"
+printf "Running multisig-join.sh"
 printf "\n************************************\n"
-#"${script_dir}/basic/multisig-join.sh"
-#isSuccess
+"${script_dir}/basic/multisig-join.sh"
+isSuccess

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -405,7 +405,7 @@ class ConfirmDoer(doing.DoDoer):
                 ghab = self.hby.joinGroupHab(pre, group=alias, mhab=mhab, smids=smids, rmids=rmids)
 
             try:
-                ghab.rotate(serder=orot)
+                ghab.rotate(serder=orot, smids=smids, rmids=rmids)
             except ValueError:
                 return False
 

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -177,8 +177,8 @@ class ConfirmDoer(doing.DoDoer):
         inits["isith"] = oicp.ked["kt"]
         inits["nsith"] = oicp.ked["nt"]
 
-        inits["estOnly"] = eventing.TraitCodex.EstOnly in oicp.ked["c"]
-        inits["DnD"] = eventing.TraitCodex.DoNotDelegate in oicp.ked["c"]
+        inits["estOnly"] = kering.TraitCodex.EstOnly in oicp.ked["c"]
+        inits["DnD"] = kering.TraitCodex.DoNotDelegate in oicp.ked["c"]
 
         inits["toad"] = oicp.ked["bt"]
         inits["wits"] = oicp.ked["b"]

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -47,11 +47,7 @@ class Counselor(doing.DoDoer):
             saider (Saider): saider of event of group identifier
 
         """
-        evt = ghab.makeOwnEvent(sn=seqner.sn, allowPartiallySigned=True)
-        serder = serdering.SerderKERI(raw=evt)
-        del evt[:serder.size]
-
-        logger.info(f"Waiting for other signatures for {serder.pre}:{seqner.sn}...")
+        print(f"Waiting for other signatures for {prefixer.qb64}:{seqner.sn}...")
         return self.hby.db.gpse.add(keys=(prefixer.qb64,), val=(seqner, saider))
 
     def complete(self, prefixer, seqner, saider=None):

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -1709,7 +1709,6 @@ class Kever:
         pre = pre if pre is not None else self.prefixer.qb64
         return pre in self.groups  # groups
 
-
     def locallyContributedIndices(self, verfers: list[Verfer]):
         """Returns list of indices of public keys contributed by local members
         to the KEL with current signing keys represented by verfers
@@ -1723,19 +1722,11 @@ class Kever:
             indices list[int]: list of indices of keys contributed by local members
 
         """
-        indices = []
+        habord = self.db.habs.get(keys=(self.prefixer.qb64,))
+        kever = self.kevers[habord.mid]
 
-        for i, verfer in enumerate(verfers):
-            if (couples := self.pubs.get(keys=(verfer.qb64,))) is None:
-                continue
-
-            for (prefixer, seqner) in couples:
-                if self.locallyOwned(prefixer.qb64):  # only member not group aid
-                    indices.append(i)
-                    break  # only need one local member to exclude signature
-
-        return indices
-
+        idx = [verfer.qb64 for verfer in verfers].index(kever.verfers[0].qb64)
+        return [idx]
 
     def reload(self, state):
         """
@@ -2227,13 +2218,15 @@ class Kever:
         # compromised signature remotely to satisfy threshold.
 
         if not local and self.locallyMembered():  # is this Kever's pre a local group
-            if (indices := self.locallyContributedIndices(verfers)):
+            if indices := self.locallyContributedIndices(verfers):
                 for siger in list(sigers):  # copy so clean del on original elements
                     if siger.index in indices:
                         del sigers[siger.index]
-                        self.cues.push(dict(kin="remoteMemberedSig",
-                                            serder=serder,
-                                              index=siger.index))
+                        if self.cues:
+                            self.cues.push(dict(kin="remoteMemberedSig",
+                                                serder=serder,
+                                                index=siger.index))
+
 
         # get unique verified sigers and indices lists from sigers list
         sigers, indices = verifySigs(raw=serder.raw, sigers=sigers, verfers=verfers)
@@ -2269,6 +2262,7 @@ class Kever:
             raise MissingSignatureError(f"Failure satisfying sith = {tholder.sith}"
                                         f" on sigs for {[siger.qb64 for siger in sigers]}"
                                         f" for evt = {serder.ked}.")
+
 
         # escrow if not fully signed vs prior next rotation threshold
         if serder.ilk in (Ilks.rot, Ilks.drt):  # rotation so check prior next threshold
@@ -2306,7 +2300,7 @@ class Kever:
 
         # short circuit witness validation when either locallyOwned or locallyWitnessed
         # otherwise must validate fully witnessed
-        if not (self.locallyOwned() or self.locallyWitnessed(wits=wits)):
+        if not (self.locallyOwned() or self.locallyMembered() or self.locallyWitnessed(wits=wits)):
             if wits:  # is witnessed
                 if toader.num < 1 or toader.num > len(wits):  # out of bounds toad
                     raise ValidationError(f"Invalid toad = {toader.num} for wits = {wits}")

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2221,7 +2221,7 @@ class Kever:
             if indices := self.locallyContributedIndices(verfers):
                 for siger in list(sigers):  # copy so clean del on original elements
                     if siger.index in indices:
-                        del sigers[siger.index]
+                        sigers.remove(siger)
                         if self.cues:
                             self.cues.push(dict(kin="remoteMemberedSig",
                                                 serder=serder,
@@ -2247,7 +2247,6 @@ class Kever:
             raise MisfitEventSourceError(f"Nonlocal source for locally owned"
                                              f"or locally witnessed event"
                                                  f" = {serder.ked}.")
-
 
         werfers = [Verfer(qb64=wit) for wit in wits]  # get witness public key verifiers
         # get unique verified wigers and windices lists from wigers list


### PR DESCRIPTION
A few fixes to Kever signature verification to re-enable multisig rotation.

* Add check for whether to skip witness threshold checking for locallyMembered.
* Fix method for getting list of local signature indices from a list of multiple signatures to use hab record.
* Re-enable multisig join script in CI.