### PR TITLE
fix logging substitution error

### DIFF
--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -340,7 +340,7 @@ class Revery:
                 # create cue here to request key state for sprefixer signer
                 # signer's est event not yet in signer's KEL
                 logger.info("Revery: escrowing without key state for signer"
-                            " on reply said=", serder.said)
+                            " on reply said=%s", serder.said)
                 self.escrowReply(serder=serder, saider=saider, dater=dater,
                                  route=route, prefixer=prefixer, seqner=seqner,
                                  ssaider=ssaider, sigers=sigers)


### PR DESCRIPTION
The logging changes I made earlier this year caused the reply message escrow to no longer work because of a faulty log substitution in `Revery.acceptReply` . This PR fixes that in the `1.2.4` branch, similar to https://github.com/WebOfTrust/keripy/pull/958 for `main`.

I double checked `1.1.32` and found that it does not need this same fix because the logging statement in `Revery.acceptReply` is not present.