### PR TITLE
fix: add missing private arg to proving.credential()

### DIFF
--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -805,6 +805,7 @@ class Credentialer(doing.DoDoer):
                                     recipient=recp,
                                     data=data,
                                     source=source,
+                                    private=private,
                                     private_credential_nonce=private_credential_nonce,
                                     private_subject_nonce=private_subject_nonce,
                                     rules=rules,


### PR DESCRIPTION
Looks like I missed one detail while pulling in the private credential work from the 1.1.26 branch, the `private=private` argument to `proving.credential()` call, which was failing schema validations on all private credentials. This fixes that.