### PR TITLE
Missing sn in CloneCred after fix in PR #682

### DIFF
--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -402,7 +402,11 @@ class Reger(dbing.LMDBer):
             atc = bytearray(signing.serialize(creder, prefixer, seqner, saider))
             del atc[0:creder.size]
 
-            iss = bytearray(self.cloneTvtAt(creder.said, sn=seqner.sn))
+            regk = creder.regi
+            status = self.tevers[regk].vcState(saider.qb64)
+            schemer = db.schema.get(creder.schema)
+
+            iss = bytearray(self.cloneTvtAt(creder.said, sn=0 if status.et == coring.Ilks.iss else 1))
             iserder = serdering.SerderKERI(raw=iss)
             issatc = bytes(iss[iserder.size:])
 
@@ -418,10 +422,6 @@ class Reger(dbing.LMDBer):
 
                 chainSaids.append(coring.Saider(qb64=p["n"]))
             chains = self.cloneCreds(chainSaids, db)
-
-            regk = creder.regi
-            status = self.tevers[regk].vcState(saider.qb64)
-            schemer = db.schema.get(creder.schema)
 
             cred = dict(
                 sad=creder.sad,

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -406,11 +406,15 @@ class Reger(dbing.LMDBer):
             status = self.tevers[regk].vcState(saider.qb64)
             schemer = db.schema.get(creder.schema)
 
-            iss = bytearray(self.cloneTvtAt(creder.said, sn=0 if status.et == coring.Ilks.iss else 1))
+            iss = bytearray(self.cloneTvtAt(creder.said, sn=0))
             iserder = serdering.SerderKERI(raw=iss)
             issatc = bytes(iss[iserder.size:])
-
             del iss[0:iserder.size]
+            if status.et in [coring.Ilks.rev, coring.Ilks.brv]:
+                rev = bytearray(self.cloneTvtAt(creder.said, sn=1))
+                rserder = serdering.SerderKERI(raw=rev)
+                revatc = bytes(rev[rserder.size:])
+                del rev[0:rserder.size]
 
             chainSaids = []
             for k, p in (creder.edge.items() if creder.edge is not None else {}):
@@ -428,6 +432,8 @@ class Reger(dbing.LMDBer):
                 atc=atc.decode("utf-8"),
                 iss=iserder.sad,
                 issatc=issatc.decode("utf-8"),
+                rev=rserder.sad if status.et in [coring.Ilks.rev, coring.Ilks.brv] else None,
+                revatc=revatc.decode("utf-8") if status.et in [coring.Ilks.rev, coring.Ilks.brv] else None,
                 pre=creder.issuer,
                 schema=schemer.sed,
                 chains=chains,
@@ -452,6 +458,21 @@ class Reger(dbing.LMDBer):
                 ancatc = bytes(anc[aserder.size:])
                 cred['anc'] = aserder.sad
                 cred['ancatc'] = ancatc.decode("utf-8"),
+            
+            if status.et in [coring.Ilks.rev, coring.Ilks.brv]:
+                ctr = core.Counter(qb64b=rev, strip=True, gvrsn=kering.Vrsn_1_0)
+                if ctr.code == counting.CtrDex_1_0.AttachmentGroup:
+                    ctr = core.Counter(qb64b=rev, strip=True, gvrsn=kering.Vrsn_1_0)
+
+                if ctr.code == counting.CtrDex_1_0.SealSourceCouples:
+                    coring.Seqner(qb64b=rev, strip=True)
+                    saider = coring.Saider(qb64b=rev)
+
+                    anc = db.cloneEvtMsg(pre=creder.issuer, fn=0, dig=saider.qb64b)
+                    aserder = serdering.SerderKERI(raw=anc)
+                    ancatc = bytes(anc[aserder.size:])
+                    cred['revanc'] = aserder.sad
+                    cred['revancatc'] = ancatc.decode("utf-8"),
 
             creds.append(cred)
 

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -402,7 +402,7 @@ class Reger(dbing.LMDBer):
             atc = bytearray(signing.serialize(creder, prefixer, seqner, saider))
             del atc[0:creder.size]
 
-            iss = bytearray(self.cloneTvtAt(creder.said))
+            iss = bytearray(self.cloneTvtAt(creder.said, sn=seqner.sn))
             iserder = serdering.SerderKERI(raw=iss)
             issatc = bytes(iss[iserder.size:])
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -112,8 +112,9 @@ def test_verifier(seeder):
         # also try it via the cloneCreds function
         creds = regery.reger.cloneCreds(saids=saider, db=hab.db)
 
-        for idx, cred in enumerate(creds):
+        for cred in creds:
             assert dcre.sad == cred["sad"]
+            assert cred['rev'] is None
 
         with pytest.raises(kering.MissingEntryError):
             regery.reger.cloneCred(said="nonexistantsaid")
@@ -658,5 +659,16 @@ def test_verifier_chained_credential(seeder):
         with pytest.raises(kering.RevokedChainError):
             vicverfer.processCredential(vLeiCreder, prefixer=ian.kever.prefixer, seqner=seqner,
                                         saider=coring.Saider(qb64=ian.kever.serder.said))
+        
+        creds = ronreg.reger.cloneCreds(saids=[coring.Saider(qb64=creder.said)], db=ronHby.db)
+        for cred in creds:
+            assert cred['status']['et'] == 'rev'
+            assert cred['rev'] is not None
+            assert cred['rev']['i'] == creder.said
+            assert cred['revatc'] is not None
+            assert cred['revanc'] is not None
+            assert cred['revanc']['s'] == '3'
+            assert cred['revanc']['a'][0]['s'] == '1'
+            assert cred['revancatc'] is not None
 
     """End Test"""


### PR DESCRIPTION
PR https://github.com/WebOfTrust/keripy/pull/682 omitted specifying `sn` in the call to `cloneTvtAt` at line 405. This is important for revoked credentials.
See diff changes on line 405 of PR https://github.com/WebOfTrust/keripy/pull/682

This PR inserts again the `sn` parameter.

Additionally, I corrected the sn used to search in the Tel, sn=0 for `iss` or sn=1 for `rev`
