### PR TITLE
2 fixes for delegation:

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -30,3 +30,16 @@ PID_LIST+=" $pid"
 wait $PID_LIST
 
 kli status --name delegate --alias delegate
+
+kli init --name validator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9vAl
+
+OOBI=$(kli oobi generate --name delegator --alias delegator --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegator --oobi "${OOBI}"
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegate --oobi "${OOBI}"
+
+AID=$(kli aid --name delegate --alias delegate)
+kli kevers --name validator --prefix "${AID}"
+
+
+

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1617,7 +1617,7 @@ class Baser(dbing.LMDBer):
             kever (Kever): Kever from which to clone the delegator's AID.
 
         """
-        if kever.delegated:
+        if kever.delegated and kever.delpre in self.kevers:
             dkever = self.kevers[kever.delpre]
             yield from self.cloneDelegation(dkever)
 


### PR DESCRIPTION
- Update clone delegation to not raise an exception if the delegator's KEL is not in local kevers
- Fix event handling to walk the KEL to find an anchoring event if it exists.

These changes close #842 by allowing for a witness to return a KEL for a delegated AID without the AES couple for approved events and without the delegator's KEL.

This is the expected behavior for a witness as it should not be assumed that a witness perform watcher functionality.  Any validator will have to be introduced to the delegator or OOBI with the delegator before validating the KEL of the delegate.