### PR TITLE
add null check for issuee in sendArtifacts for presenting untargeted credential.

### DIFF
--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -968,7 +968,7 @@ def sendArtifacts(hby, reger, postman, creder, recp):
         atc = msg[serder.size:]
         postman.send(serder=serder, attachment=atc)
 
-    if isse != recp:
+    if isse is not None and isse != recp:
         ikever = hby.db.kevers[isse]
         for msg in hby.db.cloneDelegation(ikever):
             serder = serdering.SerderKERI(raw=msg)


### PR DESCRIPTION
- Fix exception in `sendArtifacts` by adding a null check for issuee in case of presenting untargeted credential