### PR TITLE
fix some incorrect help docs for kli vc

### DIFF
--- a/src/keri/app/cli/commands/vc/create.py
+++ b/src/keri/app/cli/commands/vc/create.py
@@ -14,10 +14,11 @@ from keri.vdr import credentialing, verifying
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Initialize a prefix')
-parser.set_defaults(handler=lambda args: issueCredential(args),
-                    transferable=True)
-parser.add_argument('--name', '-n', help='Human readable reference', required=True)
+parser = argparse.ArgumentParser(description='Issue a verifiable credential')
+parser.set_defaults(handler=lambda args: issueCredential(args))
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
 parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
                     default=None)
 parser.add_argument('--schema', '-s', help='qb64 SAID of Schema to issue',
@@ -31,9 +32,7 @@ parser.add_argument('--recipient', '-R', help='alias or qb64 identifier prefix o
 parser.add_argument('--data', '-d', help='Credential data, \'@\' allowed', default=None, action="store", required=False)
 parser.add_argument('--credential', help='Full credential, \'@\' allowed', default=None, action="store",
                     required=False)
-parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
-                    required=False, default="")
-parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
+parser.add_argument('--alias', '-a', help='human readable alias for issuer of the new credential', required=True)
 parser.add_argument("--private", help="flag to indicate if this credential needs privacy preserving features",
                     action="store_true")
 parser.add_argument("--private-credential-nonce", help="nonce for vc",

--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -17,9 +17,8 @@ from keri.vdr import credentialing
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='List credentials and check mailboxes for any newly issued credentials')
-parser.set_defaults(handler=lambda args: export_credentials(args),
-                    transferable=True)
+parser = argparse.ArgumentParser(description='Export credential from store and any related material')
+parser.set_defaults(handler=lambda args: export_credentials(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
                     required=True)

--- a/src/keri/app/cli/commands/vc/registry/incept.py
+++ b/src/keri/app/cli/commands/vc/registry/incept.py
@@ -14,10 +14,11 @@ from keri.vdr import credentialing
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Initialize a prefix')
-parser.set_defaults(handler=lambda args: registryIncept(args),
-                    transferable=True)
-parser.add_argument('--name', '-n', help='Human readable reference', required=True)
+parser = argparse.ArgumentParser(description='Initialize a new credential registry')
+parser.set_defaults(handler=lambda args: registryIncept(args))
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
 parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
                     default=None)
 parser.add_argument('--nonce', help='Unique random value to seed the credential registry',
@@ -29,8 +30,6 @@ parser.add_argument('--backers', help='New set of backers different from the anc
                     required=False)
 parser.add_argument("--establishment-only", "-eo", help="Only allow establishment events for the anchoring events of "
                                                         "this registry", default=False, action="store")
-parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
-                    required=False, default="")
 parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran

--- a/src/keri/app/cli/commands/vc/registry/list.py
+++ b/src/keri/app/cli/commands/vc/registry/list.py
@@ -16,8 +16,7 @@ from keri.vdr import credentialing
 logger = help.ogler.getLogger()
 
 parser = argparse.ArgumentParser(description='List credential registry names and identifiers')
-parser.set_defaults(handler=lambda args: list_registries(args),
-                    transferable=True)
+parser.set_defaults(handler=lambda args: list_registries(args))
 parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")

--- a/src/keri/app/cli/commands/vc/registry/status.py
+++ b/src/keri/app/cli/commands/vc/registry/status.py
@@ -10,14 +10,13 @@ from keri.vdr import credentialing
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Initialize a prefix')
-parser.set_defaults(handler=lambda args: registryStatus(args),
-                    transferable=True)
-parser.add_argument('--name', '-n', help='Human readable reference', required=True)
-parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
-                    default=None, required=True)
+parser = argparse.ArgumentParser(description='Checks the status of a credential registry')
+parser.set_defaults(handler=lambda args: registryStatus(args))
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
 parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
                     required=False, default="")
+parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
+                    default=None, required=True)
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument("--verbose", "-V", help="print JSON of all current events", action="store_true")


### PR DESCRIPTION
- Fixes some incorrect command descriptions (probably from old copy-paste)
- Fixes some incorrect argument descriptions
- Remove `transferable=True` default args, also probably from old copy-paste
- Moved `--base` to follow `--name` in the arguments declaration to be consistent with many of the other commands in the kli.