### PR TITLE
refactor: move escrow logs to TRACE and msg body logs to DEBUG

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -3208,7 +3208,8 @@ class Kevery:
 
                 else:  # escrow likely duplicitous event
                     self.escrowLDEvent(serder=serder, sigers=sigers)
-                    raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                    logger.debug("Likely Duplicitous event Body=%s", serder.pretty())
+                    raise LikelyDuplicitousError(f"Likely Duplicitous event={serder.said}")
 
             else:  # rot, drt, or ixn, so sn matters
                 kever = self.kevers[pre]  # get existing kever for pre
@@ -3218,7 +3219,8 @@ class Kevery:
                     # escrow out-of-order event
                     self.escrowOOEvent(serder=serder, sigers=sigers,
                                        seqner=delseqner, saider=delsaider, wigers=wigers)
-                    raise OutOfOrderError("Out-of-order event={}.".format(ked))
+                    logger.debug("Out of Order event Body=%s", serder.pretty())
+                    raise OutOfOrderError(f"Out-of-order event={serder.said}")
 
                 elif ((sn == sno) or  # inorder event (ixn, rot, drt) or
                       (ilk == Ilks.rot and  # superseding recovery rot or
@@ -3280,7 +3282,8 @@ class Kevery:
 
                     else:  # escrow likely duplicitous event
                         self.escrowLDEvent(serder=serder, sigers=sigers)
-                        raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                        logger.debug("Likely Duplicitous event Body=%s", serder.pretty())
+                        raise LikelyDuplicitousError(f"Likely Duplicitous event={serder.said}")
 
     def processReceiptWitness(self, serder, wigers):
         """
@@ -4611,7 +4614,7 @@ class Kevery:
                     # error other than out of order so remove from OO escrow
                     self.db.delOoe(snKey(pre, sn), edig)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.trace("Kevery: ooo escrow other error on escrow: %s\n", ex.args[0])
+                        logger.debug("Kevery: ooo escrow other error on escrow: %s\n", ex.args[0])
                         logger.exception("Kevery: ooo escrow other error on : %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2714,8 +2714,8 @@ class Kever:
                         fn, serder.pre, dtsb.decode())
             logger.debug("Event Body=\n%s\n", serder.pretty())
         self.db.addKe(snKey(serder.preb, serder.sn), serder.saidb)
-        logger.info("Kever: Added to KEL valid event: %s for AID %s", serder.said, serder.pre)
-        logger.debug("Event Body=\n%s\n", serder.pretty())
+        logger.info("Kever: Added to KEL valid %s event %s for AID %s", serder.ilk, serder.said, serder.pre)
+        logger.debug("KEL Event Body=\n%s\n", serder.pretty())
         return (fn, dtsb.decode("utf-8"))  # (fn int, dts str) if first else (None, dts str)
 
     def escrowPSEvent(self, serder, sigers, wigers=None):
@@ -4125,18 +4125,20 @@ class Kevery:
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
                 logger.debug("Query not found error. Query Body=%s", ked)
-                raise QueryNotFoundError(f"Query not found error for evt {ked['d']} at route {ked['r']}")
+                raise QueryNotFoundError(f"Query not found error for at route {ked['r']} for evt {ked['d']}")
 
             kever = self.kevers[pre]
             if anchor:
                 if not self.db.findAnchoringSealEvent(pre=pre, seal=anchor):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                    raise QueryNotFoundError("Query not found error={}.".format(ked))
+                    logger.debug("Query not found error. Query Body=%s", ked)
+                    raise QueryNotFoundError(f"Query not found error at route {ked['r']} for evt {ked['d']}")
 
             elif sn is not None:
                 if kever.sner.num < sn or not self.db.fullyWitnessed(kever.serder):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                    raise QueryNotFoundError("Query not found error={}.".format(ked))
+                    logger.debug("Query not found error. Query Body=%s", ked)
+                    raise QueryNotFoundError(f"Query not found error at route {ked['r']} for evt {ked['d']}")
 
             msgs = list()  # outgoing messages
             for msg in self.db.clonePreIter(pre=pre, fn=0):
@@ -4156,7 +4158,8 @@ class Kevery:
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                logger.debug("Query not found error. Query Body=%s", ked)
+                raise QueryNotFoundError(f"Query not found error at route {ked['r']} for evt {ked['d']}")
 
             kever = self.kevers[pre]
 
@@ -4166,7 +4169,8 @@ class Kevery:
 
             if len(wigers) < kever.toader.num:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                logger.debug("Query not found error. Query Body=%s", ked)
+                raise QueryNotFoundError(f"Query not found error at route {ked['r']} for evt {ked['d']}")
 
             rserder = reply(route=f"/ksn/{src}", data=kever.state()._asdict())
             self.cues.push(dict(kin="reply", src=src, route="/ksn", serder=rserder,
@@ -4179,7 +4183,8 @@ class Kevery:
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                logger.debug("Query not found error. Query Body=%s", ked)
+                raise QueryNotFoundError(f"Query not found error at route {ked['r']} for evt {ked['d']}")
 
             self.cues.push(dict(kin="stream", serder=serder, pre=pre, src=src, topics=topics))
             # if pre in self.kevers:
@@ -4188,7 +4193,8 @@ class Kevery:
             #         self.cues.push(dict(kin="stream", serder=serder, pre=pre, src=src, topics=topics))
         else:
             self.cues.push(dict(kin="invalid", serder=serder))
-            raise ValidationError("invalid query message {} for evt = {}".format(ilk, ked))
+            logger.debug("Invalid Query error. Query Body=%s", ked)
+            raise ValidationError(f"invalid query message {ilk} at route {ked['r']} for evt = {ked['d']}")
 
     def fetchEstEvent(self, pre, sn):
         """

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1101,6 +1101,12 @@ class Parser:
                     except AttributeError:
                         raise kering.ValidationError("No kevery to process so dropped msg"
                                                      "= {}.".format(serder.pretty()))
+                    except kering.QueryNotFoundError as e: # catch escrow error and log it
+                        if logger.isEnabledFor(logging.TRACE):
+                            logger.exception("Error processing query = %s", e)
+                            logger.trace("Query Body=\n%s\n", serder.pretty())
+                        else:
+                            logger.error("Error processing query = %s", e)
 
                 elif route in ["tels", "tsn"]:
                     try:

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -6,7 +6,6 @@ message stream parsing support
 """
 
 import logging
-import traceback
 from collections import namedtuple
 from dataclasses import dataclass, astuple
 
@@ -1020,8 +1019,8 @@ class Parser:
                 # when present assumes this is source seal of delegating event in delegator's KEL
                 delseqner, delsaider = sscs[-1] if sscs else (None, None)  # use last one if more than one
                 if not sigers:
-                    raise kering.ValidationError("Missing attached signature(s) for evt "
-                                                 "= {}.".format(serder.ked))
+                    logger.debug("Parser: Missing attached signature(s) for evt = \n%s\n", serder.ked)
+                    raise kering.ValidationError(f"Missing attached signature(s) for evt={serder.ked['d']}")
                 try:
                     kvy.processEvent(serder=serder,
                                      sigers=sigers,
@@ -1037,13 +1036,13 @@ class Parser:
                         kvy.processReceiptQuadruples(serder, trqs, firner=firner)
 
                 except AttributeError as ex:
-                    raise kering.ValidationError("No kevery to process so dropped msg"
-                                                 "= {}.".format(serder.pretty())) from ex
+                    logger.debug("Parser: No kevery to process so dropped msg = %s", serder.pretty())
+                    raise kering.ValidationError(f"No kevery to process so dropped msg={serder.ked['d']}") from ex
 
             elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
                 if not (cigars or wigers or tsgs):
-                    raise kering.ValidationError("Missing attached signatures on receipt"
-                                                 "msg = {}.".format(serder.ked))
+                    logger.debug("Parser: Missing attached signatures on receipt msg = %s.", serder.ked)
+                    raise kering.ValidationError(f"Missing attached sigs on receipt msg={serder.ked['d']}")
 
                 try:
                     if cigars:
@@ -1074,6 +1073,12 @@ class Parser:
                 except AttributeError as e:
                     raise kering.ValidationError("No kevery to process so dropped msg"
                                                  "= {}.".format(serder.pretty()))
+                except kering.UnverifiedReplyError as e:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Error processing reply = %s", e)
+                        logger.debug("Reply Body=\n%s\n", serder.pretty())
+                    else:
+                        logger.error("Error processing reply = %s", e)
 
             elif ilk in (Ilks.qry,):  # query message
                 args = dict(serder=serder)

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -183,7 +183,7 @@ class Revery:
          Escrow process logic is route dependent and is dispatched by route,
          i.e. route is address of buffer with route specific handler of escrow.
         """
-        for k in eventing.RPY_LABELS:
+        for k in kering.RPY_LABELS:
             if k not in serder.ked:
                 raise kering.ValidationError(f"Missing element={k} from {coring.Ilks.rpy}"
                                              f" msg={serder.ked}.")
@@ -265,26 +265,30 @@ class Revery:
 
             if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own cig
                 if not self.local:  # own cig when not local so ignore
-                    logger.info("Kevery process: skipped own attachment"
-                                " on nonlocal reply msg=\n%s\n", serder.pretty())
+                    logger.info("Kevery: skipped own attachment for AID %s"
+                                " on non-local reply at route = %s", aid, serder.ked['r'])
+                    logger.debug("Reply Body=\n%s\n", serder.pretty())
                     continue  # skip own cig attachment on non-local reply msg
 
             if aid != cigar.verfer.qb64:  # cig not by aid
-                logger.info("Kevery process: skipped cig not from aid="
-                            "%s on reply msg=\n%s\n", aid, serder.pretty())
+                logger.info("Kevery: skipped cig not from aid="
+                            "%s on reply at route %s", aid, serder.ked['r'])
+                logger.debug("Reply Body=\n%s\n", serder.pretty())
                 continue  # skip invalid cig's verfer is not aid
 
             if odater:  # get old compare datetimes to see if later
                 if dater.datetime <= odater.datetime:
-                    logger.info("Kevery process: skipped stale update from "
-                                "%s of reply msg=\n%s\n", aid, serder.pretty())
+                    logger.trace("Kevery: skipped stale update from "
+                                "%s of reply at route= %s", aid, serder.ked['r'])
+                    logger.trace("Reply Body=\n%s\n", serder.pretty())
                     continue  # skip if not later
                     # raise ValidationError(f"Stale update of {route} from {aid} "
                     # f"via {Ilks.rpy}={serder.ked}.")
 
             if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-                logger.info("Kevery process: skipped nonverifying cig from "
-                            "%s on reply msg=\n%s\n", cigar.verfer.qb64, serder.pretty())
+                logger.info("Kevery: skipped non-verifying cig from "
+                            "%s on reply at route = %s", cigar.verfer.qb64, serder.ked['r'])
+                logger.debug("Reply Body=\n%s\n", serder.pretty())
                 continue  # skip if cig not verify
 
             # All constraints satisfied so update
@@ -482,10 +486,9 @@ class Revery:
 
                 except kering.UnverifiedReplyError as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Kevery unescrow attempt failed: %s\n", ex.args[0])
                         logger.exception("Kevery unescrow attempt failed: %s\n", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrow attempt failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -88,7 +88,7 @@ class Broker:
 
                 try:
                     if not (dater and serder and (tsgs or vcigars)):
-                        raise ValueError(f"Missing escrow artifacts at said={saider.qb64}"
+                        raise ValueError(f"Broker: Missing escrow artifacts at said={saider.qb64}"
                                          f"for pre={pre}.")
 
                     cigars = []
@@ -101,40 +101,39 @@ class Broker:
                     if ((helping.nowUTC() - dater.datetime) >
                             datetime.timedelta(seconds=self.timeout)):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale txn state escrow "
-                                    " at pre = %s\n", pre)
-
-                        raise kering.ValidationError(f"Stale txn state escrow at pre = {pre}.")
+                        msg = f"Broker: {typ} escrow unescrow error: Stale txn state escrow at pre = {pre}"
+                        logger.trace(msg)
+                        raise kering.ValidationError(msg)
 
                     processReply(serder=serder, saider=saider, route=serder.ked["r"],
                                  cigars=cigars, tsgs=tsgs, aid=aid)
 
                 except extype as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow attempt failed: %s\n", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrow attempt failed: %s\n", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Broker: %s escrow unescrow attempt failed: %s\n", typ, ex.args[0])
+                        logger.exception("Broker: %s escrow  unescrow attempt failed: %s\n", typ, ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                        logger.exception("Broker: %s escrow other error on unescrow: %s\n", typ, ex.args[0])
                     else:
-                        logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+                        logger.error("Broker: %s escrow other error on unescrow: %s\n", typ, ex.args[0])
 
                 else:  # unescrow succeded
                     self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow only
-                    logger.info("Kevery unescrow succeeded for txn state=\n%s\n",
-                                serder.pretty())
+                    logger.info("Broker: %s escrow unescrow succeeded for txn state=%s",
+                                typ, serder.said)
+                    logger.debug("TXN State Body=\n%s\n", serder.pretty())
 
             except Exception as ex:  # log diagnostics errors etc
                 self.escrowdb.remIokey(iokeys=(typ, pre, aid, ion))  # remove escrow
                 self.removeState(saider)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrowed due to error: %s\n", ex.args[0])
+                    logger.exception("Broker: %s escrow unescrowed due to error: %s\n", typ, ex.args[0])
                 else:
-                    logger.error("Kevery unescrowed due to error: %s\n", ex.args[0])
+                    logger.error("Broker: %s escrow unescrowed due to error: %s\n", typ, ex.args[0])
 
     def escrowStateNotice(self, *, typ, pre, aid, serder, saider, dater, cigars=None, tsgs=None):
         """

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -13,6 +13,18 @@ utility functions
 
 from hio.help import ogling
 
+import logging
+
+# Custom TRACE log level configuration
+TRACE = 5              # TRACE (5) logging level value between DEBUG (10) and NOTSET (0)
+logging.TRACE = TRACE  # add TRACE logging level to logging module
+logging.addLevelName(logging.TRACE, "TRACE")
+def trace(self, message, *args, **kwargs):
+    """Trace logging function - logs message if TRACE (5) level enabled"""
+    if self.isEnabledFor(TRACE):
+        self._log(TRACE, message, args, **kwargs)
+logging.Logger.trace = trace
+
 #  want help.ogler always defined by default
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -125,7 +125,7 @@ class Exchanger:
                 logger.debug(f"exn body=\n{serder.ked}\n")
                 return
         except AttributeError:
-            logger.info(f"Behavior for {route} missing or does not have verify for exn={serder.said}")
+            logger.debug(f"Behavior for {route} missing or does not have verify for exn={serder.said}")
             logger.debug(f"exn Body=\n{serder.ked}\n")
 
         # Always persis events

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -121,11 +121,12 @@ class Exchanger:
         # Perform behavior specific verification, think IPEX chaining requirements
         try:
             if not behavior.verify(serder=serder, attachments=attachments):
-                logger.info(f"exn event for route {route} failed behavior verfication.  exn={serder.ked}")
+                logger.info(f"exn event for route {route} failed behavior verification. exn={serder.said}")
+                logger.debug(f"exn body=\n{serder.ked}\n")
                 return
-
         except AttributeError:
-            logger.info(f"Behavior for {route} missing or does not have verify for exn={serder.ked}")
+            logger.info(f"Behavior for {route} missing or does not have verify for exn={serder.said}")
+            logger.debug(f"exn Body=\n{serder.ked}\n")
 
         # Always persis events
         self.logEvent(serder, pathed, tsgs, cigars)
@@ -135,7 +136,9 @@ class Exchanger:
         try:
             behavior.handle(serder=serder, attachments=attachments)
         except AttributeError:
-            logger.info(f"Behavior for {route} missing or does not have handle for exn={serder.ked}")
+            logger.info(f"Behavior for {route} missing or does not have handle for exn={serder.said}")
+            logger.debug(
+                f"exn body=\n{serder.ked}\n")
 
     def processEscrow(self):
         """ Process all escrows for `exn` messages
@@ -187,24 +190,21 @@ class Exchanger:
 
             try:
                 self.processEvent(serder=serder, tsgs=tsgs, pathed=pathed)
-
             except MissingSignatureError as ex:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.info("Exchange partially signed unescrow failed: %s\n", ex.args[0])
-                else:
-                    logger.info("Exchange partially signed failed: %s\n", ex.args[0])
+                logger.trace("Exchange partially signed unescrow failed: %s\n", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.debug(f"Event body=\n{serder.pretty()}\n")
             except Exception as ex:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.esigs.rem(dig)
+                logger.info("Exchange partially signed unescrowed: %s\n", ex.args[0])
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.info("Exchange partially signed unescrowed: %s\n", ex.args[0])
-                else:
-                    logger.info("Exchange partially signed unescrowed: %s\n", ex.args[0])
+                    logger.debug(f"Event body=\n{serder.pretty()}\n")
             else:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.esigs.rem(dig)
-                logger.info("Exchanger unescrow succeeded in valid exchange: "
-                            "creder=\n%s\n", serder.pretty())
+                logger.info(f"Exchanger unescrow succeeded in valid exchange: serder={serder.said}")
+                logger.debug(f"Serder Body=\n{serder.pretty()}\n")
 
     def logEvent(self, serder, pathed=None, tsgs=None, cigars=None):
         dig = serder.said

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1268,7 +1268,7 @@ class Tever:
         self.reger.putTvt(key, serder.raw)
         self.reger.putTel(snKey(pre, sn), dig)
         logger.info("Tever state: %s Added to TEL valid event=\n%s\n",
-                    pre, json.dumps(serder.ked, indent=1))
+                    pre, serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):
         """ Validate anchor and backer signatures (bigers) when provided.
@@ -1319,12 +1319,12 @@ class Tever:
 
             if len(bindices) < toad:  # not fully witnessed yet
                 self.escrowPWEvent(serder=serder, seqner=seqner, saider=saider, bigers=bigers)
-
-                raise MissingWitnessSignatureError("Failure satisfying toad = {} "
-                                                   "on witness sigs for {} for evt = {}.".format(toad,
-                                                                                                 [siger.qb64 for siger
-                                                                                                  in bigers],
-                                                                                                 serder.ked))
+                msg = (f"Failure satisfying toad={toad} on witness sigs "
+                       f"for {[siger.qb64 for siger in bigers]} "
+                       f"for evt = {serder.said}.")
+                logger.info(msg)
+                logger.debug(f"Event Body=\n{serder.ked}\n")
+                raise MissingWitnessSignatureError(msg)
         return bigers
 
     def verifyAnchor(self, serder, seqner=None, saider=None):
@@ -2077,10 +2077,9 @@ class Tevery:
 
             except OutOfOrderError as ex:
                 # still waiting on missing prior event to validate
-                if logger.isEnabledFor(logging.DEBUG):
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Tevery unescrow failed: %s\n", ex.args[0])
                     logger.exception("Tevery unescrow failed: %s\n", ex.args[0])
-                else:
-                    logger.error("Tevery unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than out of order so remove from OO escrow
@@ -2096,7 +2095,7 @@ class Tevery:
                 # valid event escrow.
                 self.reger.delOot(snKey(pre, sn))  # removes from escrow
                 logger.info("Tevery unescrow succeeded in valid event: "
-                            "event=\n%s\n", json.dumps(tserder.ked, indent=1))
+                            "event=\n%s\n", tserder.pretty())
 
     def processEscrowAnchorless(self):
         """ Process escrow of TEL events received before the anchoring KEL event.
@@ -2117,11 +2116,9 @@ class Tevery:
                 traw = self.reger.getTvt(dgkey)
                 if traw is None:
                     # no event so raise ValidationError which unescrows below
-                    logger.info("Tevery unescrow error: Missing event at."
-                                "dig = %s\n", bytes(digb))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(digb)))
+                    msg = f"Tevery: anchorless escrow unescrow error: Missing event at dig = {bytes(digb)}"
+                    logger.trace(msg)
+                    raise ValidationError(msg)
 
                 tserder = serdering.SerderKERI(raw=bytes(traw))  # escrowed event
 
@@ -2131,11 +2128,9 @@ class Tevery:
 
                 couple = self.reger.getAnc(dgkey)
                 if couple is None:
-                    logger.info("Tevery unescrow error: Missing anchor at."
-                                "dig = %s\n", bytes(digb))
-
-                    raise MissingAnchorError("Missing escrowed anchor at dig = {}."
-                                             "".format(bytes(digb)))
+                    msg = f"Tevery: anchorless escrow unescrow error: Missing anchor at dig = {bytes(digb)}"
+                    logger.trace(msg)
+                    raise MissingAnchorError(msg)
                 ancb = bytearray(couple)
                 seqner = coring.Seqner(qb64b=ancb, strip=True)
                 saider = coring.Saider(qb64b=ancb, strip=True)
@@ -2144,23 +2139,22 @@ class Tevery:
 
             except MissingAnchorError as ex:
                 # still waiting on missing prior event to validate
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrow failed: %s\n", ex.args[0])
-                else:
-                    logger.error("Tevery unescrow failed: %s\n", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Tevery: anchorless escrow unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Tevery: anchorless escrow unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than out of order so remove from OO escrow
                 self.reger.delTae(snKey(pre, sn))  # removes one escrow at key val
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrowed: %s\n", ex.args[0])
+                    logger.exception("Tevery: anchorless escrow other error on unescrow: %s\n", ex.args[0])
                 else:
-                    logger.error("Tevery unescrowed: %s\n", ex.args[0])
+                    logger.error("Tevery: anchorless escrow other error on unescrow: %s\n", ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.reger.delTae(snKey(pre, sn))  # removes from escrow
-                logger.info("Tevery unescrow succeeded in valid event: "
-                            "event=\n%s\n", json.dumps(tserder.ked, indent=1))
+                logger.info("Tevery: anchorless escrow unescrow succeeded in valid event: "
+                            "event=\n%s\n", tserder.pretty())

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1588,7 +1588,8 @@ class Tevery:
             if ilk in (Ilks.vcp,):
                 # we don't have multiple signatures to verify so this
                 # is already first seen and then lifely duplicitious
-                raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                logger.debug("Likely Duplicitous event Body=%s", serder.pretty())
+                raise LikelyDuplicitousError(f"Likely Duplicitous event={serder.said}")
 
             tever = self.tevers[regk]
             tever.cues = self.cues
@@ -1614,7 +1615,8 @@ class Tevery:
                     # self.cues.append(dict(kin="receipt", serder=serder))
                     pass
             else:  # duplicitious
-                raise LikelyDuplicitousError("Likely Duplicitous event={} with sn {}.".format(ked, sn))
+                logger.debug("Likely Duplicitous event Body=%s", serder.pretty())
+                raise LikelyDuplicitousError(f"Likely Duplicitous event={serder.said} with sn {serder.sn}")
 
     def processQuery(self, serder, source=None, sigers=None, cigars=None):
         """ Process TEL query event message (qry)

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1267,7 +1267,7 @@ class Tever:
         self.reger.tets.pin(keys=(pre.decode("utf-8"), dig.decode("utf-8")), val=coring.Dater())
         self.reger.putTvt(key, serder.raw)
         self.reger.putTel(snKey(pre, sn), dig)
-        logger.info("Tever: Added to TEL valid %s event=%s for AID %s", serder.ilk, serder.said, pre)
+        logger.info("Tever: Added to TEL valid %s event=%s for AID %s", serder.ilk, serder.said, serder.pre)
         logger.debug("TEL Event Body=\n%s\n", serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1267,8 +1267,8 @@ class Tever:
         self.reger.tets.pin(keys=(pre.decode("utf-8"), dig.decode("utf-8")), val=coring.Dater())
         self.reger.putTvt(key, serder.raw)
         self.reger.putTel(snKey(pre, sn), dig)
-        logger.info("Tever state: %s Added to TEL valid event=\n%s\n",
-                    pre, serder.pretty())
+        logger.info("Tever: Added to TEL valid %s event=%s for AID %s", serder.ilk, serder.said, pre)
+        logger.debug("TEL Event Body=\n%s\n", serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):
         """ Validate anchor and backer signatures (bigers) when provided.

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -263,10 +263,9 @@ class Verifier:
                 self.processCredential(creder, prefixer, seqner, saider)
 
             except etype as ex:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Verifiery unescrow failed: %s\n", ex.args[0])
-                else:
-                    logger.error("Verifier unescrow failed: %s\n", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Verifier unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Verifier unescrow failed: %s\n", ex.args[0])
             except Exception as ex:  # log diagnostics errors etc
                 # error other than missing sigs so remove from PA escrow
                 db.rem(said)


### PR DESCRIPTION
Description:
- Adds TRACE logging level in `keri.help.__init__` module.
- Moves escrow logs to TRACE logging level.
- Moves event body logging to DEBUG level.
- INFO log level contains SAID or prefix of events rather than an event body.
- Uniformly uses log substitution where it would improve performance.
- Uniformly uses f-strings where performance is equivalent yet readability is enhanced.
- `serder.pretty()` used in favor of `serder.ked` or `json.dumps(serder.ked, indent=1)`
- Added escrow-specific strings to each escrow to clarify in logs which escrow produced which log message.
- Various spelling corrections and wording cleanups like `Kevery process` to `Kevery`

There will be a separate PR to `main` for similar changes. Phil has already made similar changes in `main`.