### PR TITLE
Add processing method for delegables escrow in Kevery

### DIFF
--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -130,7 +130,7 @@ class ConfirmDoer(doing.DoDoer):
 
                     if isinstance(hab, GroupHab):
                         aids = hab.smids
-                        #seqner = coring.Seqner(sn=eserder.sn)
+
                         anchor = dict(i=eserder.ked["i"], s=eserder.snh, d=eserder.said)
                         if self.interact:
                             msg = hab.interact(data=[anchor])
@@ -166,7 +166,7 @@ class ConfirmDoer(doing.DoDoer):
 
                     else:
                         cur = hab.kever.sner.num
-                        #seqner = coring.Seqner(sn=eserder.sn)
+
                         anchor = dict(i=eserder.ked["i"], s=eserder.snh, d=eserder.said)
                         if self.interact:
                             hab.interact(data=[anchor])


### PR DESCRIPTION
This PR adds new method Kevery.processEscrowDelegables for attempting to re-process events that require delegation.  This closes #785 