### PR TITLE
Externalize the size limit for LMDB map size for Baser to an environment variable.

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -593,6 +593,9 @@ def reopenDB(db, clear=False, **kwa):
         db.close(clear=clear)
 
 
+KERIBaserMapSizeKey = "KERI_BASER_MAP_SIZE"
+
+
 class Baser(dbing.LMDBer):
     """
     Baser sets up named sub databases with Keri Event Logs within main database
@@ -934,6 +937,9 @@ class Baser(dbing.LMDBer):
         self.groups = oset()  # group hab ids
         self._kevers = dbdict()
         self._kevers.db = self  # assign db for read through cache of kevers
+
+        if (mapSize := os.getenv(KERIBaserMapSizeKey)) is not None:
+            self.MapSize = int(mapSize)
 
         super(Baser, self).__init__(headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -303,6 +303,7 @@ class LMDBer(filing.Filer):
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960
     MaxNamedDBs = 96
+    MapSize = 104857600
 
     def __init__(self, readonly=False, **kwa):
         """
@@ -378,7 +379,7 @@ class LMDBer(filing.Filer):
 
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
-        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=104857600,
+        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.MapSize,
                              mode=self.perm, readonly=self.readonly)
 
         self.opened = True if opened and self.env else False


### PR DESCRIPTION
This PR exposes the KERI_BASER_MAP_SIZE environment variable to allow setting the maximum file size for the main KERIpy LMDB database.  By default it is set to 100MB, but LMDB documentation suggests on 64-bit systems it is safe to set it as high as a terabyte or more as long as you have the disk space to handle.

You can also change this value and relaunch any process using KERIpy and it will take effect.