### PR TITLE
feat: multisig join --group arg

### DIFF
--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -21,47 +21,52 @@ from keri.vdr import verifying, credentialing
 logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='Join group multisig inception, rotation or interaction event.')
-parser.set_defaults(handler=lambda args: confirm(args))
+parser.set_defaults(handler=lambda args: join(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")
+parser.add_argument('--alias', '-a', help='human readable alias for the multisig identifier prefix', required=False, default=None)
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument("--auto", "-Y", help="auto approve any delegation request non-interactively", action="store_true")
 
 
-def confirm(args):
-    """  Wait for and provide interactive confirmation of group multisig inception, rotation or interaction events
+def join(args):
+    """ Wait for and provide interactive confirmation of group multisig inception, rotation or interaction events
 
     Parameters:
-        args(Namespace): parsed arguements namespace object
+        args(Namespace): parsed arguments namespace object
 
     """
     name = args.name
     base = args.base
     bran = args.bran
     auto = args.auto
+    alias = args.alias
 
-    confirmDoer = ConfirmDoer(name=name, base=base, bran=bran, auto=auto)
+    confirmDoer = JoinDoer(name=name, base=base, bran=bran, alias=alias, auto=auto)
 
     doers = [confirmDoer]
     return doers
 
 
-class ConfirmDoer(doing.DoDoer):
-    """  Doist doer capable of polling for group multisig events and prompting user for action
+class JoinDoer(doing.DoDoer):
+    """ Doist doer capable of polling for group multisig events and prompting user for action
 
     """
 
-    def __init__(self, name, base, bran, auto=False):
+    def __init__(self, name, base, bran, alias, auto=False):
         """ Create doer for polling for group multisig events and either approve automatically or prompt user
 
         Parameters:
             name (str): database environment name
             base (str): database directory prefix
             bran (str): passcode to unlock keystore
-
+            alias (str): human-readable name for the multisig identifier prefix
+            auto (bool): non-interactively auto approve any inception, rotation, interaction, or other event
+                         while using the default alias of "test-alias"
         """
+        self.alias = alias
         self.hby = existing.setupHby(name=name, base=base, bran=bran)
         self.rgy = credentialing.Regery(hby=self.hby, name=name, base=base)
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
@@ -88,11 +93,11 @@ class ConfirmDoer(doing.DoDoer):
 
         doers = [self.hbyDoer, self.witq,  self.mbx, self.counselor, self.registrar, self.credentialer, self.postman]
         self.toRemove = list(doers)
-        doers.extend([doing.doify(self.confirmDo)])
+        doers.extend([doing.doify(self.joinDo)])
         self.auto = auto
-        super(ConfirmDoer, self).__init__(doers=doers)
+        super(JoinDoer, self).__init__(doers=doers)
 
-    def confirmDo(self, tymth, tock=0.0):
+    def joinDo(self, tymth, tock=0.0):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of
@@ -146,7 +151,7 @@ class ConfirmDoer(doing.DoDoer):
         self.remove(self.toRemove)
 
     def incept(self, attrs):
-        """ Incept group multisig
+        """ Join a group multisig inception event
 
         """
         said = attrs["d"]
@@ -196,7 +201,12 @@ class ConfirmDoer(doing.DoDoer):
 
         if approve:
             if self.auto:
-                alias = "test alias"
+                alias = self.alias
+            elif self.alias:
+                alias = self.alias
+                if self.hby.habByName(alias) is not None:
+                    print(f"AID alias {alias} is already in use, please try again")
+                    raise ValueError(f"AID alias {alias} is already in use, please try again")
             else:
                 while True:
                     alias = input(f"\nEnter alias for new AID: ")
@@ -394,6 +404,11 @@ class ConfirmDoer(doing.DoDoer):
             else:
                 if self.auto:
                     alias = "test alias"
+                elif self.alias:
+                    alias = self.alias
+                    if self.hby.habByName(alias) is not None:
+                        print(f"AID alias {alias} is already in use, please try again")
+                        raise ValueError(f"AID alias {alias} is already in use, please try again")
                 else:
                     while True:
                         alias = input(f"\nEnter alias for new AID: ")


### PR DESCRIPTION
This adds the capability to specify a multisig group name during `kli multisig join`. Previously the group name was always set to "test alias" which would cause a name collision problems when doing successive `multisig join` commands for different identifiers.

This is similar to the PR to v1.1.14: #782 

There were merge conflicts so the commits couldn't be directly cherry picked.