### PR TITLE
feat: tel state noticer to query for tel updates

### DIFF
--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -172,6 +172,10 @@ class TelStateNoticer(doing.DoDoer):
                     behind = False
 
                     if isinstance(record, viring.RegStateRecord):
+                        if self.i:  # always sent with VcStateRecord, or could be from diff TelStateNoticer
+                            self.cues.append(cue)
+                            return super(TelStateNoticer, self).recur(tyme, deeds)
+
                         if record.i != self.ri:
                             self.cues.append(cue)  # from a diff TelStateNoticer
                             return super(TelStateNoticer, self).recur(tyme, deeds)

--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -202,7 +202,8 @@ class TelStateNoticer(doing.DoDoer):
                             self.extend([VcLogQuerier(hby=self.hby, tvy=self.tvy, hab=self.hab, pre=self.pre, record=record)])
 
                     self.remove([self.witq])
-                    return True
+                    if not behind:
+                        return True
                 case _:
                     self.cues.append(cue)
 

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -10,7 +10,7 @@ from ordered_set import OrderedSet as oset
 
 from . import forwarding
 from .. import help
-from ..core import coring, serdering
+from ..core import coring, serdering, eventing
 from ..core.coring import MtrDex
 from ..db import dbing, subing
 
@@ -292,8 +292,6 @@ class Respondant(doing.DoDoer):
 
             elif cueKin in ("reply",):
                 src = cue["src"]
-                serder = cue["serder"]
-
                 dest = cue["dest"]
 
                 if dest not in self.hby.kevers:
@@ -302,6 +300,11 @@ class Respondant(doing.DoDoer):
                 hab = self.hby.habByPre(src)
                 if hab is None:
                     continue
+
+                if "serder" in cue:
+                    serder = cue["serder"]
+                else:
+                    serder = eventing.reply(route=cue["route"], data=cue["data"])
 
                 atc = hab.endorse(serder)
                 del atc[:serder.size]

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -742,21 +742,6 @@ class UnverifiedProofError(ValidationError):
     """
 
 
-class OutOfOrderKeyStateError(ValidationError):
-    """
-    Error referenced event missing from log so can't verify this key state event
-    Usage:
-        raise OutOfOrderKeyStateError("error message")
-    """
-
-
-class OutOfOrderTxnStateError(ValidationError):
-    """
-    Error referenced event missing from log so can't verify this txn state event
-    Usage:
-        raise OutOfOrderTxnStateError("error message")
-    """
-
 class MisfitEventSourceError(ValidationError):
     """
     Error referenced event missing from log so can't verify this txn state event

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1648,11 +1648,11 @@ class Tevery:
             if ri in self.tevers:
                 tever = self.tevers[ri]
                 tsn = tever.state()
-                self.cues.push(dict(kin="reply", route=f"/tsn/registry/{src}", data=asdict(tsn), dest=source.qb64))
+                self.cues.push(dict(kin="reply", route=f"/tsn/registry/{src}", src=src, data=asdict(tsn), dest=source.qb64))
 
                 if vcpre := qry["i"]:
                     tsn = tever.vcState(vci=vcpre)
-                    self.cues.push(dict(kin="reply", route=f"/tsn/credential/{src}", data=asdict(tsn), dest=source.qb64))
+                    self.cues.push(dict(kin="reply", route=f"/tsn/credential/{src}", src=src, data=asdict(tsn), dest=source.qb64))
 
         else:
             raise ValidationError("invalid query message {} for evt = {}".format(ilk, ked))

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -393,6 +393,15 @@ def test_tel_querying(seeder):
         assert len(vcLogDoer.doers) == 0
         assert vcLogDoer.done is True
 
+        # tsn against vc - no update needed
+        inqTvy.cues.clear()
+        inqTvy.cues.append(cue)
+        tsnDoer = TelStateNoticer(hby=hby, hab=inqHab, tvy=inqTvy, pre=subHab.pre, ri=issuer.regk, i=iss.pre)
+        deeds = doist.enter(doers=[tsnDoer])
+        doist.recur(deeds=deeds)
+        assert len(tsnDoer.doers) == 0
+        assert tsnDoer.done is True
+
         # tsn with vc if management registry does not exist
         inqTvyEmpty = teventing.Tevery(db=hby.db, lax=True)
         inqTvyEmpty.cues.append(cue)

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -230,7 +230,6 @@ def test_tel_querying(seeder):
         assert len(tsnDoer.doers) == 1
         regLogDoer = tsnDoer.doers[0]
         assert isinstance(regLogDoer, RegistryLogQuerier)
-        assert tsnDoer.done is True
         assert len(regLogDoer.doers) == 1
 
         anc = subHab.makeOwnEvent(1)
@@ -321,7 +320,6 @@ def test_tel_querying(seeder):
         assert len(tsnDoer.doers) == 1
         vcLogDoer = tsnDoer.doers[0]
         assert isinstance(vcLogDoer, VcLogQuerier)
-        assert tsnDoer.done is True
         assert len(vcLogDoer.doers) == 1
 
         # receive vc updates
@@ -379,7 +377,6 @@ def test_tel_querying(seeder):
         assert len(tsnDoer.doers) == 1
         vcLogDoer = tsnDoer.doers[0]
         assert isinstance(vcLogDoer, VcLogQuerier)
-        assert tsnDoer.done is True
 
         # receive vc updates
         anc = subHab.makeOwnEvent(3)
@@ -412,4 +409,3 @@ def test_tel_querying(seeder):
         assert len(tsnDoer.doers) == 1
         vcLogDoer = tsnDoer.doers[0]
         assert isinstance(vcLogDoer, VcLogQuerier)
-        assert tsnDoer.done is True


### PR DESCRIPTION
Working towards TEL Observers - made some changes to make TSN behave same as KSN with a noticer that will fetch any remaining items.

This isn't _fully_ complete as I need some feedback - I'm really not sure if we are meant to escrow notices of new events that we haven't received yet.

Looking back in the history, we did this for KSN too but changed it in #441 and #538 so thinking it might make sense for TSN to behave the same way so that we can have efficient TEL observers. So I've made some changes there to be more like KSN.

If this isn't the right approach, we need to do something to trigger fetching of tels - the `telquery` calls for escrows aren't right atm for the same reason as #865 - no src so messages are never sent.