### PR TITLE
feat: new role for schema discovery

### DIFF
--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -342,9 +342,9 @@ SEPARATOR_BYTES = SEPARATOR.encode("utf-8")
 Schemage = namedtuple("Schemage", 'tcp http https')
 Schemes = Schemage(tcp='tcp', http='http', https='https')
 
-Rolage = namedtuple("Rolage", 'controller witness registrar watcher judge juror peer mailbox agent')
+Rolage = namedtuple("Rolage", 'controller witness registrar watcher judge juror peer mailbox agent indexer')
 Roles = Rolage(controller='controller', witness='witness', registrar='registrar',
-               watcher='watcher', judge='judge', juror='juror', peer='peer', mailbox="mailbox", agent="agent")
+               watcher='watcher', judge='judge', juror='juror', peer='peer', mailbox="mailbox", agent="agent", indexer="indexer")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
To be honest, I'm not sure what to call this new role.

It's to address #886. This role is meant to allow a controller to designate a service endpoint (which may be on a different URL than the controller/agent) for discovery of schemas. Perhaps it could be used for other things, which is why I tried to leave it broad as `indexer` - like an index of OOBIs (or other things, like public ACDCs...) by SAIDs.

Open to suggestions.

---

Tested with KERIA/Signify to add a new loc scheme and end role auth where the `cid=eid`, and the service endpoint appears in the OOBI format `http://keria.com/oobi/<cid>`.