### PR TITLE
fix: merge instead of replace contact data on re-OOBI

### DIFF
--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -503,7 +503,7 @@ class Oobiery:
                         obr.cid = response["headers"][ending.OOBI_AID_HEADER]
 
                     if obr.oobialias is not None and obr.cid:
-                        self.org.replace(pre=obr.cid, data=dict(alias=obr.oobialias, oobi=url))
+                        self.org.update(pre=obr.cid, data=dict(alias=obr.oobialias, oobi=url))
 
                     self.hby.db.coobi.rem(keys=(url,))
                     obr.state = Result.resolved


### PR DESCRIPTION
On re-resolving of an OOBI then contact data is being erased due to usage of the `Organizer.replace()` function. This is resolved by using `Organizer.update()` which does a merge (in Python, shown below) of data with any existing data.

```python
class Organizer:
    ...
    def update(...):
        ...
        existing = self.get(pre)
        if existing is None:
            existing = dict()

        existing |= data

        raw = json.dumps(existing).encode("utf-8")
        cigar = self.hby.signator.sign(ser=raw)

        self.hby.db.ccigs.pin(keys=(pre,), val=cigar)
        self.hby.db.cons.pin(keys=(pre,), val=raw)
         field, val in data.items():
            self.hby.db.cfld.pin(keys=(pre, field), val=val)
````