### PR TITLE
feat: KERI_LMDB_MAP_SIZE for setting LMDB file size

### DIFF
--- a/docs/keri_db.rst
+++ b/docs/keri_db.rst
@@ -13,6 +13,8 @@ keri.db.dbing
 .. automodule:: keri.db.dbing
     :members:
 
+The `KERI_LMDB_MAP_SIZE` environment variable can be used to set the size of the LMDB map. The default size is 4GB.
+
 keri.db.escrowing
 -----------------
 

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -383,7 +383,12 @@ class LMDBer(filing.Filer):
 
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
-        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=104857600,
+        map_size = os.getenv("KERI_LMDB_MAP_SIZE", '4294967296')  # 4GB
+        try:
+            map_size = int(map_size)
+        except ValueError:
+            map_size = 4 * 1024**3  # 4GB
+        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=map_size,
                              mode=self.perm, readonly=self.readonly)
 
         self.opened = True if opened and self.env else False

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -227,8 +227,15 @@ def test_lmdber():
     assert databaser.path == None
     assert databaser.env == None
 
+    os.environ['KERI_LMDB_MAP_SIZE'] = f'{2 * 1024**3}'  # 2GB
     databaser.reopen()
     assert databaser.opened
+    assert databaser.env.info()['map_size'] == 2 * 1024**3  # 2GB
+
+    os.environ['KERI_LMDB_MAP_SIZE'] = f'invalid-size'  # will trigger default
+    databaser.reopen()
+    assert databaser.opened
+    assert databaser.env.info()['map_size'] == 4 * 1024 ** 3  # 4GB default value
     assert isinstance(databaser.env, lmdb.Environment)
     assert databaser.path.endswith("keri/db/main")
     assert databaser.env.path() == databaser.path


### PR DESCRIPTION
We hit the default size set in LMDBer of 104 megabytes and need to set a higher default. This PR sets the default to 4GB and allows setting the size with the `KERI_LMDB_MAP_SIZE` environment variable.