### PR TITLE
Allow local tever events when not in local mode

### DIFF
--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1559,8 +1559,7 @@ class Tevery:
                                      "".format(regk, self.registries))
             else:
                 if regk in self.registries:  # local event when not in local mode
-                    raise ValueError("Local event regk={} when nonlocal mode."
-                                     "".format(regk))
+                    pass
 
         if regk not in self.tevers:  # first seen for this registry
             if ilk in [Ilks.vcp]:


### PR DESCRIPTION
This PR solves issue https://github.com/WebOfTrust/keripy/issues/799
In KERIA, when a credential is issued to someone that is also part of the issuer, the credential is rejected by the issuee with `Local event regk={} when nonlocal mode`. 
I understand that this should be a valid case when the event is received as non local, so I'm proposing to remove the check that prevents to continue with the event processing. 
