### PR TITLE
to 1.2.4: Add trace logging and consistent logging

### DIFF
--- a/src/keri/app/cli/commands/aid.py
+++ b/src/keri/app/cli/commands/aid.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/challenge/generate.py
+++ b/src/keri/app/cli/commands/challenge/generate.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 from mnemonic import mnemonic
 

--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -112,6 +112,8 @@ class RespondDoer(doing.DoDoer):
         del ims[:exn.size]
 
         senderHab = hab.mhab if isinstance(hab, GroupHab) else hab
+        logger.info("RespondDoer: sending challenge exn from %s to %s", senderHab.pre, recp)
+        logger.debug("RespondDoer: Challenge exn body=\n%s\n", exn.pretty())
         self.postman.send(src=senderHab.pre, dest=recp, topic="challenge", serder=exn, attachment=ims)
         while not self.postman.cues:
             yield self.tock

--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -114,8 +114,6 @@ class RespondDoer(doing.DoDoer):
         del ims[:exn.size]
 
         senderHab = hab.mhab if isinstance(hab, GroupHab) else hab
-        logger.info("RespondDoer: sending challenge exn from %s to %s", senderHab.pre, recp)
-        logger.debug("RespondDoer: Challenge exn body=\n%s\n", exn.pretty())
         self.postman.send(src=senderHab.pre, dest=recp, topic="challenge", serder=exn, attachment=ims)
         while not self.postman.cues:
             yield self.tock

--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -7,6 +7,7 @@ import argparse
 
 from hio.base import doing
 
+from keri import help
 from keri.app import habbing, forwarding, connecting
 from keri.app.cli.common import existing
 from keri.app.habbing import GroupHab
@@ -26,6 +27,7 @@ parser.add_argument('--words', '-d', help='JSON formatted array of words to sign
 parser.add_argument('--recipient', '-r', help='Contact alias of the AID to send the signed words to',
                     action="store", required=True)
 
+logger = help.ogler.getLogger()
 
 def respond(args):
     """

--- a/src/keri/app/cli/commands/challenge/verify.py
+++ b/src/keri/app/cli/commands/challenge/verify.py
@@ -8,7 +8,7 @@ import argparse
 import datetime
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import indirecting, challenging, connecting, signaling

--- a/src/keri/app/cli/commands/clean.py
+++ b/src/keri/app/cli/commands/clean.py
@@ -5,7 +5,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/contacts/list.py
+++ b/src/keri/app/cli/commands/contacts/list.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 from keri import kering
 

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -158,6 +158,10 @@ class ConfirmDoer(doing.DoDoer):
                         others.remove(hab.mhab.pre)
 
                         for recpt in others:  # send notification to other participants as a signalling mechanism
+                            logger.info(
+                                "ConfirmDoer: sending confirm notification exn from %s to %s",
+                                hab.mhab.pre, recpt)
+                            logger.debug("ConfirmDoer: Notification exn body=\n%s\n", exn.pretty())
                             self.postman.send(src=hab.mhab.pre, dest=recpt, topic="multisig", serder=exn,
                                               attachment=atc)
 

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -158,10 +158,6 @@ class ConfirmDoer(doing.DoDoer):
                         others.remove(hab.mhab.pre)
 
                         for recpt in others:  # send notification to other participants as a signalling mechanism
-                            logger.info(
-                                "ConfirmDoer: sending confirm notification exn from %s to %s",
-                                hab.mhab.pre, recpt)
-                            logger.debug("ConfirmDoer: Notification exn body=\n%s\n", exn.pretty())
                             self.postman.send(src=hab.mhab.pre, dest=recpt, topic="multisig", serder=exn,
                                               attachment=atc)
 

--- a/src/keri/app/cli/commands/delegate/request.py
+++ b/src/keri/app/cli/commands/delegate/request.py
@@ -98,17 +98,7 @@ class RequestDoer(doing.DoDoer):
         # delegate AID ICP and exn of delegation request EXN
         srdr = serdering.SerderKERI(raw=evt)
         del evt[:srdr.size]
-
-        logger.info(
-            "RequestDoer: sending delegated inception from delegate %s to delegator %s",
-            phab.pre, delpre)
-        logger.debug("RequestDoer: Delegated inception body=\n%s\n", exn.pretty())
         self.postman.send(src=phab.pre, dest=delpre, topic="delegate", serder=srdr, attachment=evt)
-
-        logger.info(
-            "RequestDoer: sending request notification exn from delegate %s to delegator %s",
-            phab.pre, delpre)
-        logger.debug("RequestDoer: Notification exn body=\n%s\n", exn.pretty())
         self.postman.send(src=phab.pre, dest=hab.kever.delpre, topic="delegate", serder=exn, attachment=atc)
 
         while True:

--- a/src/keri/app/cli/commands/delegate/request.py
+++ b/src/keri/app/cli/commands/delegate/request.py
@@ -98,7 +98,17 @@ class RequestDoer(doing.DoDoer):
         # delegate AID ICP and exn of delegation request EXN
         srdr = serdering.SerderKERI(raw=evt)
         del evt[:srdr.size]
+
+        logger.info(
+            "RequestDoer: sending delegated inception from delegate %s to delegator %s",
+            phab.pre, delpre)
+        logger.debug("RequestDoer: Delegated inception body=\n%s\n", exn.pretty())
         self.postman.send(src=phab.pre, dest=delpre, topic="delegate", serder=srdr, attachment=evt)
+
+        logger.info(
+            "RequestDoer: sending request notification exn from delegate %s to delegator %s",
+            phab.pre, delpre)
+        logger.debug("RequestDoer: Notification exn body=\n%s\n", exn.pretty())
         self.postman.send(src=phab.pre, dest=hab.kever.delpre, topic="delegate", serder=exn, attachment=atc)
 
         while True:

--- a/src/keri/app/cli/commands/did/generate.py
+++ b/src/keri/app/cli/commands/did/generate.py
@@ -9,7 +9,7 @@ import urllib
 from urllib.parse import urlparse
 
 import sys
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/ends/add.py
+++ b/src/keri/app/cli/commands/ends/add.py
@@ -104,10 +104,6 @@ class RoleDoer(doing.DoDoer):
 
             for recp in smids:  # this goes to other participants only as a signaling mechanism
                 exn, atc = grouping.multisigRpyExn(ghab=self.hab, rpy=msg)
-                logger.info(
-                    "RoleDoer: sending endpoint role add exn on %s from %s to %s",
-                    "multisig", self.hab.mhab.pre, recp)
-                logger.debug("RoleDoer: Endpoint Role Add Exn body=\n%s\n", exn.pretty())
                 self.postman.send(src=self.hab.mhab.pre,
                                   dest=recp,
                                   topic="multisig",

--- a/src/keri/app/cli/commands/ends/add.py
+++ b/src/keri/app/cli/commands/ends/add.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/ends/add.py
+++ b/src/keri/app/cli/commands/ends/add.py
@@ -104,6 +104,10 @@ class RoleDoer(doing.DoDoer):
 
             for recp in smids:  # this goes to other participants only as a signaling mechanism
                 exn, atc = grouping.multisigRpyExn(ghab=self.hab, rpy=msg)
+                logger.info(
+                    "RoleDoer: sending endpoint role add exn on %s from %s to %s",
+                    "multisig", self.hab.mhab.pre, recp)
+                logger.debug("RoleDoer: Endpoint Role Add Exn body=\n%s\n", exn.pretty())
                 self.postman.send(src=self.hab.mhab.pre,
                                   dest=recp,
                                   topic="multisig",

--- a/src/keri/app/cli/commands/ends/export.py
+++ b/src/keri/app/cli/commands/ends/export.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/ends/list.py
+++ b/src/keri/app/cli/commands/ends/list.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/escrow.py
+++ b/src/keri/app/cli/commands/escrow.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.core import eventing

--- a/src/keri/app/cli/commands/event.py
+++ b/src/keri/app/cli/commands/event.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/export.py
+++ b/src/keri/app/cli/commands/export.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 from dataclasses import dataclass
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import habbing, agenting, indirecting, configing, delegating, forwarding

--- a/src/keri/app/cli/commands/init.py
+++ b/src/keri/app/cli/commands/init.py
@@ -8,7 +8,7 @@ import getpass
 import os
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 import keri.app.oobiing

--- a/src/keri/app/cli/commands/ipex/join.py
+++ b/src/keri/app/cli/commands/ipex/join.py
@@ -104,7 +104,7 @@ class JoinDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        print("IPEX JoinDoer: Waiting for group ipex events...")
+        print("Waiting for group ipex events...")
 
         while True:
 

--- a/src/keri/app/cli/commands/ipex/join.py
+++ b/src/keri/app/cli/commands/ipex/join.py
@@ -104,7 +104,7 @@ class JoinDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        print("Waiting for group ipex events...")
+        print("IPEX JoinDoer: Waiting for group ipex events...")
 
         while True:
 

--- a/src/keri/app/cli/commands/ipex/list.py
+++ b/src/keri/app/cli/commands/ipex/list.py
@@ -11,7 +11,7 @@ import os
 import json
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/kevers.py
+++ b/src/keri/app/cli/commands/kevers.py
@@ -8,7 +8,7 @@ import argparse
 import datetime
 
 import sys
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import indirecting

--- a/src/keri/app/cli/commands/list.py
+++ b/src/keri/app/cli/commands/list.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/local/watch.py
+++ b/src/keri/app/cli/commands/local/watch.py
@@ -8,7 +8,7 @@ import random
 import sys
 import time
 
-from hio import help
+from keri import help
 from hio.base import doing
 from keri.app import agenting, indirecting, habbing, forwarding
 from keri.app.cli.common import existing, terming

--- a/src/keri/app/cli/commands/location/add.py
+++ b/src/keri/app/cli/commands/location/add.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 from urllib.parse import urlparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/mailbox/add.py
+++ b/src/keri/app/cli/commands/mailbox/add.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 from hio.help import Hict
 

--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/mailbox/list.py
+++ b/src/keri/app/cli/commands/mailbox/list.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import connecting

--- a/src/keri/app/cli/commands/mailbox/update.py
+++ b/src/keri/app/cli/commands/mailbox/update.py
@@ -5,7 +5,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/migrate/list.py
+++ b/src/keri/app/cli/commands/migrate/list.py
@@ -5,7 +5,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 from prettytable import PrettyTable
 

--- a/src/keri/app/cli/commands/migrate/run.py
+++ b/src/keri/app/cli/commands/migrate/run.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 
 import keri
-from hio import help
+from keri import help
 from hio.base import doing
 from keri import kering
 

--- a/src/keri/app/cli/commands/migrate/show.py
+++ b/src/keri/app/cli/commands/migrate/show.py
@@ -5,7 +5,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/multisig/continue.py
+++ b/src/keri/app/cli/commands/multisig/continue.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import indirecting, grouping, agenting

--- a/src/keri/app/cli/commands/multisig/incept.py
+++ b/src/keri/app/cli/commands/multisig/incept.py
@@ -156,7 +156,7 @@ class GroupMultisigIncept(doing.DoDoer):
                                   serder=exn,
                                   attachment=ims)
 
-            print(f"Group identifier inception initialized for {ghab.pre}")
+            logger.info(f"MS Incept: Group identifier inception initialized for {ghab.pre}")
             prefixer = coring.Prefixer(qb64=ghab.pre)
             seqner = coring.Seqner(sn=0)
             saider = coring.Saider(qb64=prefixer.qb64)

--- a/src/keri/app/cli/commands/multisig/incept.py
+++ b/src/keri/app/cli/commands/multisig/incept.py
@@ -156,7 +156,7 @@ class GroupMultisigIncept(doing.DoDoer):
                                   serder=exn,
                                   attachment=ims)
 
-            logger.info(f"MS Incept: Group identifier inception initialized for {ghab.pre}")
+            print(f"Group identifier inception initialized for {ghab.pre}")
             prefixer = coring.Prefixer(qb64=ghab.pre)
             seqner = coring.Seqner(sn=0)
             saider = coring.Saider(qb64=prefixer.qb64)

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -7,7 +7,7 @@ keri.kli.commands.multisig module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -120,6 +120,10 @@ class GroupMultisigInteract(doing.DoDoer):
         others.remove(ghab.mhab.pre)
 
         for recpt in others:  # send notification to other participants as a signalling mechanism
+            logger.info(
+                "GroupMultisigInteract: sending multisig interact exn from %s to %s",
+                ghab.mhab.pre, recpt)
+            logger.debug("GroupMultisigInteract: interact exn body=\n%s\n", exn.pretty())
             self.postman.send(src=ghab.mhab.pre, dest=recpt, topic="multisig", serder=exn, attachment=ims)
 
         prefixer = coring.Prefixer(qb64=ghab.pre)

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -120,10 +120,6 @@ class GroupMultisigInteract(doing.DoDoer):
         others.remove(ghab.mhab.pre)
 
         for recpt in others:  # send notification to other participants as a signalling mechanism
-            logger.info(
-                "GroupMultisigInteract: sending multisig interact exn from %s to %s",
-                ghab.mhab.pre, recpt)
-            logger.debug("GroupMultisigInteract: interact exn body=\n%s\n", exn.pretty())
             self.postman.send(src=ghab.mhab.pre, dest=recpt, topic="multisig", serder=exn, attachment=ims)
 
         prefixer = coring.Prefixer(qb64=ghab.pre)

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -111,7 +111,7 @@ class JoinDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        print("MS JoinDoer: Waiting for group multisig events...")
+        print("Waiting for group multisig events...")
 
         while self.notifier.noter.notes.cntAll() == 0:
             yield self.tock

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -111,7 +111,7 @@ class JoinDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        print("Waiting for group multisig events...")
+        print("MS JoinDoer: Waiting for group multisig events...")
 
         while self.notifier.noter.notes.cntAll() == 0:
             yield self.tock

--- a/src/keri/app/cli/commands/multisig/notice.py
+++ b/src/keri/app/cli/commands/multisig/notice.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import habbing, forwarding, grouping

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -7,7 +7,7 @@ keri.kli.commands.multisig module
 import argparse
 from ordered_set import OrderedSet as oset
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/multisig/rotate.py
+++ b/src/keri/app/cli/commands/multisig/rotate.py
@@ -44,7 +44,7 @@ def rotateGroupIdentifier(args):
     Performs a rotation on the group identifier specified as an argument.  The identifier prefix of the environment
     represented by the name parameter must be a member of the group identifier.  This command will perform a rotation
     of the local identifier if the sequence number of the local identifier is the same as the group identifier sequence
-    number.  It will wait for all other members of the group to acheive the same sequence number (group + 1) and then
+    number.  It will wait for all other members of the group to achieve the same sequence number (group + 1) and then
     publish the signed rotation event for the group identifier to all witnesses and wait for receipts.
 
     Parameters:

--- a/src/keri/app/cli/commands/multisig/update.py
+++ b/src/keri/app/cli/commands/multisig/update.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 import time
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/oobi/clean.py
+++ b/src/keri/app/cli/commands/oobi/clean.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/oobi/generate.py
+++ b/src/keri/app/cli/commands/oobi/generate.py
@@ -6,7 +6,7 @@ keri.kli.commands.oobi module
 import argparse
 
 import sys
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/oobi/resolve.py
+++ b/src/keri/app/cli/commands/oobi/resolve.py
@@ -5,7 +5,7 @@ keri.kli.commands.oobi module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 import keri.app.oobiing

--- a/src/keri/app/cli/commands/passcode/remove.py
+++ b/src/keri/app/cli/commands/passcode/remove.py
@@ -5,7 +5,7 @@ keri.kli.common.passcode.remove module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/passcode/set.py
+++ b/src/keri/app/cli/commands/passcode/set.py
@@ -6,7 +6,7 @@ keri.kli.common.passcode.set module
 import argparse
 import getpass
 
-from hio import help
+from keri import help
 
 from hio.base import doing
 

--- a/src/keri/app/cli/commands/query.py
+++ b/src/keri/app/cli/commands/query.py
@@ -7,7 +7,7 @@ import argparse
 import datetime
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 from hio.help import decking
 

--- a/src/keri/app/cli/commands/rename.py
+++ b/src/keri/app/cli/commands/rename.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/rollback.py
+++ b/src/keri/app/cli/commands/rollback.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/saidify.py
+++ b/src/keri/app/cli/commands/saidify.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 import argparse
 import json
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.core import coring

--- a/src/keri/app/cli/commands/ssh/export.py
+++ b/src/keri/app/cli/commands/ssh/export.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/status.py
+++ b/src/keri/app/cli/commands/status.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import displaying, existing

--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from typing import Optional
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -7,7 +7,7 @@ keri.kli.commands module
 import argparse
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import signing

--- a/src/keri/app/cli/commands/vc/list.py
+++ b/src/keri/app/cli/commands/vc/list.py
@@ -9,7 +9,7 @@ import datetime
 import json
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri import kering

--- a/src/keri/app/cli/commands/vc/registry/incept.py
+++ b/src/keri/app/cli/commands/vc/registry/incept.py
@@ -1,6 +1,6 @@
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import indirecting, habbing, grouping, forwarding

--- a/src/keri/app/cli/commands/vc/registry/list.py
+++ b/src/keri/app/cli/commands/vc/registry/list.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import existing

--- a/src/keri/app/cli/commands/vc/registry/status.py
+++ b/src/keri/app/cli/commands/vc/registry/status.py
@@ -1,6 +1,6 @@
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import indirecting, habbing, grouping

--- a/src/keri/app/cli/commands/watcher/add.py
+++ b/src/keri/app/cli/commands/watcher/add.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import connecting, habbing, forwarding

--- a/src/keri/app/cli/commands/watcher/adjudicate.py
+++ b/src/keri/app/cli/commands/watcher/adjudicate.py
@@ -9,7 +9,7 @@ import datetime
 import random
 import sys
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import connecting, indirecting, querying, watching

--- a/src/keri/app/cli/commands/watcher/list.py
+++ b/src/keri/app/cli/commands/watcher/list.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import connecting

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -9,7 +9,7 @@ import json
 import sys
 
 import qrcode
-from hio import help
+from keri import help
 from hio.base import doing
 from hio.help import Hict
 

--- a/src/keri/app/cli/commands/witness/demo.py
+++ b/src/keri/app/cli/commands/witness/demo.py
@@ -8,6 +8,7 @@ Witness command line interface
 
 import argparse
 import logging
+import os
 
 from hio.base import doing
 
@@ -19,18 +20,25 @@ from keri.core import Salter
 
 
 parser = argparse.ArgumentParser(description="Run a demo collection of witnesses")
+parser.add_argument("--loglevel", action="store", required=False, default=os.getenv("KERI_LOG_LEVEL", "CRITICAL"),
+                    help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 parser.set_defaults(handler=lambda args: demo(args))
 
 
-help.ogler.level = logging.INFO
 logger = help.ogler.getLogger()
 
 
-def demo(_):
+def demo(args):
     """
     Run set of three witnesses for demo
 
     """
+    base_formatter = logging.Formatter('%(asctime)s [keri] %(module)s.%(funcName)s-%(lineno)s %(levelname)-8s %(message)s')
+    base_formatter.default_msec_format = None
+    help.ogler.baseConsoleHandler.setFormatter(base_formatter)
+    help.ogler.level = logging.getLevelName(args.loglevel.upper())
+    logger.setLevel(help.ogler.level)
+    help.ogler.reopen(name="keri", temp=True, clear=True)
 
     wancf = configing.Configer(name="wan", headDirPath="scripts", temp=False, reopen=True, clear=False)
     wilcf = configing.Configer(name="wil", headDirPath="scripts", temp=False, reopen=True, clear=False)

--- a/src/keri/app/cli/commands/witness/list.py
+++ b/src/keri/app/cli/commands/witness/list.py
@@ -6,7 +6,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app.cli.common import displaying, existing

--- a/src/keri/app/cli/commands/witness/submit.py
+++ b/src/keri/app/cli/commands/witness/submit.py
@@ -5,7 +5,7 @@ keri.kli.commands module
 """
 import argparse
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from keri.app import habbing, agenting, indirecting

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -172,7 +172,7 @@ class Anchorer(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                logger.info(f"Anchorer: Witness receipts complete, waiting for delegation approval.")
+                logger.info(f"Witness receipts complete, waiting for delegation approval.")
                 if pre not in self.hby.habs:
                     continue
 
@@ -193,15 +193,15 @@ class Anchorer(doing.DoDoer):
                 srdr = serdering.SerderKERI(raw=evt)
                 exn, atc = delegateRequestExn(phab, delpre=delpre, evt=bytes(evt), aids=smids)
 
-                logger.info("Anchorer: Sending delegation request exn for %s from %s to delegator %s",
+                logger.info("Sending delegation request exn for %s from %s to delegator %s",
                             srdr.ilk, phab.pre, delpre)
                 logger.debug("Delegation request=\n%s\n", exn.pretty())
                 self.postman.send(hab=phab, dest=hab.kever.delpre, topic="delegate", serder=exn, attachment=atc)
 
                 del evt[:srdr.size]
-                logger.info("Anchorer: Sending delegation event %s from %s to delegator %s",
+                logger.info("Sending delegation event %s from %s to delegator %s",
                             srdr.ilk, phab.pre, delpre)
-                logger.debug("Anchorer: Delegated inception=\n%s\n", srdr.pretty())
+                logger.debug("Delegated inception=\n%s\n", srdr.pretty())
                 self.postman.send(hab=phab, dest=delpre, topic="delegate", serder=srdr, attachment=evt)
 
                 seal = dict(i=srdr.pre, s=srdr.snh, d=srdr.said)

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -172,7 +172,7 @@ class Anchorer(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                logger.info(f"Witness receipts complete, waiting for delegation approval.")
+                logger.info(f"Anchorer: Witness receipts complete, waiting for delegation approval.")
                 if pre not in self.hby.habs:
                     continue
 
@@ -190,12 +190,18 @@ class Anchorer(doing.DoDoer):
                     raise kering.ValidationError("no proxy to send messages for delegation")
 
                 evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
+                srdr = serdering.SerderKERI(raw=evt)
                 exn, atc = delegateRequestExn(phab, delpre=delpre, evt=bytes(evt), aids=smids)
 
+                logger.info("Anchorer: Sending delegation request exn for %s from %s to delegator %s",
+                            srdr.ilk, phab.pre, delpre)
+                logger.debug("Delegation request=\n%s\n", exn.pretty())
                 self.postman.send(hab=phab, dest=hab.kever.delpre, topic="delegate", serder=exn, attachment=atc)
 
-                srdr = serdering.SerderKERI(raw=evt)
                 del evt[:srdr.size]
+                logger.info("Anchorer: Sending delegation event %s from %s to delegator %s",
+                            srdr.ilk, phab.pre, delpre)
+                logger.debug("Anchorer: Delegated inception=\n%s\n", srdr.pretty())
                 self.postman.send(hab=phab, dest=delpre, topic="delegate", serder=srdr, attachment=evt)
 
                 seal = dict(i=srdr.pre, s=srdr.snh, d=srdr.said)

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -6,7 +6,7 @@ keri.app.delegating module
 module for enveloping and forwarding KERI message
 """
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from . import agenting, forwarding

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -49,8 +49,7 @@ class Counselor(doing.DoDoer):
         """
         evt = ghab.makeOwnEvent(sn=seqner.sn, allowPartiallySigned=True) # used just for the log message
         serder = serdering.SerderKERI(raw=evt)                           # used just for the log message
-        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Multisig start; "
-                    f"Waiting for other signatures for {serder.ilk} {prefixer.qb64}:{seqner.sn}...")
+        logger.info("Waiting for other signatures on %s for %s:%s...", serder.ilk, prefixer.qb64, seqner.sn)
         return self.hby.db.gpse.add(keys=(prefixer.qb64,), val=(seqner, saider))
 
     def complete(self, prefixer, seqner, saider=None):
@@ -132,7 +131,8 @@ class Counselor(doing.DoDoer):
                 if kever.delegated and kever.ilk in (coring.Ilks.dip, coring.Ilks.drt):
                     # We are a delegated identifier, must wait for delegator approval for dip and drt
                     if witered:  # We are elected to perform delegation and witnessing messaging
-                        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: We are the witnesser, sending {pre} to delegator")
+                        logger.info("AID %s...%s: We are the witnesser, sending %s to delegator",
+                                    pre[:4], pre[-4:], pre)
                         self.swain.delegation(pre=pre, sn=seqner.sn)
                     else:
                         anchor = dict(i=pre, s=seqner.snh, d=saider.qb64)
@@ -141,15 +141,17 @@ class Counselor(doing.DoDoer):
                         else:
                             self.witq.query(src=ghab.mhab.pre, pre=kever.delpre, anchor=anchor)
 
-                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for delegation approval...")
+                    logger.info("AID %s...%s: Waiting for delegation approval...", pre[:4], pre[-4:])
                     self.hby.db.gdee.add(keys=(pre,), val=(seqner, saider))
                 else:  # Non-delegation, move on to witnessing
                     if witered:  # We are elected witnesser, send off event to witnesses
-                        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: We are the fully signed witnesser {seqner.sn}, sending to witnesses")
+                        logger.info("AID %s...%s: We are the fully signed witnesser %s, sending to witnesses",
+                                    pre[:4], pre[-4:], seqner.sn)
                         self.witDoer.msgs.append(dict(pre=pre, sn=seqner.sn))
 
                     # Move to escrow waiting for witness receipts
-                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for fully signed witness receipts for {seqner.sn}")
+                    logger.info("AID %s...%s: Waiting for fully signed witness receipts for %s",
+                                pre[:4], pre[-4:], seqner.sn)
                     self.hby.db.gpwe.add(keys=(pre,), val=(seqner, saider))
 
     def processDelegateEscrow(self):
@@ -169,7 +171,8 @@ class Counselor(doing.DoDoer):
             if witer:  # We are elected witnesser, We've already done out part in Boatswain, we are done.
                 if self.swain.complete(prefixer=kever.prefixer, seqner=coring.Seqner(sn=kever.sn)):
                     self.hby.db.gdee.rem(keys=(pre,))
-                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Delegation approval for {pre} received.")
+                    logger.info("AID %s...%s: Delegation approval for %s received.",
+                                pre[:4], pre[-4:], pre)
 
                     self.hby.db.cgms.put(keys=(pre, seqner.qb64), val=saider)
 
@@ -181,10 +184,10 @@ class Counselor(doing.DoDoer):
                     dgkey = dbing.dgKey(pre, saider.qb64b)
                     self.hby.db.setAes(dgkey, couple)  # authorizer event seal (delegator/issuer)
                     self.hby.db.gdee.rem(keys=(pre,))
-                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Delegation approval for {pre} received.")
+                    logger.info("AID %s...%s: Delegation approval for %s received.", pre[:4], pre[-4:], pre)
 
                     # Move to escrow waiting for witness receipts
-                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for witness receipts for {pre}")
+                    logger.info("AID %s...%s: Waiting for witness receipts for %s", pre[:4], pre[-4:], pre)
                     self.hby.db.gdee.rem(keys=(pre,))
                     self.hby.db.gpwe.add(keys=(pre,), val=(seqner, saider))
 
@@ -212,7 +215,7 @@ class Counselor(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Witness receipts complete, {pre} confirmed.")
+                logger.info("AID %s...%s: Witness receipts complete, %s confirmed.", pre[:4], pre[-4:], pre)
                 self.hby.db.gpwe.rem(keys=(pre,))
                 self.hby.db.cgms.put(keys=(pre, seqner.qb64), val=saider)
             elif not witer:
@@ -243,8 +246,8 @@ class MultisigNotificationHandler:
             attachments (list): list of tuples of pather, CESR SAD path attachments to the exn event
 
         """
-        logger.info("MS Note Hdlr: %s event SAID=%s", self.resource, serder.said)
-        logger.debug("MS Note Hdlr: EXN Body=\n%s\n", serder.pretty())
+        logger.info("Notification for %s event SAID=%s", self.resource, serder.said)
+        logger.debug("EXN Body=\n%s\n", serder.pretty())
         self.mux.add(serder=serder)
 
 

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -47,7 +47,10 @@ class Counselor(doing.DoDoer):
             saider (Saider): saider of event of group identifier
 
         """
-        print(f"Waiting for other signatures for {prefixer.qb64}:{seqner.sn}...")
+        evt = ghab.makeOwnEvent(sn=seqner.sn, allowPartiallySigned=True) # used just for the log message
+        serder = serdering.SerderKERI(raw=evt)                           # used just for the log message
+        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Multisig start; "
+                    f"Waiting for other signatures for {serder.ilk} {prefixer.qb64}:{seqner.sn}...")
         return self.hby.db.gpse.add(keys=(prefixer.qb64,), val=(seqner, saider))
 
     def complete(self, prefixer, seqner, saider=None):
@@ -129,7 +132,7 @@ class Counselor(doing.DoDoer):
                 if kever.delegated and kever.ilk in (coring.Ilks.dip, coring.Ilks.drt):
                     # We are a delegated identifier, must wait for delegator approval for dip and drt
                     if witered:  # We are elected to perform delegation and witnessing messaging
-                        logger.info(f"We are the witnesser, sending {pre} to delegator")
+                        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: We are the witnesser, sending {pre} to delegator")
                         self.swain.delegation(pre=pre, sn=seqner.sn)
                     else:
                         anchor = dict(i=pre, s=seqner.snh, d=saider.qb64)
@@ -138,15 +141,15 @@ class Counselor(doing.DoDoer):
                         else:
                             self.witq.query(src=ghab.mhab.pre, pre=kever.delpre, anchor=anchor)
 
-                    logger.info("Waiting for delegation approval...")
+                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for delegation approval...")
                     self.hby.db.gdee.add(keys=(pre,), val=(seqner, saider))
                 else:  # Non-delegation, move on to witnessing
                     if witered:  # We are elected witnesser, send off event to witnesses
-                        logger.info(f"We are the fully signed witnesser {seqner.sn}, sending to witnesses")
+                        logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: We are the fully signed witnesser {seqner.sn}, sending to witnesses")
                         self.witDoer.msgs.append(dict(pre=pre, sn=seqner.sn))
 
                     # Move to escrow waiting for witness receipts
-                    logger.info(f"Waiting for fully signed witness receipts for {seqner.sn}")
+                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for fully signed witness receipts for {seqner.sn}")
                     self.hby.db.gpwe.add(keys=(pre,), val=(seqner, saider))
 
     def processDelegateEscrow(self):
@@ -166,7 +169,7 @@ class Counselor(doing.DoDoer):
             if witer:  # We are elected witnesser, We've already done out part in Boatswain, we are done.
                 if self.swain.complete(prefixer=kever.prefixer, seqner=coring.Seqner(sn=kever.sn)):
                     self.hby.db.gdee.rem(keys=(pre,))
-                    logger.info(f"Delegation approval for {pre} received.")
+                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Delegation approval for {pre} received.")
 
                     self.hby.db.cgms.put(keys=(pre, seqner.qb64), val=saider)
 
@@ -178,10 +181,10 @@ class Counselor(doing.DoDoer):
                     dgkey = dbing.dgKey(pre, saider.qb64b)
                     self.hby.db.setAes(dgkey, couple)  # authorizer event seal (delegator/issuer)
                     self.hby.db.gdee.rem(keys=(pre,))
-                    logger.info(f"Delegation approval for {pre} received.")
+                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Delegation approval for {pre} received.")
 
                     # Move to escrow waiting for witness receipts
-                    logger.info(f"Waiting for witness receipts for {pre}")
+                    logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Waiting for witness receipts for {pre}")
                     self.hby.db.gdee.rem(keys=(pre,))
                     self.hby.db.gpwe.add(keys=(pre,), val=(seqner, saider))
 
@@ -209,7 +212,7 @@ class Counselor(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                logger.info(f"Witness receipts complete, {pre} confirmed.")
+                logger.info(f"[Counselor {ghab.mhab.pre[:8]}]: Witness receipts complete, {pre} confirmed.")
                 self.hby.db.gpwe.rem(keys=(pre,))
                 self.hby.db.cgms.put(keys=(pre, seqner.qb64), val=saider)
             elif not witer:
@@ -240,6 +243,8 @@ class MultisigNotificationHandler:
             attachments (list): list of tuples of pather, CESR SAD path attachments to the exn event
 
         """
+        logger.info("MS Note Hdlr: %s event SAID=%s", self.resource, serder.said)
+        logger.debug("MS Note Hdlr: EXN Body=\n%s\n", serder.pretty())
         self.mux.add(serder=serder)
 
 

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -479,13 +479,11 @@ class MailboxDirector(doing.DoDoer):
         hby (Habitat: local controller's context
 
     Properties:
-        tyme (float): relative cycle time of associated Tymist, obtained
-            via injected .tymth function wrapper closure.
-        tymth (function): function wrapper closure returned by Tymist .tymeth()
-            method.  When .tymth is called it returns associated Tymist .tyme.
-            .tymth provides injected dependency on Tymist tyme base.
-        tock (float): desired time in seconds between runs or until next run,
-            non negative, zero means run asap
+        hby (Habery): the Habery in which mailbox messages are routed
+        verifier (Verifier): TEL event acceptor and validator
+        exchanger (Exchanger): Exchange (exn) message delivery component
+        rep (Respondant): Respondant for reply messages
+        cues (Deck): Queue for new actions to schedule shared between the Revery, Kevery (and Kever), and Tevery (and Tever)
 
 
     Methods:

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -224,6 +224,8 @@ class Respondant(doing.DoDoer):
                 # sign the exn to get the signature
                 eattach = senderHab.endorse(exn, last=False, pipelined=False)
                 del eattach[:exn.size]
+                logger.info("Respondant: sending exn on %s from %s to %s", topic, sender, recipient)
+                logger.debug("Respondant: exn body=\n%s\n", exn.pretty())
                 self.postman.send(recipient, topic=topic, serder=exn, hab=forwardHab, attachment=eattach)
 
                 yield self.tock  # throttle just do one cue at a time

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -224,8 +224,8 @@ class Respondant(doing.DoDoer):
                 # sign the exn to get the signature
                 eattach = senderHab.endorse(exn, last=False, pipelined=False)
                 del eattach[:exn.size]
-                logger.info("Respondant: sending exn on %s from %s to %s", topic, sender, recipient)
-                logger.debug("Respondant: exn body=\n%s\n", exn.pretty())
+                logger.info("Sending exn on %s from %s to %s", topic, sender, recipient)
+                logger.debug("exn body=\n%s\n", exn.pretty())
                 self.postman.send(recipient, topic=topic, serder=exn, hab=forwardHab, attachment=eattach)
 
                 yield self.tock  # throttle just do one cue at a time

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2321,9 +2321,12 @@ class Kever:
         if not tholder.satisfy(indices):  # at least one but not enough
             self.escrowPSEvent(serder=serder, sigers=sigers, wigers=wigers,
                                seqner=delseqner, saider=delsaider, local=local)
-            raise MissingSignatureError(f"Failure satisfying sith = {tholder.sith}"
-                                        f" on sigs for {[siger.qb64 for siger in sigers]}"
-                                        f" for evt = {serder.ked}.")
+            msg = (f"[{self.prefixer.qb64[:8]}] Failure satisfying sith = {tholder.sith} "
+                   f"on sigs {[siger.qb64 for siger in sigers]} "
+                   f"for evt = {serder.said}")
+            logger.info("Kever: %s", msg)
+            logger.debug("Event Body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
 
 
         # escrow if not fully signed vs prior next rotation threshold
@@ -2333,10 +2336,13 @@ class Kever:
             if not self.ntholder.satisfy(indices=ondices):
                 self.escrowPSEvent(serder=serder, sigers=sigers, wigers=wigers,
                                    seqner=delseqner, saider=delsaider,local=local)
-                raise MissingSignatureError(f"Failure satisfying prior nsith="
-                                            f"{self.ntholder.sith} with exposed "
-                                            f"sigs= {[siger.qb64 for siger in sigers]}"
-                                            f" for new est evt={serder.ked}.")
+                msg = (
+                    f"[{self.prefixer.qb64[:8]}] Failure satisfying prior nsith = {self.ntholder.sith} "
+                    f"with exposed sigs {[siger.qb64 for siger in sigers]} "
+                    f"for new est evt={serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingSignatureError(msg)
 
         # this point the sigers have been verified and the wigers have been verified
         # even if locallyOwned or locallyMembered or locallyWitnessed.
@@ -2364,10 +2370,12 @@ class Kever:
                                           local=local):
                         # cue to query for witness receipts
                         self.cues.push(dict(kin="query", q=dict(pre=serder.pre, sn=serder.snh)))
-                    raise MissingWitnessSignatureError(f"Failure satisfying toad={toader.num} "
-                                                       f"on witness sigs="
-                                                       f"{[siger.qb64 for siger in wigers]} "
-                                                       f"for event={serder.ked}.")
+                    msg = (f"[{self.prefixer.qb64[:8]}] Failure satisfying toad={toader.num} "
+                           f"on witness sigs {[siger.qb64 for siger in wigers]} "
+                           f"for event={serder.said}")
+                    logger.info("Kever: %s", msg)
+                    logger.debug("Event Body=\n%s\n", serder.pretty())
+                    raise MissingWitnessSignatureError(msg)
 
 
         # Delegator approves delegation by attaching valid source
@@ -2388,9 +2396,10 @@ class Kever:
                 # seal to delegating event, i.e. delseqner, delsaider.
                 self.escrowDelegableEvent(serder=serder, sigers=sigers,
                                           wigers=wigers, local=local)
-                raise MissingDelegableApprovalError(f"Missing approval for "
-                                                    f" delegation by {delpre} of"
-                                                    f"event = {serder.ked}.")
+                msg = f"Missing approval for delegation by {delpre} of event = {serder.said}"
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegableApprovalError(msg)
 
         # validateDelegation returns (None, None) when delegation validation
         # does not apply. Raises ValidationError if validation applies but
@@ -2746,14 +2755,19 @@ class Kever:
             # of delegator if still missing when processing escrow later.
             self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                seqner=delseqner, saider=delsaider, local=local)
-            raise MissingDelegationError(f"Missing KEL of delegator "
-                                         f"{delpre} of evt = {serder.ked}.")
+            msg = f"Missing KEL of delegator {delpre} of evt {serder.sn} {serder.ilk} {serder.said}"
+            logger.info("Kever: %s", msg)
+            logger.debug("Event Body=\n%s\n", serder.pretty())
+            raise MissingDelegationError(msg)
 
 
         dkever = self.kevers[delpre]  # get delegator's KEL
         if dkever.doNotDelegate:  # drop event if delegation not allowed
-            raise ValidationError(f"Delegator = {delpre} for evt = {serder.ked},"
-                                  f" does not allow delegation.")
+            msg = (f"Delegator {delpre} does not allow delegation on evt "
+                   f"{serder.sn} {serder.ilk} {serder.said}")
+            logger.info("Kever: %s", msg)
+            logger.debug("Event Body=\n%s\n", serder.pretty())
+            raise ValidationError(msg)
 
         dserder = None  # no delegation event yet
         if delseqner is None or delsaider is None: # missing delegation seal ref
@@ -2768,8 +2782,11 @@ class Kever:
             if not dserder: # just escrow and try later
                 self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                    seqner=delseqner, saider=delsaider, local=local)
-                raise MissingDelegationError(f"No delegation seal for delegator "
-                                             f"{delpre} of evt = {serder.ked}.")
+                msg = (f"No delegation seal for delegator {delpre} on evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegationError(msg)
 
         if delseqner and delsaider and not dserder:  # given couple not found
             # ToDo XXXX need to replace Seqners with Numbers
@@ -2795,17 +2812,22 @@ class Kever:
                 # otherwise escrowPDEvent
                 self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                    seqner=delseqner, saider=delsaider, local=local)
-                raise MissingDelegationError(f"No delegating event from {delpre}"
-                                                 f" at {delsaider.qb64} for "
-                                                 f"evt = {serder.ked}.")
+                msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegationError(msg)
 
             # get the latest delegating event candidate from dig given by pre,sn index
             ddig = bytes(raw)
             key = dgKey(pre=delpre, dig=ddig)  # database key
             raw = self.db.getEvt(key)  # get actual last event
             if raw is None:   # drop event should never happen unless database is broken
-                raise ValidationError(f"Missing delegation from {delpre} at event "
-                                      f"dig = {ddig} for evt = {serder.ked}.")
+                msg = (f"Missing delegation from {delpre} at event dig = {ddig} for evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise ValidationError(msg)
 
             dserder = serdering.SerderKERI(raw=bytes(raw))  # purported delegating event
 
@@ -2829,8 +2851,11 @@ class Kever:
                 delseqner = delsaider = None  # nullify
                 self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                            seqner=delseqner, saider=delsaider, local=local)
-                raise MissingDelegationError(f"No delegation seal for delegator "
-                                                     f"{delpre} of evt = {serder.ked}.")
+                msg = (f"No delegation seal for delegator {delpre} of evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegationError(msg)
 
             ## Found valid anchoring seal of delegator delpre
             ## compare saids to ensure match of delegating event and source seal
@@ -2872,9 +2897,11 @@ class Kever:
                                                    eager=eager)):
             self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                 seqner=delseqner, saider=delsaider, local=local)
-            raise MissingDelegationError(f"No delegating event from {delpre}"
-                                                     f" at {delsaider.qb64} for "
-                                                     f"evt = {serder.ked}.")
+            msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
+                   f"{serder.sn} {serder.ilk} {serder.said}")
+            logger.info("Kever: %s", msg)
+            logger.debug("Event Body=\n%s\n", serder.pretty())
+            raise MissingDelegationError(msg)
         # already have new potential superseding delegation
         serfn = serder  # new potentially superseding delegated event i.e. serf new
         bossn = dserder # new delegating event of superseding delegated event i.e. boss new
@@ -2908,8 +2935,11 @@ class Kever:
                 else:  # not superseded
                     # ToDo: XXXX may want to cue up business logic for delegator
                     # if self.mine(delegator):  # failed attempt at recovery
-                    raise ValidationError(f"Invalid delegation recovery rotation"
-                                          f"of {serfo.ked} by {serfn.ked}")
+                    msg = f"Invalid delegation recovery rotation of {serfo.pre} by {serfn.pre}"
+                    logger.info("Kever: %s", msg)
+                    logger.debug("Delegate Event Body=\n%s\n", serfo.pretty())
+                    logger.debug("Delegator Event Body=\n%s\n", serfn.pretty())
+                    raise ValidationError(msg)
 
             # tie condition same sn and drt so need to climb delegation chain
             serfn = bossn
@@ -2918,18 +2948,22 @@ class Kever:
                                                        eager=eager)):
                 self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                 seqner=delseqner, saider=delsaider, local=local)
-                raise MissingDelegationError(f"No delegating event from {delpre}"
-                                             f" at {delsaider.qb64} for "
-                                             f"evt = {serder.ked}.")
+                msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegationError(msg)
             serfo = bosso
             if not (bosso := self.fetchDelegatingEvent(delpre, serfo,
                                                        original=True,
                                                        eager=eager)):
                 self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                 seqner=delseqner, saider=delsaider, local=local)
-                raise MissingDelegationError(f"No delegating event from {delpre}"
-                                             f" at {delsaider.qb64} for "
-                                             f"evt = {serder.ked}.")
+                msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
+                       f"{serder.sn} {serder.ilk} {serder.said}")
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise MissingDelegationError(msg)
             # repeat
         # should never get to here
 
@@ -3015,7 +3049,10 @@ class Kever:
             ddgkey = dgKey(pre=delpre, dig=deldig)  # database key of delegation
             if not (raw := self.db.getEvt(ddgkey)):  # in fons but no event
                 # database broken this should never happen
-                raise ValidationError(f"Missing delegation event for {serder.ked}")
+                msg = f"Missing delegation event for {serder.said}"
+                logger.info("Kever: %s", msg)
+                logger.debug("Event Body=\n%s\n", serder.pretty())
+                raise ValidationError(msg)
             # original delegating event i.e. boss original
             dserder = serdering.SerderKERI(raw=bytes(raw))
             return dserder
@@ -3028,6 +3065,9 @@ class Kever:
                     # database broken this should never happen so do not validate
                     # since original must have been validated so it must have
                     # all its delegation chain.
+                    msg = f"Missing delegation source seal for {serder.said}"
+                    logger.info("Kever: %s", msg)
+                    logger.debug("Event Body=\n%s\n", serder.pretty())
                     raise ValidationError(f"Missing delegation source seal for {serder.ked}")
             else:  # only search last events in delegator's kel
                 if not (dserder := self.db.fetchLastSealingEventByEventSeal(pre=delpre,
@@ -3134,18 +3174,19 @@ class Kever:
                 logger.info("Kever Mismatch Cloned Replay FN: %s First seen "
                             "ordinal fn %s and clone fn %s, said=%s",
                             serder.preb, fn, firner.sn, serder.said)
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.debug("Event body=\n%s\n", serder.pretty())
             if dater:  # cloned replay use original's dts from dater
                 dtsb = dater.dtsb
             self.db.setDts(dgkey, dtsb)  # first seen so set dts to now
             self.db.fons.pin(keys=dgkey, val=Seqner(sn=fn))
-            logger.info("Kever state: %s First seen ordinal %s at %s, said=%s",
-                        serder.pre, fn, dtsb.decode("utf-8"), serder.said)
-            logger.debug(f"event=\n{serder.pretty()}\n")
+            logger.debug("Kever [%.8s]: First seen %s %s SAID=%s for %s at %s",
+                         self.prefixer.qb64, fn, serder.ilk, serder.said,
+                         serder.pre, dtsb.decode("utf-8"))
+            logger.debug("Event Body=\n%s\n", serder.pretty())
         self.db.addKe(snKey(serder.preb, serder.sn), serder.saidb)
-        logger.info("Kever state: %s Added to KEL valid said=%s",
-                    serder.pre, serder.said)
-        logger.debug(f"event=\n{serder.pretty()}\n")
+        logger.info("Kever [%.8s]: Added to KEL %s at sn=%s valid event SAID=%s for AID %s",
+                    self.prefixer.qb64, serder.ilk, serder.sn, serder.said, serder.pre)
+        logger.debug("Event Body=\n%s\n", serder.pretty())
         return (fn, dtsb.decode("utf-8"))  # (fn int, dts str) if first else (None, dts str)
 
 
@@ -3820,7 +3861,10 @@ class Kevery:
 
                 else:  # escrow likely duplicitous event
                     self.escrowLDEvent(serder=serder, sigers=sigers)
-                    raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                    msg = f"Likely Duplicitous Event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
+                    logger.debug("Kevery: %s", msg)
+                    logger.debug("Duplicitous event body=\n%s\n", serder.pretty())
+                    raise LikelyDuplicitousError(msg)
 
             else:  # rot, drt, or ixn, so sn matters
                 kever = self.kevers[pre]  # get existing kever for pre
@@ -3830,7 +3874,10 @@ class Kevery:
                     # escrow out-of-order event
                     self.escrowOOEvent(serder=serder, sigers=sigers,
                                        seqner=delseqner, saider=delsaider, wigers=wigers, local=local)
-                    raise OutOfOrderError("Out-of-order event={}.".format(ked))
+                    msg = f"Out-of-order event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
+                    logger.debug("Kevery: %s", msg)
+                    logger.debug("Out-of-order event body=\n%s\n", serder.pretty())
+                    raise OutOfOrderError(msg)
 
                 elif ((sn == sno) or  # inorder event (ixn, rot, drt) or
                       (ilk == Ilks.rot and  # superseding recovery rot or
@@ -3899,7 +3946,10 @@ class Kevery:
 
                     else:  # escrow likely duplicitous event
                         self.escrowLDEvent(serder=serder, sigers=sigers)
-                        raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                        msg = f"Likely Duplicitous Event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
+                        logger.debug("Kevery: %s", msg)
+                        logger.debug("Duplicitous event body=\n%s\n", serder.pretty())
+                        raise LikelyDuplicitousError(msg)
 
 
     def processReceiptWitness(self, serder, wigers, local=None):
@@ -3944,8 +3994,10 @@ class Kevery:
             lserder = serdering.SerderKERI(raw=raw)  # deserialize event raw
 
             if not lserder.compare(said=ked["d"]):  # stale receipt at sn discard
-                raise ValidationError("Stale receipt at sn = {} for rct = {}."
-                                      "".format(ked["s"], ked))
+                msg = f"Stale receipt at sn = {ked['s']} for rct = {serder.said}."
+                logger.info("Kevery: %s", msg)
+                logger.debug("Stale receipt event body=\n%s\n", serder.pretty())
+                raise ValidationError(msg)
 
             # process each couple verify sig and write to db
             wits = [wit.qb64 for wit in self.fetchWitnessState(pre, sn)]
@@ -3960,15 +4012,15 @@ class Kevery:
                 if not self.lax and wiger.verfer.qb64 in self.prefixes:  # own is witness
                     if pre in self.prefixes:  # skip own receiptor of own event
                         # sign own events not receipt them
-                        logger.info("Kevery process: skipped own receipt attachment"
-                                    " on own event receipt=%s", serder.said)
-                        logger.debug(f"event=\n{serder.pretty()}\n")
+                        logger.info("Kevery: skipped own receipt attachment"
+                                     " on own event receipt=%s", serder.said)
+                        logger.debug("Event=\n%s\n", serder.pretty())
 
                         continue  # skip own receipt attachment on own event
                     if not local:  # so skip own receipt on other event when non-local source
-                        logger.info("Kevery process: skipped own receipt attachment"
-                                    " on nonlocal event receipt=%s", serder.said)
-                        logger.debug(f"event=\n{serder.pretty()}\n")
+                        logger.debug("Kevery: skipped own receipt attachment"
+                                     " on nonlocal event receipt=%s", serder.said)
+                        logger.debug("Event=\n%s\n", serder.pretty())
                         continue  # skip own receipt attachment on non-local event
 
                 if wiger.verfer.verify(wiger.raw, lserder.raw):
@@ -3978,8 +4030,10 @@ class Kevery:
         else:  # no events to be receipted yet at that sn so escrow
             # get digest from receipt message not receipted event
             self.escrowUWReceipt(serder=serder, wigers=wigers, said=ked["d"])
-            raise UnverifiedWitnessReceiptError("Unverified witness receipt={}."
-                                                "".format(ked))
+            msg = f"Unverified witness receipt={serder.said}"
+            logger.info("Kevery: %s", msg)
+            logger.debug("Event=\n%s\n", serder.pretty())
+            raise UnverifiedWitnessReceiptError(msg)
 
     def processReceipt(self, serder, cigars, local=None):
         """
@@ -4035,15 +4089,15 @@ class Kevery:
                 if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own is receiptor
                     if pre in self.prefixes:  # skip own receipter of own event
                         # sign own events not receipt them
-                        logger.info("Kevery process: skipped own receipt attachment"
-                                    " on own event receipt=%s", serder.said)
-                        logger.debug(f"event=\n{serder.pretty()}\n")
+                        logger.debug("Kevery process: skipped own receipt attachment"
+                                     " on own event receipt=%s", serder.said)
+                        logger.debug("Event=\n%s\n", serder.pretty())
 
                         continue  # skip own receipt attachment on own event
                     if not local:  # skip own receipt on other event when not local
-                        logger.info("Kevery process: skipped own receipt attachment"
-                                    " on nonlocal event receipt=%s", serder.said)
-                        logger.debug(f"event=\n{serder.pretty()}\n")
+                        logger.debug("Kevery process: skipped own receipt attachment"
+                                     " on nonlocal event receipt=%s", serder.said)
+                        logger.debug("Event=\n%s\n", serder.pretty())
                         continue  # skip own receipt attachment on non-local event
 
                 if cigar.verfer.verify(cigar.raw, lserder.raw):
@@ -4060,7 +4114,10 @@ class Kevery:
 
         else:  # no events to be receipted yet at that sn so escrow
             self.escrowUReceipt(serder, cigars, said=ked["d"])  # digest in receipt
-            raise UnverifiedReceiptError("Unverified receipt={}.".format(ked))
+            msg = f"Unverified receipt = {serder.said}"
+            logger.info("Kevery: %s", msg)
+            logger.debug("event=\n%s\n", serder.pretty())
+            raise UnverifiedReceiptError(msg)
 
 
     def processAttachedReceiptCouples(self, serder, cigars, firner=None, local=None):
@@ -4119,15 +4176,15 @@ class Kevery:
             if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own is receiptor
                 if pre in self.prefixes:  # skip own receipter on own event
                     # sign own events not receipt them
-                    logger.info("Kevery process: skipped own receipt attachment"
-                                " on own event receipt=%s", serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.debug("Kevery process: skipped own receipt attachment"
+                                 " on own event receipt=%s", serder.said)
+                    logger.debug("Event=\n%s\n", serder.pretty())
 
                     continue  # skip own receipt attachment on own event
                 if not local:  # own receipt on other event when not local
-                    logger.info("Kevery process: skipped own receipt attachment"
-                                " on nonlocal event receipt=%s", serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.debug("Kevery process: skipped own receipt attachment"
+                                 " on nonlocal event receipt=%s", serder.said)
+                    logger.debug("Event=\n%s\n", serder.pretty())
 
                     continue  # skip own receipt attachment on non-local event
 
@@ -4333,12 +4390,9 @@ class Kevery:
 
                 siger.verfer = sverfers[siger.index]  # assign verfer
                 if not siger.verfer.verify(siger.raw, serder.raw):  # verify sig
-                    logger.info("Kevery unescrow error: Bad trans receipt sig."
-                                "pre=%s sn=%x receipter=%s", pre, sn, sprefixer.qb64)
-
-                    raise ValidationError("Bad escrowed trans receipt sig at "
-                                          "pre={} sn={:x} receipter={}."
-                                          "".format(pre, sn, sprefixer.qb64))
+                    msg = f"Bad trans receipt sig pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # good sig so write receipt quadruple to database
 
@@ -4467,8 +4521,10 @@ class Kevery:
                                         aid=aid, osaider=osaider, cigars=cigars,
                                         tsgs=tsgs)
         if not accepted:
-            logger.debug(f"Unverified end role reply ked={serder.ked}")
-            raise UnverifiedReplyError(f"Unverified end role reply. {serder.said}")
+            msg = f"Unverified end role reply = {serder.said} role = {role}"
+            logger.debug(f"Kevery: %s", msg)
+            logger.debug(f"Event=\n%s\n", serder.pretty())
+            raise UnverifiedReplyError(msg)
 
         self.updateEnd(keys=keys, saider=saider, allowed=allowed)  # update .eans and .ends
 
@@ -4565,7 +4621,10 @@ class Kevery:
                                       aid=aid, osaider=osaider, cigars=cigars,
                                       tsgs=tsgs)
         if not accepted:
-            raise UnverifiedReplyError(f"Unverified loc scheme reply. {serder.ked}")
+            msg = f"Unverified loc scheme reply URL={url} SAID={serder.said}"
+            logger.debug(msg)
+            logger.debug("Event Body=\n%s\n", serder.pretty())
+            raise UnverifiedReplyError(msg)
 
         self.updateLoc(keys=keys, saider=saider, url=url)  # update .lans and .locs
 
@@ -4891,18 +4950,27 @@ class Kevery:
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                msg = f"Query not found error on event route={route} SAID={serder.said}"
+                logger.debug("Kevery: %s", msg)
+                logger.debug("Query Body=\n%s\n", serder.pretty())
+                raise QueryNotFoundError(msg)
 
             kever = self.kevers[pre]
             if anchor:
                 if not self.db.fetchAllSealingEventByEventSeal(pre=pre, seal=anchor):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                    raise QueryNotFoundError("Query not found error={}.".format(ked))
+                    msg = f"Query not found error on event route={route} SAID={serder.said}"
+                    logger.debug("Kevery: %s", msg)
+                    logger.debug("Query Body=\n%s\n", serder.pretty())
+                    raise QueryNotFoundError(msg)
 
             elif sn is not None:
                 if kever.sner.num < sn or not self.db.fullyWitnessed(kever.serder):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                    raise QueryNotFoundError("Query not found error={}.".format(ked))
+                    msg = f"Query not found error on event route={route} SAID={serder.said}"
+                    logger.debug("Kevery: %s", msg)
+                    logger.debug("Query Body=\n%s\n", serder.pretty())
+                    raise QueryNotFoundError(msg)
 
             msgs = list()  # outgoing messages
             for msg in self.db.clonePreIter(pre=pre, fn=fn):
@@ -4922,7 +4990,10 @@ class Kevery:
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                msg = f"Query not found error on event route={route} SAID={serder.said}"
+                logger.debug("Kevery: %s", msg)
+                logger.debug("Query Body=\n%s\n", serder.pretty())
+                raise QueryNotFoundError(msg)
 
             kever = self.kevers[pre]
 
@@ -4932,7 +5003,10 @@ class Kevery:
 
             if len(wigers) < kever.toader.num:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                msg = f"Query not found error on event route={route} SAID={serder.said}"
+                logger.debug(msg)
+                logger.debug("Query Body=\n%s\n", serder.pretty())
+                raise QueryNotFoundError(msg)
 
             rserder = reply(route=f"/ksn/{src}", data=kever.state()._asdict())
             self.cues.push(dict(kin="reply", src=src, route="/ksn", serder=rserder,
@@ -4945,7 +5019,10 @@ class Kevery:
 
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
-                raise QueryNotFoundError("Query not found error={}.".format(ked))
+                msg = f"Query not found error on event route={route} SAID={serder.said}"
+                logger.debug(msg)
+                logger.debug("Query Body=\n%s\n", serder.pretty())
+                raise QueryNotFoundError(msg)
 
             self.cues.push(dict(kin="stream", serder=serder, pre=pre, src=src, topics=topics))
             # if pre in self.kevers:
@@ -4954,7 +5031,10 @@ class Kevery:
             #         self.cues.push(dict(kin="stream", serder=serder, pre=pre, src=src, topics=topics))
         else:
             self.cues.push(dict(kin="invalid", serder=serder))
-            raise ValidationError("invalid query message {} for evt = {}".format(ilk, ked))
+            msg = f"Invalid query message {ilk} for event route={route} SAID={serder.said}"
+            logger.info("Kevery: %s", msg)
+            logger.debug("Query Body=\n%s\n", serder.pretty())
+            raise ValidationError(msg)
 
     def fetchEstEvent(self, pre, sn):
         """
@@ -5383,40 +5463,35 @@ class Kevery:
                     pre, sn = splitSnKey(ekey)  # get pre and sn from escrow item
                     dgkey = dgKey(pre, bytes(edig))
                     if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                        # no local sourde so raise ValidationError which unescrows below
-                        raise ValidationError("Missing escrowed event source "
-                                              "at dig = {}.".format(bytes(edig)))
+                        # no local source so raise ValidationError which unescrows below
+                        msg = f"OOO Missing escrowed event source at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # check date if expired then remove escrow.
                     dtb = self.db.getDts(dgkey)
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"OOO Missing escrowed event datetime at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutOOE):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale event escrow "
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Stale event escrow "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"OOO Stale event escrow at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # get the escrowed event using edig
                     eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt at dig = {}."
-                                              "".format(bytes(edig)))
+                        msg = f"OOO Missing escrowed event at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -5424,11 +5499,9 @@ class Kevery:
                     sigs = self.db.getSigs(dgKey(pre, bytes(edig)))
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event sigs at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt sigs at "
-                                              "dig = {}.".format(bytes(edig)))
+                        msg = f"OOO Missing escrowed event sigs at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # process event
                     sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
@@ -5471,9 +5544,9 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delOoe(snKey(pre, sn), edig)  # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded in valid event: "
+                    logger.info("Kevery OOO unescrow succeeded in valid event: "
                                 "event=%s", eserder.said)
-                    logger.debug(f"event=\n{eserder.pretty()}\n")
+                    logger.debug("Event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
                 break
@@ -5523,51 +5596,44 @@ class Kevery:
                 pre, sn = splitSnKey(ekey)  # get pre and sn from escrow item
                 dgkey = dgKey(pre, bytes(edig))
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                    # no local sourde so raise ValidationError which unescrows below
-                    raise ValidationError("Missing escrowed event source "
-                                          "at dig = {}.".format(bytes(edig)))
+                    # no local source so raise ValidationError which unescrows below
+                    msg = f"PS Missing escrowed event source at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event datetime"
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed event datetime "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PS Missing escrowed event datetime at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
                 dtnow = helping.nowUTC()
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPSE):
                     # escrow stale so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Stale event escrow "
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Stale event escrow "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PS Stale event escrow at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # get the escrowed event using edig
                 eraw = self.db.getEvt(dgkey)
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(edig)))
+                    msg = f"PS Missing escrowed evt at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
                 #  get sigs and attach
                 sigs = self.db.getSigs(dgkey)
                 if not sigs:  # otherwise its a list of sigs
                     # no sigs so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event sigs at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt sigs at "
-                                          "dig = {}.".format(bytes(edig)))
+                    msg = f"PS Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
                 wigs = self.db.getWigs(dgKey(pre, bytes(edig)))  # list of wigs
                 if not wigs:  # empty list wigs witness sigs not wits
                     # wigs maybe empty  if not wits or if wits while waiting
@@ -5647,9 +5713,9 @@ class Kevery:
                 if eserder is not None and eserder.ked["t"] in (Ilks.dip, Ilks.drt,):
                     self.cues.push(dict(kin="psUnescrow", serder=eserder))
 
-                logger.info("Kevery unescrow succeeded in valid event: "
+                logger.info("Kevery PS unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
-                logger.debug(f"event=\n{eserder.pretty()}\n")
+                logger.debug("event=\n%s\n", eserder.pretty())
 
             #if ekey == key:  # still same so no escrows found on last while iteration
                 #break
@@ -5696,40 +5762,35 @@ class Kevery:
                 pre, sn = splitSnKey(ekey)  # get pre and sn from escrow item
                 dgkey = dgKey(pre, bytes(edig))
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                    # no local sourde so raise ValidationError which unescrows below
-                    raise ValidationError("Missing escrowed event source "
-                                          "at dig = {}.".format(bytes(edig)))
+                    # no local source so raise ValidationError which unescrows below
+                    msg = f"PW Missing escrowed event source at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event datetime"
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed event datetime "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PW Missing escrowed event datetime at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
                 dtnow = helping.nowUTC()
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Stale event escrow "
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Stale event escrow "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PW Stale event escrow at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # get the escrowed event using edig
                 eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(edig)))
+                    msg = f"PW Missing escrowed evt at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -5737,11 +5798,9 @@ class Kevery:
                 sigs = self.db.getSigs(dgKey(pre, bytes(edig)))  # list of sigs
                 if not sigs:  # empty list
                     # no sigs so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event sigs at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt sigs at "
-                                          "dig = {}.".format(bytes(edig)))
+                    msg = f"PW Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 #  get witness signatures (wigs not wits)
                 wigs = self.db.getWigs(dgKey(pre, bytes(edig)))  # list of wigs
@@ -5822,9 +5881,9 @@ class Kevery:
                 # valid event escrow.
                 self.db.delPwe(snKey(pre, sn), edig)  # removes one escrow at key val
                 self.db.udes.rem(keys=dgkey)  # remove escrow if any
-                logger.info("Kevery unescrow succeeded in valid event: "
+                logger.info("Kevery PW unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
-                logger.debug(f"event=\n{eserder.pretty()}\n")
+                logger.debug("Event=\n%s\n", eserder.pretty())
 
 
     def processEscrowPartialDels(self):
@@ -5859,40 +5918,35 @@ class Kevery:
                 #pre, sn = splitSnKey(ekey)  # get pre and sn from escrow item
                 dgkey = dgKey(epre, edig)
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                    # no local sourde so raise ValidationError which unescrows below
-                    raise ValidationError("Missing escrowed event source "
-                                          "at dig = {}.".format(bytes(edig)))
+                    # no local source so raise ValidationError which unescrows below
+                    msg = f"PD Missing escrowed event source at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event datetime"
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed event datetime "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PD Missing escrowed event datetime at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
                 dtnow = helping.nowUTC()
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Stale event escrow "
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Stale event escrow "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"PD Stale event escrow at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # get the escrowed event using edig
                 eraw = self.db.getEvt(dgkey)
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(edig)))
+                    msg = f"PD Missing escrowed evt at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -5900,11 +5954,9 @@ class Kevery:
                 sigs = self.db.getSigs(dgkey)  # list of sigs
                 if not sigs:  # empty list
                     # no sigs so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event sigs at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt sigs at "
-                                          "dig = {}.".format(bytes(edig)))
+                    msg = f"PD Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", bytes(edig))
+                    raise ValidationError(msg)
 
                 # get witness signatures (wigs not wits) assumes wont be in this
                 # escrow if wigs not needed because no wits
@@ -5990,9 +6042,9 @@ class Kevery:
                  # removes one event escrow at key val
                 self.db.pdes.remOn(keys=epre, on=esn, val=edig)  # event idx escrow
                 self.db.udes.rem(keys=dgkey)  # remove source seal escrow if any
-                logger.info("Kevery unescrow succeeded in valid event: "
+                logger.info("Kevery PD unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
-                logger.debug(f"event=\n{eserder.pretty()}\n")
+                logger.debug("Event=\n%s\n", eserder.pretty())
 
 
     def processEscrowUnverWitness(self):
@@ -6059,22 +6111,18 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(rdiger.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", rdiger.qb64b)
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(rdiger.qb64b))
+                        msg = f"UW Missing escrowed event datetime at dig = {rdiger.qb64b}"
+                        logger.info("Kevery unescrow error: %s", rdiger.qb64b)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutUWE):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale event escrow "
-                                    " at dig = %s", rdiger.qb64b)
-
-                        raise ValidationError("Stale event escrow "
-                                              "at dig = {}.".format(rdiger.qb64b))
+                        msg = f"UW Stale event escrow at dig = {rdiger.qb64b}"
+                        logger.info("Kevery unescrow error: %s", rdiger.qb64b)
+                        raise ValidationError(msg)
 
                     # lookup database dig of the receipted event in pwes escrow
                     # using pre and sn lastEvt
@@ -6085,11 +6133,9 @@ class Kevery:
 
                     if not found:  # no partial witness escrow of event found
                         # so keep in escrow by raising UnverifiedWitnessReceiptError
-                        logger.debug("Kevery unescrow error: Missing witness "
-                                    "receipted evt at pre=%s sn=%x", (pre, sn))
-
-                        raise UnverifiedWitnessReceiptError("Missing witness "
-                                                            "receipted evt at pre={}  sn={:x}".format(pre, sn))
+                        msg = f"UW Missing witness receipted evt at pre={pre}  sn={sn:x}"
+                        logger.debug("Kevery unescrow error: %s", msg)
+                        raise UnverifiedWitnessReceiptError(msg)
 
                 except UnverifiedWitnessReceiptError as ex:
                     # still waiting on missing prior event to validate
@@ -6110,7 +6156,7 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delUwe(snKey(pre, sn), ecouple)  # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded for event pre=%s "
+                    logger.info("Kevery UW unescrow succeeded for event pre=%s "
                                 "sn=%s", pre, sn)
 
             if ekey == key:  # still same so no escrows found on last while iteration
@@ -6177,22 +6223,18 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(rsaider.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", rsaider.qb64b)
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(rsaider.qb64b))
+                        msg = f"UNT Missing escrowed event datetime at dig = {rsaider.qb64b}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutURE):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale event escrow "
-                                    " at dig = %s", rsaider.qb64b)
-
-                        raise ValidationError("Stale event escrow "
-                                              "at dig = {}.".format(rsaider.qb64b))
+                        msg = f"UNT Stale event escrow at dig = {rsaider.qb64b}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # Is receipt for unverified witnessed event in .Pwes escrow
                     # if found then try else clause will remove from escrow
@@ -6209,41 +6251,31 @@ class Kevery:
 
                         dig = self.db.getKeLast(snKey(pre, sn))
                         if dig is None:  # no receipted event so keep in escrow
-                            logger.debug("Kevery unescrow error: Missing receipted "
-                                        "event at pre=%s sn=%x", pre, sn)
-
-                            raise UnverifiedReceiptError("Missing receipted evt "
-                                                         "at pre={} sn={:x}".format(pre, sn))
+                            msg = f"UNT Missing receipted evt at pre={pre} sn={sn:x}"
+                            logger.debug("Kevery unescrow error: %s", msg)
+                            raise UnverifiedReceiptError(msg)
 
                         # get receipted event using pre and edig
                         raw = self.db.getEvt(dgKey(pre, dig))
                         if raw is None:  # receipted event superseded so remove from escrow
-                            logger.info("Kevery unescrow error: Invalid receipted "
-                                        "event refereance at pre=%s sn=%x", pre, sn)
-
-                            raise ValidationError("Invalid receipted evt reference"
-                                                  " at pre={} sn={:x}".format(pre, sn))
+                            msg = f"UNT Invalid receipted event reference at pre={pre} sn={sn:x}"
+                            logger.info("Kevery unescrow error: %s", msg)
+                            raise ValidationError(msg)
 
                         serder = serdering.SerderKERI(raw=bytes(raw))  # receipted event
 
                         #  compare digs
                         if rsaider.qb64b != serder.saidb:
-                            logger.info("Kevery unescrow error: Bad receipt dig."
-                                        "pre=%s sn=%x receipter=%s", pre, sn, sprefixer.qb64)
-
-                            raise ValidationError("Bad escrowed receipt dig at "
-                                                  "pre={} sn={:x} receipter={}."
-                                                  "".format(pre, sn, sprefixer.qb64))
+                            msg = f"UNT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                            logger.info("Kevery unescrow error: %s", msg)
+                            raise ValidationError(msg)
 
                         #  verify sig verfer key is prefixer from triple
                         if not cigar.verfer.verify(cigar.raw, serder.raw):
                             # no sigs so raise ValidationError which unescrows below
-                            logger.info("Kevery unescrow error: Bad receipt sig."
-                                        "pre=%s sn=%x receipter=%s", pre, sn, sprefixer.qb64)
-
-                            raise ValidationError("Bad escrowed receipt sig at "
-                                                  "pre={} sn={:x} receipter={}."
-                                                  "".format(pre, sn, sprefixer.qb64))
+                            msg = f"UNT Bad escrowed receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                            logger.info("Kevery unescrow error: %s", msg)
+                            raise ValidationError(msg)
 
                         # get current wits from kever state assuming not stale
                         # receipt. Need function here to compute wits for actual
@@ -6281,7 +6313,7 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delUre(snKey(pre, sn), etriplet)  # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded for event pre=%s "
+                    logger.info("Kevery UNT unescrow succeeded for event pre=%s "
                                 "sn=%s", pre, sn)
 
             if ekey == key:  # still same so no escrows found on last while iteration
@@ -6316,40 +6348,35 @@ class Kevery:
                 edig = dig.encode("utf-8")
                 dgkey = dgKey(pre.encode("utf-8"), edig)
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                    # no local sourde so raise ValidationError which unescrows below
-                    raise ValidationError("Missing escrowed event source "
-                                          "at dig = {}.".format(bytes(edig)))
+                    # no local source so raise ValidationError which unescrows below
+                    msg = f"DEL Missing escrowed event source at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event datetime"
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed event datetime "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"DEL Missing escrowed event datetime at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
                 dtnow = helping.nowUTC()
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutOOE):
                     # escrow stale so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Stale event escrow "
-                                " at dig = %s", bytes(edig))
-
-                    raise ValidationError("Stale event escrow "
-                                          "at dig = {}.".format(bytes(edig)))
+                    msg = f"DEL Stale event escrow at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 # get the escrowed event using edig
                 eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                 if eraw is None:
                     # no event so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(edig)))
+                    msg = f"DEL Missing escrowed evt at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -6357,11 +6384,9 @@ class Kevery:
                 sigs = self.db.getSigs(dgKey(pre, bytes(edig)))
                 if not sigs:  # otherwise its a list of sigs
                     # no sigs so raise ValidationError which unescrows below
-                    logger.info("Kevery unescrow error: Missing event sigs at."
-                                "dig = %s", bytes(edig))
-
-                    raise ValidationError("Missing escrowed evt sigs at "
-                                          "dig = {}.".format(bytes(edig)))
+                    msg = f"DEL Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
 
@@ -6400,9 +6425,9 @@ class Kevery:
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.db.delegables.rem(keys=(pre, sn,), val=edig)  # removes one escrow at key val
-                logger.info("Kevery unescrow succeeded in valid event: "
+                logger.info("Kevery DEL unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
-                logger.debug(f"event=\n{eserder.pretty()}\n")
+                logger.debug("event=\n%s\n", eserder.pretty())
 
     def processQueryNotFound(self):
         """
@@ -6440,32 +6465,26 @@ class Kevery:
                     dtb = self.db.getDts(dgkey)
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"QNF Missing escrowed event datetime at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutQNF):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale qry event escrow "
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Stale qry event escrow "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"QNF Stale qry event escrow at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # get the escrowed event using edig
                     eraw = self.db.getEvt(dgkey)
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt at dig = {}."
-                                              "".format(bytes(edig)))
+                        msg = f"QNF Missing escrowed evt at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -6473,11 +6492,9 @@ class Kevery:
                     sigs = self.db.getSigs(dgkey)
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event sigs at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt sigs at "
-                                              "dig = {}.".format(bytes(edig)))
+                        msg = f"QNF Missing escrowed evt sigs at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # process event
                     sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
@@ -6515,9 +6532,9 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.qnfs.rem(keys=(pre, said), val=edig)   # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded in valid event: "
+                    logger.info("Kevery QNF unescrow succeeded in valid event: "
                                 "event=%s", eserder.said)
-                    logger.debug(f"event=\n{eserder.pretty()}\n")
+                    logger.debug("Event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
                 break
@@ -6608,10 +6625,9 @@ class Kevery:
             elif wiger:  # check index and assign verfier to wiger
                 if wiger.index >= len(wits):  # bad index
                     # raise ValidationError which removes from escrow by caller
-                    logger.info("Kevery unescrow error: Bad witness receipt"
-                                " index=%i for pre=%s sn=%x", wiger.index, pre, sn)
-                    raise ValidationError("Bad escrowed witness receipt index={}"
-                                          " at pre={} sn={:x}.".format(wiger.index, pre, sn))
+                    msg = f"FUV Bad escrowed witness receipt index={wiger.index} at pre={pre} sn={sn:x}"
+                    logger.info("Kevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 wiger.verfer = Verfer(qb64=wits[wiger.index])
                 found = True
@@ -6620,12 +6636,9 @@ class Kevery:
         if found:  # verify signature and if verified write to .Wigs
             if not wiger.verfer.verify(wiger.raw, serder.raw):  # not verify
                 # raise ValidationError which unescrows .Uwes or .Ures in caller
-                logger.info("Kevery unescrow error: Bad witness receipt"
-                            " wig. pre=%s sn=%x", pre, sn)
-
-                raise ValidationError("Bad escrowed witness receipt wig"
-                                      " at pre={} sn={:x}."
-                                      "".format(pre, sn))
+                msg = f"Bad escrowed witness receipt wig at pre={pre} sn={sn:x}."
+                logger.info("Kevery FUV unescrow error: %s", msg)
+                raise ValidationError(msg)
             self.db.addWig(key=dgKey(pre, serder.said), val=wiger.qb64b)
             # processEscrowPartialWigs removes from this .Pwes escrow
             # when fully witnessed using self.db.delPwe(snkey, dig)
@@ -6689,53 +6702,42 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(esaider.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", esaider.qb64b)
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(esaider.qb64b))
+                        msg = f"UT Missing escrowed event datetime at dig = {esaider.qb64b}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutVRE):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale event escrow "
-                                    " at dig = %s", esaider.qb64b)
-
-                        raise ValidationError("Stale event escrow "
-                                              "at dig = {}.".format(esaider.qb64b))
+                        msg = f"UT Stale event escrow at dig = {esaider.qb64b}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # get dig of the receipted event using pre and sn lastEvt
                     raw = self.db.getKeLast(snKey(pre, sn))
                     if raw is None:
                         # no event so keep in escrow
-                        logger.debug("Kevery unescrow error: Missing receipted "
-                                    "event at pre=%s sn=%x", pre, sn)
-
-                        raise UnverifiedTransferableReceiptError("Missing receipted evt at pre={} "
-                                                                 " sn={:x}".format(pre, sn))
+                        msg = f"UT Missing receipted evt at pre={pre} sn={sn:x}"
+                        logger.debug("Kevery unescrow error: %s", msg)
+                        raise UnverifiedTransferableReceiptError(msg)
 
                     dig = bytes(raw)
                     # get receipted event using pre and edig
                     raw = self.db.getEvt(dgKey(pre, dig))
                     if raw is None:  # receipted event superseded so remove from escrow
-                        logger.info("Kevery unescrow error: Invalid receipted "
-                                    "event referenace at pre=%s sn=%x", pre, sn)
-
-                        raise ValidationError("Invalid receipted evt reference "
-                                              "at pre={} sn={:x}".format(pre, sn))
+                        msg = f"UT Invalid receipted evt reference at pre={pre} sn={sn:x}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     serder = serdering.SerderKERI(raw=bytes(raw))  # receipted event
 
                     #  compare digs
                     if esaider.qb64b != serder.saidb:
-                        logger.info("Kevery unescrow error: Bad receipt dig."
-                                    "pre=%s sn=%x receipter=%s", (pre, sn, sprefixer.qb64))
-
-                        raise ValidationError("Bad escrowed receipt dig at "
-                                              "pre={} sn={:x} receipter={}."
-                                              "".format(pre, sn, sprefixer.qb64))
+                        msg = f"UT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # get receipter's last est event
                     # retrieve dig of last event at sn of receipter.
@@ -6743,11 +6745,9 @@ class Kevery:
                                                        sn=sseqner.sn))
                     if sdig is None:
                         # no event so keep in escrow
-                        logger.debug("Kevery unescrow error: Missing receipted "
-                                    "event at pre=%s sn=%x", pre, sn)
-
-                        raise UnverifiedTransferableReceiptError("Missing receipted evt at pre={} "
-                                                                 " sn={:x}".format(pre, sn))
+                        msg = f"UT Missing receipted evt at pre={pre} sn={sn:x}"
+                        logger.debug("Kevery unescrow error: %s", msg)
+                        raise UnverifiedTransferableReceiptError(msg)
 
                     # retrieve last event itself of receipter
                     sraw = self.db.getEvt(key=dgKey(pre=sprefixer.qb64b, dig=bytes(sdig)))
@@ -6755,31 +6755,31 @@ class Kevery:
                     sserder = serdering.SerderKERI(raw=bytes(sraw))
                     if not sserder.compare(said=ssaider.qb64):  # seal dig not match event
                         # this unescrows
-                        raise ValidationError("Bad chit seal at sn = {} for rct = {}."
-                                              "".format(sseqner.sn, sserder.ked))
+                        msg = f"UT Bad chit seal at sn = {sseqner.sn} for rct = {sserder.ked}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # verify sigs and if so write quadruple to database
                     verfers = sserder.verfers
                     if not verfers:
-                        raise ValidationError("Invalid seal est. event dig = {} for "
-                                              "receipt from pre ={} no keys."
-                                              "".format(ssaider.qb64, sprefixer.qb64))
+                        msg = (f"UT Invalid seal est. event dig = {ssaider.qb64} "
+                               f"for receipt from pre = {sprefixer.qb64} no keys")
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # Set up quadruple
                     sealet = sprefixer.qb64b + sseqner.qb64b + ssaider.qb64b
 
                     if siger.index >= len(verfers):
-                        raise ValidationError("Index = {} to large for keys."
-                                              "".format(siger.index))
+                        msg = f"UT Index = {siger.index} too large for keys"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     siger.verfer = verfers[siger.index]  # assign verfer
                     if not siger.verfer.verify(siger.raw, serder.raw):  # verify sig
-                        logger.info("Kevery unescrow error: Bad trans receipt sig."
-                                    "pre=%s sn=%x receipter=%s", pre, sn, sprefixer.qb64)
-
-                        raise ValidationError("Bad escrowed trans receipt sig at "
-                                              "pre={} sn={:x} receipter={}."
-                                              "".format(pre, sn, sprefixer.qb64))
+                        msg = f"UT Bad escrowed trans receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # good sig so write receipt quadruple to database
                     quadruple = sealet + siger.qb64b
@@ -6805,8 +6805,8 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delVre(snKey(pre, sn), equinlet)  # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded for event = %s", serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.info("Kevery UT unescrow succeeded for event = %s", serder.said)
+                    logger.debug("Event=\n%s\n", serder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
                 break
@@ -6855,40 +6855,35 @@ class Kevery:
                     pre, sn = splitSnKey(ekey)  # get pre and sn from escrow item
                     dgkey = dgKey(pre, bytes(edig))
                     if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
-                        # no local sourde so raise ValidationError which unescrows below
-                        raise ValidationError("Missing escrowed event source "
-                                              "at dig = {}.".format(bytes(edig)))
+                        # no local source so raise ValidationError which unescrows below
+                        msg = f"DUP Missing escrowed event source at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # check date if expired then remove escrow.
                     dtb = self.db.getDts(dgkey)
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event datetime"
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed event datetime "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"DUP Missing escrowed event datetime at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
                     dtnow = helping.nowUTC()
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutLDE):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale event escrow "
-                                    " at dig = %s", bytes(edig))
-
-                        raise ValidationError("Stale event escrow "
-                                              "at dig = {}.".format(bytes(edig)))
+                        msg = f"DUP Stale event escrow at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     # get the escrowed event using edig
                     eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt at dig = {}."
-                                              "".format(bytes(edig)))
+                        msg = f"DUP Missing escrowed evt at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
 
@@ -6896,11 +6891,9 @@ class Kevery:
                     sigs = self.db.getSigs(dgKey(pre, bytes(edig)))
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Missing event sigs at."
-                                    "dig = %s", bytes(edig))
-
-                        raise ValidationError("Missing escrowed evt sigs at "
-                                              "dig = {}.".format(bytes(edig)))
+                        msg = f"DUP Missing escrowed evt sigs at dig = {bytes(edig)}"
+                        logger.info("Kevery unescrow error: %s", msg)
+                        raise ValidationError(msg)
 
                     sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
                     self.processEvent(serder=eserder, sigers=sigers, local=esr.local)
@@ -6937,9 +6930,9 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delLde(snKey(pre, sn), edig)  # removes one escrow at key val
-                    logger.info("Kevery unescrow succeeded in valid event: "
+                    logger.info("Kevery DUP unescrow succeeded in valid event: "
                                 "event=%s", eserder.said)
-                    logger.debug(f"event=\n{eserder.pretty()}\n")
+                    logger.debug("event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
                 break

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2324,8 +2324,8 @@ class Kever:
             msg = (f"[{self.prefixer.qb64[:8]}] Failure satisfying sith = {tholder.sith} "
                    f"on sigs {[siger.qb64 for siger in sigers]} "
                    f"for evt = {serder.said}")
-            logger.info("Kever: %s", msg)
-            logger.debug("Event Body=\n%s\n", serder.pretty())
+            logger.trace("Kever: %s", msg)
+            logger.trace("Event Body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
 
 
@@ -2340,8 +2340,8 @@ class Kever:
                     f"[{self.prefixer.qb64[:8]}] Failure satisfying prior nsith = {self.ntholder.sith} "
                     f"with exposed sigs {[siger.qb64 for siger in sigers]} "
                     f"for new est evt={serder.said}")
-                logger.info("Kever: %s", msg)
-                logger.debug("Event Body=\n%s\n", serder.pretty())
+                logger.trace("Kever: %s", msg)
+                logger.trace("Event Body=\n%s\n", serder.pretty())
                 raise MissingSignatureError(msg)
 
         # this point the sigers have been verified and the wigers have been verified
@@ -3171,7 +3171,7 @@ class Kever:
                 if self.cues is not None:  # cue to notice BadCloneFN
                     self.cues.push(dict(kin="noticeBadCloneFN", serder=serder,
                                         fn=fn, firner=firner, dater=dater))
-                logger.info("Kever Mismatch Cloned Replay FN: %s First seen "
+                logger.info("Kever: Mismatch Cloned Replay FN: %s First seen "
                             "ordinal fn %s and clone fn %s, said=%s",
                             serder.preb, fn, firner.sn, serder.said)
                 logger.debug("Event body=\n%s\n", serder.pretty())
@@ -3229,8 +3229,7 @@ class Kever:
 
         res = self.db.misfits.add(keys=(serder.pre, serder.snh), val=serder.saidb)
         # log escrowed
-        logger.debug("Kever state: escrowed misfit event=\n%s\n",
-                    json.dumps(serder.ked, indent=1))
+        logger.debug("Kever state: escrowed misfit event=\n%s\n", serder.pretty())
 
 
     def escrowDelegableEvent(self, serder, sigers, wigers=None, local=True):
@@ -3267,8 +3266,7 @@ class Kever:
             self.db.putWigs(dgkey, [siger.qb64b for siger in wigers])
         self.db.delegables.add(snKey(serder.preb, serder.sn), serder.saidb)
         # log escrowed
-        logger.debug("Kever state: escrowed delegable event=\n%s\n",
-                     json.dumps(serder.ked, indent=1))
+        logger.debug("Kever state: escrowed delegable event=\n%s\n", serder.pretty())
 
 
     def escrowPSEvent(self, serder, *, sigers=None, wigers=None,
@@ -3354,8 +3352,8 @@ class Kever:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        logger.debug("Kever state: Escrowed partially witnessed "
-                    "event = %s\n", serder.ked)
+        logger.trace("Kever state: Escrowed partially witnessed event = %s", serder.said)
+        logger.trace("Event Body=\n%s\n", serder.pretty())
         return self.db.addPwe(snKey(serder.preb, serder.sn), serder.saidb)
 
 
@@ -4390,8 +4388,8 @@ class Kevery:
 
                 siger.verfer = sverfers[siger.index]  # assign verfer
                 if not siger.verfer.verify(siger.raw, serder.raw):  # verify sig
-                    msg = f"Bad trans receipt sig pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    msg = f"Bad escrowed trans receipt sig pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 # good sig so write receipt quadruple to database
@@ -4403,10 +4401,11 @@ class Kevery:
 
             else:  # escrow  either receiptor or receipted event not yet in database
                 self.escrowTRQuadruple(serder, sprefixer, sseqner, saider, siger)
-                raise UnverifiedTransferableReceiptError("Unverified receipt: "
-                                                         "missing associated event for transferable "
-                                                         "validator receipt quadruple for event={}."
-                                                         "".format(ked))
+                msg = (f"Unverified receipt: missing associated event for transferable validator"
+                       f"receipt quadruple for event {serder.said}")
+                logger.info("Kevery: %s", msg)
+                logger.debug("Event=\n%s\n", serder.pretty())
+                raise UnverifiedTransferableReceiptError(msg)
 
     def removeStaleReplyEndRole(self, saider):
         """
@@ -5107,8 +5106,7 @@ class Kevery:
             self.db.udes.put(keys=dgkey, val=(seqner, saider))  # idempotent
         self.db.misfits.add(keys=(serder.pre, serder.snh), val=serder.saidb)
         # log escrowed
-        logger.debug("Kevery process: escrowed misfit event=\n%s",
-                    json.dumps(serder.ked, indent=1))
+        logger.debug("Kevery process: escrowed misfit event=\n%s", serder.pretty())
 
 
     def escrowOOEvent(self, serder, sigers, seqner=None, saider=None, wigers=None, local=True):
@@ -5148,8 +5146,7 @@ class Kevery:
             self.db.udes.put(keys=dgkey, val=(seqner, saider))  # idempotent
         self.db.addOoe(snKey(serder.preb, serder.sn), serder.saidb)
         # log escrowed
-        logger.debug("Kevery process: escrowed out of order event=\n%s",
-                     json.dumps(serder.ked, indent=1))
+        logger.debug("Kevery process: escrowed out of order event=\n%s", serder.pretty())
 
     def escrowQueryNotFoundEvent(self, prefixer, serder, sigers, cigars=None):
         """
@@ -5172,8 +5169,8 @@ class Kevery:
             self.db.addRct(key=dgkey, val=cigar.verfer.qb64b + cigar.qb64b)
 
         # log escrowed
-        logger.debug("Kevery process: escrowed query not found event=\n%s",
-                     json.dumps(serder.ked, indent=1))
+        logger.trace("Kevery: escrowed query not found event = %s", serder.said)
+        logger.trace("Event Body=\n%s\n", serder.pretty())
 
     def escrowLDEvent(self, serder, sigers, local=True):
         """
@@ -5413,9 +5410,8 @@ class Kevery:
 
         except Exception as ex:  # log diagnostics errors etc
             if logger.isEnabledFor(logging.DEBUG):
-                logger.exception("Kevery escrow process error: %s", ex.args[0])
-            else:
-                logger.error("Kevery escrow process error: %s", ex.args[0])
+                logger.trace("Kevery: other escrow process error: %s\n", ex.args[0])
+                logger.exception("Kevery other escrow process error: %s\n", ex.args[0])
             raise ex
 
     def processEscrowOutOfOrders(self):
@@ -5464,16 +5460,16 @@ class Kevery:
                     dgkey = dgKey(pre, bytes(edig))
                     if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
                         # no local source so raise ValidationError which unescrows below
-                        msg = f"OOO Missing escrowed event source at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"OOO Missing escrowed event source at dig = {bytes(edig).decode()}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # check date if expired then remove escrow.
                     dtb = self.db.getDts(dgkey)
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        msg = f"OOO Missing escrowed event datetime at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"OOO Missing escrowed event datetime at dig = {bytes(edig).decode()}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -5481,16 +5477,16 @@ class Kevery:
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutOOE):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"OOO Stale event escrow at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"OOO Stale event escrow at dig = {bytes(edig).decode()}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # get the escrowed event using edig
                     eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
-                        msg = f"OOO Missing escrowed event at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"OOO Missing escrowed event at dig = {bytes(edig).decode()}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
@@ -5499,8 +5495,8 @@ class Kevery:
                     sigs = self.db.getSigs(dgKey(pre, bytes(edig)))
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
-                        msg = f"OOO Missing escrowed event sigs at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"OOO Missing escrowed event sigs at dig = {bytes(edig).decode()}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # process event
@@ -5528,16 +5524,16 @@ class Kevery:
 
                 except OutOfOrderError as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Kevery OOO escrow unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery OOO escrow unescrow failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.delOoe(snKey(pre, sn), edig)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.debug("Kevery: OOO escrow other error on escrow: %s\n", ex.args[0])
+                        logger.exception("Kevery: OOO escrow other error on : %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
@@ -5606,7 +5602,7 @@ class Kevery:
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
                     msg = f"PS Missing escrowed event datetime at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
@@ -5615,7 +5611,7 @@ class Kevery:
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPSE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"PS Stale event escrow at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 # get the escrowed event using edig
@@ -5623,7 +5619,7 @@ class Kevery:
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
                     msg = f"PS Missing escrowed evt at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
@@ -5632,7 +5628,7 @@ class Kevery:
                 if not sigs:  # otherwise its a list of sigs
                     # no sigs so raise ValidationError which unescrows below
                     msg = f"PS Missing escrowed evt sigs at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
                 wigs = self.db.getWigs(dgKey(pre, bytes(edig)))  # list of wigs
                 if not wigs:  # empty list wigs witness sigs not wits
@@ -5687,8 +5683,9 @@ class Kevery:
             except MissingSignatureError  as ex:  # MissingDelegationError)
                 # still waiting on missing sigs or missing seal to validate
                 # processEvent idempotently reescrowed
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Kevery: partial sig escrow unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Kevery: partial sig escrow unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than waiting on sigs  so remove from escrow
@@ -5699,9 +5696,10 @@ class Kevery:
                     self.cues.push(dict(kin="psUnescrow", serder=eserder))
 
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrowed: %s", ex.args[0])
-                else:
-                    logger.error("Kevery unescrowed: %s", ex.args[0])
+                    logger.trace("Kevery: partial sig escrow other error on unescrow: %s\n",
+                                 ex.args[0])
+                    logger.exception("Kevery: partial sig escrow other error on unescrow: %s\n",
+                                     ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be
@@ -5713,8 +5711,8 @@ class Kevery:
                 if eserder is not None and eserder.ked["t"] in (Ilks.dip, Ilks.drt,):
                     self.cues.push(dict(kin="psUnescrow", serder=eserder))
 
-                logger.info("Kevery PS unescrow succeeded in valid event: "
-                            "event=%s", eserder.said)
+                logger.trace("Kevery: partial sig escrow unescrow succeeded in valid event: "
+                             "key = %s \tdigest = %s", bytes(ekey).decode(), bytes(edig).decode())
                 logger.debug("event=\n%s\n", eserder.pretty())
 
             #if ekey == key:  # still same so no escrows found on last while iteration
@@ -5772,7 +5770,7 @@ class Kevery:
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
                     msg = f"PW Missing escrowed event datetime at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 # do date math here and discard if stale nowIso8601() bytes
@@ -5781,7 +5779,7 @@ class Kevery:
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"PW Stale event escrow at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 # get the escrowed event using edig
@@ -5789,7 +5787,7 @@ class Kevery:
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
                     msg = f"PW Missing escrowed evt at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
@@ -5799,7 +5797,7 @@ class Kevery:
                 if not sigs:  # empty list
                     # no sigs so raise ValidationError which unescrows below
                     msg = f"PW Missing escrowed evt sigs at dig = {bytes(edig)}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 #  get witness signatures (wigs not wits)
@@ -5811,8 +5809,8 @@ class Kevery:
                     # which may not arrive until some time after event is fully signed
                     # so just log for debugging but do not unescrow by raising
                     # ValidationError
-                    logger.debug("Kevery unescrow wigs: No event wigs yet at."
-                                 "dig = %s", bytes(edig))
+                    logger.debug("Kevery unescrow wigs: PW No event wigs yet at."
+                                 "dig = %s", bytes(edig).decode())
 
                     # raise ValidationError("Missing escrowed evt wigs at "
                     # "dig = {}.".format(bytes(edig)))
@@ -5863,17 +5861,19 @@ class Kevery:
             except MissingWitnessSignatureError as ex:  # MissingDelegationError
                 # still waiting on missing witness sigs or delegation
                 # processEvent idempotently reescrowed
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Kevery: partial wig escrow unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Kevery: partial wig escrow unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than waiting on wigs so remove from escrow
                 self.db.delPwe(snKey(pre, sn), edig)  # removes one escrow at key val
                 #self.db.udes.rem(keys=dgkey)  # leave here since could PartialDelegationEscrow
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrowed: %s", ex.args[0])
-                else:
-                    logger.error("Kevery unescrowed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Kevery: partial wig escrow other error on unescrow: %s\n",
+                                 ex.args[0])
+                    logger.exception("Kevery: partial wig escrow other error unescrow: %s\n",
+                                     ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be
@@ -5881,8 +5881,8 @@ class Kevery:
                 # valid event escrow.
                 self.db.delPwe(snKey(pre, sn), edig)  # removes one escrow at key val
                 self.db.udes.rem(keys=dgkey)  # remove escrow if any
-                logger.info("Kevery PW unescrow succeeded in valid event: "
-                            "event=%s", eserder.said)
+                logger.info("Kevery: partial wig escrow unescrow succeeded in valid event: "
+                             "key = %s \tdigest = %s", bytes(ekey).decode(), bytes(edig).decode())
                 logger.debug("Event=\n%s\n", eserder.pretty())
 
 
@@ -6111,8 +6111,8 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(rdiger.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        msg = f"UW Missing escrowed event datetime at dig = {rdiger.qb64b}"
-                        logger.info("Kevery unescrow error: %s", rdiger.qb64b)
+                        msg = f"UWE Missing escrowed event datetime at dig = {rdiger.qb64b}"
+                        logger.trace("Kevery unescrow error: %s", rdiger.qb64b)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -6120,8 +6120,8 @@ class Kevery:
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutUWE):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"UW Stale event escrow at dig = {rdiger.qb64b}"
-                        logger.info("Kevery unescrow error: %s", rdiger.qb64b)
+                        msg = f"UWE Stale event escrow at dig = {rdiger.qb64b}"
+                        logger.trace("Kevery unescrow error: %s", rdiger.qb64b)
                         raise ValidationError(msg)
 
                     # lookup database dig of the receipted event in pwes escrow
@@ -6133,31 +6133,31 @@ class Kevery:
 
                     if not found:  # no partial witness escrow of event found
                         # so keep in escrow by raising UnverifiedWitnessReceiptError
-                        msg = f"UW Missing witness receipted evt at pre={pre}  sn={sn:x}"
-                        logger.debug("Kevery unescrow error: %s", msg)
+                        msg = f"UWE Missing witness receipted evt at pre={pre}  sn={sn:x}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise UnverifiedWitnessReceiptError(msg)
 
                 except UnverifiedWitnessReceiptError as ex:
                     # still waiting on missing prior event to validate
                     # only happens if we process above
                     if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                        logger.trace("Kevery: UWE unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery: UWE unescrow failed: %s\n",
+                                         ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.delUwe(snKey(pre, sn), ecouple)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.trace("Kevery: UWE other unescrow error: %s\n", ex.args[0])
+                        logger.exception("Kevery: UWE other unescrow error: %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delUwe(snKey(pre, sn), ecouple)  # removes one escrow at key val
-                    logger.info("Kevery UW unescrow succeeded for event pre=%s "
-                                "sn=%s", pre, sn)
+                    logger.info("Kevery UWE unescrow succeeded for event pre=%s sn=%s", pre, sn)
 
             if ekey == key:  # still same so no escrows found on last while iteration
                 break
@@ -6224,7 +6224,7 @@ class Kevery:
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
                         msg = f"UNT Missing escrowed event datetime at dig = {rsaider.qb64b}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -6233,7 +6233,7 @@ class Kevery:
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutURE):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"UNT Stale event escrow at dig = {rsaider.qb64b}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # Is receipt for unverified witnessed event in .Pwes escrow
@@ -6252,14 +6252,14 @@ class Kevery:
                         dig = self.db.getKeLast(snKey(pre, sn))
                         if dig is None:  # no receipted event so keep in escrow
                             msg = f"UNT Missing receipted evt at pre={pre} sn={sn:x}"
-                            logger.debug("Kevery unescrow error: %s", msg)
+                            logger.trace("Kevery unescrow error: %s", msg)
                             raise UnverifiedReceiptError(msg)
 
                         # get receipted event using pre and edig
                         raw = self.db.getEvt(dgKey(pre, dig))
                         if raw is None:  # receipted event superseded so remove from escrow
                             msg = f"UNT Invalid receipted event reference at pre={pre} sn={sn:x}"
-                            logger.info("Kevery unescrow error: %s", msg)
+                            logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
                         serder = serdering.SerderKERI(raw=bytes(raw))  # receipted event
@@ -6267,14 +6267,14 @@ class Kevery:
                         #  compare digs
                         if rsaider.qb64b != serder.saidb:
                             msg = f"UNT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
-                            logger.info("Kevery unescrow error: %s", msg)
+                            logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
                         #  verify sig verfer key is prefixer from triple
                         if not cigar.verfer.verify(cigar.raw, serder.raw):
                             # no sigs so raise ValidationError which unescrows below
                             msg = f"UNT Bad escrowed receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
-                            logger.info("Kevery unescrow error: %s", msg)
+                            logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
                         # get current wits from kever state assuming not stale
@@ -6297,8 +6297,9 @@ class Kevery:
                 except UnverifiedReceiptError as ex:
                     # still waiting on missing prior event to validate
                     # only happens if we process above
-                    if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):  # adds exception data
+                        logger.trace("Kevery: UNT escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.exception("Kevery: UNT escrow other error on unescrow: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
@@ -6466,7 +6467,7 @@ class Kevery:
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
                         msg = f"QNF Missing escrowed event datetime at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -6475,7 +6476,7 @@ class Kevery:
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutQNF):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"QNF Stale qry event escrow at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # get the escrowed event using edig
@@ -6483,7 +6484,7 @@ class Kevery:
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
                         msg = f"QNF Missing escrowed evt at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
@@ -6493,7 +6494,7 @@ class Kevery:
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
                         msg = f"QNF Missing escrowed evt sigs at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # process event
@@ -6517,23 +6518,23 @@ class Kevery:
 
                 except QueryNotFoundError as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Kevery: QNF escrow unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery: QNF escrow unescrow failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.qnfs.rem(keys=(pre, said), val=edig)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.debug("Kevery: QNF other unescrow error: %s\n", ex.args[0])
+                        logger.exception("Kevery: QNF other unescrow error: %s\n", ex.args[0])
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.qnfs.rem(keys=(pre, said), val=edig)   # removes one escrow at key val
-                    logger.info("Kevery QNF unescrow succeeded in valid event: "
-                                "event=%s", eserder.said)
+                    logger.info("Kevery: QNF unescrow succeeded in valid event: "
+                                "key = %s \tdigest = %s", ekey.decode(), edig)
                     logger.debug("Event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
@@ -6626,7 +6627,7 @@ class Kevery:
                 if wiger.index >= len(wits):  # bad index
                     # raise ValidationError which removes from escrow by caller
                     msg = f"FUV Bad escrowed witness receipt index={wiger.index} at pre={pre} sn={sn:x}"
-                    logger.info("Kevery unescrow error: %s", msg)
+                    logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 wiger.verfer = Verfer(qb64=wits[wiger.index])
@@ -6636,8 +6637,8 @@ class Kevery:
         if found:  # verify signature and if verified write to .Wigs
             if not wiger.verfer.verify(wiger.raw, serder.raw):  # not verify
                 # raise ValidationError which unescrows .Uwes or .Ures in caller
-                msg = f"Bad escrowed witness receipt wig at pre={pre} sn={sn:x}."
-                logger.info("Kevery FUV unescrow error: %s", msg)
+                msg = f"FUV Bad escrowed witness receipt wig at pre={pre} sn={sn:x}."
+                logger.trace("Kevery unescrow error: %s", msg)
                 raise ValidationError(msg)
             self.db.addWig(key=dgKey(pre, serder.said), val=wiger.qb64b)
             # processEscrowPartialWigs removes from this .Pwes escrow
@@ -6702,8 +6703,8 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(esaider.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        msg = f"UT Missing escrowed event datetime at dig = {esaider.qb64b}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Missing escrowed event datetime at dig = {esaider.qb64b}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -6711,32 +6712,32 @@ class Kevery:
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutVRE):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"UT Stale event escrow at dig = {esaider.qb64b}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Stale event escrow at dig = {esaider.qb64b}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # get dig of the receipted event using pre and sn lastEvt
                     raw = self.db.getKeLast(snKey(pre, sn))
                     if raw is None:
                         # no event so keep in escrow
-                        msg = f"UT Missing receipted evt at pre={pre} sn={sn:x}"
-                        logger.debug("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Missing receipted evt at pre={pre} sn={sn:x}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise UnverifiedTransferableReceiptError(msg)
 
                     dig = bytes(raw)
                     # get receipted event using pre and edig
                     raw = self.db.getEvt(dgKey(pre, dig))
                     if raw is None:  # receipted event superseded so remove from escrow
-                        msg = f"UT Invalid receipted evt reference at pre={pre} sn={sn:x}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Invalid receipted evt reference at pre={pre} sn={sn:x}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     serder = serdering.SerderKERI(raw=bytes(raw))  # receipted event
 
                     #  compare digs
                     if esaider.qb64b != serder.saidb:
-                        msg = f"UT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # get receipter's last est event
@@ -6745,8 +6746,8 @@ class Kevery:
                                                        sn=sseqner.sn))
                     if sdig is None:
                         # no event so keep in escrow
-                        msg = f"UT Missing receipted evt at pre={pre} sn={sn:x}"
-                        logger.debug("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Missing receipted evt at pre={pre} sn={sn:x}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise UnverifiedTransferableReceiptError(msg)
 
                     # retrieve last event itself of receipter
@@ -6755,14 +6756,14 @@ class Kevery:
                     sserder = serdering.SerderKERI(raw=bytes(sraw))
                     if not sserder.compare(said=ssaider.qb64):  # seal dig not match event
                         # this unescrows
-                        msg = f"UT Bad chit seal at sn = {sseqner.sn} for rct = {sserder.ked}"
+                        msg = f"UVT Bad chit seal at sn = {sseqner.sn} for rct = {sserder.ked}"
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # verify sigs and if so write quadruple to database
                     verfers = sserder.verfers
                     if not verfers:
-                        msg = (f"UT Invalid seal est. event dig = {ssaider.qb64} "
+                        msg = (f"UVT Invalid seal est. event dig = {ssaider.qb64} "
                                f"for receipt from pre = {sprefixer.qb64} no keys")
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
@@ -6771,14 +6772,14 @@ class Kevery:
                     sealet = sprefixer.qb64b + sseqner.qb64b + ssaider.qb64b
 
                     if siger.index >= len(verfers):
-                        msg = f"UT Index = {siger.index} too large for keys"
+                        msg = f"UVT Index = {siger.index} too large for keys"
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     siger.verfer = verfers[siger.index]  # assign verfer
                     if not siger.verfer.verify(siger.raw, serder.raw):  # verify sig
-                        msg = f"UT Bad escrowed trans receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        msg = f"UVT Bad escrowed trans receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # good sig so write receipt quadruple to database
@@ -6789,23 +6790,23 @@ class Kevery:
                 except UnverifiedTransferableReceiptError as ex:
                     # still waiting on missing prior event to validate
                     # only happens if we process above
-                    if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):  # adds exception data
+                        logger.trace("Kevery: UVT escrow unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery: UVT escrow unescrow failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.delVre(snKey(pre, sn), equinlet)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.debug("Kevery: UVT escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.exception("Kevery: UVT escrow other error on unescrow: %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delVre(snKey(pre, sn), equinlet)  # removes one escrow at key val
-                    logger.info("Kevery UT unescrow succeeded for event = %s", serder.said)
+                    logger.info("Kevery UVT unescrow succeeded for event = %s", serder.said)
                     logger.debug("Event=\n%s\n", serder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
@@ -6865,7 +6866,7 @@ class Kevery:
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
                         msg = f"DUP Missing escrowed event datetime at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # do date math here and discard if stale nowIso8601() bytes
@@ -6874,7 +6875,7 @@ class Kevery:
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutLDE):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"DUP Stale event escrow at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # get the escrowed event using edig
@@ -6882,7 +6883,7 @@ class Kevery:
                     if eraw is None:
                         # no event so raise ValidationError which unescrows below
                         msg = f"DUP Missing escrowed evt at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
@@ -6892,7 +6893,7 @@ class Kevery:
                     if not sigs:  # otherwise its a list of sigs
                         # no sigs so raise ValidationError which unescrows below
                         msg = f"DUP Missing escrowed evt sigs at dig = {bytes(edig)}"
-                        logger.info("Kevery unescrow error: %s", msg)
+                        logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
@@ -6914,24 +6915,23 @@ class Kevery:
 
                 except LikelyDuplicitousError as ex:
                     # still can't determine if duplicitous
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Kevery: DUP escrow unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery: DUP escrow unescrow failed: %s\n",ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than likely duplicitous so remove from escrow
                     self.db.delLde(snKey(pre, sn), edig)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
-                    else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.trace("Kevery: DUP escrow other unescrow error: %s\n", ex.args[0])
+                        logger.exception("Kevery: DUP escrow other unescrow error: %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delLde(snKey(pre, sn), edig)  # removes one escrow at key val
-                    logger.info("Kevery DUP unescrow succeeded in valid event: "
-                                "event=%s", eserder.said)
+                    logger.info("Kevery DUP unescrow succeeded in valid event: event=%s", eserder.said)
                     logger.debug("event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -2318,13 +2318,14 @@ class Kever:
         # each wiger now has added to it a werfer of its wit in its .verfer property
 
         # escrow if not fully signed vs signing threshold
+        pre = self.prefixer.qb64
         if not tholder.satisfy(indices):  # at least one but not enough
             self.escrowPSEvent(serder=serder, sigers=sigers, wigers=wigers,
                                seqner=delseqner, saider=delsaider, local=local)
-            msg = (f"[{self.prefixer.qb64[:8]}] Failure satisfying sith = {tholder.sith} "
+            msg = (f"AID {pre[:4]}...{pre[-4:]}: Failure satisfying sith = {tholder.sith} "
                    f"on sigs {[siger.qb64 for siger in sigers]} "
                    f"for evt = {serder.said}")
-            logger.trace("Kever: %s", msg)
+            logger.trace(msg)
             logger.trace("Event Body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
 
@@ -2337,10 +2338,10 @@ class Kever:
                 self.escrowPSEvent(serder=serder, sigers=sigers, wigers=wigers,
                                    seqner=delseqner, saider=delsaider,local=local)
                 msg = (
-                    f"[{self.prefixer.qb64[:8]}] Failure satisfying prior nsith = {self.ntholder.sith} "
+                    f"AID {pre[:4]}...{pre[-4:]}: Failure satisfying prior nsith = {self.ntholder.sith} "
                     f"with exposed sigs {[siger.qb64 for siger in sigers]} "
                     f"for new est evt={serder.said}")
-                logger.trace("Kever: %s", msg)
+                logger.trace(msg)
                 logger.trace("Event Body=\n%s\n", serder.pretty())
                 raise MissingSignatureError(msg)
 
@@ -2370,10 +2371,10 @@ class Kever:
                                           local=local):
                         # cue to query for witness receipts
                         self.cues.push(dict(kin="query", q=dict(pre=serder.pre, sn=serder.snh)))
-                    msg = (f"[{self.prefixer.qb64[:8]}] Failure satisfying toad={toader.num} "
+                    msg = (f"AID {pre[:4]}...{pre[-4:]}: Failure satisfying toad={toader.num} "
                            f"on witness sigs {[siger.qb64 for siger in wigers]} "
                            f"for event={serder.said}")
-                    logger.info("Kever: %s", msg)
+                    logger.info(msg)
                     logger.debug("Event Body=\n%s\n", serder.pretty())
                     raise MissingWitnessSignatureError(msg)
 
@@ -2397,7 +2398,7 @@ class Kever:
                 self.escrowDelegableEvent(serder=serder, sigers=sigers,
                                           wigers=wigers, local=local)
                 msg = f"Missing approval for delegation by {delpre} of event = {serder.said}"
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegableApprovalError(msg)
 
@@ -2756,7 +2757,7 @@ class Kever:
             self.escrowPDEvent(serder=serder, sigers=sigers, wigers=wigers,
                                seqner=delseqner, saider=delsaider, local=local)
             msg = f"Missing KEL of delegator {delpre} of evt {serder.sn} {serder.ilk} {serder.said}"
-            logger.info("Kever: %s", msg)
+            logger.info(msg)
             logger.debug("Event Body=\n%s\n", serder.pretty())
             raise MissingDelegationError(msg)
 
@@ -2765,7 +2766,7 @@ class Kever:
         if dkever.doNotDelegate:  # drop event if delegation not allowed
             msg = (f"Delegator {delpre} does not allow delegation on evt "
                    f"{serder.sn} {serder.ilk} {serder.said}")
-            logger.info("Kever: %s", msg)
+            logger.info(msg)
             logger.debug("Event Body=\n%s\n", serder.pretty())
             raise ValidationError(msg)
 
@@ -2784,7 +2785,7 @@ class Kever:
                                    seqner=delseqner, saider=delsaider, local=local)
                 msg = (f"No delegation seal for delegator {delpre} on evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegationError(msg)
 
@@ -2814,7 +2815,7 @@ class Kever:
                                    seqner=delseqner, saider=delsaider, local=local)
                 msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegationError(msg)
 
@@ -2825,7 +2826,7 @@ class Kever:
             if raw is None:   # drop event should never happen unless database is broken
                 msg = (f"Missing delegation from {delpre} at event dig = {ddig} for evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise ValidationError(msg)
 
@@ -2853,7 +2854,7 @@ class Kever:
                                            seqner=delseqner, saider=delsaider, local=local)
                 msg = (f"No delegation seal for delegator {delpre} of evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegationError(msg)
 
@@ -2899,7 +2900,7 @@ class Kever:
                                 seqner=delseqner, saider=delsaider, local=local)
             msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
                    f"{serder.sn} {serder.ilk} {serder.said}")
-            logger.info("Kever: %s", msg)
+            logger.info(msg)
             logger.debug("Event Body=\n%s\n", serder.pretty())
             raise MissingDelegationError(msg)
         # already have new potential superseding delegation
@@ -2936,7 +2937,7 @@ class Kever:
                     # ToDo: XXXX may want to cue up business logic for delegator
                     # if self.mine(delegator):  # failed attempt at recovery
                     msg = f"Invalid delegation recovery rotation of {serfo.pre} by {serfn.pre}"
-                    logger.info("Kever: %s", msg)
+                    logger.info(msg)
                     logger.debug("Delegate Event Body=\n%s\n", serfo.pretty())
                     logger.debug("Delegator Event Body=\n%s\n", serfn.pretty())
                     raise ValidationError(msg)
@@ -2950,7 +2951,7 @@ class Kever:
                                 seqner=delseqner, saider=delsaider, local=local)
                 msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegationError(msg)
             serfo = bosso
@@ -2961,7 +2962,7 @@ class Kever:
                                 seqner=delseqner, saider=delsaider, local=local)
                 msg = (f"No delegating event from {delpre} at {delsaider.qb64} for evt "
                        f"{serder.sn} {serder.ilk} {serder.said}")
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise MissingDelegationError(msg)
             # repeat
@@ -3050,7 +3051,7 @@ class Kever:
             if not (raw := self.db.getEvt(ddgkey)):  # in fons but no event
                 # database broken this should never happen
                 msg = f"Missing delegation event for {serder.said}"
-                logger.info("Kever: %s", msg)
+                logger.info(msg)
                 logger.debug("Event Body=\n%s\n", serder.pretty())
                 raise ValidationError(msg)
             # original delegating event i.e. boss original
@@ -3066,9 +3067,9 @@ class Kever:
                     # since original must have been validated so it must have
                     # all its delegation chain.
                     msg = f"Missing delegation source seal for {serder.said}"
-                    logger.info("Kever: %s", msg)
+                    logger.info(msg)
                     logger.debug("Event Body=\n%s\n", serder.pretty())
-                    raise ValidationError(f"Missing delegation source seal for {serder.ked}")
+                    raise ValidationError(msg)
             else:  # only search last events in delegator's kel
                 if not (dserder := self.db.fetchLastSealingEventByEventSeal(pre=delpre,
                                                                             seal=seal)):
@@ -3165,6 +3166,7 @@ class Kever:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkeys, val=esr)
 
+        pre = self.prefixer.qb64
         if first:  # append event dig to first seen database in order
             fn = self.db.appendFe(serder.preb, serder.saidb)
             if firner and fn != firner.sn:  # cloned replay but replay fn not match
@@ -3179,13 +3181,13 @@ class Kever:
                 dtsb = dater.dtsb
             self.db.setDts(dgkey, dtsb)  # first seen so set dts to now
             self.db.fons.pin(keys=dgkey, val=Seqner(sn=fn))
-            logger.debug("Kever [%.8s]: First seen %s %s SAID=%s for %s at %s",
-                         self.prefixer.qb64, fn, serder.ilk, serder.said,
+            logger.debug("AID %s...%s: First seen %s at sn=%s valid event SAID=%s for %s at %s",
+                         pre[:4], pre[-4:], serder.ilk, fn, serder.said,
                          serder.pre, dtsb.decode("utf-8"))
             logger.debug("Event Body=\n%s\n", serder.pretty())
         self.db.addKe(snKey(serder.preb, serder.sn), serder.saidb)
-        logger.info("Kever [%.8s]: Added to KEL %s at sn=%s valid event SAID=%s for AID %s",
-                    self.prefixer.qb64, serder.ilk, serder.sn, serder.said, serder.pre)
+        logger.info("AID %s...%s: Added to KEL %s at sn=%s valid event SAID=%s",
+                    pre[:4], pre[-4:], serder.ilk, serder.sn, serder.said)
         logger.debug("Event Body=\n%s\n", serder.pretty())
         return (fn, dtsb.decode("utf-8"))  # (fn int, dts str) if first else (None, dts str)
 
@@ -3860,7 +3862,7 @@ class Kevery:
                 else:  # escrow likely duplicitous event
                     self.escrowLDEvent(serder=serder, sigers=sigers)
                     msg = f"Likely Duplicitous Event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
-                    logger.debug("Kevery: %s", msg)
+                    logger.debug(msg)
                     logger.debug("Duplicitous event body=\n%s\n", serder.pretty())
                     raise LikelyDuplicitousError(msg)
 
@@ -3873,7 +3875,7 @@ class Kevery:
                     self.escrowOOEvent(serder=serder, sigers=sigers,
                                        seqner=delseqner, saider=delsaider, wigers=wigers, local=local)
                     msg = f"Out-of-order event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
-                    logger.debug("Kevery: %s", msg)
+                    logger.debug(msg)
                     logger.debug("Out-of-order event body=\n%s\n", serder.pretty())
                     raise OutOfOrderError(msg)
 
@@ -3945,7 +3947,7 @@ class Kevery:
                     else:  # escrow likely duplicitous event
                         self.escrowLDEvent(serder=serder, sigers=sigers)
                         msg = f"Likely Duplicitous Event sn={serder.sn} type={serder.ilk} SAID={serder.said}"
-                        logger.debug("Kevery: %s", msg)
+                        logger.debug(msg)
                         logger.debug("Duplicitous event body=\n%s\n", serder.pretty())
                         raise LikelyDuplicitousError(msg)
 
@@ -3993,7 +3995,7 @@ class Kevery:
 
             if not lserder.compare(said=ked["d"]):  # stale receipt at sn discard
                 msg = f"Stale receipt at sn = {ked['s']} for rct = {serder.said}."
-                logger.info("Kevery: %s", msg)
+                logger.info(msg)
                 logger.debug("Stale receipt event body=\n%s\n", serder.pretty())
                 raise ValidationError(msg)
 
@@ -4029,7 +4031,7 @@ class Kevery:
             # get digest from receipt message not receipted event
             self.escrowUWReceipt(serder=serder, wigers=wigers, said=ked["d"])
             msg = f"Unverified witness receipt={serder.said}"
-            logger.info("Kevery: %s", msg)
+            logger.info(msg)
             logger.debug("Event=\n%s\n", serder.pretty())
             raise UnverifiedWitnessReceiptError(msg)
 
@@ -4113,7 +4115,7 @@ class Kevery:
         else:  # no events to be receipted yet at that sn so escrow
             self.escrowUReceipt(serder, cigars, said=ked["d"])  # digest in receipt
             msg = f"Unverified receipt = {serder.said}"
-            logger.info("Kevery: %s", msg)
+            logger.info(msg)
             logger.debug("event=\n%s\n", serder.pretty())
             raise UnverifiedReceiptError(msg)
 
@@ -4403,7 +4405,7 @@ class Kevery:
                 self.escrowTRQuadruple(serder, sprefixer, sseqner, saider, siger)
                 msg = (f"Unverified receipt: missing associated event for transferable validator"
                        f"receipt quadruple for event {serder.said}")
-                logger.info("Kevery: %s", msg)
+                logger.info(msg)
                 logger.debug("Event=\n%s\n", serder.pretty())
                 raise UnverifiedTransferableReceiptError(msg)
 
@@ -4950,7 +4952,7 @@ class Kevery:
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
                 msg = f"Query not found error on event route={route} SAID={serder.said}"
-                logger.debug("Kevery: %s", msg)
+                logger.debug(msg)
                 logger.debug("Query Body=\n%s\n", serder.pretty())
                 raise QueryNotFoundError(msg)
 
@@ -4959,7 +4961,7 @@ class Kevery:
                 if not self.db.fetchAllSealingEventByEventSeal(pre=pre, seal=anchor):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
                     msg = f"Query not found error on event route={route} SAID={serder.said}"
-                    logger.debug("Kevery: %s", msg)
+                    logger.debug(msg)
                     logger.debug("Query Body=\n%s\n", serder.pretty())
                     raise QueryNotFoundError(msg)
 
@@ -4967,7 +4969,7 @@ class Kevery:
                 if kever.sner.num < sn or not self.db.fullyWitnessed(kever.serder):
                     self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
                     msg = f"Query not found error on event route={route} SAID={serder.said}"
-                    logger.debug("Kevery: %s", msg)
+                    logger.debug(msg)
                     logger.debug("Query Body=\n%s\n", serder.pretty())
                     raise QueryNotFoundError(msg)
 
@@ -4990,7 +4992,7 @@ class Kevery:
             if pre not in self.kevers:
                 self.escrowQueryNotFoundEvent(serder=serder, prefixer=source, sigers=sigers, cigars=cigars)
                 msg = f"Query not found error on event route={route} SAID={serder.said}"
-                logger.debug("Kevery: %s", msg)
+                logger.debug(msg)
                 logger.debug("Query Body=\n%s\n", serder.pretty())
                 raise QueryNotFoundError(msg)
 
@@ -5031,7 +5033,7 @@ class Kevery:
         else:
             self.cues.push(dict(kin="invalid", serder=serder))
             msg = f"Invalid query message {ilk} for event route={route} SAID={serder.said}"
-            logger.info("Kevery: %s", msg)
+            logger.info(msg)
             logger.debug("Query Body=\n%s\n", serder.pretty())
             raise ValidationError(msg)
 
@@ -5540,7 +5542,7 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delOoe(snKey(pre, sn), edig)  # removes one escrow at key val
-                    logger.info("Kevery OOO unescrow succeeded in valid event: "
+                    logger.info("Kevery out of order unescrow succeeded in valid event: "
                                 "event=%s", eserder.said)
                     logger.debug("Event=\n%s\n", eserder.pretty())
 
@@ -5593,7 +5595,7 @@ class Kevery:
                 dgkey = dgKey(pre, bytes(edig))
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
                     # no local source so raise ValidationError which unescrows below
-                    msg = f"PS Missing escrowed event source at dig = {bytes(edig)}"
+                    msg = f"PSE Missing escrowed event source at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5601,7 +5603,7 @@ class Kevery:
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    msg = f"PS Missing escrowed event datetime at dig = {bytes(edig)}"
+                    msg = f"PSE Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5610,7 +5612,7 @@ class Kevery:
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPSE):
                     # escrow stale so raise ValidationError which unescrows below
-                    msg = f"PS Stale event escrow at dig = {bytes(edig)}"
+                    msg = f"PSE Stale event escrow at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5618,7 +5620,7 @@ class Kevery:
                 eraw = self.db.getEvt(dgkey)
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    msg = f"PS Missing escrowed evt at dig = {bytes(edig)}"
+                    msg = f"PSE Missing escrowed evt at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5627,7 +5629,7 @@ class Kevery:
                 sigs = self.db.getSigs(dgkey)
                 if not sigs:  # otherwise its a list of sigs
                     # no sigs so raise ValidationError which unescrows below
-                    msg = f"PS Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    msg = f"PSE Missing escrowed evt sigs at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
                 wigs = self.db.getWigs(dgKey(pre, bytes(edig)))  # list of wigs
@@ -5684,8 +5686,8 @@ class Kevery:
                 # still waiting on missing sigs or missing seal to validate
                 # processEvent idempotently reescrowed
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.trace("Kevery: partial sig escrow unescrow failed: %s\n", ex.args[0])
-                    logger.exception("Kevery: partial sig escrow unescrow failed: %s\n", ex.args[0])
+                    logger.trace("Kevery: PSE unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Kevery: PSE unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than waiting on sigs  so remove from escrow
@@ -5696,9 +5698,9 @@ class Kevery:
                     self.cues.push(dict(kin="psUnescrow", serder=eserder))
 
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.trace("Kevery: partial sig escrow other error on unescrow: %s\n",
+                    logger.trace("Kevery: PSE other error on unescrow: %s\n",
                                  ex.args[0])
-                    logger.exception("Kevery: partial sig escrow other error on unescrow: %s\n",
+                    logger.exception("Kevery: PSE other error on unescrow: %s\n",
                                      ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
@@ -5761,7 +5763,7 @@ class Kevery:
                 dgkey = dgKey(pre, bytes(edig))
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
                     # no local source so raise ValidationError which unescrows below
-                    msg = f"PW Missing escrowed event source at dig = {bytes(edig)}"
+                    msg = f"PWE Missing escrowed event source at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5769,7 +5771,7 @@ class Kevery:
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    msg = f"PW Missing escrowed event datetime at dig = {bytes(edig)}"
+                    msg = f"PWE Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5778,7 +5780,7 @@ class Kevery:
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
-                    msg = f"PW Stale event escrow at dig = {bytes(edig)}"
+                    msg = f"PWE Stale event escrow at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5786,7 +5788,7 @@ class Kevery:
                 eraw = self.db.getEvt(dgKey(pre, bytes(edig)))
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    msg = f"PW Missing escrowed evt at dig = {bytes(edig)}"
+                    msg = f"PWE Missing escrowed evt at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5796,7 +5798,7 @@ class Kevery:
                 sigs = self.db.getSigs(dgKey(pre, bytes(edig)))  # list of sigs
                 if not sigs:  # empty list
                     # no sigs so raise ValidationError which unescrows below
-                    msg = f"PW Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    msg = f"PWE Missing escrowed evt sigs at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5862,17 +5864,17 @@ class Kevery:
                 # still waiting on missing witness sigs or delegation
                 # processEvent idempotently reescrowed
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.trace("Kevery: partial wig escrow unescrow failed: %s\n", ex.args[0])
-                    logger.exception("Kevery: partial wig escrow unescrow failed: %s\n", ex.args[0])
+                    logger.trace("Kevery: PWE unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Kevery: PWE unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than waiting on wigs so remove from escrow
                 self.db.delPwe(snKey(pre, sn), edig)  # removes one escrow at key val
                 #self.db.udes.rem(keys=dgkey)  # leave here since could PartialDelegationEscrow
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.trace("Kevery: partial wig escrow other error on unescrow: %s\n",
+                    logger.trace("Kevery: PWE other error on unescrow: %s\n",
                                  ex.args[0])
-                    logger.exception("Kevery: partial wig escrow other error unescrow: %s\n",
+                    logger.exception("Kevery: PWE other error unescrow: %s\n",
                                      ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
@@ -5919,7 +5921,7 @@ class Kevery:
                 dgkey = dgKey(epre, edig)
                 if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
                     # no local source so raise ValidationError which unescrows below
-                    msg = f"PD Missing escrowed event source at dig = {bytes(edig)}"
+                    msg = f"PDE Missing escrowed event source at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5927,7 +5929,7 @@ class Kevery:
                 dtb = self.db.getDts(dgkey)
                 if dtb is None:  # othewise is a datetime as bytes
                     # no date time so raise ValidationError which unescrows below
-                    msg = f"PD Missing escrowed event datetime at dig = {bytes(edig)}"
+                    msg = f"PDE Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5936,7 +5938,7 @@ class Kevery:
                 dte = helping.fromIso8601(bytes(dtb))
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
-                    msg = f"PD Stale event escrow at dig = {bytes(edig)}"
+                    msg = f"PDE Stale event escrow at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5944,7 +5946,7 @@ class Kevery:
                 eraw = self.db.getEvt(dgkey)
                 if eraw is None:
                     # no event so so raise ValidationError which unescrows below
-                    msg = f"PD Missing escrowed evt at dig = {bytes(edig)}"
+                    msg = f"PDE Missing escrowed evt at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
@@ -5954,7 +5956,7 @@ class Kevery:
                 sigs = self.db.getSigs(dgkey)  # list of sigs
                 if not sigs:  # empty list
                     # no sigs so raise ValidationError which unescrows below
-                    msg = f"PD Missing escrowed evt sigs at dig = {bytes(edig)}"
+                    msg = f"PDE Missing escrowed evt sigs at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", bytes(edig))
                     raise ValidationError(msg)
 
@@ -6023,7 +6025,7 @@ class Kevery:
                 # still waiting on missing delegation source seal
                 # processEvent idempotently reescrowed
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrow failed: %s", ex.args[0])
+                    logger.exception("Kevery PDE unescrow failed: %s", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than waiting on sigs or seal so remove from escrow
@@ -6031,9 +6033,9 @@ class Kevery:
                 self.db.pdes.remOn(keys=epre, on=esn, val=edig)  # event idx escrow
                 self.db.udes.rem(keys=dgkey)  # remove source seal escrow if any
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrowed: %s", ex.args[0])
+                    logger.exception("Kevery PDE unescrowed: %s", ex.args[0])
                 else:
-                    logger.error("Kevery unescrowed: %s", ex.args[0])
+                    logger.error("Kevery PDE unescrowed: %s", ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be
@@ -6042,7 +6044,7 @@ class Kevery:
                  # removes one event escrow at key val
                 self.db.pdes.remOn(keys=epre, on=esn, val=edig)  # event idx escrow
                 self.db.udes.rem(keys=dgkey)  # remove source seal escrow if any
-                logger.info("Kevery PD unescrow succeeded in valid event: "
+                logger.info("Kevery partial delegation escrow unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
                 logger.debug("Event=\n%s\n", eserder.pretty())
 
@@ -6223,7 +6225,7 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(rsaider.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        msg = f"UNT Missing escrowed event datetime at dig = {rsaider.qb64b}"
+                        msg = f"URE Missing escrowed event datetime at dig = {rsaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6232,7 +6234,7 @@ class Kevery:
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutURE):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"UNT Stale event escrow at dig = {rsaider.qb64b}"
+                        msg = f"URE Stale event escrow at dig = {rsaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6251,14 +6253,14 @@ class Kevery:
 
                         dig = self.db.getKeLast(snKey(pre, sn))
                         if dig is None:  # no receipted event so keep in escrow
-                            msg = f"UNT Missing receipted evt at pre={pre} sn={sn:x}"
+                            msg = f"URE Missing receipted evt at pre={pre} sn={sn:x}"
                             logger.trace("Kevery unescrow error: %s", msg)
                             raise UnverifiedReceiptError(msg)
 
                         # get receipted event using pre and edig
                         raw = self.db.getEvt(dgKey(pre, dig))
                         if raw is None:  # receipted event superseded so remove from escrow
-                            msg = f"UNT Invalid receipted event reference at pre={pre} sn={sn:x}"
+                            msg = f"URE Invalid receipted event reference at pre={pre} sn={sn:x}"
                             logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
@@ -6266,14 +6268,14 @@ class Kevery:
 
                         #  compare digs
                         if rsaider.qb64b != serder.saidb:
-                            msg = f"UNT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                            msg = f"URE Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
                             logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
                         #  verify sig verfer key is prefixer from triple
                         if not cigar.verfer.verify(cigar.raw, serder.raw):
                             # no sigs so raise ValidationError which unescrows below
-                            msg = f"UNT Bad escrowed receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                            msg = f"URE Bad escrowed receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
                             logger.trace("Kevery unescrow error: %s", msg)
                             raise ValidationError(msg)
 
@@ -6298,16 +6300,16 @@ class Kevery:
                     # still waiting on missing prior event to validate
                     # only happens if we process above
                     if logger.isEnabledFor(logging.TRACE):  # adds exception data
-                        logger.trace("Kevery: UNT escrow other error on unescrow: %s\n", ex.args[0])
-                        logger.exception("Kevery: UNT escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.trace("Kevery: URE escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.exception("Kevery: URE escrow other error on unescrow: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.delUre(snKey(pre, sn), etriplet)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.exception("Kevery unescrowed: %s", ex.args[0])
+                        logger.exception("Kevery URE unescrowed: %s", ex.args[0])
                     else:
-                        logger.error("Kevery unescrowed: %s", ex.args[0])
+                        logger.error("Kevery URE unescrowed: %s", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
@@ -6426,7 +6428,7 @@ class Kevery:
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.db.delegables.rem(keys=(pre, sn,), val=edig)  # removes one escrow at key val
-                logger.info("Kevery DEL unescrow succeeded in valid event: "
+                logger.info("Kevery delegables escrow unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
                 logger.debug("event=\n%s\n", eserder.pretty())
 
@@ -6533,7 +6535,7 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.qnfs.rem(keys=(pre, said), val=edig)   # removes one escrow at key val
-                    logger.info("Kevery: QNF unescrow succeeded in valid event: "
+                    logger.info("Kevery: query not found escrow unescrow succeeded in valid event: "
                                 "key = %s \tdigest = %s", ekey.decode(), edig)
                     logger.debug("Event=\n%s\n", eserder.pretty())
 
@@ -6703,7 +6705,7 @@ class Kevery:
                     dtb = self.db.getDts(dgKey(pre, bytes(esaider.qb64b)))
                     if dtb is None:  # othewise is a datetime as bytes
                         # no date time so raise ValidationError which unescrows below
-                        msg = f"UVT Missing escrowed event datetime at dig = {esaider.qb64b}"
+                        msg = f"VRE Missing escrowed event datetime at dig = {esaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6712,7 +6714,7 @@ class Kevery:
                     dte = helping.fromIso8601(bytes(dtb))
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutVRE):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"UVT Stale event escrow at dig = {esaider.qb64b}"
+                        msg = f"VRE Stale event escrow at dig = {esaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6720,7 +6722,7 @@ class Kevery:
                     raw = self.db.getKeLast(snKey(pre, sn))
                     if raw is None:
                         # no event so keep in escrow
-                        msg = f"UVT Missing receipted evt at pre={pre} sn={sn:x}"
+                        msg = f"VRE Missing receipted evt at pre={pre} sn={sn:x}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise UnverifiedTransferableReceiptError(msg)
 
@@ -6728,7 +6730,7 @@ class Kevery:
                     # get receipted event using pre and edig
                     raw = self.db.getEvt(dgKey(pre, dig))
                     if raw is None:  # receipted event superseded so remove from escrow
-                        msg = f"UVT Invalid receipted evt reference at pre={pre} sn={sn:x}"
+                        msg = f"VRE Invalid receipted evt reference at pre={pre} sn={sn:x}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6736,7 +6738,7 @@ class Kevery:
 
                     #  compare digs
                     if esaider.qb64b != serder.saidb:
-                        msg = f"UVT Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        msg = f"VRE Bad escrowed receipt dig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6746,7 +6748,7 @@ class Kevery:
                                                        sn=sseqner.sn))
                     if sdig is None:
                         # no event so keep in escrow
-                        msg = f"UVT Missing receipted evt at pre={pre} sn={sn:x}"
+                        msg = f"VRE Missing receipted evt at pre={pre} sn={sn:x}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise UnverifiedTransferableReceiptError(msg)
 
@@ -6756,14 +6758,14 @@ class Kevery:
                     sserder = serdering.SerderKERI(raw=bytes(sraw))
                     if not sserder.compare(said=ssaider.qb64):  # seal dig not match event
                         # this unescrows
-                        msg = f"UVT Bad chit seal at sn = {sseqner.sn} for rct = {sserder.ked}"
+                        msg = f"VRE Bad chit seal at sn = {sseqner.sn} for rct = {sserder.ked}"
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     # verify sigs and if so write quadruple to database
                     verfers = sserder.verfers
                     if not verfers:
-                        msg = (f"UVT Invalid seal est. event dig = {ssaider.qb64} "
+                        msg = (f"VRE Invalid seal est. event dig = {ssaider.qb64} "
                                f"for receipt from pre = {sprefixer.qb64} no keys")
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
@@ -6772,13 +6774,13 @@ class Kevery:
                     sealet = sprefixer.qb64b + sseqner.qb64b + ssaider.qb64b
 
                     if siger.index >= len(verfers):
-                        msg = f"UVT Index = {siger.index} too large for keys"
+                        msg = f"VRE Index = {siger.index} too large for keys"
                         logger.info("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
                     siger.verfer = verfers[siger.index]  # assign verfer
                     if not siger.verfer.verify(siger.raw, serder.raw):  # verify sig
-                        msg = f"UVT Bad escrowed trans receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
+                        msg = f"VRE Bad escrowed trans receipt sig at pre={pre} sn={sn:x} receipter={sprefixer.qb64}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
@@ -6791,22 +6793,22 @@ class Kevery:
                     # still waiting on missing prior event to validate
                     # only happens if we process above
                     if logger.isEnabledFor(logging.TRACE):  # adds exception data
-                        logger.trace("Kevery: UVT escrow unescrow failed: %s\n", ex.args[0])
-                        logger.exception("Kevery: UVT escrow unescrow failed: %s\n", ex.args[0])
+                        logger.trace("Kevery: VRE escrow unescrow failed: %s\n", ex.args[0])
+                        logger.exception("Kevery: VRE escrow unescrow failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # log diagnostics errors etc
                     # error other than out of order so remove from OO escrow
                     self.db.delVre(snKey(pre, sn), equinlet)  # removes one escrow at key val
                     if logger.isEnabledFor(logging.DEBUG):  # adds exception data
-                        logger.debug("Kevery: UVT escrow other error on unescrow: %s\n", ex.args[0])
-                        logger.exception("Kevery: UVT escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.debug("Kevery: VRE escrow other error on unescrow: %s\n", ex.args[0])
+                        logger.exception("Kevery: VRE escrow other error on unescrow: %s\n", ex.args[0])
 
                 else:  # unescrow succeeded, remove from escrow
                     # We don't remove all escrows at pre,sn because some might be
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delVre(snKey(pre, sn), equinlet)  # removes one escrow at key val
-                    logger.info("Kevery UVT unescrow succeeded for event = %s", serder.said)
+                    logger.info("Kevery VRE unescrow succeeded for event = %s", serder.said)
                     logger.debug("Event=\n%s\n", serder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration
@@ -6931,7 +6933,7 @@ class Kevery:
                     # duplicitous so we process remaining escrows in spite of found
                     # valid event escrow.
                     self.db.delLde(snKey(pre, sn), edig)  # removes one escrow at key val
-                    logger.info("Kevery DUP unescrow succeeded in valid event: event=%s", eserder.said)
+                    logger.info("Kevery duplicitous escrow unescrow succeeded in valid event: event=%s", eserder.said)
                     logger.debug("event=\n%s\n", eserder.pretty())
 
             if ekey == key:  # still same so no escrows found on last while iteration

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1032,8 +1032,10 @@ class Parser:
 
             elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
                 if not (cigars or wigers or tsgs):
-                    raise kering.ValidationError("Missing attached signatures on receipt"
-                                                 "msg = {}.".format(serder.ked))
+                    msg = f"Missing attached signatures on receipt msg sn={serder.sn} SAID={serder.said}"
+                    logger.info(msg)
+                    logger.debug("Receipt body=\n%s\n", serder.pretty())
+                    raise kering.ValidationError(msg)
 
                 try:
                     if cigars:

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -443,9 +443,9 @@ class Parser:
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s", ex.args[0])
+                    logger.exception("Parser sized group error: %s", ex.args[0])
                 else:
-                    logger.error("Parser msg extraction error: %s", ex.args[0])
+                    logger.error("Parser sized group error: %s", ex.args[0])
 
             except (kering.ColdStartError, kering.ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
@@ -457,10 +457,10 @@ class Parser:
             except (kering.ValidationError, Exception) as ex:  # non Extraction Error
                 # Non extraction errors happen after successfully extracted from stream
                 # so we don't flush rest of stream just resume
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.exception("Parser msg validation or non-extraction error: %s", ex)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg non-extraction error: %s", ex)
-                else:
-                    logger.error("Parser msg non-extraction error: %s", ex)
+                    logger.error("Parser msg validation or non-extraction error: %s", ex)
             yield
 
         return True
@@ -618,9 +618,9 @@ class Parser:
             except kering.SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s", ex.args[0])
+                    logger.exception("Parser sized group error: %s", ex.args[0])
                 else:
-                    logger.error("Parser msg extraction error: %s", ex.args[0])
+                    logger.error("Parser sized group error: %s", ex.args[0])
 
             except (kering.ColdStartError, kering.ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
@@ -632,9 +632,9 @@ class Parser:
             except (kering.ValidationError, Exception) as ex:  # non Extraction Error
                 # Non extraction errors happen after successfully extracted from stream
                 # so we don't flush rest of stream just resume
-                if logger.isEnabledFor(logging.DEBUG):
+                if logger.isEnabledFor(logging.TRACE):
                     logger.exception("Parser msg non-extraction error: %s", ex.args[0])
-                else:
+                if logger.isEnabledFor(logging.DEBUG):
                     logger.error("Parser msg non-extraction error: %s", ex.args[0])
             yield
 
@@ -1008,7 +1008,7 @@ class Parser:
                 delseqner, delsaider = sscs[-1] if sscs else (None, None)  # use last one if more than one
                 if not sigers:
                     msg = f"Missing attached signature(s) for evt = {serder.ked['d']}"
-                    logger.info("Parser: %s", msg)
+                    logger.info(msg)
                     logger.debug("Event Body = \n%s\n", serder.pretty())
                     raise kering.ValidationError(msg)
                 try:
@@ -1030,14 +1030,14 @@ class Parser:
 
                 except AttributeError as ex:
                     msg = f"No kevery to process so dropped msg={serder.said}"
-                    logger.info("Parser: %s", msg)
+                    logger.info(msg)
                     logger.debug("Event Body = \n%s\n", serder.pretty())
                     raise kering.ValidationError(msg) from ex
 
             elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
                 if not (cigars or wigers or tsgs):
                     msg = f"Missing attached signatures on receipt msg sn={serder.sn} SAID={serder.said}"
-                    logger.info("Parser: %s", msg)
+                    logger.info(msg)
                     logger.debug("Receipt body=\n%s\n", serder.pretty())
                     raise kering.ValidationError(msg)
 

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1007,8 +1007,10 @@ class Parser:
                 # when present assumes this is source seal of delegating event in delegator's KEL
                 delseqner, delsaider = sscs[-1] if sscs else (None, None)  # use last one if more than one
                 if not sigers:
-                    raise kering.ValidationError("Missing attached signature(s) for evt "
-                                                 "= {}.".format(serder.ked))
+                    msg = f"Missing attached signature(s) for evt = {serder.ked['d']}"
+                    logger.info("Parser: %s", msg)
+                    logger.debug("Event Body = \n%s\n", serder.pretty())
+                    raise kering.ValidationError(msg)
                 try:
                     kvy.processEvent(serder=serder,
                                      sigers=sigers,
@@ -1027,13 +1029,15 @@ class Parser:
                                                              firner=firner, local=local)
 
                 except AttributeError as ex:
-                    raise kering.ValidationError("No kevery to process so dropped msg"
-                                                 "= {}.".format(serder.pretty())) from ex
+                    msg = f"No kevery to process so dropped msg={serder.said}"
+                    logger.info("Parser: %s", msg)
+                    logger.debug("Event Body = \n%s\n", serder.pretty())
+                    raise kering.ValidationError(msg) from ex
 
             elif ilk in [Ilks.rct]:  # event receipt msg (nontransferable)
                 if not (cigars or wigers or tsgs):
                     msg = f"Missing attached signatures on receipt msg sn={serder.sn} SAID={serder.said}"
-                    logger.info(msg)
+                    logger.info("Parser: %s", msg)
                     logger.debug("Receipt body=\n%s\n", serder.pretty())
                     raise kering.ValidationError(msg)
 
@@ -1053,6 +1057,12 @@ class Parser:
                 except AttributeError:
                     raise kering.ValidationError("No kevery to process so dropped msg"
                                                  "= {}.".format(serder.pretty()))
+                except kering.UnverifiedReplyError as e:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.exception("Error processing reply = %s", e)
+                        logger.debug("Reply Body=\n%s\n", serder.pretty())
+                    else:
+                        logger.error("Error processing reply = %s", e)
 
             elif ilk in (Ilks.rpy,):  # reply message
                 if not (cigars or tsgs):
@@ -1098,6 +1108,12 @@ class Parser:
                     except AttributeError as e:
                         raise kering.ValidationError("No tevery to process so dropped msg"
                                                      "= {} from {}.".format(serder.pretty(), e))
+                    except kering.QueryNotFoundError as e:  # catch escrow error and log it
+                        if logger.isEnabledFor(logging.TRACE):
+                            logger.exception("Error processing query = %s", e)
+                            logger.trace("Query Body=\n%s\n", serder.pretty())
+                        else:
+                            logger.error("Error processing query = %s", e)
 
                 else:
                     raise kering.ValidationError("Invalid resource type {} so dropped msg"

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -261,37 +261,37 @@ class Revery:
 
         for cigar in cigars:  # process each couple to verify sig and write to db
             if cigar.verfer.transferable:  # ignore invalid transferable verfers
-                logger.info("Kevery process: skipped invalid transferable verfers"
-                            " on reply said=", serder.said)
+                logger.info("Revery: skipped invalid transferable verfers "
+                            "on reply said = %s", serder.said)
                 continue  # skip invalid transferable
 
             if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own cig
                 if not self.local:  # own cig when not local so ignore
-                    logger.info("Kevery process: skipped own attachment"
-                                " on nonlocal reply said=", serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.info("Revery: skipped own attachment "
+                                "on nonlocal reply said=", serder.said)
+                    logger.debug("event=\n%s\n", serder.pretty())
 
                     continue  # skip own cig attachment on non-local reply msg
 
             if aid != cigar.verfer.qb64:  # cig not by aid
-                logger.info("Kevery process: skipped cig not from aid="
-                            "%s on reply said=%s", aid, serder.said)
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.debug("Revery: skipped cig not from aid = "
+                             "%s on reply said=%s", aid, serder.said)
+                logger.debug("event=\n%s\n", serder.pretty())
                 continue  # skip invalid cig's verfer is not aid
 
             if odater:  # get old compare datetimes to see if later
                 if dater.datetime <= odater.datetime:
-                    logger.info("Kevery process: skipped stale update from "
-                                "%s of reply said=%s", aid, serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.debug("Revery: skipped stale update from "
+                                 "%s of reply said=%s", aid, serder.said)
+                    logger.debug("event=\n%s\n", serder.pretty())
                     continue  # skip if not later
                     # raise ValidationError(f"Stale update of {route} from {aid} "
                     # f"via {Ilks.rpy}={serder.ked}.")
 
             if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-                logger.info("Kevery process: skipped nonverifying cig from "
-                            "%s on reply said=%s", cigar.verfer.qb64, serder.said)
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.debug("Revery: skipped non-verifying cig from "
+                             "%s on reply said=%s", cigar.verfer.qb64, serder.said)
+                logger.debug("event=\n%s\n", serder.pretty())
                 continue  # skip if cig not verify
 
             # All constraints satisfied so update
@@ -303,16 +303,16 @@ class Revery:
         for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
             if not self.lax and prefixer.qb64 in self.prefixes:  # own sig
                 if not self.local:  # own sig when not local so ignore
-                    logger.info("Kevery process: skipped own attachment"
-                                " on nonlocal reply said=%s", serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.debug("Revery: skipped own attachment "
+                                 "on nonlocal reply said=%s", serder.said)
+                    logger.debug("event=\n%s\n", serder.pretty())
                     continue  # skip own sig attachment on non-local reply msg
 
             spre = prefixer.qb64
             if aid != spre:  # sig not by aid
-                logger.info("Kevery process: skipped signature not from aid="
-                            "%s on reply said=%s", aid, serder.said)
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.debug("Revery: skipped signature not from aid = "
+                             "%s on reply said=%s", aid, serder.said)
+                logger.debug("event=\n%s\n", serder.pretty())
                 continue  # skip invalid signature is not from aid
 
             if osaider:  # check if later logic  sn > or sn == and dt >
@@ -320,19 +320,18 @@ class Revery:
                     _, osqr, _, _ = otsgs[0]  # zeroth should be authoritative
 
                     if seqner.sn < osqr.sn:  # sn earlier
-                        logger.info("Kevery process: skipped stale key state sig"
+                        logger.info("Revery: skipped stale key state sig "
                                     "from %s sn=%s<%s on reply said=%s",
                                     aid, seqner.sn, osqr.sn, serder.said)
-                        logger.debug(f"event=\n{serder.pretty()}\n")
+                        logger.debug("event=\n%s\n", serder.pretty())
                         continue  # skip if sn earlier
 
                     if seqner.sn == osqr.sn:  # sn same so check datetime
                         if odater:
                             if dater.datetime <= odater.datetime:
-                                logger.info("Kevery process: skipped stale key"
-                                            "state sig datetime from %s on reply said=%s",
-                                            aid, serder.said)
-                                logger.debug(f"event=\n{serder.pretty()}\n")
+                                logger.info("Revery: skipped stale key state sig datetime "
+                                            "from %s on reply said=%s", aid, serder.said)
+                                logger.debug("event=\n%s\n", serder.pretty())
                                 continue  # skip if not later
 
             # retrieve sdig of last event at sn of signer.
@@ -340,7 +339,7 @@ class Revery:
             if sdig is None:
                 # create cue here to request key state for sprefixer signer
                 # signer's est event not yet in signer's KEL
-                logger.info("Kevery process: escrowing without key state for signer"
+                logger.info("Revery: escrowing without key state for signer"
                             " on reply said=", serder.said)
                 self.escrowReply(serder=serder, saider=saider, dater=dater,
                                  route=route, prefixer=prefixer, seqner=seqner,
@@ -508,9 +507,8 @@ class Revery:
 
                 else:  # unescrow succeded
                     self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only
-                    logger.info("Kevery unescrow succeeded for reply said=%s",
-                                serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.info("Revery unescrow succeeded for reply said=%s", serder.said)
+                    logger.debug("event=\n%s\n", serder.pretty())
 
             except Exception as ex:  # log diagnostics errors etc
                 self.db.rpes.rem(keys=(route,), val=saider)  # remove escrow only

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -267,31 +267,31 @@ class Revery:
 
             if not self.lax and cigar.verfer.qb64 in self.prefixes:  # own cig
                 if not self.local:  # own cig when not local so ignore
-                    logger.info("Revery: skipped own attachment "
-                                "on nonlocal reply said=", serder.said)
-                    logger.debug("event=\n%s\n", serder.pretty())
+                    logger.info("Revery: skipped own attachment for AID %s"
+                                " on non-local reply at route = %s", aid, serder.ked['r'])
+                    logger.debug("Reply Body=\n%s\n", serder.pretty())
 
                     continue  # skip own cig attachment on non-local reply msg
 
             if aid != cigar.verfer.qb64:  # cig not by aid
-                logger.debug("Revery: skipped cig not from aid = "
-                             "%s on reply said=%s", aid, serder.said)
-                logger.debug("event=\n%s\n", serder.pretty())
+                logger.info("Revery: skipped cig not from aid="
+                            "%s on reply at route %s", aid, serder.ked['r'])
+                logger.debug("Reply Body=\n%s\n", serder.pretty())
                 continue  # skip invalid cig's verfer is not aid
 
             if odater:  # get old compare datetimes to see if later
                 if dater.datetime <= odater.datetime:
-                    logger.debug("Revery: skipped stale update from "
-                                 "%s of reply said=%s", aid, serder.said)
-                    logger.debug("event=\n%s\n", serder.pretty())
+                    logger.trace("Revery: skipped stale update from "
+                                 "%s of reply at route= %s", aid, serder.ked['r'])
+                    logger.trace("Reply Body=\n%s\n", serder.pretty())
                     continue  # skip if not later
                     # raise ValidationError(f"Stale update of {route} from {aid} "
                     # f"via {Ilks.rpy}={serder.ked}.")
 
             if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-                logger.debug("Revery: skipped non-verifying cig from "
-                             "%s on reply said=%s", cigar.verfer.qb64, serder.said)
-                logger.debug("event=\n%s\n", serder.pretty())
+                logger.info("Revery: skipped non-verifying cig from "
+                            "%s on reply at route = %s", cigar.verfer.qb64, serder.ked['r'])
+                logger.debug("Reply Body=\n%s\n", serder.pretty())
                 continue  # skip if cig not verify
 
             # All constraints satisfied so update
@@ -494,8 +494,8 @@ class Revery:
 
                 except kering.UnverifiedReplyError as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow attempt failed: %s", ex.args[0])
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Kevery unescrow attempt failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -104,8 +104,8 @@ class Broker:
                     if ((helping.nowUTC() - dater.datetime) >
                             datetime.timedelta(seconds=self.timeout)):
                         # escrow stale so raise ValidationError which unescrows below
-                        msg = f"Stale txn state escrow at pre = {pre}."
-                        logger.info("Broker %s: unescrow error %s", typ, msg)
+                        msg = f"Escrow unescrow error: Stale txn state escrow at pre = {pre}"
+                        logger.trace("Broker %s: %s", typ, msg)
                         raise kering.ValidationError(msg)
 
                     processReply(serder=serder, saider=saider, route=serder.ked["r"],
@@ -113,7 +113,8 @@ class Broker:
 
                 except extype as ex:
                     # still waiting on missing prior event to validate
-                    if logger.isEnabledFor(logging.DEBUG):
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Broker %s: unescrow attempt failed: %s\n", typ, ex.args[0])
                         logger.exception("Broker %s: unescrow attempt failed: %s", typ, ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
@@ -127,7 +128,7 @@ class Broker:
                     self.escrowdb.rem(keys=(typ, pre, aid), val=saider)  # remove escrow
                     logger.info("Broker %s: unescrow succeeded for txn state=%s",
                                 typ, serder.said)
-                    logger.debug("event=\n%s\n", serder.pretty())
+                    logger.debug("TXN State Body=\n%s\n", serder.pretty())
 
             except Exception as ex:  # log diagnostics errors etc
                 self.escrowdb.rem(keys=(typ, pre, aid), val=saider)  # remove escrow

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -90,8 +90,9 @@ class Broker:
 
                 try:
                     if not (dater and serder and (tsgs or vcigars)):
-                        raise ValueError(f"Missing escrow artifacts at said={saider.qb64}"
-                                         f"for pre={pre}.")
+                        msg = f"Missing escrow artifacts at said={saider.qb64} for pre={pre}."
+                        logger.info("Broker %s: unescrow error: %s", typ, msg)
+                        raise ValueError(msg)
 
                     cigars = []
                     if vcigars:
@@ -103,10 +104,9 @@ class Broker:
                     if ((helping.nowUTC() - dater.datetime) >
                             datetime.timedelta(seconds=self.timeout)):
                         # escrow stale so raise ValidationError which unescrows below
-                        logger.info("Kevery unescrow error: Stale txn state escrow "
-                                    " at pre = %s", pre)
-
-                        raise kering.ValidationError(f"Stale txn state escrow at pre = {pre}.")
+                        msg = f"Stale txn state escrow at pre = {pre}."
+                        logger.info("Broker %s: unescrow error %s", typ, msg)
+                        raise kering.ValidationError(msg)
 
                     processReply(serder=serder, saider=saider, route=serder.ked["r"],
                                  cigars=cigars, tsgs=tsgs, aid=aid)
@@ -114,28 +114,28 @@ class Broker:
                 except extype as ex:
                     # still waiting on missing prior event to validate
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrow attempt failed: %s", ex.args[0])
+                        logger.exception("Broker %s: unescrow attempt failed: %s", typ, ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
                     self.escrowdb.rem(keys=(typ, pre, aid), val=saider)   # remove escrow
                     if logger.isEnabledFor(logging.DEBUG):
-                        logger.exception("Kevery unescrowed due to error: %s", ex.args[0])
+                        logger.exception("Broker %s: unescrowed due to error: %s", typ, ex.args[0])
                     else:
-                        logger.error("Kevery unescrowed due to error: %s", ex.args[0])
+                        logger.error("Broker  %s: unescrowed due to error: %s", typ, ex.args[0])
 
                 else:  # unescrow succeded
                     self.escrowdb.rem(keys=(typ, pre, aid), val=saider)  # remove escrow
-                    logger.info("Kevery unescrow succeeded for txn state=%s",
-                                serder.said)
-                    logger.debug(f"event=\n{serder.pretty()}\n")
+                    logger.info("Broker %s: unescrow succeeded for txn state=%s",
+                                typ, serder.said)
+                    logger.debug("event=\n%s\n", serder.pretty())
 
             except Exception as ex:  # log diagnostics errors etc
                 self.escrowdb.rem(keys=(typ, pre, aid), val=saider)  # remove escrow
                 self.removeState(saider)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery unescrowed due to error: %s", ex.args[0])
+                    logger.exception("Broker %s: unescrowed due to error: %s", typ, ex.args[0])
                 else:
-                    logger.error("Kevery unescrowed due to error: %s", ex.args[0])
+                    logger.error("Broker %s: unescrowed due to error: %s", typ, ex.args[0])
 
     def escrowStateNotice(self, *, typ, pre, aid, serder, saider, dater, cigars=None, tsgs=None):
         """

--- a/src/keri/demo/demo_kev.py
+++ b/src/keri/demo/demo_kev.py
@@ -8,7 +8,7 @@ Utilities for demos
 import argparse
 import logging
 
-from hio import help
+from keri import help
 from hio.base import doing
 
 from ..app import habbing, keeping, apping

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -28,16 +28,5 @@ logging.Logger.trace = trace
 #  want help.ogler always defined by default
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import
 
-#  set log formatters with detailed log output
-logFmt = "%(asctime)s [keri] %(levelname)-8s %(message)s"
-formatter = logging.Formatter(logFmt)
-
-ch = logging.StreamHandler()
-ch.setFormatter(formatter)
-ogler.baseConsoleHandler = ch
-ogler.baseFormatter = formatter
-
-ogler.reopen(headDirPath=ogler.headDirPath)
-
 from .helping import (nowIso8601, toIso8601, fromIso8601,
                       nonStringSequence, nonStringIterable)

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -6,12 +6,24 @@ keri.help package
 utility functions
 
 """
+import logging
+
 # Setup module global ogler as package logger factory. This must be done on
 #  import to ensure global is defined so all modules in package have access to
 #  logggers via ogling.ogler.getLoggers(). May always change level and reopen log file
 #  if need be
-
 from hio.help import ogling
+
+
+# Custom TRACE log level configuration
+TRACE = 5              # TRACE (5) logging level value between DEBUG (10) and NOTSET (0)
+logging.TRACE = TRACE  # add TRACE logging level to logging module
+logging.addLevelName(logging.TRACE, "TRACE")
+def trace(self, message, *args, **kwargs):
+    """Trace logging function - logs message if TRACE (5) level enabled"""
+    if self.isEnabledFor(TRACE):
+        self._log(TRACE, message, args, **kwargs)
+logging.Logger.trace = trace
 
 #  want help.ogler always defined by default
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -28,5 +28,16 @@ logging.Logger.trace = trace
 #  want help.ogler always defined by default
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import
 
+#  set log formatters with detailed log output
+logFmt = "%(asctime)s [keri] %(levelname)-8s %(message)s"
+formatter = logging.Formatter(logFmt)
+
+ch = logging.StreamHandler()
+ch.setFormatter(formatter)
+ogler.baseConsoleHandler = ch
+ogler.baseFormatter = formatter
+
+ogler.reopen(headDirPath=ogler.headDirPath)
+
 from .helping import (nowIso8601, toIso8601, fromIso8601,
                       nonStringSequence, nonStringIterable)

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -25,7 +25,7 @@ class Exchanger:
      Peer to Peer KERI message Exchanger.
     """
 
-    TimeoutPSE = 10  # seconds to timeout partially signed or delegated escrows
+    TimeoutPSE = 20  # seconds to timeout partially signed or delegated escrows
 
     def __init__(self, hby, handlers, cues=None, delta=ExchangeMessageTimeWindow):
         """ Initialize instance
@@ -82,7 +82,7 @@ class Exchanger:
                 if sender != prefixer.qb64:  # sig not by aid
                     msg = (f"Skipped signature not from aid = "
                            f"{sender}, from {prefixer.qb64} on exn msg = {serder.said}")
-                    logger.info("Exchanger: %s", msg)
+                    logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
@@ -90,7 +90,7 @@ class Exchanger:
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                         msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
-                        logger.info("Exchanger: %s", msg)
+                        logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
@@ -103,7 +103,7 @@ class Exchanger:
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                     msg = (f"Not enough signatures in idx={indices} route={route} "
                            f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info("Exchanger: %s", msg)
+                    logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
@@ -112,14 +112,14 @@ class Exchanger:
                 if sender != cigar.verfer.qb64:  # cig not by aid
                     msg = (f"Skipped cig not from aid={sender} route={route} "
                            f"for exn evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info("Exchanger: %s", msg)
+                    logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
                 if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
                     msg = (f"Failure satisfying exn on cigs for {cigar} route={route} "
                            f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info("Exchanger: %s", msg)
+                    logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
         else:
@@ -127,7 +127,7 @@ class Exchanger:
             msg = (
                 f"Failure satisfying exn, no cigs or sigs for evt = {serder.said} "
                 f"on route {route} recipient = {serder.ked.get('rp', '')}")
-            logger.info("Exchanger: %s", msg)
+            logger.info(msg)
             logger.debug("Exchange message body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
 
@@ -555,7 +555,7 @@ def verify(hby, serder):
     for prefixer, seqner, ssaider, sigers in tsgs:
         if prefixer.qb64 not in hby.kevers or hby.kevers[prefixer.qb64].sn < seqner.sn:
             msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
-            logger.info("exchanging.verify: %s", msg)
+            logger.info(msg)
             logger.debug("Exn Body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
 
@@ -565,7 +565,7 @@ def verify(hby, serder):
 
         if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
             msg = f"Not enough signatures in idx={indices} for evt = {serder.said}"
-            logger.info("exchanging.verify: %s", msg)
+            logger.info(msg)
             logger.debug("Exn Body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
         accepted = True
@@ -574,14 +574,14 @@ def verify(hby, serder):
     for cigar in cigars:
         if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
             msg = f"Failure satisfying exn on cigs for {cigar} for evt = {serder.said}"
-            logger.info("exchanging.verify: %s", msg)
+            logger.info(msg)
             logger.debug("Exn Body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
         accepted = True
 
     if not accepted:
         msg = f"No valid signatures stored for evt = {serder.said}"
-        logger.info("exchanging.verify: %s", msg)
+        logger.info(msg)
         logger.debug("Exn Body=\n%s\n", serder.pretty())
         raise MissingSignatureError(msg)
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -80,14 +80,19 @@ class Exchanger:
         if tsgs:
             for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
                 if sender != prefixer.qb64:  # sig not by aid
-                    raise MissingSignatureError(f"Exchange process: skipped signature not from aid="
-                                                f"{sender}, from {prefixer.qb64} on exn msg=\n{serder.pretty()}\n")
+                    msg = (f"Skipped signature not from aid = "
+                           f"{sender}, from {prefixer.qb64} on exn msg = {serder.said}")
+                    logger.info("Exchanger: %s", msg)
+                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                    raise MissingSignatureError(msg)
 
                 if prefixer.qb64 not in self.kevers or self.kevers[prefixer.qb64].sn < seqner.sn:
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
-                    raise MissingSignatureError(f"Unable to find sender {prefixer.qb64} in kevers"
-                                                f" for evt = {serder.ked}.")
+                        msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
+                        logger.info("Exchanger: %s", msg)
+                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                    raise MissingSignatureError(msg)
 
                 # Verify the signatures are valid and that the signature threshold as of the signing event is met
                 tholder, verfers = self.hby.db.resolveVerifiers(pre=prefixer.qb64, sn=seqner.sn, dig=ssaider.qb64)
@@ -96,23 +101,35 @@ class Exchanger:
                 if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
-                    raise MissingSignatureError(f"Not enough signatures in  {indices}"
-                                                f" for evt = {serder.ked}.")
+                    msg = (f"Not enough signatures in idx={indices} route={route} "
+                           f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
+                    logger.info("Exchanger: %s", msg)
+                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                    raise MissingSignatureError(msg)
 
         elif cigars:
             for cigar in cigars:
                 if sender != cigar.verfer.qb64:  # cig not by aid
-                    raise MissingSignatureError(" process: skipped cig not from aid="
-                                                "%s on exn msg=\n%s\n", sender, serder.pretty())
+                    msg = (f"Skipped cig not from aid={sender} route={route} "
+                           f"for exn evt = {serder.said} recipient={serder.ked.get('rp', '')}")
+                    logger.info("Exchanger: %s", msg)
+                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                    raise MissingSignatureError(msg)
 
                 if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-                    raise MissingSignatureError("Failure satisfying exn on cigs for {}"
-                                                " for evt = {}.".format(cigar,
-                                                                        serder.ked))
+                    msg = (f"Failure satisfying exn on cigs for {cigar} route={route} "
+                           f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
+                    logger.info("Exchanger: %s", msg)
+                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                    raise MissingSignatureError(msg)
         else:
             self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed)
-            raise MissingSignatureError("Failure satisfying exn, no cigs or sigs"
-                                        " for evt = {}.".format(serder.ked))
+            msg = (
+                f"Failure satisfying exn, no cigs or sigs for evt = {serder.said} "
+                f"on route {route} recipient = {serder.ked.get('rp', '')}")
+            logger.info("Exchanger: %s", msg)
+            logger.debug("Exchange message body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
 
         e = coring.Pather(path=["e"])
 
@@ -142,13 +159,13 @@ class Exchanger:
         # Perform behavior specific verification, think IPEX chaining requirements
         try:
             if not behavior.verify(serder=serder, **kwargs):
-                logger.info(f"exn event for route {route} failed behavior verfication.  said={serder.said}")
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.info("exn event for route %s failed behavior verification.  said=%s", route, serder.said)
+                logger.debug(f"Event=\n%s\n", serder.pretty())
                 return
 
         except AttributeError:
-            logger.info(f"Behavior for {route} missing or does not have verify for said={serder.said}")
-            logger.debug(f"event=\n{serder.pretty()}\n")
+            logger.debug("Behavior for %s missing or does not have verify for said %s", route, serder.said)
+            logger.debug("Exn Event Body=\n%s\n", serder.pretty())
 
         # Always persist events
         self.logEvent(serder, pathed, tsgs, cigars, essrs)
@@ -158,8 +175,8 @@ class Exchanger:
         try:
             behavior.handle(serder=serder, **kwargs)
         except AttributeError:
-            logger.info(f"Behavior for {route} missing or does not have handle for said={serder.said}")
-            logger.debug(f"event=\n{serder.pretty()}\n")
+            logger.debug("Behavior for %s missing or does not have handle for SAID=%s", route, serder.said)
+            logger.debug("Event=\n%s\n", serder.pretty())
 
     def processEscrow(self):
         """ Process all escrows for `exn` messages
@@ -232,23 +249,23 @@ class Exchanger:
 
             except MissingSignatureError as ex:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.info("Exchange partially signed unescrow failed: %s", ex.args[0])
+                    logger.info("Exchanger: partially signed unescrow failed: %s", ex.args[0])
                 else:
-                    logger.info("Exchange partially signed failed: %s", ex.args[0])
+                    logger.info("Exchanger: partially signed failed: %s", ex.args[0])
             except Exception as ex:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)
                 self.hby.db.esigs.rem(dig)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Exchange partially signed unescrowed: %s", ex.args[0])
+                    logger.exception("Exchanger: partially signed unescrowed: %s", ex.args[0])
                 else:
-                    logger.error("Exchange partially signed unescrowed: %s", ex.args[0])
+                    logger.error("Exchanger: partially signed unescrowed: %s", ex.args[0])
             else:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.esigs.rem(dig)
-                logger.info("Exchanger unescrow succeeded in valid exchange: "
+                logger.info("Exchanger: unescrow succeeded in valid exchange: "
                             "creder=%s", serder.said)
-                logger.debug(f"event=\n{serder.pretty()}\n")
+                logger.debug("Event=\n%s\n", serder.pretty())
 
     def logEvent(self, serder, pathed=None, tsgs=None, cigars=None, essrs=None):
         dig = serder.said
@@ -538,27 +555,35 @@ def verify(hby, serder):
     accepted = False
     for prefixer, seqner, ssaider, sigers in tsgs:
         if prefixer.qb64 not in hby.kevers or hby.kevers[prefixer.qb64].sn < seqner.sn:
-            raise MissingSignatureError(f"Unable to find sender {prefixer.qb64} in kevers"
-                                        f" for evt = {serder.ked}.")
+            msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
+            logger.info("exchanging.verify: %s", msg)
+            logger.debug("Exn Body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
 
         # Verify the signatures are valid and that the signature threshold as of the signing event is met
         tholder, verfers = hby.db.resolveVerifiers(pre=prefixer.qb64, sn=seqner.sn, dig=ssaider.qb64)
         _, indices = eventing.verifySigs(serder.raw, sigers, verfers)
 
         if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
-            raise MissingSignatureError(f"Not enough signatures in  {indices}"
-                                        f" for evt = {serder.ked}.")
+            msg = f"Not enough signatures in idx={indices} for evt = {serder.said}"
+            logger.info("exchanging.verify: %s", msg)
+            logger.debug("Exn Body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
         accepted = True
 
     cigars = hby.db.ecigs.get(keys=(serder.said,))
     for cigar in cigars:
         if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-            raise MissingSignatureError("Failure satisfying exn on cigs for {}"
-                                        " for evt = {}.".format(cigar,
-                                                                serder.ked))
+            msg = f"Failure satisfying exn on cigs for {cigar} for evt = {serder.said}"
+            logger.info("exchanging.verify: %s", msg)
+            logger.debug("Exn Body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
         accepted = True
 
     if not accepted:
-        raise MissingSignatureError(f"No valid signatures stored for evt = {serder.ked}")
+        msg = f"No valid signatures stored for evt = {serder.said}"
+        logger.info("exchanging.verify: %s", msg)
+        logger.debug("Exn Body=\n%s\n", serder.pretty())
+        raise MissingSignatureError(msg)
 
     return tsgs, cigars

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -159,7 +159,7 @@ class Exchanger:
         # Perform behavior specific verification, think IPEX chaining requirements
         try:
             if not behavior.verify(serder=serder, **kwargs):
-                logger.info("exn event for route %s failed behavior verification.  said=%s", route, serder.said)
+                logger.error("exn event for route %s failed behavior verification.  said=%s", route, serder.said)
                 logger.debug(f"Event=\n%s\n", serder.pretty())
                 return
 
@@ -248,10 +248,9 @@ class Exchanger:
                 self.processEvent(serder=serder, tsgs=tsgs, pathed=pathed, **kwargs)
 
             except MissingSignatureError as ex:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.info("Exchanger: partially signed unescrow failed: %s", ex.args[0])
-                else:
-                    logger.info("Exchanger: partially signed failed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Exchange partially signed unescrow failed: %s\n", ex.args[0])
+                    logger.debug(f"Event body=\n%s\n", serder.pretty())
             except Exception as ex:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -235,8 +235,8 @@ class BaseRegistry:
         try:
             self.tvy.processEvent(serder=serder)
         except kering.MissingAnchorError:
-            logger.info("Credential registry missing anchor for inception = {}".format(serder.said))
-            logger.debug(f"event=\n{serder.pretty()}\n")
+            logger.info("Credential registry missing anchor for inception = %s", serder.said)
+            logger.debug("event=\n%s\n", serder.pretty())
 
     def anchorMsg(self, pre, regd, seqner, saider):
         """  Create key event with seal to serder anchored as data.

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1253,8 +1253,8 @@ class Tever:
         self.reger.tets.pin(keys=(pre.decode("utf-8"), dig.decode("utf-8")), val=coring.Dater())
         self.reger.putTvt(key, serder.raw)
         self.reger.putTel(snKey(pre, sn), dig)
-        logger.info("Tever [reg=%.8s iss=%.8s]: Added to TEL valid %s event %s said=%s",
-                    self.regk, self.pre, serder.ilk, pre.decode(), serder.said)
+        logger.info("Tever: Added to TEL valid %s event %s said=%s reg=%.8s iss=%.8s",
+                    serder.ilk, pre.decode(), serder.said, self.regk, self.pre)
         logger.debug("TEL Event Body=\n%s\n", serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1255,7 +1255,7 @@ class Tever:
         self.reger.putTel(snKey(pre, sn), dig)
         logger.info("Tever [reg=%.8s iss=%.8s]: Added to TEL valid %s event %s said=%s",
                     self.regk, self.pre, serder.ilk, pre.decode(), serder.said)
-        logger.debug("event=\n%s\n", serder.pretty())
+        logger.debug("TEL Event Body=\n%s\n", serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):
         """ Validate anchor and backer signatures (bigers) when provided.
@@ -1306,12 +1306,11 @@ class Tever:
 
             if len(bindices) < toad:  # not fully witnessed yet
                 self.escrowPWEvent(serder=serder, seqner=seqner, saider=saider, bigers=bigers)
-
-                raise MissingWitnessSignatureError("Failure satisfying toad = {} "
-                                                   "on witness sigs for {} for evt = {}.".format(toad,
-                                                                                                 [siger.qb64 for siger
-                                                                                                  in bigers],
-                                                                                                 serder.ked))
+                msg = (f"Failure satisfying toad = {toad} on witness sigs "
+                       f"for {[siger.qb64 for siger in bigers]} for evt = {serder.said}")
+                logger.info("Tever: %s", msg)
+                logger.debug(f"Event Body=\n%s\n", serder.pretty())
+                raise MissingWitnessSignatureError(msg)
         return bigers
 
     def verifyAnchor(self, serder, seqner=None, saider=None):
@@ -2071,25 +2070,24 @@ class Tevery:
 
             except OutOfOrderError as ex:
                 # still waiting on missing prior event to validate
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrow failed: %s", ex.args[0])
-                else:
-                    logger.error("Tevery unescrow failed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Tevery: OOO unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Tevery: OOO unescrow failed: %s\n", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than out of order so remove from OO escrow
                 self.reger.delOot(snKey(pre, sn))  # removes one escrow at key val
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrowed: %s", ex.args[0])
+                    logger.exception("Tevery: OOO unescrowed: %s", ex.args[0])
                 else:
-                    logger.error("Tevery unescrowed: %s", ex.args[0])
+                    logger.error("Tevery: OOO unescrowed: %s", ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.reger.delOot(snKey(pre, sn))  # removes from escrow
-                logger.info("Tevery OOO unescrow succeeded in valid event: "
+                logger.info("Tevery: OOO unescrow succeeded in valid event: "
                             "said=%s", tserder.said)
                 logger.debug("Event=\n%s\n", tserder.pretty())
 
@@ -2113,8 +2111,8 @@ class Tevery:
                 traw = self.reger.getTvt(dgkey)
                 if traw is None:
                     # no event so raise ValidationError which unescrows below
-                    msg = f"Missing escrowed event at dig = {bytes(digb).decode()}"
-                    logger.info("Tevery unescrow error: %s", msg)
+                    msg = f"ANC Missing escrowed event at dig = {bytes(digb).decode()}"
+                    logger.trace("Tevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
                 tserder = serdering.SerderKERI(raw=bytes(traw))  # escrowed event
@@ -2125,8 +2123,8 @@ class Tevery:
 
                 couple = self.reger.getAnc(dgkey)
                 if couple is None:
-                    msg = f"Missing escrowed anchor at dig = {bytes(digb).decode()}"
-                    logger.info("Tevery unescrow error: %s", msg)
+                    msg = f"ANC Missing escrowed anchor at dig = {bytes(digb).decode()}"
+                    logger.trace("Tevery unescrow error: %s", msg)
                     raise MissingAnchorError(msg)
                 ancb = bytearray(couple)
                 seqner = coring.Seqner(qb64b=ancb, strip=True)
@@ -2137,17 +2135,17 @@ class Tevery:
             except MissingAnchorError as ex:
                 # still waiting on missing prior event to validate
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrow failed: %s", ex.args[0])
+                    logger.exception("Tevery ANC unescrow failed: %s", ex.args[0])
                 else:
-                    logger.error("Tevery unescrow failed: %s", ex.args[0])
+                    logger.error("Tevery ANC unescrow failed: %s", ex.args[0])
 
             except Exception as ex:  # log diagnostics errors etc
                 # error other than out of order so remove from OO escrow
                 self.reger.delTae(snKey(pre, sn))  # removes one escrow at key val
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Tevery unescrowed: %s", ex.args[0])
+                    logger.exception("Tevery ANC unescrowed: %s", ex.args[0])
                 else:
-                    logger.error("Tevery unescrowed: %s", ex.args[0])
+                    logger.error("Tevery ANC unescrowed: %s", ex.args[0])
 
             else:  # unescrow succeeded, remove from escrow
                 # We don't remove all escrows at pre,sn because some might be

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1253,9 +1253,9 @@ class Tever:
         self.reger.tets.pin(keys=(pre.decode("utf-8"), dig.decode("utf-8")), val=coring.Dater())
         self.reger.putTvt(key, serder.raw)
         self.reger.putTel(snKey(pre, sn), dig)
-        logger.info("Tever state: %s Added to TEL valid said=%s",
-                    pre, serder.said)
-        logger.debug(f"event=\n{serder.pretty()}\n")
+        logger.info("Tever [reg=%.8s iss=%.8s]: Added to TEL valid %s event %s said=%s",
+                    self.regk, self.pre, serder.ilk, pre.decode(), serder.said)
+        logger.debug("event=\n%s\n", serder.pretty())
 
     def valAnchorBigs(self, serder, seqner, saider, bigers, toad, baks):
         """ Validate anchor and backer signatures (bigers) when provided.
@@ -1570,13 +1570,19 @@ class Tevery:
             else:
                 # out of order, need to escrow
                 self.escrowOOEvent(serder=serder, seqner=seqner, saider=saider)
-                raise OutOfOrderError("escrowed out of order event {}".format(ked))
+                msg = f"Escrowed out of order event of type = {ilk} pre = {pre} SAID = {serder.said}"
+                logger.debug("Tevery: %s", msg)
+                logger.debug("TEL Event Body=\n%s\n", serder.pretty())
+                raise OutOfOrderError(msg)
 
         else:
             if ilk in (Ilks.vcp,):
                 # we don't have multiple signatures to verify so this
-                # is already first seen and then lifely duplicitious
-                raise LikelyDuplicitousError("Likely Duplicitous event={}.".format(ked))
+                # is already first seen and then likely duplicitious
+                msg = f"Likely Duplicitous Event of type={serder.ilk} sn={sn} SAID={serder.said}"
+                logger.debug("Tevery: %s", msg)
+                logger.debug("TEL Event Body=\n%s\n", serder.pretty())
+                raise LikelyDuplicitousError(msg)
 
             tever = self.tevers[regk]
             tever.cues = self.cues
@@ -1602,7 +1608,10 @@ class Tevery:
                     # self.cues.append(dict(kin="receipt", serder=serder))
                     pass
             else:  # duplicitious
-                raise LikelyDuplicitousError("Likely Duplicitous event={} with sn {}.".format(ked, sn))
+                msg = f"Likely Duplicitous Event type={serder.ilk} sn={sn} SAID={serder.said}"
+                logger.debug("Tevery: %s", msg)
+                logger.debug("TEL Event Body=\n%s\n", serder.pretty())
+                raise LikelyDuplicitousError(msg)
 
     def processQuery(self, serder, source=None, sigers=None, cigars=None):
         """ Process TEL query event message (qry)
@@ -2039,11 +2048,9 @@ class Tevery:
                 traw = self.reger.getTvt(dgkey)
                 if traw is None:
                     # no event so raise ValidationError which unescrows below
-                    logger.info("Tevery unescrow error: Missing event at."
-                                "dig = %s", bytes(digb))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(digb)))
+                    msg = f"OOO Missing escrowed event at dig = {bytes(digb).decode()}"
+                    logger.info("Tevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 tserder = serdering.SerderKERI(raw=bytes(traw))  # escrowed event
 
@@ -2053,11 +2060,9 @@ class Tevery:
 
                 couple = self.reger.getAnc(dgkey)
                 if couple is None:
-                    logger.info("Tevery unescrow error: Missing anchor at."
-                                "dig = %s", bytes(digb))
-
-                    raise ValidationError("Missing escrowed anchor at dig = {}."
-                                          "".format(bytes(digb)))
+                    msg = f"OOO Missing escrowed anchor at dig = {bytes(digb).decode()}"
+                    logger.info("Tevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
                 ancb = bytearray(couple)
                 seqner = coring.Seqner(qb64b=ancb, strip=True)
                 saider = coring.Saider(qb64b=ancb, strip=True)
@@ -2084,9 +2089,9 @@ class Tevery:
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.reger.delOot(snKey(pre, sn))  # removes from escrow
-                logger.info("Tevery unescrow succeeded in valid event: "
+                logger.info("Tevery OOO unescrow succeeded in valid event: "
                             "said=%s", tserder.said)
-                logger.debug(f"event=\n{tserder.pretty()}\n")
+                logger.debug("Event=\n%s\n", tserder.pretty())
 
     def processEscrowAnchorless(self):
         """ Process escrow of TEL events received before the anchoring KEL event.
@@ -2108,11 +2113,9 @@ class Tevery:
                 traw = self.reger.getTvt(dgkey)
                 if traw is None:
                     # no event so raise ValidationError which unescrows below
-                    logger.info("Tevery unescrow error: Missing event at."
-                                "dig = %s", bytes(digb))
-
-                    raise ValidationError("Missing escrowed evt at dig = {}."
-                                          "".format(bytes(digb)))
+                    msg = f"Missing escrowed event at dig = {bytes(digb).decode()}"
+                    logger.info("Tevery unescrow error: %s", msg)
+                    raise ValidationError(msg)
 
                 tserder = serdering.SerderKERI(raw=bytes(traw))  # escrowed event
 
@@ -2122,11 +2125,9 @@ class Tevery:
 
                 couple = self.reger.getAnc(dgkey)
                 if couple is None:
-                    logger.info("Tevery unescrow error: Missing anchor at."
-                                "dig = %s", bytes(digb))
-
-                    raise MissingAnchorError("Missing escrowed anchor at dig = {}."
-                                             "".format(bytes(digb)))
+                    msg = f"Missing escrowed anchor at dig = {bytes(digb).decode()}"
+                    logger.info("Tevery unescrow error: %s", msg)
+                    raise MissingAnchorError(msg)
                 ancb = bytearray(couple)
                 seqner = coring.Seqner(qb64b=ancb, strip=True)
                 saider = coring.Saider(qb64b=ancb, strip=True)
@@ -2153,6 +2154,6 @@ class Tevery:
                 # duplicitous so we process remaining escrows in spite of found
                 # valid event escrow.
                 self.reger.delTae(snKey(pre, sn))  # removes from escrow
-                logger.info("Tevery unescrow succeeded in valid event: "
+                logger.info("Tevery ANC unescrow succeeded in valid event: "
                             "said=%s", tserder.said)
-                logger.debug(f"event=\n{tserder.pretty()}\n")
+                logger.debug("event=\n%s\n", tserder.pretty())

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -263,10 +263,9 @@ class Verifier:
                 self.processCredential(creder, prefixer, seqner, saider)
 
             except etype as ex:
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Verifiery unescrow failed: %s", ex.args[0])
-                else:
-                    logger.error("Verifier unescrow failed: %s", ex.args[0])
+                if logger.isEnabledFor(logging.TRACE):
+                    logger.trace("Verifier unescrow failed: %s\n", ex.args[0])
+                    logger.exception("Verifier unescrow failed: %s\n", ex.args[0])
             except Exception as ex:  # log diagnostics errors etc
                 # error other than missing sigs so remove from PA escrow
                 db.rem(said)
@@ -278,7 +277,7 @@ class Verifier:
                 db.rem(said)
                 logger.info("Verifier unescrow succeeded in valid group op: "
                             "creder=%s", creder.said)
-                logger.debug(f"event=\n{creder.pretty()}\n")
+                logger.debug(f"Event=\n%s\n", creder.pretty())
 
     def saveCredential(self, creder, prefixer, seqner, saider):
         """ Write the credential and associated indicies to the database


### PR DESCRIPTION
This PR adds the logging changes made to 1.1.27+ from here: https://github.com/WebOfTrust/keripy/pull/913
and from here: https://github.com/WebOfTrust/keripy/pull/930

There is be a similar PR to the `main` branch: https://github.com/WebOfTrust/keripy/pull/933

The result of this PR is:
- Adds TRACE logging level in keri.help.__init__ module.
- Moves escrow logs to TRACE logging level.
- Moves event body logging to DEBUG level.
- INFO log level contains SAID or prefix of events rather than an event body.
- Uniformly uses log substitution where it would improve performance.
- Uniformly uses f-strings where performance is equivalent yet readability is enhanced.
- serder.pretty() used in favor of serder.ked or json.dumps(serder.ked, indent=1)
- Added escrow-specific strings to each escrow to clarify in logs which escrow produced which log message.
- Various spelling corrections and wording cleanups like Kevery process to Kevery
