### PR TITLE
Last bit of clean up for V1.2.0 rc4

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -70,7 +70,7 @@ class Receiptor(doing.DoDoer):
         ser = serdering.SerderKERI(raw=msg)
 
         # If we are a rotation event, may need to catch new witnesses up to current key state
-        if ser.ked['t'] in (coring.Ilks.rot,):
+        if ser.ked['t'] in (coring.Ilks.rot, coring.Ilks.drt,):
             adds = ser.ked["ba"]
             for wit in adds:
                 yield from self.catchup(ser.pre, wit)
@@ -351,7 +351,7 @@ class WitnessReceiptor(doing.DoDoer):
                             witer.msgs.append(bytearray(dmsg))
 
                         if ser.ked['t'] in (coring.Ilks.icp, coring.Ilks.dip) or \
-                                "ba" in ser.ked and wit in ser.ked["ba"]:  # Newly added witness, must send full KEL to catch up
+                                "ba" in ser.ked and wit in ser.ked["ba"]:  # Newly added witness, must catch up
                             for fmsg in hab.db.clonePreIter(pre=pre):
                                 witer.msgs.append(bytearray(fmsg))
 

--- a/src/keri/app/cli/commands/interact.py
+++ b/src/keri/app/cli/commands/interact.py
@@ -119,7 +119,7 @@ class InteractDoer(doing.DoDoer):
             for wit in hab.kever.wits:
                 if wit in auths:
                     continue
-                code = input(f"Entire code for {wit}: ")
+                code = input(f"Enter code for {wit}: ")
                 auths[wit] = f"{code}#{helping.nowIso8601()}"
 
         if self.endpoint:

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -210,7 +210,7 @@ class RotateDoer(doing.DoDoer):
             for wit in hab.kever.wits:
                 if wit in auths:
                     continue
-                code = input(f"Entire code for {wit}: ")
+                code = input(f"Enter code for {wit}: ")
                 auths[wit] = f"{code}#{helping.nowIso8601()}"
 
         if hab.kever.delpre:

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -117,7 +117,7 @@ class AuthDoer(doing.DoDoer):
 
         client.request(
             method="POST",
-            path=f"{client.requester.path}/aids",
+            path=f"{client.requester.path.rstrip('/')}/aids",
             headers=headers,
             fargs=fargs
         )
@@ -131,7 +131,7 @@ class AuthDoer(doing.DoDoer):
             totp = data["totp"]
             m = coring.Matter(qb64=totp)  # refactor this to use cipher
             d = coring.Matter(qb64=self.hab.decrypt(ser=m.raw))
-            otpurl = f"otpauth://totp/KERIpy:{self.witness}?secret={d.raw.decode('utf-8')}&issuer=KERIpy"
+            otpurl = f"otpauth://totp/KERI:{self.witness}?secret={d.raw.decode('utf-8')}&issuer=KERIpy"
 
             if not self.urlOnly:
                 qr = qrcode.QRCode()

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -131,7 +131,7 @@ class AuthDoer(doing.DoDoer):
             totp = data["totp"]
             m = coring.Matter(qb64=totp)  # refactor this to use cipher
             d = coring.Matter(qb64=self.hab.decrypt(ser=m.raw))
-            otpurl = f"otpauth://totp/KERI:{self.witness}?secret={d.raw.decode('utf-8')}&issuer=KERIpy"
+            otpurl = f"otpauth://totp/KERI:{self.witness}?secret={d.raw.decode('utf-8')}&issuer=KERI"
 
             if not self.urlOnly:
                 qr = qrcode.QRCode()

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2379,9 +2379,9 @@ class Kever:
         # seal in this case can't be malicious since sourced locally.
         # Doesn't get to here until fully signed and witnessed.
 
-        if self.locallyDelegated(delpre):  # local delegator
+        if self.locallyDelegated(delpre) and not self.locallyOwned():  # local delegator
             # must be local if locallyDelegated or caught above as misfit
-            if delseqner is None or delsaider is None: # missing delegation seal
+            if delseqner is None or delsaider is None:  # missing delegation seal
                 # so escrow delegable. So local delegator can approve OOB.
                 # and create delegator event with valid event seal of this
                 # delegated event and then reprocess event with attached source


### PR DESCRIPTION
This PR includes the following:

* Fix delegation "catchup" logic for witnesses during delegated rotation.
* Fix witness authenticate to handle service endpoint urls with a trailing slash.
* Minor fix to parsing for local delegators and 3 typo fixes