### PR TITLE
Two command line changes:

### DIFF
--- a/src/keri/app/cli/commands/oobi/resolve.py
+++ b/src/keri/app/cli/commands/oobi/resolve.py
@@ -107,6 +107,11 @@ class OobiDoer(doing.DoDoer):
             yield 0.25
 
         obr = self.obi.hby.db.roobi.get(keys=(self.oobi,))
+        if self.force:
+            while obr.cid not in self.hby.kevers:
+                self.hby.kvy.processEscrows()
+                yield 0.25
+
         print(self.oobi, obr.state)
 
         self.remove([self.hbyDoer, *self.obi.doers, *self.authn.doers])

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -16,6 +16,7 @@ from hio.help import Hict
 from keri.app import httping, connecting
 from keri.app.agenting import httpClient
 from keri.app.cli.common import existing
+from keri.app.httping import CESR_DESTINATION_HEADER
 from keri.core import coring
 
 logger = help.ogler.getLogger()
@@ -107,7 +108,8 @@ class AuthDoer(doing.DoDoer):
             fargs['delkel'] = delkel.decode("utf-8")
 
         headers = (Hict([
-            ("Content-Type", "multipart/form-data")
+            ("Content-Type", "multipart/form-data"),
+            (CESR_DESTINATION_HEADER, self.witness)
         ]))
 
         client, clientDoer = httpClient(self.hab, self.witness)

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -275,7 +275,7 @@ def siginput(name, method, path, headers, fields, hab=None, signers=None, expire
         expires (str): iso8601 formated date string indicating exiration of header signature
         signers (list): Optional signer objects used to sign the values
         hab (Hab): Optional Hab used to sign the values.  One of signers or Hab is required
-        fields (str): Fields in request to sign.  Includes special fields as well as Header fields
+        fields (list): Fields in request to sign.  Includes special fields as well as Header fields
         headers (dict): HTTP request headers
         path (str): HTTP request path
         method (str): HTTP request method (POST, GET, PUT, etc)


### PR DESCRIPTION
- OOBI resolve now waits until the AID is in Kevers before completing
- Witness authenticate includes the CESR http header.