### PR TITLE
Add kli import command for importing dot CESR file, add gateway role

### DIFF
--- a/src/keri/app/cli/commands/import.py
+++ b/src/keri/app/cli/commands/import.py
@@ -68,7 +68,7 @@ class ImportDoer(doing.DoDoer):
 
         with open(self.file, 'rb') as f:
             ims = f.read()
-            parsing.Parser(kvy=self.hby.kvy, local=False).parse(ims=ims)
+            parsing.Parser(kvy=self.hby.kvy, rvy=self.hby.rvy, local=False).parse(ims=ims)
             self.hby.kvy.processEscrows()
 
         self.exit()

--- a/src/keri/app/cli/commands/import.py
+++ b/src/keri/app/cli/commands/import.py
@@ -1,0 +1,75 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+import sys
+
+from hio import help
+from hio.base import doing
+
+from keri.app import habbing
+from keri.app.cli.common import existing
+from keri.core import coring, serdering, parsing
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Import key events in CESR stream format')
+parser.set_defaults(handler=lambda args: export(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument("--file", help="File of streamed CESR events to import", required=True)
+
+
+def export(args):
+    """ Command line list credential registries handler
+
+    """
+
+    ed = ImportDoer(name=args.name,
+                    base=args.base,
+                    bran=args.bran,
+                    file=args.file)
+    return [ed]
+
+
+class ImportDoer(doing.DoDoer):
+
+    def __init__(self, name, base, bran, file):
+        self.file = file
+
+        self.hby = existing.setupHby(name=name, base=base, bran=bran)
+
+        doers = [doing.doify(self.exportDo), habbing.HaberyDoer(self.hby)]
+
+        super(ImportDoer, self).__init__(doers=doers)
+
+    def exportDo(self, tymth, tock=0.0):
+        """ Export credential from store and any related material
+
+        Parameters:
+            tymth (function): injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock (float): injected initial tock value
+
+        Returns:  doifiable Doist compatible generator method
+
+        """
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        with open(self.file, 'rb') as f:
+            ims = f.read()
+            parsing.Parser(kvy=self.hby.kvy, local=False).parse(ims=ims)
+            self.hby.kvy.processEscrows()
+
+        self.exit()
+        return True

--- a/src/keri/app/cli/commands/init.py
+++ b/src/keri/app/cli/commands/init.py
@@ -51,7 +51,7 @@ parser.add_argument('--config-file',
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)
 parser.add_argument('--nopasscode', help='create an unencrypted keystore', action='store_true')
-parser.add_argument('--aeid', '-a', help='qualified base64 of non-transferable identifier prefix for  authentication '
+parser.add_argument('--aeid', '-a', help='qualified base64 of non-transferable identifier prefix for authentication '
                                          'and encryption of secrets in keystore', default=None)
 parser.add_argument('--seed', '-e', help='qualified base64 private-signing key (seed) for the aeid from which the '
                                          'private decryption key may be derived', default=None)

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -342,8 +342,8 @@ SEPARATOR_BYTES = SEPARATOR.encode("utf-8")
 Schemage = namedtuple("Schemage", 'tcp http https')
 Schemes = Schemage(tcp='tcp', http='http', https='https')
 
-Rolage = namedtuple("Rolage", 'controller witness registrar watcher judge juror peer mailbox agent')
-Roles = Rolage(controller='controller', witness='witness', registrar='registrar',
+Rolage = namedtuple("Rolage", 'controller witness registrar gateway watcher judge juror peer mailbox agent')
+Roles = Rolage(controller='controller', witness='witness', registrar='registrar', gateway="gateway",
                watcher='watcher', judge='judge', juror='juror', peer='peer', mailbox="mailbox", agent="agent")
 
 

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -3,6 +3,8 @@
 tests.peer.test_exchanging module
 
 """
+import json
+
 import pysodium
 import pytest
 
@@ -57,10 +59,10 @@ def test_essrs():
         ims = hab.makeOwnInception()
         parsing.Parser().parse(ims=ims, kvy=recHby.kvy)
         # create the test message with essr attachment
-        msg = "This is a test message that must be secured"
+        msg = dict(msg="This is a test message that must be secured", i=hab.pre)
         rkever = recHab.kever
         pubkey = pysodium.crypto_sign_pk_to_box_pk(rkever.verfers[0].raw)
-        raw = pysodium.crypto_box_seal(msg.encode("utf-8"), pubkey)
+        raw = pysodium.crypto_box_seal(json.dumps(msg).encode("utf-8"), pubkey)
 
         texter = coring.Texter(raw=raw)
         diger = coring.Diger(ser=raw, code=MtrDex.Blake3_256)
@@ -84,7 +86,7 @@ def test_essrs():
         # Pull the logged ESSR attachment and verify it is the one attached
         texter = recHby.db.essrs.get(keys=(serder.said,))
         raw = recHab.decrypt(ser=texter[0].raw)
-        assert raw.decode("utf-8") == msg
+        assert json.loads(raw.decode("utf-8")) == msg
 
         # Test with invalid diger
         diger = coring.Diger(qb64="EKC8085pwSwzLwUGzh-HrEoFDwZnCJq27bVp5atdMT9o")


### PR DESCRIPTION
This PR includes:

* Import command that is the sister of the kli export command for importing a KEL into a local database
* A new gateway role for end role authorizations
* Fix ESSR test to encrypt sender correctly.