### PR TITLE
Clear both KEL and TEL escrows; list all events in escrow, or their counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: build-keri
 
-VERSION=1.1.22
+VERSION=1.1.23
 
 define DOCKER_WARNING
 In order to use the multi-platform build enable the containerd image store

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to get a version string similar to the following:
 ### Local installation - Docker build
 Run `make build-keri` to build your docker image.
 
-Then run `docker run --pull=never -it --entrypoint /bin/bash weboftrust/keri:1.1.22` and you can run `kli version` from within the running container to play with KERIpy.
+Then run `docker run --pull=never -it --entrypoint /bin/bash weboftrust/keri:1.1.23` and you can run `kli version` from within the running container to play with KERIpy.
 
 Make sure the image tag matches the version used in the `Makefile`.
 We use `--pull=never` to ensure that docker does not implicitly pull a remote image and relies on the local image tagged during `make build-keri`.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from os.path import splitext
 from setuptools import find_packages, setup
 setup(
     name='keri',
-    version='1.1.22',  # also change in src/keri/__init__.py
+    version='1.1.23',  # also change in src/keri/__init__.py
     license='Apache Software License 2.0',
     description='Key Event Receipt Infrastructure',
     long_description="KERI Decentralized Key Management Infrastructure",

--- a/src/keri/__init__.py
+++ b/src/keri/__init__.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-__version__ = '1.1.22'  # also change in setup.py
+__version__ = '1.1.23'  # also change in setup.py
 
 

--- a/src/keri/app/cli/commands/escrow/clear.py
+++ b/src/keri/app/cli/commands/escrow/clear.py
@@ -1,0 +1,57 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.escrow module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+from keri.app.cli.common import existing
+from keri.vdr import viring
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Clear escrows')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument('--force', '-f', action="store_true", required=False,
+                    help='True means perform clear without prompting the user')
+
+
+def handler(args):
+    if not args.force:
+        print()
+        print("This command will clear all escrows and is not reversible.")
+        print()
+        yn = input("Are you sure you want to continue? [y|N]: ")
+
+        if yn not in ("y", "Y"):
+            print("...exiting")
+            return []
+
+    kwa = dict(args=args)
+    return [doing.doify(clear, **kwa)]
+
+
+def clear(tymth, tock=0.0, **opts):
+    """ Command line clear handler
+    """
+    _ = (yield tock)
+    args = opts["args"]
+    name = args.name
+    base = args.base
+    bran = args.bran
+    logger.setLevel("INFO")
+
+    with existing.existingHby(name=name, base=base, bran=bran) as hby:
+        hby.db.clearEscrows()
+        reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+        reger.clearEscrows()
+

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -54,16 +54,10 @@ def escrows(tymth, tock=0.0, **opts):
             # KEL / Baser escrows
 
             if (not escrow) or escrow == "unverified-receipts":
-                count = 0
-                for key, _ in hby.db.getUreItemIter():
-                    count += 1
-                escrows["unverified-receipts"] = count
+                escrows["unverified-receipts"] = sum(1 for key, _ in hby.db.getUreItemIter())
 
             if (not escrow) or escrow == "verified-receipts":
-                count = 0
-                for key, _ in hby.db.getVreItemIter():
-                    count += 1
-                escrows["verified-receipts"] = count
+                escrows["verified-receipts"] = sum(1 for key, _ in hby.db.getVreItemIter())
 
             if (not escrow) or escrow == "partially-signed-events":
                 pses = list()
@@ -102,10 +96,7 @@ def escrows(tymth, tock=0.0, **opts):
                 escrows["partially-witnessed-events"] = pwes
 
             if (not escrow) or escrow == "unverified-event-indexed-couples":
-                count = 0
-                for key, _ in hby.db.getUweItemIter():
-                    count += 1
-                escrows["unverified-event-indexed-couples"] = count
+                escrows["unverified-event-indexed-couples"] = sum(1 for key, _ in hby.db.getUweItemIter())
 
             if (not escrow) or escrow == "out-of-order-events":
                 oots = list()
@@ -144,85 +135,46 @@ def escrows(tymth, tock=0.0, **opts):
                 escrows["likely-duplicitous-events"] = ldes
 
             if (not escrow) or escrow == "query-not-found":
-                count  = 0
-                for key, _ in hby.db.getQnfItemsNextIter():
-                    count += 1
-                escrows["query-not-found"] = count
+                escrows["query-not-found"] = sum(1 for key, _ in hby.db.getQnfItemsNextIter())
 
             if (not escrow) or escrow == "partially-delegated-events":
-                count = 0
-                for key, _ in hby.db.getPdesItemsNextIter():
-                    count += 1
-                escrows["partially-delegated-events"] = count
+                escrows["partially-delegated-events"] = sum(1 for key, _ in hby.db.getPdesItemsNextIter())
 
             if (not escrow) or escrow == "reply":
-                count = 0
-                for key, _ in hby.db.rpes.getItemIter():
-                    count += 1
-                escrows["reply"] = count
+                escrows["reply"] = sum(1 for key, _ in hby.db.rpes.getItemIter())
 
             if (not escrow) or escrow == "failed-oobi":
-                count = 0
-                for key, _ in hby.db.eoobi.getItemIter():
-                    count += 1
-                escrows["failed-oobi"] = count
+                escrows["failed-oobi"] = sum(1 for key, _ in hby.db.eoobi.getItemIter())
 
             if (not escrow) or escrow == 'group-partial-witness':
-                count = 0
-                for key, _ in hby.db.gpwe.getItemIter():
-                    count += 1
-                escrows["group-partial-witness"] = count
+                escrows["group-partial-witness"] = sum(1 for key, _ in hby.db.gpwe.getItemIter())
 
             if (not escrow) or escrow == 'group-delegate':
-                count = 0
-                for key, _ in hby.db.gdee.getItemIter():
-                    count += 1
-                escrows["group-delegate"] = count
+                escrows["group-delegate"] = sum(1 for key, _ in hby.db.gdee.getItemIter())
 
             if (not escrow) or escrow == 'delegated-partial-witness':
-                count = 0
-                for key, _ in hby.db.dpwe.getItemIter():
-                    count += 1
-                escrows["delegated-partial-witness"] = count
+                escrows["delegated-partial-witness"] = sum(1 for key, _ in hby.db.dpwe.getItemIter())
 
             if (not escrow) or escrow == 'group-partial-signed':
-                count = 0
-                for key, _ in hby.db.gpse.getItemIter():
-                    count += 1
-                escrows["group-partial-signed"] = count
+                escrows["group-partial-signed"] = sum(1 for key, _ in hby.db.gpse.getItemIter())
 
             if (not escrow) or escrow == 'exchange-partial-signed':
-                count = 0
-                for key, _ in hby.db.epse.getItemIter():
-                    count += 1
-                escrows["exchange-partial-signed"] = count
+                escrows["exchange-partial-signed"] = sum(1 for key, _ in hby.db.epse.getItemIter())
 
             if (not escrow) or escrow == 'delegated-unanchored':
-                count = 0
-                for key, _ in hby.db.dune.getItemIter():
-                    count += 1
-                escrows["delegated-unanchored"] = count
+                escrows["delegated-unanchored"] = sum(1 for key, _ in hby.db.dune.getItemIter())
 
             # TEL / Reger escrows
             reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
 
             if (not escrow) or escrow == 'tel-out-of-order':
-                count = 0
-                for key, _ in reger.getOotItemIter():
-                    count += 1
-                escrows["tel-out-of-order"] = count
+                escrows["tel-out-of-order"] = sum(1 for key, _ in reger.getOotItemIter())
 
             if (not escrow) or escrow == 'tel-partially-witnessed':
-                count = 0
-                for key, _ in reger.getAllItemIter(reger.twes):
-                    count += 1
-                escrows["tel-partially-witnessed"] = count
+                escrows["tel-partially-witnessed"] = sum(1 for key, _ in reger.getAllItemIter(reger.twes))
 
             if (not escrow) or escrow == 'tel-anchorless':
-                count = 0
-                for key, _ in reger.getAllItemIter(reger.taes):
-                    count += 1
-                escrows["tel-anchorless"] = count
+                escrows["tel-anchorless"] = sum(1 for key, _ in reger.getAllItemIter(reger.taes))
 
             if (not escrow) or escrow == "missing-registry-escrow":
                 creds = list()
@@ -249,28 +201,16 @@ def escrows(tymth, tock=0.0, **opts):
                 escrows["missing-schema-escrow"] = creds
 
             if (not escrow) or escrow == 'tel-missing-signature':
-                count = 0
-                for key, _ in reger.cmse.getItemIter():
-                    count += 1
-                escrows["tel-missing-signature"] = count
+                escrows["tel-missing-signature"] = sum(1 for key, _ in reger.cmse.getItemIter())
 
             if (not escrow) or escrow == 'tel-partial-witness-escrow':
-                count = 0
-                for (regk, snq), (prefixer, seqner, saider) in reger.tpwe.getItemIter():
-                    count += 1
-                escrows["tel-partial-witness-escrow"] = count
+                escrows["tel-partial-witness-escrow"] = sum(1 for key, _ in reger.tpwe.getItemIter())
 
             if (not escrow) or escrow == 'tel-multisig':
-                count = 0
-                for key, _ in reger.tmse.getItemIter():
-                    count += 1
-                escrows["tel-multisig"] = count
+                escrows["tel-multisig"] = sum(1 for key, _ in reger.tmse.getItemIter())
 
             if (not escrow) or escrow == 'tel-event-dissemination':
-                count = 0
-                for key, _ in reger.tede.getItemIter():
-                    count += 1
-                escrows["tel-event-dissemination"] = count
+                escrows["tel-event-dissemination"] = sum(1 for key, _ in reger.tede.getItemIter())
 
             print(json.dumps(escrows, indent=2))
 

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -1,0 +1,279 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.escrow module
+
+"""
+import argparse
+import json
+
+from hio import help
+from hio.base import doing
+
+from keri.core import eventing
+from keri.app.cli.common import existing
+from keri.db import dbing
+from keri.kering import ConfigurationError
+from keri.vdr import viring
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Views events in escrow state.')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+
+parser.add_argument("--escrow", "-e", help="show values for one specific escrow", default=None)
+
+
+def handler(args):
+    """ Command line escrow handler
+
+    """
+    kwa = dict(args=args)
+    return [doing.doify(escrows, **kwa)]
+
+
+def escrows(tymth, tock=0.0, **opts):
+    _ = (yield tock)
+
+    args = opts["args"]
+    name = args.name
+    base = args.base
+    bran = args.bran
+    escrow = args.escrow
+
+    try:
+        with existing.existingHby(name=name, base=base, bran=bran) as hby:
+            escrows = dict()
+
+            # KEL / Baser escrows
+
+            if (not escrow) or escrow == "unverified-receipts":
+                count = 0
+                for key, _ in hby.db.getUreItemIter():
+                    count += 1
+                escrows["unverified-receipts"] = count
+
+            if (not escrow) or escrow == "verified-receipts":
+                count = 0
+                for key, _ in hby.db.getVreItemIter():
+                    count += 1
+                escrows["verified-receipts"] = count
+
+            if (not escrow) or escrow == "partially-signed-events":
+                pses = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getPseItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+
+                        try:
+                            pses.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
+
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
+
+                escrows["partially-signed-events"] = pses
+
+            if (not escrow) or escrow == "partially-witnessed-events":
+                pwes = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getPweItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+
+                        try:
+                            pwes.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
+
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
+
+                escrows["partially-witnessed-events"] = pwes
+
+            if (not escrow) or escrow == "unverified-event-indexed-couples":
+                count = 0
+                for key, _ in hby.db.getUweItemIter():
+                    count += 1
+                escrows["unverified-event-indexed-couples"] = count
+
+            if (not escrow) or escrow == "out-of-order-events":
+                oots = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:
+                    for ekey, edig in hby.db.getOoeItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+
+                        try:
+                            oots.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
+
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
+
+                escrows["out-of-order-events"] = oots
+
+            if (not escrow) or escrow == "likely-duplicitous-events":
+                ldes = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getLdeItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+
+                        try:
+                            ldes.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
+
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
+
+                escrows["likely-duplicitous-events"] = ldes
+
+            if (not escrow) or escrow == "query-not-found":
+                count  = 0
+                for key, _ in hby.db.getQnfItemsNextIter():
+                    count += 1
+                escrows["query-not-found"] = count
+
+            if (not escrow) or escrow == "partially-delegated-events":
+                count = 0
+                for key, _ in hby.db.getPdesItemsNextIter():
+                    count += 1
+                escrows["partially-delegated-events"] = count
+
+            if (not escrow) or escrow == "reply":
+                count = 0
+                for key, _ in hby.db.rpes.getItemIter():
+                    count += 1
+                escrows["reply"] = count
+
+            if (not escrow) or escrow == "failed-oobi":
+                count = 0
+                for key, _ in hby.db.eoobi.getItemIter():
+                    count += 1
+                escrows["failed-oobi"] = count
+
+            if (not escrow) or escrow == 'group-partial-witness':
+                count = 0
+                for key, _ in hby.db.gpwe.getItemIter():
+                    count += 1
+                escrows["group-partial-witness"] = count
+
+            if (not escrow) or escrow == 'group-delegate':
+                count = 0
+                for key, _ in hby.db.gdee.getItemIter():
+                    count += 1
+                escrows["group-delegate"] = count
+
+            if (not escrow) or escrow == 'delegated-partial-witness':
+                count = 0
+                for key, _ in hby.db.dpwe.getItemIter():
+                    count += 1
+                escrows["delegated-partial-witness"] = count
+
+            if (not escrow) or escrow == 'group-partial-signed':
+                count = 0
+                for key, _ in hby.db.gpse.getItemIter():
+                    count += 1
+                escrows["group-partial-signed"] = count
+
+            if (not escrow) or escrow == 'exchange-partial-signed':
+                count = 0
+                for key, _ in hby.db.epse.getItemIter():
+                    count += 1
+                escrows["exchange-partial-signed"] = count
+
+            if (not escrow) or escrow == 'delegated-unanchored':
+                count = 0
+                for key, _ in hby.db.dune.getItemIter():
+                    count += 1
+                escrows["delegated-unanchored"] = count
+
+            # TEL / Reger escrows
+            reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+
+            if (not escrow) or escrow == 'tel-out-of-order':
+                count = 0
+                for key, _ in reger.getOotItemIter():
+                    count += 1
+                escrows["tel-out-of-order"] = count
+
+            if (not escrow) or escrow == 'tel-partially-witnessed':
+                count = 0
+                for key, _ in reger.getAllItemIter(reger.twes):
+                    count += 1
+                escrows["tel-partially-witnessed"] = count
+
+            if (not escrow) or escrow == 'tel-anchorless':
+                count = 0
+                for key, _ in reger.getAllItemIter(reger.taes):
+                    count += 1
+                escrows["tel-anchorless"] = count
+
+            if (not escrow) or escrow == "missing-registry-escrow":
+                creds = list()
+                for (said,), dater in reger.mre.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
+
+                escrows["missing-registry-escrow"] = creds
+
+            if (not escrow) or escrow == "broken-chain-escrow":
+                creds = list()
+                for (said,), dater in reger.mce.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
+
+                escrows["broken-chain-escrow"] = creds
+
+            if (not escrow) or escrow == "missing-schema-escrow":
+                creds = list()
+                for (said,), dater in reger.mse.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
+
+                escrows["missing-schema-escrow"] = creds
+
+            if (not escrow) or escrow == 'tel-missing-signature':
+                count = 0
+                for key, _ in reger.cmse.getItemIter():
+                    count += 1
+                escrows["tel-missing-signature"] = count
+
+            if (not escrow) or escrow == 'tel-partial-witness-escrow':
+                count = 0
+                for (regk, snq), (prefixer, seqner, saider) in reger.tpwe.getItemIter():
+                    count += 1
+                escrows["tel-partial-witness-escrow"] = count
+
+            if (not escrow) or escrow == 'tel-multisig':
+                count = 0
+                for key, _ in reger.tmse.getItemIter():
+                    count += 1
+                escrows["tel-multisig"] = count
+
+            if (not escrow) or escrow == 'tel-event-dissemination':
+                count = 0
+                for key, _ in reger.tede.getItemIter():
+                    count += 1
+                escrows["tel-event-dissemination"] = count
+
+            print(json.dumps(escrows, indent=2))
+
+    except ConfigurationError as e:
+        print(f"identifier prefix for {name} does not exist, incept must be run first", )
+        return -1

--- a/src/keri/app/cli/commands/migrate/run.py
+++ b/src/keri/app/cli/commands/migrate/run.py
@@ -11,7 +11,7 @@ from keri import help
 from keri import kering
 from keri.db import basing
 
-logger = help.ogler.getLogger("keri")
+logger = help.ogler.getLogger()
 
 def handler(args):
     """

--- a/src/keri/app/cli/kli.py
+++ b/src/keri/app/cli/kli.py
@@ -4,7 +4,7 @@ keri.kli.commands module
 
 """
 import multicommand
-from keri import help
+from hio import help
 
 from keri.app import directing
 from keri.app.cli import commands

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -22,6 +22,10 @@ from ..help import helping
 from ..vc import proving
 from ..vdr import eventing
 
+from hio import help
+
+logger = help.ogler.getLogger()
+
 
 class rbdict(dict):
     """ Reger backed read through cache for registry state
@@ -383,6 +387,42 @@ class Reger(dbing.LMDBer):
         self.ccrd = subing.SerderSuber(db=self, subkey="ccrd.", klas=serdering.SerderACDC)
 
         return self.env
+
+    def clearEscrows(self):
+        """Clear credential event escrows"""
+        # self.oots, self.twes, self.taes
+        count = 0
+        for (k, _) in self.getOotItemIter():
+            count += 1
+            self.delOot(k)
+        logger.info(f"TEL: Cleared {count} out of order escrows.")
+
+        count = 0
+        for (k, ) in self.getAllItemIter(self.twes):
+            count += 1
+            self.delTwe(k)
+        logger.info(f"TEL: Cleared {count} partially witnessed escrows.")
+
+        count = 0
+        for (k, _) in self.getAllItemIter(self.taes):
+            count += 1
+            self.delTae(k)
+        logger.info(f"TEL: Cleared {count} anchorless escrows.")
+
+        for name, sub, desc in [
+                ( 'mre',  self.mre, 'missing registry escrows'),
+                ( 'mce',  self.mce, 'broken chain escrows'),
+                ( 'mse',  self.mse, 'missing schema escrows'),
+                ('cmse', self.cmse, 'missing signature escrows'),
+                ('tpwe', self.tpwe, 'partial witness escrows'),
+                ('tmse', self.tmse, 'multisig escrows'),
+                ('tede', self.tede, 'event dissemination escrows'),
+            ]:
+            count = 0
+            for (k, _) in sub.getItemIter():
+                count += 1
+            sub.trim()
+            logger.info(f"TEL: Cleared {count} escrows from ({name.ljust(5)}): {desc}")
 
     def cloneCreds(self, saids, db):
         """ Returns fully expanded credential with chained credentials attached.

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -233,19 +233,39 @@ def test_standalone_kli_commands(helpers, capsys):
                            '\t3. DEMwUl3u8mJ-cWxSnReA0rQesIgZ8SFoHp0U2WyiZjRt\n'
                            '\n')
 
-    args = parser.parse_args(["escrow", "--name", "test"])
+    args = parser.parse_args(["escrow", "list", "--name", "test"])
     assert args.handler is not None
     doers = args.handler(args)
     directing.runController(doers=doers)
     capesc = capsys.readouterr()
     assert capesc.out == ('{\n'
-                          '  "out-of-order-events": [],\n'
-                          '  "partially-witnessed-events": [],\n'
+                          '  "unverified-receipts": 0,\n'
+                          '  "verified-receipts": 0,\n'
                           '  "partially-signed-events": [],\n'
+                          '  "partially-witnessed-events": [],\n'
+                          '  "unverified-event-indexed-couples": 0,\n'
+                          '  "out-of-order-events": [],\n'
                           '  "likely-duplicitous-events": [],\n'
+                          '  "query-not-found": 0,\n'
+                          '  "partially-delegated-events": 0,\n'
+                          '  "reply": 0,\n'
+                          '  "failed-oobi": 0,\n'
+                          '  "group-partial-witness": 0,\n'
+                          '  "group-delegate": 0,\n'
+                          '  "delegated-partial-witness": 0,\n'
+                          '  "group-partial-signed": 0,\n'
+                          '  "exchange-partial-signed": 0,\n'
+                          '  "delegated-unanchored": 0,\n'
+                          '  "tel-out-of-order": 0,\n'
+                          '  "tel-partially-witnessed": 0,\n'
+                          '  "tel-anchorless": 0,\n'
                           '  "missing-registry-escrow": [],\n'
                           '  "broken-chain-escrow": [],\n'
-                          '  "missing-schema-escrow": []\n'
+                          '  "missing-schema-escrow": [],\n'
+                          '  "tel-missing-signature": 0,\n'
+                          '  "tel-partial-witness-escrow": 0,\n'
+                          '  "tel-multisig": 0,\n'
+                          '  "tel-event-dissemination": 0\n'
                           '}\n')
 
 


### PR DESCRIPTION
This backports `kli escrow clear` and `kli escrow list` into the 1.1.x release branch.
I also added clearing for every escrow I could find as there seemed to be some missing from the 1.2.x branch. I upgraded the `kli escrow list` command to show a count of all existing escrows.