### PR TITLE
Windows Compatibility

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, ubuntu-latest ]
+        os: [ macos-13, ubuntu-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -27,20 +27,24 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest hio
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install flake8 pytest
+          if (Test-Path requirements.txt) { pip install -r requirements.txt }
+        shell: pwsh
       - name: Lint changes
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
+        shell: pwsh
       - name: Run core KERI tests
         run: |
           pytest tests/ --ignore tests/demo/ --ignore test/scripts
+        shell: pwsh
       - name: Run KERI demo tests
         run: |
           pytest tests/demo/
+        shell: pwsh
 
   coverage:
     runs-on: ubuntu-latest
@@ -53,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov hio
+          pip install pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run core KERI tests
         run: |
@@ -74,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov hio pytest-shell
+          pip install pytest pytest-cov pytest-shell
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run KERI kli tests
         run: |

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -37,6 +37,16 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
         shell: pwsh
+      - name: Create \tmp directory on Windows
+        if: runner.os == 'Windows'
+        run: |
+          if (-not (Test-Path -Path '\tmp')) {
+            New-Item -Path '\tmp' -ItemType Directory -Force
+            Write-Host "Created \tmp directory for testing"
+          } else {
+            Write-Host "\tmp directory already exists"
+          }
+        shell: pwsh
       - name: Run core KERI tests
         run: |
           pytest tests/ --ignore tests/demo/ --ignore test/scripts

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.12.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12.2
+          python-version: 3.12.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,14 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.12.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12.2
+          python-version: 3.12.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov hio
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run core KERI tests
         run: |
@@ -71,14 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.12.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12.2
+          python-version: 3.12.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov pytest-shell
+          pip install pytest pytest-cov hio pytest-shell
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run KERI kli tests
         run: |

--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -18,6 +18,7 @@ function isSuccess() {
     ret=$?
     if [ $ret -ne 0 ]; then
        echo "Error $ret"
+       read -p "Press Enter to continue..."
        exit $ret
     fi
 }
@@ -82,3 +83,4 @@ printf "Running rename.sh"
 printf "\n************************************\n"
 "${script_dir}/basic/rename-alias.sh"
 isSuccess
+

--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -18,7 +18,6 @@ function isSuccess() {
     ret=$?
     if [ $ret -ne 0 ]; then
        echo "Error $ret"
-       read -p "Press Enter to continue..."
        exit $ret
     fi
 }

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
                         'cbor2>=5.6.2',
                         'multidict>=6.0.5',
                         'ordered-set>=4.1.0',
-                        'hio>=0.6.14',
+                        'hio>=0.6.18',
                         'multicommand>=1.0.0',
                         'jsonschema>=4.21.1',
                         'falcon>=3.1.3',

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -92,7 +92,7 @@ class Receiptor(doing.DoDoer):
             if wit in auths:
                 headers["Authorization"] = auths[wit]
 
-            httping.streamCESRRequests(client=client, dest=wit, ims=bytearray(msg), path="receipts", headers=headers)
+            httping.streamCESRRequests(client=client, dest=wit, ims=bytearray(msg), path="/receipts", headers=headers)
             while not client.responses:
                 yield self.tock
 

--- a/src/keri/app/cli/commands/challenge/verify.py
+++ b/src/keri/app/cli/commands/challenge/verify.py
@@ -88,7 +88,7 @@ class VerifyDoer(doing.DoDoer):
 
         super(VerifyDoer, self).__init__(doers=doers)
 
-    def verifyDo(self, tymth, tock=0.0):
+    def verifyDo(self, tymth, tock=0.0, **kwa):
         """ Check for any credential messages in mailboxes and list all held credentials
 
         Parameters:

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -94,7 +94,7 @@ class ConfirmDoer(doing.DoDoer):
         self.auto = auto
         super(ConfirmDoer, self).__init__(doers=doers)
 
-    def confirmDo(self, tymth, tock=0.0):
+    def confirmDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/delegate/request.py
+++ b/src/keri/app/cli/commands/delegate/request.py
@@ -62,7 +62,7 @@ class RequestDoer(doing.DoDoer):
 
         super(RequestDoer, self).__init__(doers=doers)
 
-    def requestDo(self, tymth, tock=0.0):
+    def requestDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/ends/add.py
+++ b/src/keri/app/cli/commands/ends/add.py
@@ -74,7 +74,7 @@ class RoleDoer(doing.DoDoer):
 
         super(RoleDoer, self).__init__(doers=self.toRemove + [doing.doify(self.roleDo)])
 
-    def roleDo(self, tymth, tock=0.0):
+    def roleDo(self, tymth, tock=0.0, **kwa):
         """ Export any end reply messages previous saved for the provided AID
 
         Parameters:

--- a/src/keri/app/cli/commands/ends/export.py
+++ b/src/keri/app/cli/commands/ends/export.py
@@ -49,7 +49,7 @@ class ExportDoer(doing.DoDoer):
 
         super(ExportDoer, self).__init__(doers=doers)
 
-    def exportDo(self, tymth, tock=0.0):
+    def exportDo(self, tymth, tock=0.0, **kwa):
         """ Export any end reply messages previous saved for the provided AID
 
         Parameters:

--- a/src/keri/app/cli/commands/ends/list.py
+++ b/src/keri/app/cli/commands/ends/list.py
@@ -52,7 +52,7 @@ class RoleDoer(doing.DoDoer):
 
         super(RoleDoer, self).__init__(doers=doers)
 
-    def roleDo(self, tymth, tock=0.0):
+    def roleDo(self, tymth, tock=0.0, **kwa):
         """ Export any end reply messages previous saved for the provided AID
 
         Parameters:

--- a/src/keri/app/cli/commands/export.py
+++ b/src/keri/app/cli/commands/export.py
@@ -57,7 +57,7 @@ class ExportDoer(doing.DoDoer):
 
         super(ExportDoer, self).__init__(doers=doers)
 
-    def exportDo(self, tymth, tock=0.0):
+    def exportDo(self, tymth, tock=0.0, **kwa):
         """ Export credential from store and any related material
 
         Parameters:

--- a/src/keri/app/cli/commands/import.py
+++ b/src/keri/app/cli/commands/import.py
@@ -50,7 +50,7 @@ class ImportDoer(doing.DoDoer):
 
         super(ImportDoer, self).__init__(doers=doers)
 
-    def exportDo(self, tymth, tock=0.0):
+    def exportDo(self, tymth, tock=0.0, **kwa):
         """ Export credential from store and any related material
 
         Parameters:

--- a/src/keri/app/cli/commands/ipex/admit.py
+++ b/src/keri/app/cli/commands/ipex/admit.py
@@ -77,7 +77,7 @@ class AdmitDoer(doing.DoDoer):
         self.toRemove = [mbx, self.witq]
         super(AdmitDoer, self).__init__(doers=self.toRemove + [doing.doify(self.admitDo)])
 
-    def admitDo(self, tymth, tock=0.0):
+    def admitDo(self, tymth, tock=0.0, **kwa):
         """ Admit credential by accepting into database and sending /ipex/admit exn message
 
         Parameters:

--- a/src/keri/app/cli/commands/ipex/agree.py
+++ b/src/keri/app/cli/commands/ipex/agree.py
@@ -18,7 +18,7 @@ def handler(_):
     return [doing.doify(nonce)]
 
 
-def nonce(tymth, tock=0.0):
+def nonce(tymth, tock=0.0, **kwa):
     """ nonce
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/ipex/apply.py
+++ b/src/keri/app/cli/commands/ipex/apply.py
@@ -17,7 +17,7 @@ def handler(_):
     return [doing.doify(nonce)]
 
 
-def nonce(tymth, tock=0.0):
+def nonce(tymth, tock=0.0, **kwa):
     """ nonce
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/ipex/grant.py
+++ b/src/keri/app/cli/commands/ipex/grant.py
@@ -71,7 +71,7 @@ class GrantDoer(doing.DoDoer):
         self.toRemove = [mbx]
         super(GrantDoer, self).__init__(doers=self.toRemove + [doing.doify(self.grantDo)])
 
-    def grantDo(self, tymth, tock=0.0):
+    def grantDo(self, tymth, tock=0.0, **kwa):
         """ Grant credential by creating /ipex/grant exn message
 
         Parameters:

--- a/src/keri/app/cli/commands/ipex/join.py
+++ b/src/keri/app/cli/commands/ipex/join.py
@@ -90,7 +90,7 @@ class JoinDoer(doing.DoDoer):
         self.auto = auto
         super(JoinDoer, self).__init__(doers=doers)
 
-    def joinDo(self, tymth, tock=0.0):
+    def joinDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/ipex/list.py
+++ b/src/keri/app/cli/commands/ipex/list.py
@@ -89,7 +89,7 @@ class ListDoer(doing.DoDoer):
 
         super(ListDoer, self).__init__(doers=self.doers + [doing.doify(self.listDo)])
 
-    def listDo(self, tymth, tock=0.0):
+    def listDo(self, tymth, tock=0.0, **kwa):
         """ Check for any credential messages in mailboxes and list all held credentials
 
         Parameters:

--- a/src/keri/app/cli/commands/ipex/offer.py
+++ b/src/keri/app/cli/commands/ipex/offer.py
@@ -18,7 +18,7 @@ def handler(_):
     return [doing.doify(nonce)]
 
 
-def nonce(tymth, tock=0.0):
+def nonce(tymth, tock=0.0, **kwa):
     """ nonce
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/ipex/spurn.py
+++ b/src/keri/app/cli/commands/ipex/spurn.py
@@ -74,7 +74,7 @@ class SpurnDoer(doing.DoDoer):
         self.toRemove = [mbx]
         super(SpurnDoer, self).__init__(doers=self.toRemove + [doing.doify(self.spurnDo)])
 
-    def spurnDo(self, tymth, tock=0.0):
+    def spurnDo(self, tymth, tock=0.0, **kwa):
         """ Sprun any IPEX message
 
         Parameters:

--- a/src/keri/app/cli/commands/location/add.py
+++ b/src/keri/app/cli/commands/location/add.py
@@ -75,7 +75,7 @@ class LocationDoer(doing.DoDoer):
 
         super(LocationDoer, self).__init__(doers=self.toRemove + [doing.doify(self.roleDo)])
 
-    def roleDo(self, tymth, tock=0.0):
+    def roleDo(self, tymth, tock=0.0, **kwa):
         """ Export any end reply messages previous saved for the provided AID
 
         Parameters:

--- a/src/keri/app/cli/commands/mailbox/add.py
+++ b/src/keri/app/cli/commands/mailbox/add.py
@@ -70,7 +70,7 @@ class AddDoer(doing.DoDoer):
 
         super(AddDoer, self).__init__(doers=doers)
 
-    def addDo(self, tymth, tock=0.0):
+    def addDo(self, tymth, tock=0.0, **kwa):
         """ Grant credential by creating /ipex/grant exn message
 
         Parameters:

--- a/src/keri/app/cli/commands/mailbox/debug.py
+++ b/src/keri/app/cli/commands/mailbox/debug.py
@@ -66,7 +66,7 @@ class ReadDoer(doing.DoDoer):
 
         super(ReadDoer, self).__init__(doers=doers)
 
-    def readDo(self, tymth, tock=0.0):
+    def readDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/multisig/interact.py
+++ b/src/keri/app/cli/commands/multisig/interact.py
@@ -91,7 +91,7 @@ class GroupMultisigInteract(doing.DoDoer):
 
         super(GroupMultisigInteract, self).__init__(doers=doers)
 
-    def interactDo(self, tymth, tock=0.0):
+    def interactDo(self, tymth, tock=0.0, **kwa):
         """ Create or participate in an interaction event for a distributed multisig identifier
 
         Parameters:

--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -97,7 +97,7 @@ class JoinDoer(doing.DoDoer):
         self.auto = auto
         super(JoinDoer, self).__init__(doers=doers)
 
-    def joinDo(self, tymth, tock=0.0):
+    def joinDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/multisig/notice.py
+++ b/src/keri/app/cli/commands/multisig/notice.py
@@ -66,7 +66,7 @@ class NoticeDoer(doing.DoDoer):
 
         super(NoticeDoer, self).__init__(doers=doers)
 
-    def noticeDo(self, tymth, tock=0.0):
+    def noticeDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/nonce.py
+++ b/src/keri/app/cli/commands/nonce.py
@@ -18,7 +18,7 @@ def handler(_):
     return [doing.doify(nonce)]
 
 
-def nonce(tymth, tock=0.0):
+def nonce(tymth, tock=0.0, **kwa):
     """ nonce
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/notifications/list.py
+++ b/src/keri/app/cli/commands/notifications/list.py
@@ -60,7 +60,7 @@ class NotesDoer(doing.DoDoer):
 
         super(NotesDoer, self).__init__(doers=doers)
 
-    def readDo(self, tymth, tock=0.0):
+    def readDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/notifications/mark.py
+++ b/src/keri/app/cli/commands/notifications/mark.py
@@ -62,7 +62,7 @@ class MarkDoer(doing.DoDoer):
 
         super(MarkDoer, self).__init__(doers=doers)
 
-    def markDo(self, tymth, tock=0.0):
+    def markDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/notifications/rem.py
+++ b/src/keri/app/cli/commands/notifications/rem.py
@@ -62,7 +62,7 @@ class RemoveDoer(doing.DoDoer):
 
         super(RemoveDoer, self).__init__(doers=doers)
 
-    def remDoer(self, tymth, tock=0.0):
+    def remDoer(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/oobi/resolve.py
+++ b/src/keri/app/cli/commands/oobi/resolve.py
@@ -80,7 +80,7 @@ class OobiDoer(doing.DoDoer):
 
         super(OobiDoer, self).__init__(doers=doers)
 
-    def waitDo(self, tymth, tock=0.0):
+    def waitDo(self, tymth, tock=0.0, **kwa):
         """ Waits for oobis to load
 
         Parameters:

--- a/src/keri/app/cli/commands/passcode/generate.py
+++ b/src/keri/app/cli/commands/passcode/generate.py
@@ -20,7 +20,7 @@ def handler(_):
     return [doing.doify(salt)]
 
 
-def salt(tymth, tock=0.0):
+def salt(tymth, tock=0.0, **kwa):
     """ Command line version handler
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/salt.py
+++ b/src/keri/app/cli/commands/salt.py
@@ -18,7 +18,7 @@ def handler(_):
     return [doing.doify(passcode)]
 
 
-def passcode(tymth, tock=0.0):
+def passcode(tymth, tock=0.0, **kwa):
     """ Command line version handler
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/time.py
+++ b/src/keri/app/cli/commands/time.py
@@ -17,7 +17,7 @@ def handler(_):
     return [doing.doify(time)]
 
 
-def time(tymth, tock=0.0):
+def time(tymth, tock=0.0, **kwa):
     """ time
     """
     _ = (yield tock)

--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -200,7 +200,7 @@ class CredentialIssuer(doing.DoDoer):
         doers.extend([doing.doify(self.createDo)])
         super(CredentialIssuer, self).__init__(doers=doers)
 
-    def createDo(self, tymth, tock=0.0):
+    def createDo(self, tymth, tock=0.0, **kwa):
         """  Issue Credential doer method
 
 

--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -78,7 +78,7 @@ class ExportDoer(doing.DoDoer):
 
         super(ExportDoer, self).__init__(doers=doers)
 
-    def exportDo(self, tymth, tock=0.0):
+    def exportDo(self, tymth, tock=0.0, **kwa):
         """ Export credential from store and any related material
 
         Parameters:

--- a/src/keri/app/cli/commands/vc/list.py
+++ b/src/keri/app/cli/commands/vc/list.py
@@ -79,7 +79,7 @@ class ListDoer(doing.DoDoer):
 
         super(ListDoer, self).__init__(doers=doers)
 
-    def listDo(self, tymth, tock=0.0):
+    def listDo(self, tymth, tock=0.0, **kwa):
         """ Check for any credential messages in mailboxes and list all held credentials
 
         Parameters:

--- a/src/keri/app/cli/commands/vc/registry/status.py
+++ b/src/keri/app/cli/commands/vc/registry/status.py
@@ -61,7 +61,7 @@ class RegistryStatusor(doing.DoDoer):
         doers.extend([doing.doify(self.statusDo)])
         super(RegistryStatusor, self).__init__(doers=doers)
 
-    def statusDo(self, tymth, tock=0.0):
+    def statusDo(self, tymth, tock=0.0, **kwa):
         """ Process incoming messages to incept a credential registry
 
         Parameters:

--- a/src/keri/app/cli/commands/vc/revoke.py
+++ b/src/keri/app/cli/commands/vc/revoke.py
@@ -71,7 +71,7 @@ class RevokeDoer(doing.DoDoer):
         doers.extend([doing.doify(self.revokeDo)])
         super(RevokeDoer, self).__init__(doers=doers, **kwa)
 
-    def revokeDo(self, tymth, tock=0.0):
+    def revokeDo(self, tymth, tock=0.0, **kwa):
         """  Revoke Credential doer method
 
 

--- a/src/keri/app/cli/commands/watcher/add.py
+++ b/src/keri/app/cli/commands/watcher/add.py
@@ -93,7 +93,7 @@ class AddDoer(doing.DoDoer):
 
         super(AddDoer, self).__init__(doers=doers)
 
-    def addDo(self, tymth, tock=0.0):
+    def addDo(self, tymth, tock=0.0, **kwa):
         """ Add an AID to a watcher's list of AIDs to watch
 
         Parameters:

--- a/src/keri/app/cli/commands/witness/authenticate.py
+++ b/src/keri/app/cli/commands/witness/authenticate.py
@@ -77,7 +77,7 @@ class AuthDoer(doing.DoDoer):
 
         super(AuthDoer, self).__init__(doers=doers)
 
-    def authDo(self, tymth, tock=0.0):
+    def authDo(self, tymth, tock=0.0, **kwa):
         """ Export credential from store and any related material
 
         Parameters:

--- a/src/keri/app/cli/commands/witness/demo.py
+++ b/src/keri/app/cli/commands/witness/demo.py
@@ -70,7 +70,7 @@ class InitDoer(doing.DoDoer):
 
         super(InitDoer, self).__init__(doers=[doing.doify(self.initialize)])
 
-    def initialize(self, tymth, tock=0.0):
+    def initialize(self, tymth, tock=0.0, **kwa):
         # enter context
         self.wind(tymth)
         self.tock = tock

--- a/src/keri/app/cli/commands/witness/submit.py
+++ b/src/keri/app/cli/commands/witness/submit.py
@@ -77,7 +77,7 @@ class SubmitDoer(doing.DoDoer):
 
         super(SubmitDoer, self).__init__(doers=doers)
 
-    def submitDo(self, tymth, tock=0.0):
+    def submitDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/configing.py
+++ b/src/keri/app/configing.py
@@ -70,10 +70,10 @@ class Configer(filing.Filer):
       ]
     }
     """
-    TailDirPath = "keri/cf"
-    CleanTailDirPath = "keri/clean/cf"
-    AltTailDirPath = ".keri/cf"
-    AltCleanTailDirPath = ".keri/clean/cf"
+    TailDirPath = os.path.join("keri", "cf")
+    CleanTailDirPath = os.path.join("keri", "clean", "cf")
+    AltTailDirPath = os.path.join(".keri", "cf")
+    AltCleanTailDirPath = os.path.join(".keri", "clean", "cf")
     TempPrefix = "keri_cf_"
 
     def __init__(self, name="conf", base="main", filed=True, mode="r+b",

--- a/src/keri/app/httping.py
+++ b/src/keri/app/httping.py
@@ -166,7 +166,7 @@ def streamCESRRequests(client, ims, dest, path=None, headers=None):
 
     """
     path = path if path is not None else "/"
-    path = str(Path(client.requester.path) / path)
+    path = parse.urljoin(client.requester.path, path)
 
     cold = kering.sniff(ims)  # check for spurious counters at front of stream
     if cold in (parsing.Colds.txt, parsing.Colds.bny):  # not message error out to flush stream

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -756,7 +756,7 @@ class Poller(doing.DoDoer):
 
         super(Poller, self).__init__(doers=doers, **kwa)
 
-    def eventDo(self, tymth=None, tock=0.0):
+    def eventDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:
            doifiable Doist compatible generator method

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -6,7 +6,7 @@ keri.app.indirecting module
 simple indirect mode demo support classes
 """
 import datetime
-
+import platform
 import falcon
 import time
 import sys
@@ -42,6 +42,8 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
 
     """
     host = "0.0.0.0"
+    if platform.system() == "Windows":
+        host = "127.0.0.1"
     cues = decking.Deck()
     doers = []
 

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -3,6 +3,7 @@
 keri.app.notifying module
 
 """
+import os
 from collections.abc import Iterable
 from typing import Union, Type
 
@@ -204,8 +205,8 @@ class Noter(dbing.LMDBer):
     intended to be read and dismissed by the controller of the agent.
 
     """
-    TailDirPath = "keri/not"
-    AltTailDirPath = ".keri/not"
+    TailDirPath = os.path.join("keri", "not")
+    AltTailDirPath = os.path.join(".keri", "not")
     TempPrefix = "keri_not_"
 
     def __init__(self, name="not", headDirPath=None, reopen=True, **kwa):

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1557,7 +1557,7 @@ class Baser(dbing.LMDBer):
                 self.groups.clear()
                 self.groups.update(copy.groups)
 
-            # remove own db directory replace with clean clone copy
+        # remove own db directory replace with clean clone copy
         if os.path.exists(self.path):
             shutil.rmtree(self.path)
 

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -329,13 +329,13 @@ class LMDBer(filing.Filer):
         stat.S_IWUSR Owner has write permission.
         stat.S_IXUSR Owner has execute permission.
     """
-    HeadDirPath = "/usr/local/var"  # default in /usr/local/var
-    TailDirPath = "keri/db"
-    CleanTailDirPath = "keri/clean/db"
-    AltHeadDirPath = "~"  # put in ~ as fallback when desired not permitted
-    AltTailDirPath = ".keri/db"
-    AltCleanTailDirPath = ".keri/clean/db"
-    TempHeadDir = "/tmp"
+    HeadDirPath = os.path.join(os.path.sep, "usr", "local", "var")  # default in /usr/local/var
+    TailDirPath = os.path.join("keri", "db")
+    CleanTailDirPath = os.path.join("keri", "clean", "db")
+    AltHeadDirPath = os.path.expanduser("~")  # put in ~ as fallback when desired not permitted
+    AltTailDirPath = os.path.join(".keri", "db")
+    AltCleanTailDirPath = os.path.join(".keri", "clean", "db")
+    TempHeadDir = os.path.join(os.path.sep, "tmp")
     TempPrefix = "keri_lmdb_"
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960

--- a/tests/app/test_configing.py
+++ b/tests/app/test_configing.py
@@ -3,6 +3,7 @@
 tests.app.configin module
 """
 import os
+import platform
 import shutil
 
 import pytest
@@ -16,14 +17,14 @@ def test_configer():
     Test Configer class
     """
     # Test Filer with file not dir
-    filepath = '/usr/local/var/keri/cf/main/conf.json'
+    filepath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'keri', 'cf', 'main', 'conf.json')
     if os.path.exists(filepath):
         os.remove(filepath)
 
     cfr = configing.Configer()  # defaults
     # assert cfr.path == filepath
     # github runner does not allow /usr/local/var
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
     assert cfr.file
@@ -54,7 +55,7 @@ def test_configer():
     assert not cfr.opened
     assert cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     with pytest.raises(ValueError):
         rdata = cfr.get()
@@ -63,7 +64,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
@@ -71,7 +72,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
@@ -79,7 +80,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -91,7 +92,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -108,7 +109,7 @@ def test_configer():
     cfr = configing.Configer(human=False)
     # assert cfr.path == filepath
     # github runner does not allow /usr/local/var
-    assert cfr.path.endswith("keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
     assert cfr.file
@@ -128,14 +129,19 @@ def test_configer():
     assert not os.path.exists(cfr.path)
 
     # Test with altPath by using not permitted headDirPath /opt/keri to force Alt
-    filepath = '/Users/samuel/.keri/cf/main/conf.json'
+
+    filepath = os.path.join(os.path.sep, cfr.AltHeadDirPath, cfr.AltTailDirPath, "main", "conf.json")
     if os.path.exists(filepath):
         os.remove(filepath)
 
-    cfr = configing.Configer(headDirPath="/root/keri")
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    headDirPath = "/root/keri"
+    if platform.system() == "Windows":
+        headDirPath="C:\\Windows\\System32"
+    cfr = configing.Configer(headDirPath=headDirPath)
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
+    print(cfr.path)
     assert cfr.file
     assert not cfr.file.closed
     assert not cfr.file.read()
@@ -157,7 +163,7 @@ def test_configer():
     cfr.close()
     assert not cfr.opened
     assert cfr.file.closed
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     with pytest.raises(ValueError):
         rdata = cfr.get()
@@ -165,21 +171,25 @@ def test_configer():
     cfr.reopen(reuse=True)  # reuse True and clear False so don't remake
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
     cfr.reopen()  # reuse False so remake but not clear
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
-    cfr.reopen(reuse=True, clear=True)  # clear True so remake even if reuse
+    if platform.system() == "Windows":
+        cfr.reopen(reuse=True, clear=True, headDirPath="C:\\Windows\\System32\\keri")  # clear True so remake even if reuse
+    else:
+        cfr.reopen(reuse=True, clear=True)
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    print(cfr.path)
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -190,7 +200,7 @@ def test_configer():
     cfr.reopen(clear=True)  # clear True so remake
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(".keri/cf/main/conf.json")
+    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -205,9 +215,10 @@ def test_configer():
 
     #test openCF hjson
     with configing.openCF() as cfr:  # default uses json and temp==True
-        filepath = '/tmp/keri_cf_2_zu01lb_test/keri/cf/main/test.json'
-        assert cfr.path.startswith('/tmp/keri_')
-        assert cfr.path.endswith('_test/keri/cf/main/test.json')
+        filepath = os.path.join(os.path.sep, 'tmp', 'keri_cf_2_zu01lb_test', 'keri', 'cf', 'main', 'test.json')
+        _, path = os.path.splitdrive(os.path.normpath(cfr.path))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.json'))
         assert cfr.opened
         assert cfr.human
         assert os.path.exists(cfr.path)
@@ -222,8 +233,9 @@ def test_configer():
     #test openCF json
     with configing.openCF(human=False) as cfr:  # default uses json and temp==True
         filepath = '/tmp/keri_cf_2_zu01lb_test/keri/cf/main/test.json'
-        assert cfr.path.startswith('/tmp/keri_')
-        assert cfr.path.endswith('_test/keri/cf/main/test.json')
+        _, path = os.path.splitdrive(os.path.normpath(cfr.path))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.json'))
         assert cfr.opened
         assert not cfr.human
         assert os.path.exists(cfr.path)
@@ -237,8 +249,9 @@ def test_configer():
 
     #test openCF mgpk
     with configing.openCF(fext='mgpk') as cfr:  # default uses temp==True
-        assert cfr.path.startswith('/tmp/keri_')
-        assert cfr.path.endswith('_test/keri/cf/main/test.mgpk')
+        _, path = os.path.splitdrive(os.path.normpath(cfr.path))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.mgpk'))
         assert cfr.opened
         assert os.path.exists(cfr.path)
         assert cfr.file
@@ -251,8 +264,9 @@ def test_configer():
 
     # test openCF cbor
     with configing.openCF(fext='cbor') as cfr:  # default uses temp==True
-        assert cfr.path.startswith('/tmp/keri_')
-        assert cfr.path.endswith('_test/keri/cf/main/test.cbor')
+        _, path = os.path.splitdrive(os.path.normpath(cfr.path))
+        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.cbor'))
         assert cfr.opened
         assert os.path.exists(cfr.path)
         assert cfr.file
@@ -300,7 +314,7 @@ def test_configer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.configer.opened
-        assert "_test/keri/cf/main/" in doer.configer.path
+        assert os.path.join('_test', 'keri', 'cf', 'main') in doer.configer.path
 
     doist.recur()
     assert doist.tyme == 0.03125  # on next cycle
@@ -354,7 +368,7 @@ def test_configer_doer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.configer.opened
-        assert "_test/keri/cf/main/" in doer.configer.path
+        assert os.path.join('_test', 'keri', 'cf', 'main') in doer.configer.path
         assert  doer.configer.path.endswith(".json")
         assert doer.configer.file is not None
         assert not doer.configer.file.closed

--- a/tests/app/test_configing.py
+++ b/tests/app/test_configing.py
@@ -135,7 +135,7 @@ def test_configer():
 
     headDirPath = "/root/keri"
     if platform.system() == "Windows":
-        headDirPath="C:\\Windows\\System32"
+        headDirPath="C:\\Windows\\System32\\not\\a\\path"
     cfr = configing.Configer(headDirPath=headDirPath)
     assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
@@ -182,7 +182,7 @@ def test_configer():
     assert (rdata := cfr.get()) == wdata  # not empty
 
     if platform.system() == "Windows":
-        cfr.reopen(reuse=True, clear=True, headDirPath="C:\\Windows\\System32\\keri")  # clear True so remake even if reuse
+        cfr.reopen(reuse=True, clear=True, headDirPath="C:\\Windows\\System32\\keri\\not\\a\\path")  # clear True so remake even if reuse
     else:
         cfr.reopen(reuse=True, clear=True)
     assert cfr.opened

--- a/tests/app/test_configing.py
+++ b/tests/app/test_configing.py
@@ -24,7 +24,7 @@ def test_configer():
     cfr = configing.Configer()  # defaults
     # assert cfr.path == filepath
     # github runner does not allow /usr/local/var
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
     assert cfr.file
@@ -55,7 +55,7 @@ def test_configer():
     assert not cfr.opened
     assert cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     with pytest.raises(ValueError):
         rdata = cfr.get()
@@ -64,7 +64,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
@@ -72,7 +72,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
@@ -80,7 +80,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -92,7 +92,7 @@ def test_configer():
     assert cfr.opened
     assert not cfr.file.closed
     # assert cfr.path == filepath
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -109,7 +109,7 @@ def test_configer():
     cfr = configing.Configer(human=False)
     # assert cfr.path == filepath
     # github runner does not allow /usr/local/var
-    assert cfr.path.endswith(os.path.join(os.path.sep, 'keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
     assert cfr.file
@@ -129,7 +129,6 @@ def test_configer():
     assert not os.path.exists(cfr.path)
 
     # Test with altPath by using not permitted headDirPath /opt/keri to force Alt
-
     filepath = os.path.join(os.path.sep, cfr.AltHeadDirPath, cfr.AltTailDirPath, "main", "conf.json")
     if os.path.exists(filepath):
         os.remove(filepath)
@@ -138,7 +137,7 @@ def test_configer():
     if platform.system() == "Windows":
         headDirPath="C:\\Windows\\System32"
     cfr = configing.Configer(headDirPath=headDirPath)
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
     assert os.path.exists(cfr.path)
     print(cfr.path)
@@ -163,7 +162,7 @@ def test_configer():
     cfr.close()
     assert not cfr.opened
     assert cfr.file.closed
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     with pytest.raises(ValueError):
         rdata = cfr.get()
@@ -171,14 +170,14 @@ def test_configer():
     cfr.reopen(reuse=True)  # reuse True and clear False so don't remake
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
     cfr.reopen()  # reuse False so remake but not clear
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == wdata  # not empty
 
@@ -188,8 +187,8 @@ def test_configer():
         cfr.reopen(reuse=True, clear=True)
     assert cfr.opened
     assert not cfr.file.closed
-    print(cfr.path)
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
+
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")
@@ -200,7 +199,7 @@ def test_configer():
     cfr.reopen(clear=True)  # clear True so remake
     assert cfr.opened
     assert not cfr.file.closed
-    assert cfr.path.endswith(os.path.join(os.path.sep, '.keri', 'cf', 'main', 'conf.json'))
+    assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert os.path.exists(cfr.path)
     assert (rdata := cfr.get()) == {}  # empty
     wdata = dict(name="hope", oobi="abc")

--- a/tests/app/test_configing.py
+++ b/tests/app/test_configing.py
@@ -135,7 +135,7 @@ def test_configer():
 
     headDirPath = "/root/keri"
     if platform.system() == "Windows":
-        headDirPath="C:\\Windows\\System32\\not\\a\\path"
+        headDirPath="C:\\System Volume Information"
     cfr = configing.Configer(headDirPath=headDirPath)
     assert cfr.path.endswith(os.path.join('.keri', 'cf', 'main', 'conf.json'))
     assert cfr.opened
@@ -182,7 +182,7 @@ def test_configer():
     assert (rdata := cfr.get()) == wdata  # not empty
 
     if platform.system() == "Windows":
-        cfr.reopen(reuse=True, clear=True, headDirPath="C:\\Windows\\System32\\keri\\not\\a\\path")  # clear True so remake even if reuse
+        cfr.reopen(reuse=True, clear=True, headDirPath="C:\\System Volume Information")  # clear True so remake even if reuse
     else:
         cfr.reopen(reuse=True, clear=True)
     assert cfr.opened

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -6,6 +6,7 @@ tests.app.apping module
 import pytest
 
 import os
+import platform
 import shutil
 
 from hio.base import doing
@@ -40,19 +41,19 @@ def test_habery():
     assert hby.db.name == "test" == hby.name
     assert hby.db.base == "" == hby.base
     assert not hby.db.filed
-    assert hby.db.path.endswith("/keri/db/test")
+    assert hby.db.path.endswith(os.path.join(os.path.sep, "keri", "db", "test"))
     assert hby.db.opened
 
     assert hby.ks.name == "test" == hby.name
     assert hby.ks.base == "" == hby.base
     assert not hby.ks.filed
-    assert hby.ks.path.endswith("/keri/ks/test")
+    assert hby.ks.path.endswith(os.path.join(os.path.sep, "keri", "ks", "test"))
     assert hby.ks.opened
 
     assert hby.cf.name == "test" == hby.name
     assert hby.cf.base == "" == hby.base
     assert hby.cf.filed
-    assert hby.cf.path.endswith("/keri/cf/test.json")
+    assert hby.cf.path.endswith(os.path.join(os.path.sep, "keri", "cf", "test.json"))
     assert hby.cf.opened
     assert not hby.cf.file.closed
 
@@ -249,19 +250,19 @@ def test_habery():
         assert hby.db.name == "test" == hby.name
         assert hby.db.base == "" == hby.base
         assert not hby.db.filed
-        assert hby.db.path.endswith("/keri/db/test")
+        assert hby.db.path.endswith(os.path.join(os.path.sep, "keri", "db", "test"))
         assert hby.db.opened
 
         assert hby.ks.name == "test" == hby.name
         assert hby.ks.base == "" == hby.base
         assert not hby.ks.filed
-        assert hby.ks.path.endswith("/keri/ks/test")
+        assert hby.ks.path.endswith(os.path.join(os.path.sep, "keri", "ks", "test"))
         assert hby.ks.opened
 
         assert hby.cf.name == "test" == hby.name
         assert hby.cf.base == "" == hby.base
         assert hby.cf.filed
-        assert hby.cf.path.endswith("/keri/cf/test.json")
+        assert hby.cf.path.endswith(os.path.join(os.path.sep, "keri", "cf", "test.json"))
         assert hby.cf.opened
         assert not hby.cf.file.closed
 
@@ -297,19 +298,19 @@ def test_habery():
         assert hby.db.name == "test" == hby.name
         assert hby.db.base == "" == hby.base
         assert not hby.db.filed
-        assert hby.db.path.endswith("/keri/db/test")
+        assert hby.db.path.endswith(os.path.join(os.path.sep, "keri", "db", "test"))
         assert hby.db.opened
 
         assert hby.ks.name == "test" == hby.name
         assert hby.ks.base == "" == hby.base
         assert not hby.ks.filed
-        assert hby.ks.path.endswith("/keri/ks/test")
+        assert hby.ks.path.endswith(os.path.join(os.path.sep, "keri", "ks", "test"))
         assert hby.ks.opened
 
         assert hby.cf.name == "test" == hby.name
         assert hby.cf.base == "" == hby.base
         assert hby.cf.filed
-        assert hby.cf.path.endswith("/keri/cf/test.json")
+        assert hby.cf.path.endswith(os.path.join(os.path.sep, "keri", "cf", "test.json"))
         assert hby.cf.opened
         assert not hby.cf.file.closed
 
@@ -381,21 +382,32 @@ def test_make_load_hab_with_habery():
     assert not os.path.exists(hby.ks.path)
 
     # create not temp and then reload from not temp
-    if os.path.exists('/usr/local/var/keri/cf/hold/test.json'):
-        os.remove('/usr/local/var/keri/cf/hold/test.json')
-    if os.path.exists('/usr/local/var/keri/db/hold/test'):
-        shutil.rmtree('/usr/local/var/keri/db/hold/test')
-    if os.path.exists('/usr/local/var/keri/ks/hold/test'):
-        shutil.rmtree('/usr/local/var/keri/ks/hold/test')
+    if platform.system() == "Windows":
+        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
+        for drive in drives:
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json")):
+                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test"))
+    else:
+        if os.path.exists('/usr/local/var/keri/cf/hold/test.json'):
+            os.remove('/usr/local/var/keri/cf/hold/test.json')
+        if os.path.exists('/usr/local/var/keri/db/hold/test'):
+            shutil.rmtree('/usr/local/var/keri/db/hold/test')
+        if os.path.exists('/usr/local/var/keri/ks/hold/test'):
+            shutil.rmtree('/usr/local/var/keri/ks/hold/test')
 
     base = "hold"
     suePre = 'EAxe215BJ4Iy9r0mfoMEGVmHW8A4Avk3RYBC1A1_DZam'  # with temp=False
     bobPre = 'ENya5E5pvc6MVCe75huDK0QQhE4_64J55vCn4aKdXhR9'  # with temp=False
 
     with habbing.openHby(base=base, temp=False, salt=core.Salter(raw=b'0123456789abcdef').qb64) as hby:  # default is temp=True
-        assert hby.cf.path.endswith("keri/cf/hold/test.json")
-        assert hby.db.path.endswith("keri/db/hold/test")
-        assert hby.ks.path.endswith('keri/ks/hold/test')
+
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
 
         sueHab = hby.makeHab(name='Sue')
         assert isinstance(sueHab, habbing.Hab)
@@ -436,9 +448,9 @@ def test_make_load_hab_with_habery():
     # test load from database
     base = "hold"
     with habbing.openHby(base=base, temp=False) as hby:  # default is temp=True
-        assert hby.cf.path.endswith("keri/cf/hold/test.json")
-        assert hby.db.path.endswith("keri/db/hold/test")
-        assert hby.ks.path.endswith('keri/ks/hold/test')
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
 
         assert hby.inited
         assert len(hby.habs) == 2
@@ -474,13 +486,22 @@ def test_hab_rotate_with_witness():
     """
     Reload from disk and rotate hab with witness
     """
-
-    if os.path.exists('/usr/local/var/keri/cf/test/phil-test.json'):
-        os.remove('/usr/local/var/keri/cf/test/phil-test.json')
-    if os.path.exists('/usr/local/var/keri/db/test/phil-test'):
-        shutil.rmtree('/usr/local/var/keri/db/test/phil-test')
-    if os.path.exists('/usr/local/var/keri/ks/test/phil-test'):
-        shutil.rmtree('/usr/local/var/keri/ks/test/phil-test')
+    if platform.system() == "Windows":
+        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
+        for drive in drives:
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json")):
+                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test"))
+    else:
+        if os.path.exists('/usr/local/var/keri/cf/test/phil-test.json'):
+            os.remove('/usr/local/var/keri/cf/test/phil-test.json')
+        if os.path.exists('/usr/local/var/keri/db/test/phil-test'):
+            shutil.rmtree('/usr/local/var/keri/db/test/phil-test')
+        if os.path.exists('/usr/local/var/keri/ks/test/phil-test'):
+            shutil.rmtree('/usr/local/var/keri/ks/test/phil-test')
 
     name = "phil-test"
 
@@ -514,13 +535,22 @@ def test_hab_rotate_with_witness():
 def test_habery_reinitialization():
     """Test Reinitializing Habery and its Habs
     """
-
-    if os.path.exists('/usr/local/var/keri/cf/test/bob-test.json'):
-        os.remove('/usr/local/var/keri/cf/test/bob-test.json')
-    if os.path.exists('/usr/local/var/keri/db/test/bob-test'):
-        shutil.rmtree('/usr/local/var/keri/db/test/bob-test')
-    if os.path.exists('/usr/local/var/keri/ks/test/bob-test'):
-        shutil.rmtree('/usr/local/var/keri/ks/test/bob-test')
+    if platform.system() == "Windows":
+        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
+        for drive in drives:
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json")):
+                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test"))
+            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test")):
+                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test"))
+    else:
+        if os.path.exists('/usr/local/var/keri/cf/test/bob-test.json'):
+            os.remove('/usr/local/var/keri/cf/test/bob-test.json')
+        if os.path.exists('/usr/local/var/keri/db/test/bob-test'):
+            shutil.rmtree('/usr/local/var/keri/db/test/bob-test')
+        if os.path.exists('/usr/local/var/keri/ks/test/bob-test'):
+            shutil.rmtree('/usr/local/var/keri/ks/test/bob-test')
 
     name = "bob-test"
 

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -198,15 +198,15 @@ def test_wit_query_ends(seeder):
 
 class QueryTestDoer(doing.Doer):
     def __init__(self, **opts):
-        self.opts = opts
+        self.options = opts
         super(QueryTestDoer, self).__init__(**opts)
 
     def recur(self, tyme=0.0, deeds=None):
-
-        wesHab = self.opts["wesHab"]
-        palHby = self.opts["palHby"]
-        witDoer = self.opts["witDoer"]
-        wesClient = self.opts["wesClient"]
+        print(self.options)
+        wesHab = self.options["wesHab"]
+        palHby = self.options["palHby"]
+        witDoer = self.options["witDoer"]
+        wesClient = self.options["wesClient"]
 
         palHab = palHby.makeHab(name="pal", wits=[wesHab.pre], transferable=True)
 

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -4,6 +4,7 @@ tests.app.indirecting module
 
 """
 import json
+import platform
 import time
 
 import falcon
@@ -160,9 +161,12 @@ def test_qrymailbox_iter():
 def test_wit_query_ends(seeder):
     with habbing.openHby(name="wes", salt=core.Salter(raw=b'wess-the-witness').qb64) as wesHby, \
             habbing.openHby(name="pal", salt=core.Salter(raw=b'0123456789abcdef').qb64) as palHby:
-
+        print(wesHby.ks.path)
+        print(palHby.ks.path)
         wesDoers = indirecting.setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644)
         witDoer = agenting.Receiptor(hby=palHby)
+        #C:\tmp\keri_lmdb_z2wqjh2t_test\keri\db\wes
+        #C:\tmp\keri_lmdb_cye2r_mg_test\keri\db\pal
 
         wesHab = wesHby.habByName(name="wes")
         seeder.seedWitEnds(palHby.db, witHabs=[wesHab], protocols=[kering.Schemes.http])
@@ -179,8 +183,8 @@ def test_wit_query_ends(seeder):
             witDoer=witDoer,
             wesClient=wesClient
         )
-
-        doers = wesDoers + [witDoer, doing.doify(wit_querier_test_do, **opts)]
+        testDo = QueryTestDoer(**opts)
+        doers = wesDoers + [witDoer, testDo]
 
         limit = 1.0
         tock = 0.03125
@@ -189,80 +193,84 @@ def test_wit_query_ends(seeder):
 
         tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
 
-        while not tymer.expired:
+        while not testDo.done:
             doist.recur()
             time.sleep(doist.tock)
-        # doist.do(doers=doers)
 
         assert doist.limit == limit
 
         doist.exit()
 
 
-def wit_querier_test_do(tymth=None, tock=0.0, **opts):
-    yield tock  # enter context
+class QueryTestDoer(doing.Doer):
+    def __init__(self, **opts):
+        self.opts = opts
+        super(QueryTestDoer, self).__init__(**opts)
 
-    wesHab = opts["wesHab"]
-    palHby = opts["palHby"]
-    witDoer = opts["witDoer"]
-    wesClient = opts["wesClient"]
+    def recur(self, tyme=0.0, deeds=None):
 
-    palHab = palHby.makeHab(name="pal", wits=[wesHab.pre], transferable=True)
+        wesHab = self.opts["wesHab"]
+        palHby = self.opts["palHby"]
+        witDoer = self.opts["witDoer"]
+        wesClient = self.opts["wesClient"]
 
-    assert palHab.pre == "EEWz3RVIvbGWw4VJC7JEZnGCLPYx4-QgWOwAzGnw-g8y"
+        palHab = palHby.makeHab(name="pal", wits=[wesHab.pre], transferable=True)
 
-    witDoer.msgs.append(dict(pre=palHab.pre))
-    while not witDoer.cues:
-        yield tock
+        assert palHab.pre == "EEWz3RVIvbGWw4VJC7JEZnGCLPYx4-QgWOwAzGnw-g8y"
 
-    witDoer.cues.popleft()
-    msg = next(wesHab.db.clonePreIter(pre=palHab.pre))
+        witDoer.msgs.append(dict(pre=palHab.pre))
+        while not witDoer.cues:
+            yield self.tock
 
-    # Test valid KEL query with 'pre'
-    res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre})
-    assert res.status_code == 200
-    assert res.headers['Content-Type'] == "application/json+cesr"
-    assert bytearray(res.content) == bytearray(msg)
+        msg = next(wesHab.db.clonePreIter(pre=palHab.pre))
 
-    # Test KEL query without 'pre'
-    res = wesClient.simulate_get("/query", params={"typ": "kel"})
-    assert res.status_code == 400
-    assert res.headers['Content-Type'] == "application/json"
-    assert "'pre' query param is required" in res.text
 
-    # Test KEL query with 'sn' parameter
-    res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre, "sn": 0})
-    assert res.status_code == 200
-    assert res.headers['Content-Type'] == "application/json+cesr"
+        # Test valid KEL query with 'pre'
+        res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre})
+        assert res.status_code == 200
+        assert res.headers['Content-Type'] == "application/json+cesr"
+        assert bytearray(res.content) == bytearray(msg)
 
-    # Test KEL query with non-existant 'sn' parameter
-    res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre, "sn": 5})
-    assert res.status_code == 400
-    assert res.headers['Content-Type'] == "application/json"
-    assert "non-existant event at seq-num 5" in res.text
+        # Test KEL query without 'pre'
+        res = wesClient.simulate_get("/query", params={"typ": "kel"})
+        assert res.status_code == 400
+        assert res.headers['Content-Type'] == "application/json"
+        assert "'pre' query param is required" in res.text
 
-    # Test valid TEL query with 'reg'
-    res = wesClient.simulate_get("/query", params={"typ": "tel", "reg": "mock_reg"})
-    assert res.status_code == 200
-    assert res.headers['Content-Type'] == "application/json+cesr"
+        # Test KEL query with 'sn' parameter
+        res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre, "sn": 0})
+        assert res.status_code == 200
+        assert res.headers['Content-Type'] == "application/json+cesr"
 
-    # Test valid TEL query with 'vcid'
-    res = wesClient.simulate_get("/query", params={"typ": "tel", "vcid": "mock_vcid"})
-    assert res.status_code == 200
-    assert res.headers['Content-Type'] == "application/json+cesr"
+        # Test KEL query with non-existant 'sn' parameter
+        res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre, "sn": 5})
+        assert res.status_code == 400
+        assert res.headers['Content-Type'] == "application/json"
+        assert "non-existant event at seq-num 5" in res.text
 
-    # Test TEL query missing both 'reg' and 'vcid'
-    res = wesClient.simulate_get("/query", params={"typ": "tel"})
-    assert res.status_code == 400
-    assert res.headers['Content-Type'] == "application/json"
-    assert "Either 'reg' or 'vcid' query param is required for TEL query" in res.text
+        # Test valid TEL query with 'reg'
+        res = wesClient.simulate_get("/query", params={"typ": "tel", "reg": "mock_reg"})
+        assert res.status_code == 200
+        assert res.headers['Content-Type'] == "application/json+cesr"
 
-    # Test invalid 'typ' parameter
-    res = wesClient.simulate_get("/query", params={"typ": "invalid"})
-    assert res.status_code == 400
-    assert res.headers['Content-Type'] == "application/json"
-    assert "unkown query type" in res.text
+        # Test valid TEL query with 'vcid'
+        res = wesClient.simulate_get("/query", params={"typ": "tel", "vcid": "mock_vcid"})
+        assert res.status_code == 200
+        assert res.headers['Content-Type'] == "application/json+cesr"
 
+        # Test TEL query missing both 'reg' and 'vcid'
+        res = wesClient.simulate_get("/query", params={"typ": "tel"})
+        assert res.status_code == 400
+        assert res.headers['Content-Type'] == "application/json"
+        assert "Either 'reg' or 'vcid' query param is required for TEL query" in res.text
+
+        # Test invalid 'typ' parameter
+        res = wesClient.simulate_get("/query", params={"typ": "invalid"})
+        assert res.status_code == 400
+        assert res.headers['Content-Type'] == "application/json"
+        assert "unkown query type" in res.text
+
+        return True
 
 
 class MockServerTls:
@@ -277,6 +285,8 @@ class MockHttpServer:
 
 def test_createHttpServer(monkeypatch):
     host = "0.0.0.0"
+    if platform.system() == "Windows":
+        host = "127.0.0.1"
     port = 5632
     app = falcon.App()
     server = indirecting.createHttpServer(host, port, app)

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -161,12 +161,8 @@ def test_qrymailbox_iter():
 def test_wit_query_ends(seeder):
     with habbing.openHby(name="wes", salt=core.Salter(raw=b'wess-the-witness').qb64) as wesHby, \
             habbing.openHby(name="pal", salt=core.Salter(raw=b'0123456789abcdef').qb64) as palHby:
-        print(wesHby.ks.path)
-        print(palHby.ks.path)
         wesDoers = indirecting.setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644)
         witDoer = agenting.Receiptor(hby=palHby)
-        #C:\tmp\keri_lmdb_z2wqjh2t_test\keri\db\wes
-        #C:\tmp\keri_lmdb_cye2r_mg_test\keri\db\pal
 
         wesHab = wesHby.habByName(name="wes")
         seeder.seedWitEnds(palHby.db, witHabs=[wesHab], protocols=[kering.Schemes.http])
@@ -190,8 +186,6 @@ def test_wit_query_ends(seeder):
         tock = 0.03125
         doist = doing.Doist(tock=tock, limit=limit, doers=doers)
         doist.enter()
-
-        tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
 
         while not testDo.done:
             doist.recur()

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -202,7 +202,6 @@ class QueryTestDoer(doing.Doer):
         super(QueryTestDoer, self).__init__(**opts)
 
     def recur(self, tyme=0.0, deeds=None):
-        print(self.options)
         wesHab = self.options["wesHab"]
         palHby = self.options["palHby"]
         witDoer = self.options["witDoer"]

--- a/tests/app/test_keeping.py
+++ b/tests/app/test_keeping.py
@@ -3,6 +3,8 @@
 tests.app.keeping module
 
 """
+import platform
+
 import pytest
 
 import os
@@ -185,8 +187,9 @@ def test_openkeeper():
         assert isinstance(ks, keeping.Keeper)
         assert ks.name == "test"
         assert isinstance(ks.env, lmdb.Environment)
-        assert ks.path.startswith("/tmp/keri_ks_")
-        assert ks.path.endswith("_test/keri/ks/test")
+        _, path = os.path.splitdrive(os.path.normpath(ks.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert ks.path.endswith(os.path.join("_test", "keri", "ks", "test"))
         assert ks.env.path() == ks.path
         assert os.path.exists(ks.path)
         assert ks.opened
@@ -198,8 +201,9 @@ def test_openkeeper():
         assert isinstance(ks, keeping.Keeper)
         assert ks.name == "blue"
         assert isinstance(ks.env, lmdb.Environment)
-        assert ks.path.startswith("/tmp/keri_ks_")
-        assert ks.path.endswith("_test/keri/ks/blue")
+        _, path = os.path.splitdrive(os.path.normpath(ks.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert ks.path.endswith(os.path.join("_test", "keri", "ks", "blue"))
         assert ks.env.path() == ks.path
         assert os.path.exists(ks.path)
         assert ks.opened
@@ -251,10 +255,13 @@ def test_keeper():
     assert keeper.name == "main"
     assert keeper.temp == False
     assert isinstance(keeper.env, lmdb.Environment)
-    assert keeper.path.endswith("keri/ks/main")
+    assert keeper.path.endswith(os.path.join("keri", "ks", "main"))
     assert keeper.env.path() == keeper.path
     assert os.path.exists(keeper.path)
-    assert oct(os.stat(keeper.path).st_mode)[-4:] == "1700"
+    if platform.system() == "Windows":
+        assert oct(os.stat(keeper.path).st_mode)[-4:] == "0777"
+    else:
+        assert oct(os.stat(keeper.path).st_mode)[-4:] == "1700"
     assert keeper.Perm == perm
 
     assert isinstance(keeper.gbls.sdb, lmdb._Database)
@@ -272,10 +279,13 @@ def test_keeper():
     assert keeper.name == "main"
     assert keeper.temp == False
     assert isinstance(keeper.env, lmdb.Environment)
-    assert keeper.path.endswith("keri/ks/main")
+    assert keeper.path.endswith(os.path.join("keri", "ks", "main"))
     assert keeper.env.path() == keeper.path
     assert os.path.exists(keeper.path)
-    assert oct(os.stat(keeper.path).st_mode)[-4:] == "0775"
+    if platform.system() == "Windows":
+        assert oct(os.stat(keeper.path).st_mode)[-4:] == "0777"
+    else:
+        assert oct(os.stat(keeper.path).st_mode)[-4:] == "0775"
 
     assert isinstance(keeper.gbls.sdb, lmdb._Database)
     assert isinstance(keeper.pris.sdb, lmdb._Database)
@@ -297,7 +307,7 @@ def test_keeper():
     keeper.reopen()
     assert keeper.opened
     assert isinstance(keeper.env, lmdb.Environment)
-    assert keeper.path.endswith("keri/ks/main")
+    assert keeper.path.endswith(os.path.join("keri", "ks", "main"))
     assert keeper.env.path() == keeper.path
     assert os.path.exists(keeper.path)
 
@@ -315,8 +325,9 @@ def test_keeper():
         assert keeper.name == "test"
         assert keeper.temp == True
         assert isinstance(keeper.env, lmdb.Environment)
-        assert keeper.path.startswith("/tmp/keri_ks_")
-        assert keeper.path.endswith("_test/keri/ks/test")
+        _, path = os.path.splitdrive(os.path.normpath(keeper.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert keeper.path.endswith(os.path.join("_test", "keri", "ks", "test"))
         assert keeper.env.path() == keeper.path
         assert os.path.exists(keeper.path)
 
@@ -559,7 +570,7 @@ def test_keeperdoer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.keeper.opened
-        assert "_test/keri/ks/test" in doer.keeper.path
+        assert os.path.join("_test", "keri", "ks", "test") in doer.keeper.path
 
     doist.recur()
     assert doist.tyme == 0.03125  # on next cycle

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -5,7 +5,9 @@ tests.app.test_multisig module
 """
 import datetime
 
+import time
 import pytest
+import os
 
 from keri.app import notifying, habbing
 from keri.core import coring
@@ -89,10 +91,13 @@ def test_dictersuber():
         assert n3 is None
 
         note = notifying.notice(attrs=dict(a=1))
+        time.sleep(0.001)
         assert dsub.put(keys=(note.datetime, note.rid), val=note) is True
         note = notifying.notice(attrs=dict(a=2))
+        time.sleep(0.001)
         assert dsub.put(keys=(note.datetime, note.rid), val=note) is True
         note = notifying.notice(attrs=dict(a=3))
+        time.sleep(0.001)
         assert dsub.put(keys=(note.datetime, note.rid), val=note) is True
 
         res = []
@@ -107,12 +112,13 @@ def test_dictersuber():
 
 def test_noter(mockHelpingNowUTC):
     noter = notifying.Noter()
-    assert noter.path.endswith("/not/not")
+    assert noter.path.endswith(os.path.join(os.path.sep, "not", "not"))
     noter.reopen()
     noter.close(clear=True)
 
     noter = notifying.Noter(temp=True)
-    assert noter.path.startswith("/tmp")
+    _, path = os.path.splitdrive(os.path.normpath(noter.path))
+    assert path.startswith(os.path.join(os.path.sep, "tmp"))
 
     payload = dict(name="John", email="john@example.com", msg="test")
     dt = helping.fromIso8601("2022-07-08T15:01:05.453632")

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -90,6 +90,7 @@ def test_dictersuber():
         n3 = dsub.get(keys=(dt, said))
         assert n3 is None
 
+        # Add a small delay to ensure timestamps are different
         note = notifying.notice(attrs=dict(a=1))
         time.sleep(0.001)
         assert dsub.put(keys=(note.datetime, note.rid), val=note) is True

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -24,7 +24,7 @@ def test_mailboxing():
     assert mber.name == "mbx"
     assert mber.temp is False
     assert isinstance(mber.env, lmdb.Environment)
-    assert mber.path.endswith("keri/mbx/mbx")
+    assert mber.path.endswith(os.path.join("keri", "mbx", "mbx"))
     assert mber.env.path() == mber.path
     assert os.path.exists(mber.path)
 
@@ -47,7 +47,7 @@ def test_mailboxing():
     assert mber.opened
     assert mber.path is not None
     assert isinstance(mber.env, lmdb.Environment)
-    assert mber.path.endswith("keri/mbx/mbx")
+    assert mber.path.endswith(os.path.join("keri", "mbx", "mbx"))
     assert mber.env.path() == mber.path
     assert os.path.exists(mber.path)
 

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -76,6 +76,7 @@ def test_partial_signed_escrow():
         assert len(escrows) == 1
         assert escrows[0] == srdr.saidb  #  escrow entry for event
 
+        time.sleep(0.001)
         # verify Kevery process partials escrow is idempotent to previously escrowed events
         # assuming not stale but nothing else has changed
         kvy.processEscrowPartialSigs()
@@ -103,6 +104,7 @@ def test_partial_signed_escrow():
         # get DTS set by escrow date time stamp on event
         edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
 
+        time.sleep(0.001)
         # verify Kevery process partials escrow now unescrows correctly given
         # two signatures and assuming not stale
         kvy.processEscrowPartialSigs()
@@ -221,6 +223,7 @@ def test_partial_signed_escrow():
         # get DTS set by escrow date time stamp on event
         edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
 
+        time.sleep(0.001)
         # Process partials but now escrow not stale
         kvy.processEscrowPartialSigs()
         assert kvr.serder.said == srdr.said  # key state updated so event was validated
@@ -313,6 +316,7 @@ def test_partial_signed_escrow():
         # kvy.process(ims=bytearray(msg))  # process local copy of msg
         assert kvr.serder.said != srdr.said  # key state not updated
 
+        time.sleep(0.001)
         # process escrow
         kvy.processEscrowPartialSigs()
         assert kvr.serder.said != srdr.said  # key state not updated
@@ -330,6 +334,7 @@ def test_partial_signed_escrow():
         # get DTS set by escrow date time stamp on event
         edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
 
+        time.sleep(0.001)
         # process escrow
         kvy.processEscrowPartialSigs()
         assert kvr.serder.said == srdr.said  # key state updated

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -4735,7 +4735,7 @@ def test_reload_kever(mockHelpingNowUTC):
         assert natHab.db.opened
         assert natHab.pre in natHab.kevers
         assert natHab.pre in natHab.prefixes
-        assert natHab.db.path.endswith("/keri/db/test/nat")
+        assert natHab.db.path.endswith(os.path.join(os.path.sep, "keri", "db", "test", "nat"))
         path = natHab.db.path  # save for later
 
         # Create series of events for Nat

--- a/tests/core/test_reply.py
+++ b/tests/core/test_reply.py
@@ -1285,7 +1285,7 @@ def test_reply(mockHelpingNowUTC):
 def test_watcher_add_cut():
     salt = core.Salter(raw=b'abcdef0123456789').qb64
 
-    with habbing.openHby(name="con", base="test", salt=salt) as conHby, \
+    with habbing.openHby(name="controller", base="test", salt=salt) as conHby, \
             habbing.openHby(name="wat0", base="test", salt=salt) as wat0hby, \
             habbing.openHby(name="wat1", base="test", salt=salt) as wat1hby, \
             habbing.openHby(name="wat2", base="test", salt=salt) as wat2hby, \
@@ -1293,7 +1293,7 @@ def test_watcher_add_cut():
             habbing.openHby(name="obv1", base="test", salt=salt) as obv1hby, \
             habbing.openHby(name="obv2", base="test", salt=salt) as obv2hby:
 
-        conHab = conHby.makeHab(name="con", isith="1", icount=1, transferable=True)
+        conHab = conHby.makeHab(name="controller", isith="1", icount=1, transferable=True)
         assert conHab.kever.prefixer.transferable
         conKvy = eventing.Kevery(db=conHab.db, lax=False, local=False)
 

--- a/tests/core/test_reply.py
+++ b/tests/core/test_reply.py
@@ -1285,7 +1285,7 @@ def test_reply(mockHelpingNowUTC):
 def test_watcher_add_cut():
     salt = core.Salter(raw=b'abcdef0123456789').qb64
 
-    with habbing.openHby(name="controller", base="test", salt=salt) as conHby, \
+    with habbing.openHby(name="cont", base="test", salt=salt) as conHby, \
             habbing.openHby(name="wat0", base="test", salt=salt) as wat0hby, \
             habbing.openHby(name="wat1", base="test", salt=salt) as wat1hby, \
             habbing.openHby(name="wat2", base="test", salt=salt) as wat2hby, \
@@ -1293,7 +1293,7 @@ def test_watcher_add_cut():
             habbing.openHby(name="obv1", base="test", salt=salt) as obv1hby, \
             habbing.openHby(name="obv2", base="test", salt=salt) as obv2hby:
 
-        conHab = conHby.makeHab(name="controller", isith="1", icount=1, transferable=True)
+        conHab = conHby.makeHab(name="cont", isith="1", icount=1, transferable=True)
         assert conHab.kever.prefixer.transferable
         conKvy = eventing.Kevery(db=conHab.db, lax=False, local=False)
 

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -40,7 +40,7 @@ def test_baser():
     assert baser.name == "main"
     assert baser.temp == False
     assert isinstance(baser.env, lmdb.Environment)
-    assert baser.path.endswith("keri/db/main")
+    assert baser.path.endswith(os.path.join("keri", "db", "main"))
     assert baser.env.path() == baser.path
     assert os.path.exists(baser.path)
 
@@ -71,7 +71,7 @@ def test_baser():
     baser.reopen()
     assert baser.opened
     assert isinstance(baser.env, lmdb.Environment)
-    assert baser.path.endswith("keri/db/main")
+    assert baser.path.endswith(os.path.join("keri", "db", "main"))
     assert baser.env.path() == baser.path
     assert os.path.exists(baser.path)
 
@@ -98,8 +98,9 @@ def test_baser():
         assert baser.name == "test"
         assert baser.temp == True
         assert isinstance(baser.env, lmdb.Environment)
-        assert baser.path.startswith("/tmp/keri_lmdb_")
-        assert baser.path.endswith("_test/keri/db/test")
+        _, path = os.path.splitdrive(os.path.normpath(baser.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert baser.path.endswith(os.path.join("_test", "keri", "db", "test"))
         assert baser.env.path() == baser.path
         assert os.path.exists(baser.path)
 
@@ -1188,7 +1189,7 @@ def test_clean_baser():
         assert natHab.db.opened
         assert natHab.pre in natHab.kevers
         assert natHab.pre in natHab.prefixes
-        assert natHab.db.path.endswith("/keri/db/nat")
+        assert natHab.db.path.endswith(os.path.join(os.path.sep, "keri", "db", "nat"))
         path = natHab.db.path  # save for later
 
         # Create series of events for Nat
@@ -1249,7 +1250,7 @@ def test_clean_baser():
                           headDirPath=natHab.db.headDirPath,
                           perm=natHab.db.perm,
                           clean=True) as copy:
-            assert copy.path.endswith("/keri/clean/db/nat")
+            assert copy.path.endswith(os.path.join(os.path.sep, "keri", "clean", "db", "nat"))
             assert copy.env.stat()['entries'] >= 18
 
         # Nat's kever and the signatory kever
@@ -1730,7 +1731,7 @@ def test_baserdoer():
     assert [val[1] for val in doist.deeds] == [0.0, 0.0]  #  retymes
     for doer in doers:
         assert doer.baser.opened
-        assert "_test/keri/db/test" in doer.baser.path
+        assert os.path.join("_test", "keri", "db", "test") in doer.baser.path
 
     doist.recur()
     assert doist.tyme == 0.03125  # on next cycle

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -178,8 +178,9 @@ def test_opendatabaser():
         assert isinstance(databaser, LMDBer)
         assert databaser.name == "test"
         assert isinstance(databaser.env, lmdb.Environment)
-        assert databaser.path.startswith("/tmp/keri_lmdb_")
-        assert databaser.path.endswith("_test/keri/db/test")
+        _, path = os.path.splitdrive(os.path.normpath(databaser.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert databaser.path.endswith(os.path.join("_test", "keri", "db", "test"))
         assert databaser.env.path() == databaser.path
         assert os.path.exists(databaser.path)
         assert databaser.opened
@@ -191,8 +192,9 @@ def test_opendatabaser():
         assert isinstance(databaser, LMDBer)
         assert databaser.name == "blue"
         assert isinstance(databaser.env, lmdb.Environment)
-        assert databaser.path.startswith("/tmp/keri_lmdb_")
-        assert databaser.path.endswith("_test/keri/db/blue")
+        _, path = os.path.splitdrive(os.path.normpath(databaser.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert databaser.path.endswith(os.path.join("_test", "keri", "db", "blue"))
         assert databaser.env.path() == databaser.path
         assert os.path.exists(databaser.path)
         assert databaser.opened
@@ -229,7 +231,7 @@ def test_lmdber():
     assert databaser.name == "main"
     assert databaser.temp == False
     assert isinstance(databaser.env, lmdb.Environment)
-    assert databaser.path.endswith("keri/db/main")
+    assert databaser.path.endswith(os.path.join("keri", "db", "main"))
     assert databaser.env.path() == databaser.path
     assert os.path.exists(databaser.path)
     assert databaser.opened
@@ -259,7 +261,7 @@ def test_lmdber():
     databaser.reopen()
     assert databaser.opened
     assert isinstance(databaser.env, lmdb.Environment)
-    assert databaser.path.endswith("keri/db/main")
+    assert databaser.path.endswith(os.path.join("keri", "db", "main"))
     assert databaser.env.path() == databaser.path
     assert os.path.exists(databaser.path)
 

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -6,6 +6,7 @@ Includes Falcon ReST endpoints for testing purposes
 
 """
 import logging
+import platform
 
 import falcon
 from falcon import testing
@@ -254,6 +255,8 @@ def test_get_static_sink():
              '        <p>Hello World.</p>\n'
              '    </body>\n'
              '</html>\n')
+    if platform.system() == "Windows":
+        index = index.replace("\n", "\r\n")
 
     # get default at  /  which is index.html
     rep = client.simulate_get('/')
@@ -300,14 +303,20 @@ def test_get_static_sink():
     rep = client.simulate_get('/static/robots.txt')
     assert rep.status == falcon.HTTP_OK
     assert rep.headers['content-type'] == 'text/plain; charset=UTF-8'
-    assert rep.text == '# robotstxt.org\n\nUser-agent: *\n'
+    if platform.system() == "Windows":
+        assert rep.text == '# robotstxt.org\r\n\r\nUser-agent: *\r\n'
+    else:
+        assert rep.text == '# robotstxt.org\n\nUser-agent: *\n'
 
     # get trial.js
     rep = client.simulate_get('/static/index.js')
     assert rep.status == falcon.HTTP_OK
     assert "javascript" in rep.headers['content-type']
     assert len(rep.text) > 0
-    assert rep.text == '// vanilla index.js\n\nm.render(document.body, "Hello world")\n'
+    if platform.system() == "Windows":
+        assert rep.text == '// vanilla index.js\r\n\r\nm.render(document.body, "Hello world")\r\n'
+    else:
+        assert rep.text == '// vanilla index.js\n\nm.render(document.body, "Hello world")\n'
 
 
 def test_seid_api():

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -245,7 +245,7 @@ def test_iso8601():
     dt1 = helping.fromIso8601(dts1)
     
     # Add a small delay to ensure timestamps are different
-    time.sleep(0.001)  # Sleep for 1 millisecond
+    time.sleep(0.001)
     
     dts2 = helping.nowIso8601()
     dt2 = helping.fromIso8601(dts2)

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -8,6 +8,7 @@ import pytest
 import datetime
 import pysodium
 import fractions
+import time
 
 from dataclasses import dataclass, asdict
 
@@ -242,6 +243,10 @@ def test_iso8601():
 
     dts1 = helping.nowIso8601()
     dt1 = helping.fromIso8601(dts1)
+    
+    # Add a small delay to ensure timestamps are different
+    time.sleep(0.001)  # Sleep for 1 millisecond
+    
     dts2 = helping.nowIso8601()
     dt2 = helping.fromIso8601(dts2)
 
@@ -250,6 +255,8 @@ def test_iso8601():
     assert dts1 == helping.toIso8601(dt1)
     assert dts2 == helping.toIso8601(dt2)
 
+    time.sleep(0.001)
+    
     dts3 = helping.toIso8601()
     dt3 = helping.fromIso8601(dts3)
 

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -6,6 +6,7 @@ tests.help.test_ogling module
 import pytest
 
 import os
+import platform
 import logging
 
 from hio.help import ogling
@@ -26,16 +27,20 @@ def test_openogler():
         assert ogler.level == logging.DEBUG
         assert ogler.temp == True
         assert ogler.prefix == 'keri'
-        assert ogler.headDirPath == ogler.HeadDirPath == "/usr/local/var"
-        assert ogler.dirPath.startswith("/tmp/keri/logs/test_")
+        assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, "usr", "local", "var")
+        _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
         assert ogler.dirPath.endswith("_temp")
-        assert ogler.path.endswith("/test.log")
+        assert ogler.path.endswith(os.path.join("test.log"))
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == "Windows":
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -51,7 +56,10 @@ def test_openogler():
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == "Windows":
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -75,15 +83,18 @@ def test_openogler():
         assert ogler.level == logging.DEBUG
         assert ogler.temp == False
         assert ogler.prefix == 'keri'
-        assert ogler.headDirPath == ogler.HeadDirPath == "/usr/local/var"
-        assert ogler.dirPath.endswith("keri/logs")
-        assert ogler.path.endswith('/mine.log')
+        assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, "usr", "local", "var")
+        assert ogler.dirPath.endswith(os.path.join("keri", "logs"))
+        assert ogler.path.endswith(os.path.join('mine.log'))
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == "Windows":
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -99,7 +110,10 @@ def test_openogler():
         # logger console: All should log  because level DEBUG
         # logger file: All should log because path created and DEBUG
         logger = ogler.getLogger()
-        assert len(logger.handlers) == 3
+        if platform.system() == "Windows":
+            assert len(logger.handlers) == 2
+        else:
+            assert len(logger.handlers) == 3
         logger.debug("Test logger at debug level")
         logger.info("Test logger at info level")
         logger.error("Test logger at error level")
@@ -136,7 +150,10 @@ def test_ogler():
     # logger console: Only Error should log  because level ERROR
     # logger file: Nothing should log because .path not created
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -154,9 +171,10 @@ def test_ogler():
     ogler = ogling.Ogler(name="test", level=logging.DEBUG, temp=True,
                          prefix='keri', reopen=True, clear=True)
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.join("test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -165,7 +183,10 @@ def test_ogler():
     # logger console: All should log  because level DEBUG
     # logger file: All should log because path created and DEBUG
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -184,9 +205,10 @@ def test_ogler():
 
     # Test reopen but not clear so file still there
     ogler.reopen(temp=True)
-    assert ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.join("test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -197,7 +219,10 @@ def test_ogler():
     # logger console: All should log  because level DEBUG
     # logger file: All should log because path created and DEBUG
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -231,11 +256,19 @@ def test_init_ogler():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.dirPath == None
     assert help.ogler.path == None
+    logger = help.ogler.getLogger()
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
 
     # nothing should log to file because .path not created and level critical
     # # nothing should log to console because level critical
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -243,7 +276,10 @@ def test_init_ogler():
     help.ogler.level = logging.DEBUG
     # nothing should log because .path not created despite loggin level debug
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -252,11 +288,15 @@ def test_init_ogler():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    assert help.ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith("/main.log")
+    assert help.ogler.path.endswith(os.path.join("main.log"))
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -271,15 +311,22 @@ def test_init_ogler():
                         temp=True, prefix='keri', reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.join("test.log"))
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
         assert contents == ''
 
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
+
+    # logger console: All should log  because level DEBUG
+    # logger file: All should log because new path on file handler
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -308,7 +355,10 @@ def test_reset_levels():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 2
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
 
     # logger console: nothing should log  because level CRITICAL
     # logger file: nothing should log because .path not created
@@ -329,12 +379,16 @@ def test_reset_levels():
     help.ogler.reopen(temp=True, clear=True)
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
-    assert help.ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith("/main.log")
+    assert help.ogler.path.endswith(os.path.join("main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because .path created
@@ -354,11 +408,15 @@ def test_reset_levels():
                             temp=True, prefix='keri', reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
-    assert ogler.dirPath.startswith("/tmp/keri/logs/test_")
+    _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
+    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith("/test.log")
+    assert ogler.path.endswith(os.path.join("test.log"))
     # Still have 3 handlers
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -376,7 +434,10 @@ def test_reset_levels():
 
     # recreate loggers to pick up new path
     logger = ogler.getLogger()
-    assert len(logger.handlers) == 3
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because new path on file handler

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -31,7 +31,7 @@ def test_openogler():
         _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
         assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
         assert ogler.dirPath.endswith("_temp")
-        assert ogler.path.endswith(os.path.join("test.log"))
+        assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
@@ -85,7 +85,7 @@ def test_openogler():
         assert ogler.prefix == 'keri'
         assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, "usr", "local", "var")
         assert ogler.dirPath.endswith(os.path.join("keri", "logs"))
-        assert ogler.path.endswith(os.path.join('mine.log'))
+        assert ogler.path.endswith(os.path.join(os.path.sep, 'mine.log'))
         assert ogler.opened
 
         # logger console: All should log  because level DEBUG
@@ -174,7 +174,7 @@ def test_ogler():
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.join("test.log"))
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -208,7 +208,7 @@ def test_ogler():
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.join("test.log"))
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -291,7 +291,7 @@ def test_init_ogler():
     _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith(os.path.join("main.log"))
+    assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
     if platform.system() == "Windows":
         assert len(logger.handlers) == 2
@@ -314,7 +314,7 @@ def test_init_ogler():
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.join("test.log"))
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
         assert contents == ''
@@ -382,7 +382,7 @@ def test_reset_levels():
     _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
-    assert help.ogler.path.endswith(os.path.join("main.log"))
+    assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
     if platform.system() == "Windows":
@@ -411,7 +411,7 @@ def test_reset_levels():
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
     assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
-    assert ogler.path.endswith(os.path.join("test.log"))
+    assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     # Still have 3 handlers
     if platform.system() == "Windows":
         assert len(logger.handlers) == 2

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -4,6 +4,7 @@ tests.peer.test_exchanging module
 
 """
 import json
+import time
 
 import pysodium
 import pytest
@@ -128,8 +129,10 @@ def test_exchanger():
         exc.processEscrowPartialSigned()
         assert recHby.db.epse.get(keys=(fwd.said,)) is not None
 
-        # Set the PSE timeout artifically low to trigger removal
+        # Set the PSE timeout artificially low to trigger removal
         exc.TimeoutPSE = 0.00001
+        # Add a small sleep to allow for processing to complete
+        time.sleep(0.0001)
         exc.processEscrowPartialSigned()
         assert recHby.db.epse.get(keys=(fwd.said,)) is None
 

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -24,7 +24,7 @@ def test_issuer():
     assert issuer.name == "main"
     assert issuer.temp is False
     assert isinstance(issuer.env, lmdb.Environment)
-    assert issuer.path.endswith("keri/reg/main")
+    assert issuer.path.endswith(os.path.join("keri", "reg", "main"))
     assert issuer.env.path() == issuer.path
     assert os.path.exists(issuer.path)
 
@@ -47,7 +47,7 @@ def test_issuer():
     assert issuer.opened
     assert issuer.path is not None
     assert isinstance(issuer.env, lmdb.Environment)
-    assert issuer.path.endswith("keri/reg/main")
+    assert issuer.path.endswith(os.path.join("keri", "reg", "main"))
     assert issuer.env.path() == issuer.path
     assert os.path.exists(issuer.path)
 
@@ -62,8 +62,9 @@ def test_issuer():
         assert issuer.name == "test"
         assert issuer.temp is True
         assert isinstance(issuer.env, lmdb.Environment)
-        assert issuer.path.startswith("/tmp/keri_reg_")
-        assert issuer.path.endswith("_test/keri/reg/test")
+        _, path = os.path.splitdrive(os.path.normpath(issuer.path))
+        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_reg_"))
+        assert issuer.path.endswith(os.path.join("_test", "keri", "reg", "test"))
         assert issuer.env.path() == issuer.path
         assert os.path.exists(issuer.path)
 


### PR DESCRIPTION
- Changed pathing to be OS agnostic
- Implemented conditional hosts:
>- 0.0.0.0 on MacOS and Linux
>- 127.0.0.1 on Windows
>- Binding to 0.0.0.0 is designed to listen on all interfaces, including 127.0.0.1, but stricter firewall settings on Windows can sometimes filter local loopback traffic when accessed via 0.0.0.0. In these cases, explicitly using 127.0.0.1 ensures that local connections are reliably routed without interference from system-wide network policies.
- Corrected streamCESRRequests URL pathing to use urllib instead of pathlib
- Changed doify method to proper doing.Doer in test_indirecting.py :: test_wit_query_ends
- Added 1 millisecond sleep to tests which could fail on higher speed CPUs due to multiple objects receiving the same datetime:
>- test_notifying.py :: test_dictersuber
>- test_helping.py :: test_iso8601
>- test_escrow.py :: test_partial_signed_escrow
>- test_exchanging :: test_exchanger
>- test_helping :: test_iso8601
- Added windows CI/CD
>- In test_reply :: test_watcher_add_cut, changed controller hby and hab name from 'con' to 'cont' as con is a reserved filename in the windows CI/CD environment
- Implemented conditional checks for number of logger handlers to account for windows incompatibility with hio sys logging
- Changed basing.py clean() method to adhere to stricter Windows policy disallowing moving files while they are still open
- Upgraded to HIO 0.6.18; this version includes windows compatibility changes.
>- Added **kwa to doified method parameters 
