### PR TITLE
feat: de-couple contact creation from OOBI resolution

### DIFF
--- a/scripts/demo/basic/challenge.sh
+++ b/scripts/demo/basic/challenge.sh
@@ -14,6 +14,12 @@ cha2_oobi="$(kli oobi generate --name cha2 --alias cha2 --role witness | sed -n 
 kli oobi resolve --name cha1 --oobi-alias cha2 --oobi "${cha2_oobi}"
 kli oobi resolve --name cha2 --oobi-alias cha1 --oobi "${cha1_oobi}"
 
+cha1_pre="$(kli aid --name cha1 --alias cha1)"
+cha2_pre="$(kli aid --name cha2 --alias cha2)"
+
+kli contacts replace --name cha1 --prefix "${cha2_pre}" --alias cha2
+kli contacts replace --name cha2 --prefix "${cha1_pre}" --alias cha1
+
 words1="$(kli challenge generate --out string)"
 words2="$(kli challenge generate --out string)"
 

--- a/scripts/demo/credentials/multisig-grant-multisig-admit.sh
+++ b/scripts/demo/credentials/multisig-grant-multisig-admit.sh
@@ -28,7 +28,9 @@ kli incept --name issuer2 --alias issuer2 --file ${KERI_DEMO_SCRIPT_DIR}/data/is
 
 # Exchange OOBIs between issuer group
 kli oobi resolve --name issuer1 --oobi-alias issuer2 --oobi http://127.0.0.1:5642/oobi/EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM/witness
+kli contacts replace --name issuer1 --prefix EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM --alias issuer2
 kli oobi resolve --name issuer2 --oobi-alias issuer1 --oobi http://127.0.0.1:5642/oobi/EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs/witness
+kli contacts replace --name issuer2 --prefix EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs --alias issuer1
 
 # Create the identifier to which the credential will be issued
 kli init --name issuee1 --salt 0ACDEyMzQ1Njc4OWxtbm9qWc --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
@@ -40,19 +42,29 @@ kli incept --name issuee2 --alias issuee2 --file ${KERI_DEMO_SCRIPT_DIR}/data/is
 
 # Exchange OOBIs between issuee group
 kli oobi resolve --name issuee1 --oobi-alias issuee2 --oobi http://127.0.0.1:5642/oobi/EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE/witness
+kli contacts replace --name issuee1 --prefix EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE --alias issuee2
 kli oobi resolve --name issuee2 --oobi-alias issuee1 --oobi http://127.0.0.1:5642/oobi/EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_/witness
+kli contacts replace --name issuee2 --prefix EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_ --alias issuee1
 
 # Introduce issuer to issuee
 kli oobi resolve --name issuee1 --oobi-alias issuer1 --oobi http://127.0.0.1:5642/oobi/EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs/witness
+kli contacts replace --name issuee1 --prefix EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs --alias issuer1
 kli oobi resolve --name issuee2 --oobi-alias issuer1 --oobi http://127.0.0.1:5642/oobi/EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs/witness
+kli contacts replace --name issuee2 --prefix EEVlFHcMWAQNwezHjyKK5cKKzF6zgLlnrLyi_CcAEXCs --alias issuer1
 kli oobi resolve --name issuee1 --oobi-alias issuer2 --oobi http://127.0.0.1:5642/oobi/EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM/witness
+kli contacts replace --name issuee1 --prefix EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM --alias issuer2
 kli oobi resolve --name issuee2 --oobi-alias issuer2 --oobi http://127.0.0.1:5642/oobi/EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM/witness
+kli contacts replace --name issuee2 --prefix EFJtDtSoE6XOOqLoLvYoB7ctCzMtJDiAJltnXiK_EdlM --alias issuer2
 
 # Introduce the issuee to issuer
 kli oobi resolve --name issuer1 --oobi-alias issuee1 --oobi http://127.0.0.1:5642/oobi/EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_/witness
+kli contacts replace --name issuer1 --prefix EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_ --alias issuee1
 kli oobi resolve --name issuer2 --oobi-alias issuee1 --oobi http://127.0.0.1:5642/oobi/EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_/witness
+kli contacts replace --name issuer2 --prefix EI0IoYyHxXc7_uQyaN2WocSC3lRZsvrDAPbREOw7fM0_ --alias issuee1
 kli oobi resolve --name issuer1 --oobi-alias issuee2 --oobi http://127.0.0.1:5642/oobi/EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE/witness
+kli contacts replace --name issuer1 --prefix EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE --alias issuee2
 kli oobi resolve --name issuer2 --oobi-alias issuee2 --oobi http://127.0.0.1:5642/oobi/EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE/witness
+kli contacts replace --name issuer2 --prefix EPw5WQAFcNXXSbg_pTKgh8-K_rfXnD1uDKS13OeNHkKE --alias issuee2
 
 ## Load Data OOBI for schema of credential to issue
 kli oobi resolve --name issuer1 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
@@ -84,10 +96,14 @@ wait $PID_LIST
 
 # Introduce issuer issuer issuer to issuees
 kli oobi resolve --name issuer1 --oobi-alias issuee --oobi http://127.0.0.1:5642/oobi/ELkmm28zQEyxkryJZQ4WVT4fjukklM4dR91l2DQfQHZK/witness
+kli contacts replace --name issuer1 --prefix ELkmm28zQEyxkryJZQ4WVT4fjukklM4dR91l2DQfQHZK --alias issuee
 kli oobi resolve --name issuer2 --oobi-alias issuee --oobi http://127.0.0.1:5642/oobi/ELkmm28zQEyxkryJZQ4WVT4fjukklM4dR91l2DQfQHZK/witness
+kli contacts replace --name issuer2 --prefix ELkmm28zQEyxkryJZQ4WVT4fjukklM4dR91l2DQfQHZK --alias issuee
 
 kli oobi resolve --name issuee1 --oobi-alias issuer --oobi http://127.0.0.1:5642/oobi/ELrnb8aI_wy2q_sSbCAwkgy2kOdMpRI1urFrhQiMJGLW/witness
+kli contacts replace --name issuee1 --prefix ELrnb8aI_wy2q_sSbCAwkgy2kOdMpRI1urFrhQiMJGLW --alias issuer
 kli oobi resolve --name issuee2 --oobi-alias issuer --oobi http://127.0.0.1:5642/oobi/ELrnb8aI_wy2q_sSbCAwkgy2kOdMpRI1urFrhQiMJGLW/witness
+kli contacts replace --name issuee2 --prefix ELrnb8aI_wy2q_sSbCAwkgy2kOdMpRI1urFrhQiMJGLW --alias issuer
 
 # Create a credential registry owned by the issuer issuer
 kli vc registry incept --name issuer1 --alias issuer --registry-name vLEI --usage "Issue vLEIs" --nonce AHSNDV3ABI6U8OIgKaj3aky91ZpNL54I5_7-qwtC6q2s &

--- a/scripts/demo/credentials/multisig-issuer-interactive.sh
+++ b/scripts/demo/credentials/multisig-issuer-interactive.sh
@@ -15,7 +15,9 @@ kli incept --name multisig2 --alias multisig2 --file ${KERI_DEMO_SCRIPT_DIR}/dat
 
 # Exchange OOBIs between multisig group
 kli oobi resolve --name multisig1 --oobi-alias multisig2 --oobi http://127.0.0.1:5642/oobi/EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1/witness
+kli contacts replace --name multisig1 --prefix EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1 --alias multisig2
 kli oobi resolve --name multisig2 --oobi-alias multisig1 --oobi http://127.0.0.1:5642/oobi/EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4/witness
+kli contacts replace --name multisig2 --prefix EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4 --alias multisig1
 
 # Create the identifier to which the credential will be issued
 kli init --name holder --salt 0ACDEyMzQ1Njc4OWxtbm9qWc --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis
@@ -23,11 +25,15 @@ kli incept --name holder --alias holder --file ${KERI_DEMO_SCRIPT_DIR}/data/glei
 
 # Introduce multisig to Holder
 kli oobi resolve --name holder --oobi-alias multisig2 --oobi http://127.0.0.1:5642/oobi/EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1/witness
+kli contacts replace --name holder --prefix EJccSRTfXYF6wrUVuenAIHzwcx3hJugeiJsEKmndi5q1 --alias multisig2
 kli oobi resolve --name holder --oobi-alias multisig1 --oobi http://127.0.0.1:5642/oobi/EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4/witness
+kli contacts replace --name holder --prefix EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4 --alias multisig1
 
 # Introduce the holder to all participants in the multisig group
 kli oobi resolve --name multisig1 --oobi-alias holder --oobi http://127.0.0.1:5642/oobi/ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k/witness
+kli contacts replace --name multisig1 --prefix ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k --alias holder
 kli oobi resolve --name multisig2 --oobi-alias holder --oobi http://127.0.0.1:5642/oobi/ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k/witness
+kli contacts replace --name multisig2 --prefix ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k --alias holder
 
 # Load Data OOBI for schema of credential to issue
 kli oobi resolve --name multisig1 --oobi-alias vc --oobi http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
@@ -48,6 +54,7 @@ kli multisig join --name multisig2
 
 wait $PID_LIST
 kli oobi resolve --name holder --oobi-alias multisig --oobi http://127.0.0.1:5642/oobi/EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2/witness
+kli contacts replace --name holder --prefix EC61gZ9lCKmHAS7U5ehUfEbGId5rcY0D7MirFZHDQcE2 --alias multisig
 
 # Create a credential registry owned by the multisig issuer
 kli vc registry incept --name multisig1 --alias multisig --registry-name vLEI --usage "Issue vLEIs" --nonce AHSNDV3ABI6U8OIgKaj3aky91ZpNL54I5_7-qwtC6q2s &

--- a/src/keri/app/cli/commands/contacts/list.py
+++ b/src/keri/app/cli/commands/contacts/list.py
@@ -1,11 +1,12 @@
 # -*- encoding: utf-8 -*-
 """
 KERI
-keri.kli.commands module
+keri.kli.commands.contacts module
 
 """
 import argparse
 import json
+import sys
 
 from hio import help
 from hio.base import doing
@@ -76,4 +77,4 @@ def list(tymth, tock=0.0, **opts):
 
     except ConfigurationError as e:
         print(f"identifier prefix for {name} does not exist, incept must be run first", )
-        return -1
+        sys.exit(-1)

--- a/src/keri/app/cli/commands/contacts/replace.py
+++ b/src/keri/app/cli/commands/contacts/replace.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.contacts module
+
+"""
+import argparse
+import sys
+
+from hio import help
+from hio.base import doing
+
+from keri.app import connecting
+from keri.app.cli.common import existing
+from keri.kering import ConfigurationError
+
+logger = help.ogler.getLogger()
+
+# Could be expanded to provide arbitrary data if desired
+parser = argparse.ArgumentParser(description='Replace contact information for identifier prefix with alias information')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--prefix', '-o', help='identifier prefix to replace contact information for', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for the contact', required=True)
+
+
+def handler(args):
+    kwa = dict(args=args)
+    return [doing.doify(replace, **kwa)]
+
+
+def replace(tymth, tock=0.0, **opts):
+    """ Command line status handler
+
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    base = args.base
+    bran = args.bran
+    prefix = args.prefix
+    alias = args.alias
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            org = connecting.Organizer(hby=hby)
+
+            if prefix not in hby.kevers:
+                print(f"{prefix} is not a known identifier, oobi must be resolved first")
+                sys.exit(-1)
+
+            org.replace(pre=prefix, data=dict(alias=alias))
+
+    except ConfigurationError:
+        print(f"identifier prefix for {name} does not exist, incept must be run first")
+        sys.exit(-1)

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -18,7 +18,6 @@ from keri.core import coring
 from . import httping
 from .. import help
 from .. import kering
-from ..app import connecting
 from ..core import routing, eventing, parsing, scheming, serdering
 from ..db import basing
 from ..end import ending
@@ -290,7 +289,6 @@ class Oobiery:
             self.registerReplyRoutes(self.rvy.rtr)
 
         self.clienter = clienter or httping.Clienter()
-        self.org = connecting.Organizer(hby=self.hby)
 
         # Set up a local parser for returned events from OOBI queries.
         rtr = routing.Router()
@@ -501,9 +499,6 @@ class Oobiery:
                     self.parser.parse(ims=bytearray(response["body"]))
                     if ending.OOBI_AID_HEADER in response["headers"]:
                         obr.cid = response["headers"][ending.OOBI_AID_HEADER]
-
-                    if obr.oobialias is not None and obr.cid:
-                        self.org.replace(pre=obr.cid, data=dict(alias=obr.oobialias, oobi=url))
 
                     self.hby.db.coobi.rem(keys=(url,))
                     obr.state = Result.resolved


### PR DESCRIPTION
This will resolve WebOfTrust/keria#291 and also avoid the lack of clarity raised in WebOfTrust/keria#292. As dicussed on [Discord](https://discord.com/channels/1148629222647148624/1154416772401860648/1295408495801401396).

kli command added to add the alias using `org.replace`. I added it to the demo scripts that seemed to need the contact to be in place. Many don't require it, but I hope I didn't miss too many.