### PR TITLE
fix: use store instead of store_true for args expecting nonces

### DIFF
--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -37,9 +37,9 @@ parser.add_argument('--alias', '-a', help='human readable alias for the new iden
 parser.add_argument("--private", help="flag to indicate if this credential needs privacy preserving features",
                     action="store_true")
 parser.add_argument("--private-credential-nonce", help="nonce for vc",
-                    action="store_true")
+                    action="store")
 parser.add_argument("--private-subject-nonce", help="nonce for subject",
-                    action="store_true")
+                    action="store")
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument("--time", help="timestamp for the credential creation", required=False, default=None)


### PR DESCRIPTION
has the fix as mentioned [here](https://github.com/WebOfTrust/keripy/pull/902).

This changes the `store_true` in the two new command line arguments 

`--private-credential-nonce`
and
`--private-subject-nonce`

to have their "action" prop set to store so that they can accept string values rather than be set only to True or False based on presence or absence of the command line arguments like `--private`.