### PR TITLE
fix alias renaming

### DIFF
--- a/src/keri/app/cli/commands/rename.py
+++ b/src/keri/app/cli/commands/rename.py
@@ -48,16 +48,19 @@ def rename(tymth, tock=0.0, **opts):
             if hby.habByName(newAlias) is not None:
                 print(f"{newAlias} is already in use")
 
-            if (pre := hab.db.names.get(keys=("", name))) is not None:
+            if (pre := hab.db.names.get(keys=("", alias))) is not None:
 
                 habord = hab.db.habs.get(keys=pre)
-                habord.name = name
+                habord.name = newAlias
                 hab.db.habs.pin(keys=habord.hid,
                                 val=habord)
-                hab.db.names.pin(keys=("", name), val=pre)
+                hab.db.names.pin(keys=("", newAlias), val=pre)
                 hab.db.names.rem(keys=("", alias))
 
                 print(f"Hab {alias} renamed to {newAlias}")
+            else:
+                raise ConfigurationError(f"No AID with name {alias} found")
+
 
     except ConfigurationError as e:
         print(f"identifier prefix for {name} does not exist, incept must be run first", )


### PR DESCRIPTION
when i was trying to rename with the command `kli rename --name test --base "${KERI_TEMP_DIR}"  --alias <old-alias> <new-alias>` i didn't get the expected result. I think this PR can fix this issue.
