### PR TITLE
fix issue 892

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -730,7 +730,7 @@ class Matter:
         '1AAB': Sizage(hs=4, ss=0, xs=0, fs=48, ls=0),
         '1AAC': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
         '1AAD': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
-        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=56, ls=0),
+        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=156, ls=0),
         '1AAF': Sizage(hs=4, ss=4, xs=0, fs=8, ls=0),
         '1AAG': Sizage(hs=4, ss=0, xs=0, fs=36, ls=0),
         '1AAH': Sizage(hs=4, ss=0, xs=0, fs=100, ls=0),

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -459,7 +459,7 @@ def test_matter_class():
         '1AAB': Sizage(hs=4, ss=0, xs=0, fs=48, ls=0),
         '1AAC': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
         '1AAD': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
-        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=56, ls=0),
+        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=156, ls=0),
         '1AAF': Sizage(hs=4, ss=4, xs=0, fs=8, ls=0),
         '1AAG': Sizage(hs=4, ss=0, xs=0, fs=36, ls=0),
         '1AAH': Sizage(hs=4, ss=0, xs=0, fs=100, ls=0),


### PR DESCRIPTION
An Ed448 signature is 114 bytes (binary). When serialized as CESR, there's a 4/3 increase in size, and a prefix. The correct size of this primitive in CESR is 156 bytes, which is what the spec claims, not 56 bytes as currently shown in the Matter class in keripy. (https://asecuritysite.com/signatures/x448_sig)

Fix requested by @SmithSamuelM 

Fixes #892 