### PR TITLE
fixes MissingDelegableApprovalError logging bug

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5806,7 +5806,7 @@ class Kevery:
                     self.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=seqner,
                                       delsaider=saider, local=esr.local)
                 else:
-                    raise MissingDelegableApprovalError()
+                    raise MissingDelegableApprovalError("No delegation seal found for event.")
 
             except MissingDelegableApprovalError as ex:
                 # still waiting on missing delegation approval

--- a/tests/core/test_delegating.py
+++ b/tests/core/test_delegating.py
@@ -739,6 +739,8 @@ def test_delegables_escrow():
         parsing.Parser().parse(ims=bytearray(gateIcp), kvy=torKvy, local=True)
         assert gateHab.pre not in torKvy.kevers
         assert len(torHab.db.delegables.get(keys=snKey(gateHab.kever.serder.preb, gateHab.kever.serder.sn))) == 1
+        # Exercise the MissingDelegableApprovalError case
+        torKvy.processEscrowDelegables()
 
         # Now create delegating interaction event
         seal = eventing.SealEvent(i=gateHab.pre,


### PR DESCRIPTION
Adds a message to the MissingDelegableApprovalError so the logging doesn't fail.
Updated test to exercise the exception and logging.