### PR TITLE
fix: logging hio.help -> keri.help

### DIFF
--- a/src/keri/app/apping.py
+++ b/src/keri/app/apping.py
@@ -4,7 +4,6 @@ KERI
 keri.app.apping module
 
 """
-import cmd
 
 from hio.base import doing
 from hio.core.serial import serialing

--- a/src/keri/app/cli/commands/aid.py
+++ b/src/keri/app/cli/commands/aid.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 

--- a/src/keri/app/cli/commands/challenge/generate.py
+++ b/src/keri/app/cli/commands/challenge/generate.py
@@ -6,10 +6,10 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 from mnemonic import mnemonic
 
+from keri import help
 logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='Generate a cryptographically random challenge phrase')

--- a/src/keri/app/cli/commands/challenge/verify.py
+++ b/src/keri/app/cli/commands/challenge/verify.py
@@ -8,9 +8,9 @@ import argparse
 import datetime
 import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import indirecting, challenging, connecting, signaling
 from keri.app.cli.commands.challenge.generate import generateWords
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/clean.py
+++ b/src/keri/app/cli/commands/clean.py
@@ -5,9 +5,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/contacts/list.py
+++ b/src/keri/app/cli/commands/contacts/list.py
@@ -8,10 +8,9 @@ import argparse
 import json
 import sys
 
-from hio import help
 from hio.base import doing
-from keri import kering
 
+from keri import help, kering
 from keri.app import connecting
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError

--- a/src/keri/app/cli/commands/contacts/replace.py
+++ b/src/keri/app/cli/commands/contacts/replace.py
@@ -7,9 +7,9 @@ keri.kli.commands.contacts module
 import argparse
 import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import connecting
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError

--- a/src/keri/app/cli/commands/did/generate.py
+++ b/src/keri/app/cli/commands/did/generate.py
@@ -9,10 +9,9 @@ import urllib
 from urllib.parse import urlparse
 
 import sys
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/ends/add.py
+++ b/src/keri/app/cli/commands/ends/add.py
@@ -6,10 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import habbing, grouping, indirecting, forwarding
 from keri.app.agenting import WitnessPublisher
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/ends/export.py
+++ b/src/keri/app/cli/commands/ends/export.py
@@ -6,12 +6,11 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app.cli.common import existing
-from keri.core import coring, eventing
+from keri.core import eventing
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/ends/list.py
+++ b/src/keri/app/cli/commands/ends/list.py
@@ -7,13 +7,10 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
-from keri.app import indirecting, habbing, forwarding, grouping
+from keri import help, kering
 from keri.app.cli.common import existing
-from keri.core import eventing, parsing, coring
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/escrow/clear.py
+++ b/src/keri/app/cli/commands/escrow/clear.py
@@ -6,8 +6,8 @@ keri.kli.commands.escrow module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
+from keri import help
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -7,9 +7,9 @@ keri.kli.commands.escrow module
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.core import eventing
 from keri.app.cli.common import existing
 from keri.db import dbing

--- a/src/keri/app/cli/commands/event.py
+++ b/src/keri/app/cli/commands/event.py
@@ -7,9 +7,9 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 

--- a/src/keri/app/cli/commands/export.py
+++ b/src/keri/app/cli/commands/export.py
@@ -7,11 +7,11 @@ keri.kli.commands module
 import argparse
 import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
-from keri.core import coring, serdering
+from keri.core import serdering
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 import argparse
 from dataclasses import dataclass
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import habbing, agenting, indirecting, configing, delegating, forwarding
 from keri.app.cli.common import existing, incepting, config
 from keri.core import coring

--- a/src/keri/app/cli/commands/init.py
+++ b/src/keri/app/cli/commands/init.py
@@ -5,17 +5,13 @@ keri.kli.commands module
 """
 import argparse
 import getpass
-import os
-import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 import keri.app.oobiing
-from keri import kering
 from keri.app import habbing, configing, oobiing
 from keri.app.keeping import Algos
-from keri.db import basing
 from keri.kering import ConfigurationError
 from keri.vdr import credentialing
 

--- a/src/keri/app/cli/commands/ipex/list.py
+++ b/src/keri/app/cli/commands/ipex/list.py
@@ -11,10 +11,9 @@ import os
 import json
 import sys
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import indirecting, notifying, connecting
 from keri.app.cli.common import existing, terming
 from keri.core import scheming

--- a/src/keri/app/cli/commands/kevers.py
+++ b/src/keri/app/cli/commands/kevers.py
@@ -8,12 +8,12 @@ import argparse
 import datetime
 
 import sys
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import indirecting
 from keri.app.cli.common import displaying, existing
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.help import helping
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/list.py
+++ b/src/keri/app/cli/commands/list.py
@@ -6,11 +6,10 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
-from keri.kering import ConfigurationError
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/local/watch.py
+++ b/src/keri/app/cli/commands/local/watch.py
@@ -8,8 +8,8 @@ import random
 import sys
 import time
 
-from hio import help
 from hio.base import doing
+from keri import help
 from keri.app import agenting, indirecting, habbing, forwarding
 from keri.app.cli.common import existing, terming
 from keri.app.habbing import GroupHab

--- a/src/keri/app/cli/commands/location/add.py
+++ b/src/keri/app/cli/commands/location/add.py
@@ -7,10 +7,10 @@ keri.kli.commands module
 import argparse
 from urllib.parse import urlparse
 
-from hio import help
+
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import habbing, grouping, indirecting, forwarding
 from keri.app.agenting import WitnessPublisher
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/mailbox/add.py
+++ b/src/keri/app/cli/commands/mailbox/add.py
@@ -6,15 +6,13 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 from hio.help import Hict
 
-from keri import kering
-from keri.app import connecting, habbing, forwarding
+from keri import help, kering
+from keri.app import connecting, habbing
 from keri.app.agenting import httpClient, WitnessPublisher
 from keri.app.cli.common import existing
-from keri.core import serdering
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -6,15 +6,12 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
-from keri.app import agenting, indirecting, habbing, httping
-from keri.app.cli.common import displaying, existing
+from keri import help, kering
+from keri.app import agenting, habbing, httping
+from keri.app.cli.common import existing
 from keri.app.habbing import GroupHab
-from keri.core import coring
-from keri.kering import ConfigurationError
 
 logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/mailbox/list.py
+++ b/src/keri/app/cli/commands/mailbox/list.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import connecting
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError, Roles

--- a/src/keri/app/cli/commands/mailbox/update.py
+++ b/src/keri/app/cli/commands/mailbox/update.py
@@ -5,9 +5,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.db import basing
 from keri.kering import ConfigurationError

--- a/src/keri/app/cli/commands/migrate/list.py
+++ b/src/keri/app/cli/commands/migrate/list.py
@@ -5,10 +5,10 @@ keri.kli.commands.migrate.list module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 from prettytable import PrettyTable
 
+from keri import help
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/migrate/run.py
+++ b/src/keri/app/cli/commands/migrate/run.py
@@ -5,10 +5,10 @@ keri.kli.commands.migrate.run module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 from keri import kering
 
+from keri import help
 from keri.db import basing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/migrate/show.py
+++ b/src/keri/app/cli/commands/migrate/show.py
@@ -5,9 +5,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/multisig/continue.py
+++ b/src/keri/app/cli/commands/multisig/continue.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import indirecting, grouping, agenting
 from keri.app.cli.common import existing, displaying
 from keri.app.habbing import GroupHab

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -7,10 +7,9 @@ keri.kli.commands.multisig module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import grouping, indirecting, habbing, forwarding
 from keri.app.cli.common import existing, displaying, config
 from keri.app.notifying import Notifier

--- a/src/keri/app/cli/commands/multisig/notice.py
+++ b/src/keri/app/cli/commands/multisig/notice.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import habbing, forwarding, grouping
 from keri.app.cli.common import existing
 from keri.core.coring import Ilks

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -7,10 +7,9 @@ keri.kli.commands.multisig module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import grouping, indirecting, habbing, forwarding
 from keri.app.cli.common import rotating, existing, displaying, config
 from keri.app.notifying import Notifier

--- a/src/keri/app/cli/commands/multisig/update.py
+++ b/src/keri/app/cli/commands/multisig/update.py
@@ -6,10 +6,9 @@ keri.kli.commands module
 import argparse
 import time
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import agenting, indirecting, habbing
 from keri.app.cli.common import displaying
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/oobi/clean.py
+++ b/src/keri/app/cli/commands/oobi/clean.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/oobi/generate.py
+++ b/src/keri/app/cli/commands/oobi/generate.py
@@ -6,10 +6,9 @@ keri.kli.commands.oobi module
 import argparse
 
 import sys
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app.cli.common import existing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/oobi/resolve.py
+++ b/src/keri/app/cli/commands/oobi/resolve.py
@@ -5,14 +5,13 @@ keri.kli.commands.oobi module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 import keri.app.oobiing
 from keri.app import habbing, oobiing
 from keri.app.cli.common import existing
 from keri.db import basing
-from keri.end import ending
 from keri.help import helping
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/passcode/remove.py
+++ b/src/keri/app/cli/commands/passcode/remove.py
@@ -5,9 +5,9 @@ keri.kli.common.passcode.remove module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 

--- a/src/keri/app/cli/commands/passcode/set.py
+++ b/src/keri/app/cli/commands/passcode/set.py
@@ -6,20 +6,16 @@ keri.kli.common.passcode.set module
 import argparse
 import getpass
 
-from hio import help
-
 from hio.base import doing
 
-from keri.kering import ConfigurationError
-
-from keri import core
+from keri import core, help
 from keri.core import coring
+from keri.kering import ConfigurationError
 
 from keri.app.cli.common import existing
 
 
-
-logger = help.ogler.getLogger()  # I think this should be keri.help not hio.help
+logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='Initialize a prefix')
 parser.set_defaults(handler=lambda args: set_passcode(args),

--- a/src/keri/app/cli/commands/query.py
+++ b/src/keri/app/cli/commands/query.py
@@ -7,10 +7,10 @@ import argparse
 import datetime
 import json
 
-from hio import help
 from hio.base import doing
 from hio.help import decking
 
+from keri import help
 from keri.app import indirecting, habbing, querying
 from keri.app.cli.common import displaying
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/rename.py
+++ b/src/keri/app/cli/commands/rename.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 

--- a/src/keri/app/cli/commands/rollback.py
+++ b/src/keri/app/cli/commands/rollback.py
@@ -6,10 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import kering, help
 from keri.app.cli.common import displaying, existing
 from keri.core import coring, serdering
 from keri.db import dbing, basing

--- a/src/keri/app/cli/commands/saidify.py
+++ b/src/keri/app/cli/commands/saidify.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.core import coring
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/ssh/export.py
+++ b/src/keri/app/cli/commands/ssh/export.py
@@ -11,9 +11,9 @@ from pathlib import Path
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 

--- a/src/keri/app/cli/commands/status.py
+++ b/src/keri/app/cli/commands/status.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import displaying, existing
 from keri.core import serdering
 from keri.kering import ConfigurationError

--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -1,15 +1,12 @@
 import argparse
 import json
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
-from keri import core
-from keri.core import coring, eventing, serdering
-
+from keri import core, help, kering
 from keri.app import indirecting, habbing, grouping, connecting, forwarding, signing, notifying
 from keri.app.cli.common import existing
+from keri.core import coring, eventing, serdering
 from keri.help import helping
 from keri.peer import exchanging
 from keri.vdr import credentialing, verifying

--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -7,9 +7,9 @@ keri.kli.commands module
 import argparse
 import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import signing
 from keri.app.cli.common import existing
 from keri.core import serdering

--- a/src/keri/app/cli/commands/vc/list.py
+++ b/src/keri/app/cli/commands/vc/list.py
@@ -9,10 +9,9 @@ import datetime
 import json
 import sys
 
-from hio import help
 from hio.base import doing
 
-from keri import kering
+from keri import help, kering
 from keri.app import indirecting
 from keri.app.cli.common import existing, terming
 from keri.core import scheming

--- a/src/keri/app/cli/commands/vc/registry/incept.py
+++ b/src/keri/app/cli/commands/vc/registry/incept.py
@@ -1,13 +1,13 @@
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import indirecting, habbing, grouping, forwarding
 from keri.app.cli.common import existing
 from keri.app.habbing import GroupHab
 from keri.app.notifying import Notifier
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.core.eventing import SealEvent
 from keri.peer import exchanging
 from keri.vdr import credentialing

--- a/src/keri/app/cli/commands/vc/registry/list.py
+++ b/src/keri/app/cli/commands/vc/registry/list.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 from keri.vdr import credentialing

--- a/src/keri/app/cli/commands/vc/registry/status.py
+++ b/src/keri/app/cli/commands/vc/registry/status.py
@@ -1,11 +1,11 @@
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import indirecting, habbing, grouping
 from keri.app.cli.common import existing
-from keri.core import coring, serdering
+from keri.core import serdering
 from keri.vdr import credentialing
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/watcher/add.py
+++ b/src/keri/app/cli/commands/watcher/add.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import connecting, habbing, forwarding
 from keri.app.cli.common import existing
 from keri.core import serdering

--- a/src/keri/app/cli/commands/watcher/adjudicate.py
+++ b/src/keri/app/cli/commands/watcher/adjudicate.py
@@ -9,12 +9,11 @@ import datetime
 import random
 import sys
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import connecting, indirecting, querying, watching
 from keri.app.cli.common import existing
-from keri.app.watching import diffState, States
 from keri.help import helping
 from keri.kering import ConfigurationError
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/watcher/list.py
+++ b/src/keri/app/cli/commands/watcher/list.py
@@ -6,9 +6,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import connecting
 from keri.app.cli.common import existing
 from keri.kering import ConfigurationError, Roles

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -6,13 +6,12 @@ keri.kli.commands module
 """
 import argparse
 import json
-import sys
 
 import qrcode
-from hio import help
 from hio.base import doing
 from hio.help import Hict
 
+from keri import help
 from keri.app import httping, connecting
 from keri.app.agenting import httpClient
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/witness/list.py
+++ b/src/keri/app/cli/commands/witness/list.py
@@ -6,11 +6,10 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
-from keri.app.cli.common import displaying, existing
-from keri.core import serdering
+from keri import help
+from keri.app.cli.common import existing
 from keri.kering import ConfigurationError
 
 logger = help.ogler.getLogger()

--- a/src/keri/app/cli/commands/witness/submit.py
+++ b/src/keri/app/cli/commands/witness/submit.py
@@ -5,9 +5,9 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
 from hio.base import doing
 
+from keri import help
 from keri.app import habbing, agenting, indirecting
 from keri.app.cli.common import existing, displaying
 from keri.help import helping

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -6,11 +6,11 @@ keri.app.delegating module
 module for enveloping and forwarding KERI message
 """
 
-from hio import help
 from hio.base import doing
 
 from . import agenting, forwarding
 from .habbing import GroupHab
+from .. import help
 from .. import kering
 from ..core import coring, serdering
 from ..db import dbing

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -7,7 +7,6 @@ module for enveloping and forwarding KERI message
 """
 
 from hio.base import doing
-from hio.help import decking
 
 from .. import kering, core
 from .. import help

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -4,7 +4,6 @@ KERI
 keri.app.habbing module
 
 """
-import json
 from contextlib import contextmanager
 from math import ceil
 from urllib.parse import urlsplit

--- a/src/keri/demo/demo_kev.py
+++ b/src/keri/demo/demo_kev.py
@@ -8,11 +8,10 @@ Utilities for demos
 import argparse
 import logging
 
-from hio import help
 from hio.base import doing
 
-from ..app import habbing, keeping, apping
-from ..db import basing
+from keri import help
+from ..app import apping
 
 logger = help.ogler.getLogger()
 


### PR DESCRIPTION
This fixes #883 by making sure all places where the `help` module is imported properly import it as `keri.help` rather than `hio.help`.

I also removed a bunch of unused imports to clean things up.