### PR TITLE
Fix calls to out of order escrow

### DIFF
--- a/scripts/demo/basic/challenge.sh
+++ b/scripts/demo/basic/challenge.sh
@@ -11,6 +11,9 @@ kli ends add --name cha2 --alias cha2 --eid BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZE
 cha1_oobi="$(kli oobi generate --name cha1 --alias cha1 --role witness | sed -n '2 p')"
 cha2_oobi="$(kli oobi generate --name cha2 --alias cha2 --role witness | sed -n '2 p')"
 
+echo "${cha1_oobi}"
+echo "${cha2_oobi}"
+
 kli oobi resolve --name cha1 --oobi-alias cha2 --oobi "${cha2_oobi}"
 kli oobi resolve --name cha2 --oobi-alias cha1 --oobi "${cha1_oobi}"
 

--- a/src/keri/app/cli/commands/did/generate.py
+++ b/src/keri/app/cli/commands/did/generate.py
@@ -73,20 +73,20 @@ def generate(tymth, tock=0.0, **opts):
                 sys.exit(-1)
 
             wit = random.choice(hab.kever.wits)
-            urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+            urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) \
+                or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
             if not urls:
                 raise kering.ConfigurationError(f"unable to query witness {wit}, no http endpoint")
 
-            url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-            up = urlparse(url)
-            enc = urllib.parse.quote_plus(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/witness")
+            url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+            enc = urllib.parse.quote_plus(f"{url.rstrip("/")}/oobi/{hab.pre}/witness")
             print(f"did:keri:{hab.pre}?oobi={enc}")
         elif role in (kering.Roles.controller,):
-            urls = hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.http) or hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.https)
+            urls = hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.http) \
+                   or hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.https)
             if not urls:
                 print(f"{alias} identifier {hab.pre} does not have any controller endpoints")
                 return
-            url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-            up = urlparse(url)
-            enc = urllib.parse.quote_plus(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/controller")
+            url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+            enc = urllib.parse.quote_plus(f"{url.rstrip("/")}/oobi/{hab.pre}/controller")
             print(f"did:keri:{hab.pre}?oobi={enc}")

--- a/src/keri/app/cli/commands/ipex/grant.py
+++ b/src/keri/app/cli/commands/ipex/grant.py
@@ -111,8 +111,8 @@ class GrantDoer(doing.DoDoer):
         iserder = serdering.SerderKERI(raw=bytes(iss))
         seqner = coring.Seqner(sn=iserder.sn)
 
-        serder = self.hby.db.fetchAllSealingEventByEventSeal(creder.sad['i'],
-                        seal=dict(i=iserder.pre, s=seqner.snh, d=iserder.said))
+        serder = self.hby.db.fetchLastSealingEventByEventSeal(creder.sad['i'],
+                                                              seal=dict(i=iserder.pre, s=seqner.snh, d=iserder.said))
         anc = self.hby.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
 
         exn, atc = protocoling.ipexGrantExn(hab=self.hab, recp=recp, message=self.message, acdc=acdc, iss=iss, anc=anc,

--- a/src/keri/app/cli/commands/oobi/generate.py
+++ b/src/keri/app/cli/commands/oobi/generate.py
@@ -4,7 +4,6 @@ keri.kli.commands.oobi module
 
 """
 import argparse
-from urllib.parse import urlparse
 
 import sys
 from hio import help
@@ -66,21 +65,21 @@ def generate(tymth, tock=0.0, **opts):
                 sys.exit(-1)
 
             for wit in hab.kever.wits:
-                urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+                urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) \
+                       or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
                 if not urls:
                     raise kering.ConfigurationError(f"unable to query witness {wit}, no http endpoint")
             
-                url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-                up = urlparse(url)
-                print(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/witness")
+                url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+                print(f"{url.rstrip("/")}/oobi/{hab.pre}/witness")
         elif role in (kering.Roles.controller,):
-            urls = hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.http) or hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.https)
+            urls = hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.http) \
+                   or hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.https)
             if not urls:
                 print(f"{alias} identifier {hab.pre} does not have any controller endpoints")
                 return
-            url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-            up = urlparse(url)
-            print(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/controller")
+            url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+            print(f"{url.rstrip("/")}/oobi/{hab.pre}/controller")
         elif role in (kering.Roles.mailbox,):
             for (_, _, eid), end in hab.db.ends.getItemIter(keys=(hab.pre, kering.Roles.mailbox, )):
                 if not (end.allowed and end.enabled is not False):
@@ -91,6 +90,5 @@ def generate(tymth, tock=0.0, **opts):
                 if not urls:
                     print(f"{alias} identifier {hab.pre} does not have any mailbox endpoints")
                     return
-                url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-                up = urlparse(url)
-                print(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/mailbox/{eid}")
+                url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+                print(f"{url.rstrip("/")}/oobi/{hab.pre}/mailbox/{eid}")

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -138,7 +138,7 @@ class Anchorer(doing.DoDoer):
             dkever = self.hby.kevers[kever.delpre]
 
             seal = dict(i=serder.pre, s=serder.snh, d=serder.said)
-            if dserder := self.hby.db.fetchAllSealingEventByEventSeal(dkever.prefixer.qb64, seal=seal):
+            if dserder := self.hby.db.fetchLastSealingEventByEventSeal(dkever.prefixer.qb64, seal=seal):
                 seqner = coring.Seqner(sn=dserder.sn)
                 couple = seqner.qb64b + dserder.saidb
                 dgkey = dbing.dgKey(kever.prefixer.qb64b, kever.serder.saidb)

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -171,8 +171,8 @@ class Counselor(doing.DoDoer):
                     self.hby.db.cgms.put(keys=(pre, seqner.qb64), val=saider)
 
             else:  # Not witnesser, we need to look for the anchor and then wait for receipts
-                if serder := self.hby.db.fetchAllSealingEventByEventSeal(kever.delpre,
-                                                                         seal=anchor):
+                if serder := self.hby.db.fetchLastSealingEventByEventSeal(kever.delpre,
+                                                                          seal=anchor):
                     aseq = coring.Seqner(sn=serder.sn)
                     couple = aseq.qb64b + serder.saidb
                     dgkey = dbing.dgKey(pre, saider.qb64b)

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -115,15 +115,15 @@ class OobiResource:
         if role in (kering.Roles.witness,):  # Fetch URL OOBIs for all witnesses
             oobis = []
             for wit in hab.kever.wits:
-                urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+                urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) \
+                       or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
                 if not urls:
                     rep.status = falcon.HTTP_404
                     rep.text = f"unable to query witness {wit}, no http endpoint"
                     return
 
-                url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-                up = urlparse(url)
-                oobis.append(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/witness/{wit}")
+                url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+                oobis.append(f"{url.rstrip("/")}/oobi/{hab.pre}/witness/{wit}")
             res["oobis"] = oobis
         elif role in (kering.Roles.controller,):  # Fetch any controller URL OOBIs
             oobis = []
@@ -134,8 +134,7 @@ class OobiResource:
                 rep.text = f"unable to query controller {hab.pre}, no http endpoint"
                 return
             url = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
-            up = urlparse(url)
-            oobis.append(f"{up.scheme}://{up.hostname}:{up.port}/oobi/{hab.pre}/controller")
+            oobis.append(f"{url.rstrip("/")}/oobi/{hab.pre}/controller")
             res["oobis"] = oobis
         else:
             rep.status = falcon.HTTP_404

--- a/src/keri/app/querying.py
+++ b/src/keri/app/querying.py
@@ -140,8 +140,7 @@ class AnchorQuerier(doing.DoDoer):
         if self.pre not in self.hab.kevers:
             return False
 
-        kever = self.hab.kevers[self.pre]
-        if self.hby.db.fetchAllSealingEventByEventSeal(self.pre, seal=self.anchor):
+        if self.hby.db.fetchLastSealingEventByEventSeal(self.pre, seal=self.anchor):
             self.remove([self.witq])
             return True
 

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -3788,7 +3788,7 @@ class Kevery:
 
             else:  # not inception so can't verify sigs etc, add to out-of-order escrow
                 self.escrowOOEvent(serder=serder, sigers=sigers,
-                                   seqner=delseqner, saider=delsaider, wigers=wigers)
+                                   seqner=delseqner, saider=delsaider, wigers=wigers, local=local)
                 raise OutOfOrderError("Out-of-order event={}.".format(ked))
 
         else:  # already accepted inception event for pre so already first seen
@@ -3829,7 +3829,7 @@ class Kevery:
                 if sn > sno:  # sn later than sno so out of order escrow
                     # escrow out-of-order event
                     self.escrowOOEvent(serder=serder, sigers=sigers,
-                                       seqner=delseqner, saider=delsaider, wigers=wigers)
+                                       seqner=delseqner, saider=delsaider, wigers=wigers, local=local)
                     raise OutOfOrderError("Out-of-order event={}.".format(ked))
 
                 elif ((sn == sno) or  # inorder event (ixn, rot, drt) or

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -3020,22 +3020,22 @@ class Kever:
             dserder = serdering.SerderKERI(raw=bytes(raw))
             return dserder
 
-        elif eager:  #missing aes but try to find seal by walking delegator's KEL
+        elif eager:  # missing aes but try to find seal by walking delegator's KEL
             seal = SealEvent(i=serder.pre, s=serder.snh, d=serder.said)._asdict
             if original:  # search all events in delegator's kel not just last
-                if not (dserder:=self.db.fetchAllSealingEventByEventSeal(pre=delpre,
-                                                                        seal=seal)):
+                if not (dserder := self.db.fetchLastSealingEventByEventSeal(pre=delpre,
+                                                                            seal=seal)):
                     # database broken this should never happen so do not validate
                     # since original must have been validated so it must have
                     # all its delegation chain.
                     raise ValidationError(f"Missing delegation source seal for {serder.ked}")
-            else: # only search last events in delegator's kel
-                if not (dserder:=self.db.fetchLastSealingEventByEventSeal(pre=delpre,
-                                                                         seal=seal)):
+            else:  # only search last events in delegator's kel
+                if not (dserder := self.db.fetchLastSealingEventByEventSeal(pre=delpre,
+                                                                            seal=seal)):
                     # superseding delegation may not have happened yet so escrow
                     # ToDo XXXX  need to cue up to get latest events in
                     # delegator's kel.
-                    #raise ValidationError(f"Missing delegation source seal for {serder.ked}")
+                    # raise ValidationError(f"Missing delegation source seal for {serder.ked}")
                     return None
 
             # Only repair .aess when found delegation is for delegated event that

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1700,7 +1700,6 @@ class Baser(dbing.LMDBer):
     # use alias here until can change everywhere for  backwards compatibility
     findAnchoringSealEvent = fetchAllSealingEventByEventSeal  # alias
 
-
     def fetchLastSealingEventByEventSeal(self, pre, seal, sn=0):
         """
         Search through a KEL for the last event at any sn but that contains a


### PR DESCRIPTION
This fix includes:

* Change `local=local` in calls to `escrowOOEvent` to propagate the locality of the event across out of order escrowing.

* Fix OOBI generation to favor HTTPS over HTTP and to honor the full URL of the service endpoint.

* Use the "Last" variant of the method for finding event seals in all locations.