### PR TITLE
Added B64IoDupSuber and B64OnIoDubSuber classes with unit tests

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -2380,7 +2380,7 @@ class Baser(dbing.LMDBer):
 
     def getUreItemIter(self, key=b''):
         """
-        Use sgKey()
+        Use snKey()
         Return iterator of partial signed escrowed event triple items at next
         key after key.
         Items is (key, val) where proem has already been stripped from val

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -17,4 +17,4 @@ from hio.help import ogling
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import
 
 from .helping import (nowIso8601, toIso8601, fromIso8601,
-                      nonStringSequence, nonStringIterable)
+                      nonStringSequence, nonStringIterable, Reb64)


### PR DESCRIPTION
Allows us to replace all uses of DeWitness Couple, DeReceiptCouple etc with Suber Instance that handles multiple field Base64 values. This is more effecient and now patterns like other Suber.

