### PR TITLE
adds a naive count all to SuberBase

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1407,7 +1407,9 @@ class Baser(dbing.LMDBer):
 
         for escrow in [self.qnfs, self.misfits, self.delegables, self.pdes, self.udes, self.rpes, self.epsd, self.eoobi,
                        self.dpub, self.gpwe, self.gdee, self.dpwe, self.gpse, self.epse, self.dune]:
+            count = escrow.cntAll()
             escrow.trim()
+            logger.info(f"KEL: Cleared {count} escrows from ({escrow}")
 
     @property
     def current(self):

--- a/src/keri/db/subing.py
+++ b/src/keri/db/subing.py
@@ -320,6 +320,21 @@ class SuberBase():
                                                top=self._tokey(keys, topive=topive)):
             yield (self._tokeys(key), self._des(val))
 
+    def cntAll(self):
+        """
+        Return iterator over the all the items in subdb
+
+        Returns:
+            iterator: of tuples of keys tuple and val dataclass instance for
+            each entry in db. Raises StopIteration when done
+
+        Example:
+            if key in database is "a.b" and val is serialization of dataclass
+               with attributes x and y then returns
+               (("a","b"), dataclass(x=1,y=2))
+        """
+        return self.db.cnt(db=self.sdb)
+
 
 class Suber(SuberBase):
     """

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -1891,21 +1891,21 @@ def test_clear_escrows():
         assert db.getUwes(key) == []
         assert db.getOoes(key) == []
         assert db.getLdes(key) == []
-        assert db.qnfs.cnt(keys=(pre, saidb)) == 0
-        assert db.misfits.cnt(keys=(pre, snh)) == 0
-        assert db.delegables.cnt(keys=snKey(pre, 0)) == 0
-        assert db.pdes.cnt(keys=snKey(pre, 0)) == 0
-        assert db.udes.get(keys=udesKey) is None
-        assert db.rpes.cnt(keys=('route',)) == 0
-        assert db.epsd.get(keys=('DAzwEHHzq7K0gzQPYGGwTmuupUhPx5_yZ-Wk1x4ejhcc',)) is None
+        assert db.qnfs.cntAll() == 0
+        assert db.pdes.cntAll() == 0
+        assert db.rpes.cntAll() == 0
         assert db.eoobi.cntAll() == 0
-        assert db.dpub.get(keys=(pre, 'said')) is None
-        assert db.gpwe.cnt(keys=(pre,)) == 0
-        assert db.gdee.cnt(keys=(pre,)) == 0
-        assert db.dpwe.get(keys=(pre, 'said')) is None
-        assert db.gpse.cnt(keys=('qb64',)) == 0
-        assert db.epse.get(keys=('dig',)) is None
-        assert db.dune.get(keys=(pre, 'said')) is None
+        assert db.gpwe.cntAll() == 0
+        assert db.gdee.cntAll() == 0
+        assert db.dpwe.cntAll() == 0
+        assert db.gpse.cntAll() == 0
+        assert db.epse.cntAll() == 0
+        assert db.dune.cntAll() == 0
+        assert db.misfits.cntAll() == 0
+        assert db.delegables.cntAll() == 0
+        assert db.udes.cntAll() == 0
+        assert db.epsd.cntAll() == 0
+        assert db.dpub.cntAll() == 0
 
 if __name__ == "__main__":
     test_baser()


### PR DESCRIPTION
During a recent issue we had a old "un-parsable" event stuck in escrow.

The current (1.1.31 and 1.2.4) code includes a "count".
The count was only used in a log message, but utilized "getItemIter" which attempts to serialize the message into a serder. Which then throws an exception because it does not have enough required fields.

The `cntAll` is naive as it doesn't account for dupes etc - but it servers the purpose for a count at the most basic level.