### PR TITLE
feat: raise MissingEntryError for missing credential

### DIFF
--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -485,6 +485,8 @@ class Reger(dbing.LMDBer):
         """
 
         creder = self.creds.get(keys=(said,))
+        if creder is None:
+            raise kering.MissingEntryError(f"no credential found with said {said}")
         prefixer, seqner, saider = self.cancs.get(keys=(said,))
         return creder, prefixer, seqner, saider
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -115,6 +115,9 @@ def test_verifier(seeder):
         for idx, cred in enumerate(creds):
             assert dcre.sad == cred["sad"]
 
+        with pytest.raises(kering.MissingEntryError):
+            regery.reger.cloneCred(said="nonexistantsaid")
+
     """End Test"""
 
 


### PR DESCRIPTION
Fetching a missing credential through KERIA gives a 500 - see description of https://github.com/WebOfTrust/keria/pull/282

This small PR be a cleaner solution that the current PR as we can just catch `kering.MissingEntryError`.

Note - the 500 error comes from the `cancs.get` line but looking at the existing code for saving credentials, it should exist in `cancs` if it's in `creds`.