### PR TITLE
docs: fix Sphinx build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,9 +12,18 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile clean html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf $(BUILDDIR)/*
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,3 +27,6 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	@echo
+
+open:
+	open _build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ except ImportError:
     sphinx_rtd_theme = None
 
 project = 'keri'
-copyright = '2022, Dr. Samuel Smith and contributors'
+copyright = '2024, Dr. Samuel Smith and contributors'
 author = 'Dr. Samuel Smith'
 
 version = release = keri.__version__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ except ImportError:
     sphinx_rtd_theme = None
 
 project = 'keri'
-copyright = '2024, Dr. Samuel Smith and contributors'
+copyright = '2022 - 2024, Dr. Samuel Smith and contributors'
 author = 'Dr. Samuel Smith'
 
 version = release = keri.__version__
@@ -62,7 +62,6 @@ napoleon_include_init_with_doc = True
 #
 if sphinx_rtd_theme:
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 else:
     html_theme = "default"
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-==================================================
-Python Implementation of the KERI Core Libraries
-==================================================
+==========================================================
+Python Reference Implementation of the KERI Core Libraries
+==========================================================
 
 .. image:: https://img.shields.io/pypi/v/keri.svg
     :target: https://pypi.org/project/keri/
@@ -35,11 +35,13 @@ API Reference
     keri_app
     keri_core
     keri_db
+    keri_demo
     keri_end
     keri_help
     keri_peer
     keri_vc
     keri_vdr
+    naming
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,16 +32,15 @@ API Reference
 .. toctree::
     :maxdepth: 1
 
+    naming
     keri_app
     keri_core
     keri_db
-    keri_demo
     keri_end
     keri_help
     keri_peer
     keri_vc
     keri_vdr
-    naming
 
 Indices and tables
 ==================

--- a/docs/keri_app.rst
+++ b/docs/keri_app.rst
@@ -13,12 +13,6 @@ keri.app.apping
 .. automodule:: keri.app.apping
     :members:
 
-keri.app.booting
-----------------
-
-.. automodule:: keri.app.booting
-    :members:
-
 keri.app.challenging
 --------------------
 
@@ -32,7 +26,7 @@ keri.app.configing
     :members:
 
 keri.app.connecting
-------------------
+-------------------
 
 .. automodule:: keri.app.connecting
     :members:
@@ -85,12 +79,6 @@ keri.app.keeping
 .. automodule:: keri.app.keeping
     :members:
 
-keri.app.kiwiing
-----------------
-
-.. automodule:: keri.app.kiwiing
-    :members:
-
 keri.app.notifying
 ------------------
 
@@ -100,7 +88,7 @@ keri.app.notifying
 keri.app.oobing
 ---------------
 
-.. automodule:: keri.app.oobing
+.. automodule:: keri.app.oobiing
     :members:
 
 keri.app.signaling

--- a/docs/keri_core.rst
+++ b/docs/keri_core.rst
@@ -7,10 +7,22 @@ keri.core.coring
 .. automodule:: keri.core.coring
     :members:
 
+keri.core.counting
+------------------
+
+.. automodule:: keri.core.counting
+    :members:
+
 keri.core.eventing
 ------------------
 
 .. automodule:: keri.core.eventing
+    :members:
+
+ker.core.indexing
+-----------------
+
+.. automodule:: keri.core.indexing
     :members:
 
 keri.core.parsing
@@ -29,5 +41,23 @@ keri.core.scheming
 ------------------
 
 .. automodule:: keri.core.scheming
+    :members:
+
+keri.core.signing
+-----------------
+
+.. automodule:: keri.core.signing
+    :members:
+
+keri.core.streaming
+-------------------
+
+.. automodule:: keri.core.streaming
+    :members:
+
+keri.core.structing
+-------------------
+
+.. automodule:: keri.core.structing
     :members:
 

--- a/docs/keri_db.rst
+++ b/docs/keri_db.rst
@@ -25,6 +25,12 @@ keri.db.koming
 .. automodule:: keri.db.koming
     :members:
 
+keri.db.migrations
+------------------
+
+.. automodule:: keri.db.migrations
+    :members:
+
 keri.db.subing
 --------------
 

--- a/docs/keri_demo.rst
+++ b/docs/keri_demo.rst
@@ -1,0 +1,8 @@
+KERI Demo API
+=============
+
+keri.demo.demoing
+-----------------
+
+.. automodule:: keri.demo.demoing
+    :members:

--- a/docs/keri_help.rst
+++ b/docs/keri_help.rst
@@ -1,5 +1,5 @@
 KERI Help API
-============
+=============
 
 keri.help.helping
 -----------------

--- a/docs/keri_peer.rst
+++ b/docs/keri_peer.rst
@@ -1,5 +1,5 @@
 KERI Peer API
-============
+=============
 
 keri.peer.exchanging
 --------------------

--- a/docs/keri_vc.rst
+++ b/docs/keri_vc.rst
@@ -1,8 +1,8 @@
 KERI Verificable Credential API
-=============
+===============================
 
 keri.vc.protocoling
-----------------
+-------------------
 
 .. automodule:: keri.vc.protocoling
     :members:

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,5 +1,5 @@
-
-# Python Style Guide for keripy
+# Naming and Style guide
+## Python Style Guide for KERIpy
 
 The Python PEPs on style have many options or allowed variants.
 The purpose of this document is to select a single preferred style

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-myst-parser >= 0.16.1
-Sphinx >= 4.3.2
+myst-parser >= 4.0.0
+Sphinx >= 8.1.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,11 @@
 myst-parser >= 4.0.0
 Sphinx >= 8.1.3
+
+sphinx-rtd-theme==3.0.1
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-jquery==4.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0


### PR DESCRIPTION
Upgrade Sphinx to 8.1.3 and myst-parser to 4.1.3.

1. doing `make clean html` builds the docs.
2. Open the docs on OSx with `open _build/html/index.html`
3. Profit

 There are a bunch of warnings yet they don't stop the docs from building.