### PR TITLE
New and updated kli commands for witnesss, watchers and mailboxes.  Delegation fixes

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -581,6 +581,7 @@ class WitnessPublisher(doing.DoDoer):
 
         """
         self.hby = hby
+        self.posted = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
         super(WitnessPublisher, self).__init__(doers=[doing.doify(self.sendDo)], **kwa)
@@ -599,6 +600,7 @@ class WitnessPublisher(doing.DoDoer):
         while True:
             while self.msgs:
                 evt = self.msgs.popleft()
+                self.posted += 1
                 pre = evt["pre"]
                 msg = evt["msg"]
 
@@ -641,6 +643,10 @@ class WitnessPublisher(doing.DoDoer):
                 return True
 
         return False
+
+    @property
+    def idle(self):
+        return len(self.msgs) == 0 and self.posted == len(self.cues)
 
 
 class TCPMessenger(doing.DoDoer):

--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -85,7 +85,7 @@ class ReadDoer(doing.DoDoer):
 
         hab = self.hby.habByName(name=self.alias)
         topics = {"/receipt": 0, "/replay": 0, "/multisig": 0, "/credential": 0, "/delegate": 0, "/challenge": 0,
-                  "/oobi": 0}
+                  "/oobi": 0, "/reply": 0}
         try:
             client, clientDoer = agenting.httpClient(hab, self.witness)
         except kering.MissingEntryError as e:
@@ -95,8 +95,11 @@ class ReadDoer(doing.DoDoer):
 
         print("Local Index per Topic")
         witrec = hab.db.tops.get((hab.pre, self.witness))
-        for topic in witrec.topics:
-            print(f"   Topic {topic}:   {witrec.topics[topic]}")
+        if witrec:
+            for topic in witrec.topics:
+                print(f"   Topic {topic}:   {witrec.topics[topic]}")
+        else:
+            print("\tNo local index")
         print()
 
         q = dict(pre=hab.pre, topics=topics)
@@ -107,7 +110,7 @@ class ReadDoer(doing.DoDoer):
 
         httping.createCESRRequest(msg, client, dest=self.witness)
 
-        while client.requests:
+        while client.requests or (not client.events and not client.requests):
             yield self.tock
 
         yield 1.0

--- a/src/keri/app/cli/commands/mailbox/list.py
+++ b/src/keri/app/cli/commands/mailbox/list.py
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app import connecting
+from keri.app.cli.common import existing
+from keri.kering import ConfigurationError, Roles
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='List current mailboxes')
+parser.set_defaults(handler=lambda args: handle(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
+                    required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+
+def handle(args):
+    """ Command line handler for adding an aid to a watcher's list of AIds to watch
+
+    Parameters:
+        args(Namespace): parsed command line arguments
+
+    """
+
+    kwa = dict(args=args)
+    return [doing.doify(listMailboxes, **kwa)]
+
+
+def listMailboxes(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    alias = args.alias
+    base = args.base
+    bran = args.bran
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            org = connecting.Organizer(hby=hby)
+            if alias is None:
+                alias = existing.aliasInput(hby)
+
+            hab = hby.habByName(alias)
+
+            for (aid, role, eid), ender in hab.db.ends.getItemIter(keys=(hab.pre, Roles.mailbox)):
+                if ender.allowed:
+                    contact = org.get(eid)
+                    print(f"{contact['alias']}: {eid}")
+
+    except ConfigurationError as e:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -31,6 +31,7 @@ parser.add_argument("--authenticate", '-z', help="Prompt the controller for auth
                     action='store_true')
 parser.add_argument('--code', help='<Witness AID>:<code> formatted witness auth codes.  Can appear multiple times',
                     default=[], action="append", required=False)
+parser.add_argument('--code-time', help='Time the witness codes were captured.', default=None, required=False)
 
 parser.add_argument("--proxy", help="alias for delegation communication proxy", default="")
 
@@ -66,7 +67,8 @@ def rotate(args):
                          cuts=opts.witsCut, adds=opts.witsAdd,
                          isith=opts.isith, nsith=opts.nsith,
                          count=opts.ncount, toad=opts.toad,
-                         data=opts.data, proxy=args.proxy, authenticate=args.authenticate, codes=args.code)
+                         data=opts.data, proxy=args.proxy, authenticate=args.authenticate,
+                         codes=args.code, codeTime=args.code_time)
 
     doers = [rotDoer]
 
@@ -122,7 +124,7 @@ class RotateDoer(doing.DoDoer):
 
     def __init__(self, name, base, bran, alias, endpoint=False, isith=None, nsith=None, count=None,
                  toad=None, wits=None, cuts=None, adds=None, data: list = None, proxy=None, authenticate=False,
-                 codes=None):
+                 codes=None, codeTime=None):
         """
         Returns DoDoer with all registered Doers needed to perform rotation.
 
@@ -149,6 +151,7 @@ class RotateDoer(doing.DoDoer):
         self.proxy = proxy
         self.authenticate = authenticate
         self.codes = codes if codes is not None else []
+        self.codeTime = codeTime
 
         self.wits = wits if wits is not None else []
         self.cuts = cuts if cuts is not None else []
@@ -198,9 +201,10 @@ class RotateDoer(doing.DoDoer):
 
         auths = {}
         if self.authenticate:
+            codeTime = helping.fromIso8601(self.codeTime) if self.codeTime is not None else helping.nowIso8601()
             for arg in self.codes:
                 (wit, code) = arg.split(":")
-                auths[wit] = f"{code}#{helping.nowIso8601()}"
+                auths[wit] = f"{code}#{codeTime}"
 
             for wit in hab.kever.wits:
                 if wit in auths:

--- a/src/keri/app/cli/commands/watcher/add.py
+++ b/src/keri/app/cli/commands/watcher/add.py
@@ -11,7 +11,8 @@ from hio.base import doing
 
 from keri.app import connecting, habbing, forwarding
 from keri.app.cli.common import existing
-from keri.core import eventing, serdering
+from keri.core import serdering
+from keri.kering import Roles
 
 logger = help.ogler.getLogger()
 
@@ -91,7 +92,7 @@ class AddDoer(doing.DoDoer):
         super(AddDoer, self).__init__(doers=doers)
 
     def addDo(self, tymth, tock=0.0):
-        """ Grant credential by creating /ipex/grant exn message
+        """ Add an AID to a watcher's list of AIDs to watch
 
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of
@@ -109,17 +110,28 @@ class AddDoer(doing.DoDoer):
         if isinstance(self.hab, habbing.GroupHab):
             raise ValueError("watchers for multisig AIDs not currently supported")
 
+        ender = self.hab.db.ends.get(keys=(self.hab.pre, Roles.watcher, self.watcher))
+        if not ender or not ender.allowed:
+            msg = self.hab.reply(route="/end/role/add",
+                                 data=dict(cid=self.hab.pre, role=Roles.watcher, eid=self.watcher))
+            self.hab.psr.parseOne(ims=msg)
+
         postman = forwarding.StreamPoster(hby=self.hby, hab=self.hab, recp=self.watcher, topic="reply")
+        for msg in self.hab.db.cloneDelegation(self.hab.kever):
+            serder = serdering.SerderKERI(raw=msg)
+            postman.send(serder=serder, attachment=msg[serder.size:])
+
         for msg in self.hab.db.clonePreIter(pre=self.hab.pre):
             serder = serdering.SerderKERI(raw=msg)
             postman.send(serder=serder, attachment=msg[serder.size:])
 
         data = dict(cid=self.hab.pre,
-                    wid=self.watched,
+                    oid=self.watched,
                     oobi=self.oobi)
 
-        route = "/watcher/aid/add"
+        route = f"/watcher/{self.watcher}/add"
         msg = self.hab.reply(route=route, data=data)
+        self.hab.psr.parseOne(ims=bytes(msg))
         rpy = serdering.SerderKERI(raw=msg)
         postman.send(serder=rpy, attachment=msg[rpy.size:])
 

--- a/src/keri/app/cli/commands/watcher/adjudicate.py
+++ b/src/keri/app/cli/commands/watcher/adjudicate.py
@@ -1,0 +1,173 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+import datetime
+import random
+import sys
+from dataclasses import asdict
+
+from hio import help
+from hio.base import doing
+
+from keri.app import connecting, indirecting, querying
+from keri.app.cli.common import existing
+from keri.app.watching import diffState, States
+from keri.help import helping
+from keri.kering import ConfigurationError
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Perform key event adjudication on any new key state from watchers.')
+parser.set_defaults(handler=lambda args: handle(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
+                    required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--toad', '-t', default=None, required=False, type=int,
+                    help='int of watcher threshold (threshold of acceptable duplicity)', )
+parser.add_argument("--watched", '-W', help="the watched AID or alias to add", required=True)
+parser.add_argument("--poll", "-P", help="Poll mailboxes for any issued credentials", action="store_true")
+
+
+def handle(args):
+    """ Command line handler for adding an aid to a watcher's list of AIds to watch
+
+    Parameters:
+        args(Namespace): parsed command line arguments
+
+    """
+
+    kwa = dict(args=args)
+    adjudicator = AdjudicationDoer(**kwa)
+
+    return [adjudicator]
+
+
+class AdjudicationDoer(doing.DoDoer):
+
+    def __init__(self, **kwa):
+        args = kwa["args"]
+        base = args.base
+        bran = args.bran
+        self.name = args.name
+        self.alias = args.alias
+        self.watched = args.watched
+        self.poll = args.poll
+        self.toad = args.toad
+
+        self.hby = existing.setupHby(name=self.name, base=base, bran=bran)
+        self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=['/reply', '/replay'])
+        doers = [doing.doify(self.adjudicate, **kwa), self.mbx]
+
+        super(AdjudicationDoer, self).__init__(**kwa, doers=doers)
+
+    def adjudicate(self, tymth, tock=0.0, **opts):
+        """ Command line status handler
+
+        """
+        _ = (yield tock)
+
+        try:
+            org = connecting.Organizer(hby=self.hby)
+
+            if self.poll:
+                end = helping.nowUTC() + datetime.timedelta(seconds=5)
+                sys.stdout.write(f"Polling mailboxes")
+                sys.stdout.flush()
+                while helping.nowUTC() < end:
+                    sys.stdout.write(".")
+                    sys.stdout.flush()
+                    yield 1.0
+                print("\n")
+
+            if self.watched in self.hby.kevers:
+                watd = self.watched
+            else:
+                watd = org.find("alias", self.watched)
+                if len(watd) != 1:
+                    raise ValueError(f"invalid recipient {self.watched}")
+                watd = watd[0]['id']
+
+            if not watd:
+                raise ValueError(f"unknown watched {self.watched}")
+
+            if self.alias is None:
+                self.alias = existing.aliasInput(self.hby)
+
+            hab = self.hby.habByName(self.alias)
+            if hab is None:
+                raise ValueError(f"unknown alias {self.alias}")
+
+            watchers = set()
+            for (cid, aid, oid), observed in hab.db.obvs.getItemIter(keys=(hab.pre,)):
+                if observed.enabled:
+                    watchers.add(aid)
+
+            toad = int(self.toad) if self.toad else len(watchers)
+            if toad > len(watchers):
+                raise ValueError(f"Threshold of {toad} is greater than number watchers {len(watchers)}")
+
+            states = []
+            mystate = hab.kever.state()
+            for watcher in watchers:
+                saider = hab.db.knas.get(keys=(self.watched, watcher))
+                if saider is None:
+                    print(f"No key state from watcher {watcher} for {self.watched}")
+                    continue
+
+                ksn = hab.db.ksns.get(keys=(saider.qb64,))
+                states.append(diffState(watcher, mystate, ksn))
+
+            dups = [state for state in states if state.state == States.duplicitous]
+            ahds = [state for state in states if state.state == States.ahead]
+            bhds = [state for state in states if state.state == States.behind]
+
+            if len(dups) > 0:
+                logger.error(f"Duplicity detected for AID {self.watched}, local key state remains intact.")
+                for state in dups:
+                    logger.error(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+
+            elif len(ahds) > 0:
+                # Only group habs can be behind their witnesses
+                # First check for duplicity among the witnesses that are ahead (possible only if toad is below
+                # super majority)
+                digs = set([state.dig for state in ahds])
+                if len(digs) > 1:  # Duplicity across witness sets
+                    logger.error(f"There are multiple duplicitous events on watcher for {self.watched}")
+                    for state in ahds:
+                        logger.error(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+                elif len(ahds) >= self.toad:  # all witnesses that are ahead agree on the event
+                    logger.info(f"Threshold ({self.toad}) satisfying number of watchers ({len(ahds)}) are ahead")
+                    for state in ahds:
+                        logger.info(f"\tWatcher {state.wit} at Seq No. {state.sn} with digest: {state.dig}")
+
+                state = random.choice(ahds)
+                querier = querying.SeqNoQuerier(hby=self.hby, hab=hab, pre=self.watched, sn=state.sn, wits=[state.wit])
+                self.extend([querier])
+
+                while not querier.done:
+                    yield self.tock
+
+            elif len(bhds) > 0:
+                logger.info("The following watchers are behind the local KEL:")
+                for state in bhds:
+                    logger.info(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+
+                logger.info(f"Recommend the checking those watchers for access to {self.watched} witnesses")
+
+            else:
+                logger.info(f"Local key state is consistent with the {len(states)} (out of "
+                            f"{len(hab.kever.wits)} total) watchers that responded")
+
+        except ConfigurationError as e:
+            print(f"identifier prefix for {self.name} does not exist, incept must be run first", )
+            return -1
+
+        self.remove([self.mbx])

--- a/src/keri/app/cli/commands/watcher/list.py
+++ b/src/keri/app/cli/commands/watcher/list.py
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app import connecting
+from keri.app.cli.common import existing
+from keri.kering import ConfigurationError, Roles
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='List current watchers')
+parser.set_defaults(handler=lambda args: handle(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
+                    required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='22 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+
+def handle(args):
+    """ Command line handler for adding an aid to a watcher's list of AIds to watch
+
+    Parameters:
+        args(Namespace): parsed command line arguments
+
+    """
+
+    kwa = dict(args=args)
+    return [doing.doify(listWatchers, **kwa)]
+
+
+def listWatchers(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    alias = args.alias
+    base = args.base
+    bran = args.bran
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            org = connecting.Organizer(hby=hby)
+            if alias is None:
+                alias = existing.aliasInput(hby)
+
+            hab = hby.habByName(alias)
+
+            for (aid, role, eid), ender in hab.db.ends.getItemIter(keys=(hab.pre, Roles.watcher, )):
+                if ender.allowed:
+                    contact = org.get(eid)
+                    print(f"{contact['alias']}: {eid}")
+
+    except ConfigurationError as e:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/cli/commands/witness/list.py
+++ b/src/keri/app/cli/commands/witness/list.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app.cli.common import displaying, existing
+from keri.core import serdering
+from keri.kering import ConfigurationError
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='List AIDs of witness for the provided AID')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', default=None)
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+
+def handler(args):
+    kwa = dict(args=args)
+    return [doing.doify(listWitnesses, **kwa)]
+
+
+def listWitnesses(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    alias = args.alias
+    base = args.base
+    bran = args.bran
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            if alias is None:
+                alias = existing.aliasInput(hby)
+
+            hab = hby.habByName(alias)
+            for idx, wit in enumerate(hab.kever.wits):
+                print(f'{wit}')
+
+    except ConfigurationError as e:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -90,13 +90,13 @@ class LogQuerier(doing.DoDoer):
 
 class SeqNoQuerier(doing.DoDoer):
 
-    def __init__(self, hby, hab, pre, sn, **opts):
+    def __init__(self, hby, hab, pre, sn, wits=None, **opts):
         self.hby = hby
         self.hab = hab
         self.pre = pre
         self.sn = sn
         self.witq = agenting.WitnessInquisitor(hby=self.hby)
-        self.witq.query(src=self.hab.pre, pre=self.pre, sn="{:x}".format(self.sn))
+        self.witq.query(src=self.hab.pre, pre=self.pre, sn="{:x}".format(self.sn), wits=wits)
         super(SeqNoQuerier, self).__init__(doers=[self.witq], **opts)
 
     def recur(self, tyme, deeds=None):

--- a/src/keri/app/watching.py
+++ b/src/keri/app/watching.py
@@ -4,22 +4,194 @@ KERI
 keri.app.watching module
 
 """
+import random
 from collections import namedtuple
+
+from hio.base import doing
+from hio.help import decking
+
+from keri import help
+
+logger = help.ogler.getLogger()
 
 Stateage = namedtuple("Stateage", 'even ahead behind duplicitous')
 
 States = Stateage(even="even", ahead="ahead", behind="behind", duplicitous="duplicitous")
 
 
-class WitnessState:
-    wit: str
-    state: Stateage
-    sn: int
-    dig: str
+class DiffState:
+    """ Difference between a remote KeyStateRecord and local for the same AID.
+
+    Uses Stateage to represent whether the remote KSR is even, ahead, behind or duplicitous
+
+    """
+    wit: str  # The entity reporting the KSR (non-local)
+    state: Stateage  # The state of the remote KSR relative to local
+    sn: int  # The sequence number of the remote KSR
+    dig: str  # The digest of the latest event of the remote KSR
+
+
+class Adjudicator:
+    """ The Adjudicator of Key State
+
+    This class performs key state adjudication by checking any key state reported by the watcher set for a given
+    watched AID and compares the reported values against the local key state for the watched AID and the key state
+    of all other responding watchers.  It uses a per-adjudication threshold to determine what is acceptable duplicity
+    for each adjudication.
+
+    Cues are sent out for each round of adjudication with the following kins:
+
+       keyStateConsistent - Key state of all queries watchers is consistent with local key state
+       keyStateLagging - Key state from some watchers is behind local key state and other watchers
+       keyStateUpdate - A threshold satisfying number of watchers report new key state for watched AID
+       keyStateDuplicitous - Duplicity has been detected on some set of watchers (provided in the cue)
+
+    Consumers of the Adjudicator's cues are safe to retrieve new key state from one of the Watchers listed in the
+    cue of `keyStateUpdated` is received.  All other kins require controller intervention and should be bubbled up.
+
+    """
+
+    def __init__(self, hby, hab, msgs=None, cues=None):
+        """ Create instance of Adjudicator for adjudicating key state
+
+        Parameters:
+            hby (Habery): database and Habitat environment
+            hab (Hab): identifier database environment
+            msgs (Deck): incoming requests to adjudicate key state
+            cues (Deck): outgoing responses to adjudication of key state
+
+        """
+        self.hby = hby
+        self.hab = hab
+        self.msgs = msgs if msgs is not None else decking.Deck()
+        self.cues = cues if cues is not None else decking.Deck()
+
+    def performAdjudications(self):
+        """ Process loop of existing messages requesting key state adjudication """
+        while self.msgs:
+            msg = self.msgs.pull()
+
+            watched = msg["oid"]
+            toad = msg["toad"] if "toad" in msg else None
+
+            self.adjudicate(watched, toad)
+
+    def adjudicate(self, watched, toad=None):
+        """ Perform key state adjudication against the `watched` AID and provided threshold
+
+        If `toad` is not provided, the full set of watchers must come to consensus before `keyStateUpdate`
+        will be reported.
+
+        Parameters:
+            watched (str): qb64 AID to adjudicate for key state duplicity
+            toad (int): threshold of acceptable duplicity amongst available watchers
+
+
+        """
+        watchers = set()
+        for (cid, aid, oid), observed in self.hab.db.obvs.getItemIter(keys=(self.hab.pre,)):
+            if observed.enabled and oid == watched:
+                watchers.add(aid)
+
+        toad = int(toad) if toad else len(watchers)
+        if toad > len(watchers):
+            raise ValueError(f"Threshold of {toad} is greater than number watchers {len(watchers)}")
+
+        states = []
+        mystate = self.hab.kever.state()
+        for watcher in watchers:
+            saider = self.hab.db.knas.get(keys=(watched, watcher))
+            if saider is None:
+                print(f"No key state from watcher {watcher} for {watched}")
+                continue
+
+            ksn = self.hab.db.ksns.get(keys=(saider.qb64,))
+            states.append(diffState(watcher, mystate, ksn))
+
+        dups = [state for state in states if state.state == States.duplicitous]
+        ahds = [state for state in states if state.state == States.ahead]
+        bhds = [state for state in states if state.state == States.behind]
+
+        if len(dups) > 0:
+            cue = dict(kin="keyStateDuplicitous", cid=self.hab.pre, oid=watched, wids=watchers, dups=dups)
+            self.cues.append(cue)
+
+            logger.error(f"Duplicity detected for AID {watched}, local key state remains intact.")
+            for state in dups:
+                logger.error(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+
+        elif len(ahds) > 0:
+            # Only group habs can be behind their watchers
+            # First check for duplicity among the watchers that are ahead (possible only if toad is below
+            # super majority)
+            digs = set([state.dig for state in ahds])
+            if len(digs) > 1:  # Duplicity across watcher sets
+                cue = dict(kin="keyStateDuplicitous", cid=self.hab.pre, oid=watched, wids=watchers, dups=ahds)
+                self.cues.append(cue)
+
+                logger.error(f"There are multiple duplicitous events on watcher for {watched}")
+                for state in ahds:
+                    logger.error(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+
+            elif len(ahds) >= toad:  # all witnesses that are ahead agree on the event
+                logger.info(f"Threshold ({toad}) satisfying number of watchers ({len(ahds)}) are ahead")
+                for state in ahds:
+                    logger.info(f"\tWatcher {state.wit} at Seq No. {state.sn} with digest: {state.dig}")
+
+                state = random.choice(ahds)
+                cue = dict(kin="keyStateUpdate", cid=self.hab.pre, oid=watched, wids=watchers, sn=state.sn, aheads=ahds)
+                self.cues.append(cue)
+
+        elif len(bhds) > 0:
+            cue = dict(kin="keyStateLagging", cid=self.hab.pre, oid=watched, wids=watchers, behind=bhds)
+            self.cues.append(cue)
+
+            logger.info("The following watchers are behind the local KEL:")
+            for state in bhds:
+                logger.info(f"\tWatcher {state.wit} at seq No. {state.sn} with digest: {state.dig}")
+
+            logger.info(f"Recommend the checking those watchers for access to {watched} witnesses")
+
+        else:
+            cue = dict(kin="keyStateConsistent", cid=self.hab.pre, oid=watched, wids=watchers, states=states)
+            self.cues.append(cue)
+            logger.info(f"Local key state is consistent with the {len(states)} (out of "
+                        f"{len(watchers)} total) watchers that responded")
+
+
+class AdjudicationDoer(doing.Doer):
+    """ Doer class responsible for process adjudication requests in an Adjudicator's msgs """
+
+    def __init__(self, adjudicator):
+        """ Create instance of Doer for performing key state adjudications """
+        self.adjudicator = adjudicator
+        super(AdjudicationDoer, self).__init__()
+
+    def recur(self, tyme):
+        """ Perform one pass over all adjudication requests
+
+        Parameters:
+            tyme (float): relative cycle time
+
+        Returns:
+
+        """
+        self.adjudicator.performAdjudications()
 
 
 def diffState(wit, preksn, witksn):
-    witstate = WitnessState()
+    """ Return a record of the differences between the states provided by `wit` and local state
+
+    Parameters:
+        wit (str): qb64 AID of entity reporting key state
+        preksn (KeyStateRecord): Local key state of AID
+        witksn (KeyStateRecord): Key state of AID as provided by `wit`
+
+    Returns:
+        state (WitnessState): record indicating the differenced between the two provided KSN records
+
+    """
+    witstate = DiffState()
     witstate.wit = wit
     mysn = int(preksn.s, 16)
     mydig = preksn.d

--- a/src/keri/app/watching.py
+++ b/src/keri/app/watching.py
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.app.watching module
+
+"""
+from collections import namedtuple
+
+Stateage = namedtuple("Stateage", 'even ahead behind duplicitous')
+
+States = Stateage(even="even", ahead="ahead", behind="behind", duplicitous="duplicitous")
+
+
+class WitnessState:
+    wit: str
+    state: Stateage
+    sn: int
+    dig: str
+
+
+def diffState(wit, preksn, witksn):
+    witstate = WitnessState()
+    witstate.wit = wit
+    mysn = int(preksn.s, 16)
+    mydig = preksn.d
+    witstate.sn = int(witksn.f, 16)
+    witstate.dig = witksn.d
+
+    # At the same sequence number, check the DIGs
+    if mysn == witstate.sn:
+        if mydig == witstate.dig:
+            witstate.state = States.even
+        else:
+            witstate.state = States.duplicitous
+
+    # This witness is behind and will need to be caught up.
+    elif mysn > witstate.sn:
+        witstate.state = States.behind
+
+    # mysn < witstate.sn - We are behind this witness (multisig or restore situation).
+    # Must ensure that controller approves this event or a recovery rotation is needed
+    else:
+        witstate.state = States.ahead
+
+    return witstate

--- a/src/keri/app/watching.py
+++ b/src/keri/app/watching.py
@@ -6,6 +6,7 @@ keri.app.watching module
 """
 import random
 from collections import namedtuple
+from dataclasses import dataclass
 
 from hio.base import doing
 from hio.help import decking
@@ -19,6 +20,7 @@ Stateage = namedtuple("Stateage", 'even ahead behind duplicitous')
 States = Stateage(even="even", ahead="ahead", behind="behind", duplicitous="duplicitous")
 
 
+@dataclass
 class DiffState:
     """ Difference between a remote KeyStateRecord and local for the same AID.
 
@@ -191,27 +193,25 @@ def diffState(wit, preksn, witksn):
         state (WitnessState): record indicating the differenced between the two provided KSN records
 
     """
-    witstate = DiffState()
-    witstate.wit = wit
     mysn = int(preksn.s, 16)
     mydig = preksn.d
-    witstate.sn = int(witksn.f, 16)
-    witstate.dig = witksn.d
+    sn = int(witksn.s, 16)
+    dig = witksn.d
 
     # At the same sequence number, check the DIGs
-    if mysn == witstate.sn:
-        if mydig == witstate.dig:
-            witstate.state = States.even
+    if mysn == sn:
+        if mydig == dig:
+            state = States.even
         else:
-            witstate.state = States.duplicitous
+            state = States.duplicitous
 
     # This witness is behind and will need to be caught up.
-    elif mysn > witstate.sn:
-        witstate.state = States.behind
+    elif mysn > sn:
+        state = States.behind
 
     # mysn < witstate.sn - We are behind this witness (multisig or restore situation).
     # Must ensure that controller approves this event or a recovery rotation is needed
     else:
-        witstate.state = States.ahead
+        state = States.ahead
 
-    return witstate
+    return DiffState(wit, state, sn, dig)

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -198,7 +198,6 @@ class Revery:
 
         self.rtr.dispatch(serder=serder, saider=saider, cigars=cigars, tsgs=tsgs)
 
-
     def acceptReply(self, serder, saider, route, aid, osaider=None,
                     cigars=None, tsgs=None):
         """ Applies Best Available Data Acceptance policy to reply and signatures
@@ -494,8 +493,6 @@ class Revery:
                     # still waiting on missing prior event to validate
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.exception("Kevery unescrow attempt failed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrow attempt failed: %s", ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-tests.peer.mailboxing
+tests.app.storing
 
 """
 import os

--- a/tests/app/test_watching.py
+++ b/tests/app/test_watching.py
@@ -1,0 +1,159 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.watching
+
+"""
+from dataclasses import asdict
+
+import pytest
+
+from keri import core
+from keri.app import watching, habbing
+from keri.app.watching import DiffState
+from keri.core import coring
+from keri.db.basing import KeyStateRecord, ObservedRecord
+
+
+def test_diffstate():
+    d0 = {'vn': [1, 0],
+          'i': 'EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM',
+          's': '0',
+          'p': 'ElsHFkbZQjRb7xHnuE-wyiarIZ9j-1CEQ89I0E3WevcE',
+          'd': 'EBiIFxr_o1b4x1YR21PblAFpFG61qDghqFBDyVSOXYW0',
+          'f': '0',
+          'dt': '2021-06-09T17:35:54.169967+00:00',
+          'et': '2021-06-09T17:35:54.169967+00:00',
+          'kt': '1',
+          'k': ["D-HwiqmaETxls3vAVSh0xpXYTs94NUJX6juupWj_EgsA"],
+          'nt': '1',
+          'n': ["ED6lKZwg-BWl_jlCrjosQkOEhqKD4BJnlqYqWmhqPhaU"],
+          'bt': '0',
+          'b': [],
+          'c': [],
+          'ee': {
+              's': '0',
+              'd': 'EBiIFxr_o1b4x1YR21PblAFpFG61qDghqFBDyVSOXYW0',
+              'br': [],
+              'ba': []
+          },
+          'di': ''}
+
+    ksr0 = KeyStateRecord(**d0)
+    d1 = {'vn': [1, 0],
+          'i': 'EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM',
+          's': '0',
+          'p': 'ElsHFkbZQjRb7xHnuE-wyiarIZ9j-1CEQ89I0E3WevcE',
+          'd': 'Ey2pXEnaoQVwxA4jB6k0QH5G2Us-0juFL5hOAHAwIEkc',
+          'f': '0',
+          'dt': '2021-06-09T17:35:54.169967+00:00',
+          'et': '2021-06-09T17:35:54.169967+00:00',
+          'kt': '1',
+          'k': ["DxVTxls3vAwiqmaEXYTs94NUJX6juVSh0xpupEgsAWj_"],
+          'nt': '1',
+          'n': ["ED6lKZwg-BWl_jlCrjosQkOEhqKD4BJnlqYqWmhqPhaU"],
+          'bt': '0',
+          'b': [],
+          'c': [],
+          'ee': {
+              's': '0',
+              'd': 'EBiIFxr_o1b4x1YR21PblAFpFG61qDghqFBDyVSOXYW0',
+              'br': [],
+              'ba': []
+          },
+          'di': ''}
+    ksr1 = KeyStateRecord(**d1)
+
+    wat = "BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s"
+    diffstate = watching.diffState(wat, ksr0, ksr1)
+
+    # Sequence numbers are the same, digest different == duplicitous
+    assert asdict(diffstate) == {'wit': 'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s',
+                                 'state': 'duplicitous',
+                                 'sn': 0, 'dig': 'Ey2pXEnaoQVwxA4jB6k0QH5G2Us-0juFL5hOAHAwIEkc'}
+
+    # Same state == event
+    diffstate = watching.diffState(wat, ksr0, ksr0)
+    assert asdict(diffstate) == {'dig': 'EBiIFxr_o1b4x1YR21PblAFpFG61qDghqFBDyVSOXYW0',
+                                 'sn': 0,
+                                 'state': 'even',
+                                 'wit': 'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}
+
+    ksr1.s = "2"
+    diffstate = watching.diffState(wat, ksr0, ksr1)
+
+    # Sequence numbers are the same, digest different == duplicitous
+    assert asdict(diffstate) == {'dig': 'Ey2pXEnaoQVwxA4jB6k0QH5G2Us-0juFL5hOAHAwIEkc',
+                                 'sn': 2,
+                                 'state': 'ahead',
+                                 'wit': 'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}
+
+    ksr0.s = "3"
+    diffstate = watching.diffState(wat, ksr0, ksr1)
+
+    # Sequence numbers are the same, digest different == duplicitous
+    assert asdict(diffstate) == {'dig': 'Ey2pXEnaoQVwxA4jB6k0QH5G2Us-0juFL5hOAHAwIEkc',
+                                 'sn': 2,
+                                 'state': 'behind',
+                                 'wit': 'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}
+
+
+def test_adjudicator():
+    default_salt = core.Salter(raw=b'0123456789abcdef').qb64
+    with habbing.openHby(name="test", base="test", salt=default_salt) as hby:
+        hab = hby.makeHab("test")
+        assert hab.pre == "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3"
+        wat = "BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s"
+        saider = coring.Saider(qb64b=b'EClqKVJREM3MWKBqR2j712s3Z6rPxhqO-h-p8Ls6_9hQ')
+
+        ksr = hab.kever.state()
+        ksr0 = KeyStateRecord(**asdict(ksr))
+
+        hab.db.knas.pin(keys=(hab.pre, wat), val=saider)
+        hab.db.ksns.pin(keys=(saider.qb64, ), val=ksr0)
+        hab.db.obvs.pin(keys=(hab.pre, wat, hab.pre), val=ObservedRecord(enabled=True))
+
+        adj = watching.Adjudicator(hby=hby, hab=hab)
+
+        adj.adjudicate(hab.pre, 1)
+        assert len(adj.cues) == 1
+        cue = adj.cues.pull()
+
+        assert cue == {'cid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'kin': 'keyStateConsistent',
+                       'oid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'states': [DiffState(wit='BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s',
+                                            state='even',
+                                            sn=0,
+                                            dig='EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3')],
+                       'wids': {'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}}
+
+        hab.rotate()
+
+        adj.adjudicate(hab.pre, 1)
+        assert len(adj.cues) == 1
+        cue = adj.cues.pull()
+        assert cue == {'behind': [DiffState(wit='BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s',
+                                            state='behind',
+                                            sn=0,
+                                            dig='EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3')],
+                       'cid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'kin': 'keyStateLagging',
+                       'oid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'wids': {'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}}
+
+        ksr0.s = '1'
+        hab.db.ksns.pin(keys=(saider.qb64, ), val=ksr0)
+        adj.adjudicate(hab.pre, 1)
+        assert len(adj.cues) == 1
+        cue = adj.cues.pull()
+        assert cue == {'cid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'dups': [DiffState(wit='BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s',
+                                          state='duplicitous',
+                                          sn=1,
+                                          dig='EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3')],
+                       'kin': 'keyStateDuplicitous',
+                       'oid': 'EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3',
+                       'wids': {'BbIg_3-11d3PYxSInLN-Q9_T2axD6kkXd3XRgbGZTm6s'}}
+
+        with pytest.raises(ValueError):
+            adj.adjudicate(hab.pre, 2)


### PR DESCRIPTION
This PR includes:

* New kli commands for listing witnesss, watchers and mailboxes.
* Update to kli command `kli watcher add` to use new BADA-RUN protected data structures for tracking AIDs being observed by a watcher on behalf of a controller

* New kli command to perform key event adjudication across the set of watchers watching an AID.  This command will retrieve updated key state if a threshold satisfying number watchers response with non-duplicitous key state change.

* Addition to rotate and delegate confirm to all the specification of witness auth code time stamps.

* Update to delegation processing to propagate the delegator anchor event to witnesses after delegation approval

* New databases to track observed AIDs (observed by watchers) and delegation propogation escrow.

* Bug fix in `kli mailbox debug` to account for empty local state.