### PR TITLE
Fixes for anchoring multiple delegates in a single delegator event, exn escrow timeout.

### DIFF
--- a/src/keri/app/cli/commands/event.py
+++ b/src/keri/app/cli/commands/event.py
@@ -1,0 +1,84 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+import json
+
+from hio import help
+from hio.base import doing
+
+from keri.app.cli.common import existing
+from keri.kering import ConfigurationError
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Print an event from an AID, or specific values from an event (defaults to latest event).')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', default=None,
+                    required=True)
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--said', '-S', help='Print the SAID of the event in question', action="store_true")
+parser.add_argument('--sn', '-s', help='Print the decimal value of the sequence number of the event in question',
+                    action="store_true")
+parser.add_argument('--snh', help='Print the decimal value of the sequence number of the event in question',
+                    action="store_true")
+parser.add_argument('--raw', '-r', help='Print the raw, signed value of the event', action="store_true")
+parser.add_argument('--json', '-j', help='Pretty print the JSON of the event.', action="store_true")
+parser.add_argument('--seal', help='Print an anchorable seal of the event in question.', action="store_true")
+
+
+def handler(args):
+    kwa = dict(args=args)
+    return [doing.doify(event, **kwa)]
+
+
+def event(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    alias = args.alias
+    base = args.base
+    bran = args.bran
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            if alias is None:
+                alias = existing.aliasInput(hby)
+
+            hab = hby.habByName(alias)
+            if hab is None:
+                print(f"{alias} is not a valid identifier")
+
+            if args.said:
+                print(hab.kever.serder.said)
+
+            if args.sn:
+                print(hab.kever.sn)
+
+            if args.snh:
+                print(hab.kever.serder.snh)
+
+            if args.raw:
+                print(hab.kever.serder.raw.decode("utf-8"))
+
+            if args.json:
+                print(hab.kever.serder.pretty())
+
+            if args.seal:
+                seal = dict(i=hab.pre, s=hab.kever.serder.snh, d=hab.kever.serder.said)
+                print(json.dumps(seal))
+
+    except ConfigurationError as e:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -138,10 +138,10 @@ class InceptDoer(doing.DoDoer):
                                     reopen=True,
                                     clear=False)
         self.endpoint = endpoint
-        self.proxy = proxy
         self.hby = existing.setupHby(name=name, base=base, bran=bran, cf=cf)
+        self.proxy = self.hby.habByName(proxy) if proxy is not None else None
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
-        self.swain = delegating.Anchorer(hby=self.hby, proxy=self.hby.habByName(self.proxy))
+        self.swain = delegating.Anchorer(hby=self.hby, proxy=self.proxy)
         self.postman = forwarding.Poster(hby=self.hby)
         self.mbx = indirecting.MailboxDirector(hby=self.hby, topics=['/receipt', "/replay", "/reply"])
         doers = [self.hbyDoer, self.postman, self.mbx, self.swain, doing.doify(self.inceptDo)]
@@ -185,7 +185,11 @@ class InceptDoer(doing.DoDoer):
                     _ = yield self.tock
 
         if hab.kever.delpre:
-            yield from self.postman.sendEvent(hab=hab, fn=hab.kever.sn)
+            if self.proxy is not None:
+                sender = self.proxy
+            else:
+                sender = hab
+            yield from self.postman.sendEventToDelegator(hab=hab, sender=sender, fn=hab.kever.sn)
 
         print(f'Prefix  {hab.pre}')
         for idx, verfer in enumerate(hab.kever.verfers):

--- a/src/keri/app/cli/commands/multisig/incept.py
+++ b/src/keri/app/cli/commands/multisig/incept.py
@@ -175,7 +175,7 @@ class GroupMultisigIncept(doing.DoDoer):
             yield self.tock
 
         if ghab.kever.delpre:
-            yield from self.postman.sendEvent(hab=ghab, fn=ghab.kever.sn)
+            yield from self.postman.sendEventToDelegator(hab=ghab, sender=ghab.mhab, fn=ghab.kever.sn)
 
         print()
         displaying.printIdentifier(self.hby, ghab.pre)

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -234,7 +234,7 @@ class GroupMultisigRotate(doing.DoDoer):
             yield self.tock
 
         if ghab.kever.delpre:
-            yield from self.postman.sendEvent(hab=ghab, fn=ghab.kever.sn)
+            yield from self.postman.sendEventToDelegator(hab=ghab, sender=ghab.mhab, fn=ghab.kever.sn)
 
         print()
         displaying.printIdentifier(self.hby, ghab.pre)

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -173,10 +173,14 @@ class Anchorer(doing.DoDoer):
                     if not witnessed:
                         continue
                 logger.info(f"Witness receipts complete, waiting for delegation approval.")
+                if pre not in self.hby.habs:
+                    continue
+
                 hab = self.hby.habs[pre]
                 delpre = hab.kever.delpre  # get the delegator identifier
                 dkever = hab.kevers[delpre]  # and the delegator's kever
                 smids = []
+
                 if isinstance(hab, GroupHab):
                     phab = hab.mhab
                     smids = hab.smids
@@ -208,6 +212,9 @@ class Anchorer(doing.DoDoer):
 
         """
         for (pre, said), serder in self.hby.db.dpub.getItemIter():  # group partial witness escrow
+            if pre not in self.publishers:
+                continue
+
             publisher = self.publishers[pre]
 
             if not publisher.idle:
@@ -220,8 +227,11 @@ class Anchorer(doing.DoDoer):
             self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Saider(qb64=serder.said))
 
     def publishDelegator(self, pre):
-        hab = self.hby.habs[pre]
+        if pre not in self.publishers:
+            return
+
         publisher = self.publishers[pre]
+        hab = self.hby.habs[pre]
         self.extend([publisher])
         for msg in hab.db.cloneDelegation(hab.kever):
             publisher.msgs.append(dict(pre=hab.pre, msg=bytes(msg)))

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -135,15 +135,14 @@ class Poster(doing.DoDoer):
 
         return False
 
-    def sendEvent(self, hab, fn=0):
+    def sendEventToDelegator(self, sender, hab, fn=0):
         """ Returns generator for sending event and waiting until send is complete """
         # Send KEL event for processing
         icp = self.hby.db.cloneEvtMsg(pre=hab.pre, fn=fn, dig=hab.kever.serder.saidb)
         ser = serdering.SerderKERI(raw=icp)
         del icp[:ser.size]
 
-        sender = hab.mhab.pre if isinstance(hab, GroupHab) else hab.pre
-        self.send(src=sender, dest=hab.kever.delpre, topic="delegate", serder=ser, attachment=icp)
+        self.send(src=sender.pre, dest=hab.kever.delpre, topic="delegate", serder=ser, attachment=icp)
         while True:
             if self.cues:
                 cue = self.cues.popleft()

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1106,6 +1106,10 @@ class Baser(dbing.LMDBer):
         # exchange message partial signature escrow
         self.epse = subing.SerderSuber(db=self, subkey="epse.")
 
+        # exchange message PS escrow date time of message
+        self.epsd = subing.CesrSuber(db=self, subkey="epsd.",
+                                     klas=coring.Dater)
+
         # exchange messages
         # TODO: clean
         self.exns = subing.SerderSuber(db=self, subkey="exns.")

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -77,7 +77,7 @@ class Exchanger:
         essrs = kwargs["essrs"] if "essrs" in kwargs else []
 
         behavior = self.routes[route] if route in self.routes else None
-        if tsgs is not None:
+        if tsgs:
             for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
                 if sender != prefixer.qb64:  # sig not by aid
                     raise MissingSignatureError(f"Exchange process: skipped signature not from aid="
@@ -99,7 +99,7 @@ class Exchanger:
                     raise MissingSignatureError(f"Not enough signatures in  {indices}"
                                                 f" for evt = {serder.ked}.")
 
-        elif cigars is not None:
+        elif cigars:
             for cigar in cigars:
                 if sender != cigar.verfer.qb64:  # cig not by aid
                     raise MissingSignatureError(" process: skipped cig not from aid="
@@ -110,6 +110,7 @@ class Exchanger:
                                                 " for evt = {}.".format(cigar,
                                                                         serder.ked))
         else:
+            self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed)
             raise MissingSignatureError("Failure satisfying exn, no cigs or sigs"
                                         " for evt = {}.".format(serder.ked))
 


### PR DESCRIPTION
This PR includes:

* Updating delegation logic to allow for multiple delegation inception commands to run simultaneously.  
* Ensure proper use of the proxy for delegation inception and rotation kli commands.
* Add timeout to exn escrow for partial sig escrow of peer-to-peer messages.

The first 2 are in support of creating many delegates at once and anchoring them all in the same delegator event.