### PR TITLE
remove unused `--alias` argument for `kli challenge verify`

### DIFF
--- a/scripts/demo/basic/challenge.sh
+++ b/scripts/demo/basic/challenge.sh
@@ -19,8 +19,8 @@ words2="$(kli challenge generate --out string)"
 
 echo "Challenging cha1 with ${words1}"
 kli challenge respond --name cha1 --alias cha1 --recipient cha2 --words "${words1}"
-kli challenge verify --name cha2 --alias cha2 --signer cha1 --words "${words1}"
+kli challenge verify --name cha2 --signer cha1 --words "${words1}"
 
 echo "Challenging cha2 with ${words2}"
 kli challenge respond --name cha2 --alias cha2 --recipient cha1 --words "${words2}"
-kli challenge verify --name cha1 --alias cha1 --signer cha2 --words "${words2}"
+kli challenge verify --name cha1 --signer cha2 --words "${words2}"

--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -18,7 +18,7 @@ parser.set_defaults(handler=lambda args: respond(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")
-parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', default=None)
+parser.add_argument('--alias', '-a', help='human readable alias for the identifier to use for responding', default=None)
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument('--words', '-d', help='JSON formatted array of words to sign, \'@\' allowed to load from a file',

--- a/src/keri/app/cli/commands/challenge/verify.py
+++ b/src/keri/app/cli/commands/challenge/verify.py
@@ -21,11 +21,9 @@ logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='Check mailbox for EXN challenge response messages and verify their '
                                              'signatures and data against provided words and signer')
-parser.set_defaults(handler=lambda args: verify(args),
-                    transferable=True)
+parser.set_defaults(handler=lambda args: verify(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
-parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
-                    default=None)
+parser.add_argument('--alias', '-a', help='Unused, kept for backwards compatibility', default=None)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
@@ -50,7 +48,6 @@ def verify(args):
 
     """
     ld = VerifyDoer(name=args.name,
-                    alias=args.alias,
                     base=args.base,
                     bran=args.bran,
                     words=args.words,
@@ -63,7 +60,7 @@ def verify(args):
 
 class VerifyDoer(doing.DoDoer):
 
-    def __init__(self, name, alias, base, bran, words, generate, strength, out, signer):
+    def __init__(self, name, base, bran, words, generate, strength, out, signer):
 
         self.wordstr = words
         self.words = words
@@ -72,10 +69,6 @@ class VerifyDoer(doing.DoDoer):
         self.out = out
         self.signer = signer
         self.hby = existing.setupHby(name=name, base=base, bran=bran)
-        if alias is None:
-            alias = existing.aliasInput(self.hby)
-
-        self.hab = self.hby.habByName(alias)
         self.exc = exchanging.Exchanger(hby=self.hby, handlers=[])
         self.org = connecting.Organizer(hby=self.hby)
         signaler = signaling.Signaler()


### PR DESCRIPTION
I found that the `--alias` argument of `kli challenge verify` is not being used for anything.

When you have a keystore with multiple AIDs, the `kli challenge verify` will interactively prompt you for an alias. That threw me off because I could not understand why it would need the alias. So I removed that code and marked the `--alias` argument as "Unused" in the documentation. Hopefully this helps the next person who encounters this. 

The reason I did not remove it completely is to not break backwards compatibility for anyone who is currently passing `--alias` anyway. Perhaps there could be a way to mark deprecated arguments. Please advise.