### PR TITLE
Update Doer method signatures to support new Hio multiprocessing safety

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -206,7 +206,7 @@ class Receiptor(doing.DoDoer):
 
         self.remove([clientDoer])
 
-    def witDo(self, tymth=None, tock=0.0):
+    def witDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery and .tevery escrows.
@@ -235,7 +235,7 @@ class Receiptor(doing.DoDoer):
 
             yield self.tock
 
-    def gitDo(self, tymth=None, tock=0.0):
+    def gitDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery and .tevery escrows.
@@ -295,7 +295,7 @@ class WitnessReceiptor(doing.DoDoer):
 
         super(WitnessReceiptor, self).__init__(doers=[doing.doify(self.receiptDo)], **kwa)
 
-    def receiptDo(self, tymth=None, tock=0.0):
+    def receiptDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatible generator method (doer dog)
 
@@ -680,7 +680,7 @@ class TCPMessenger(doing.DoDoer):
 
         super(TCPMessenger, self).__init__(doers=doers)
 
-    def receiptDo(self, tymth=None, tock=0.0):
+    def receiptDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatible generator method (doer dog)
 
@@ -774,7 +774,7 @@ class TCPStreamMessenger(doing.DoDoer):
 
         super(TCPStreamMessenger, self).__init__(doers=doers)
 
-    def receiptDo(self, tymth=None, tock=0.0):
+    def receiptDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatible generator method (doer dog)
 
@@ -875,7 +875,7 @@ class HTTPMessenger(doing.DoDoer):
 
         super(HTTPMessenger, self).__init__(doers=doers, **kwa)
 
-    def msgDo(self, tymth=None, tock=0.0):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatible generator method (doer dog)
 
@@ -901,7 +901,7 @@ class HTTPMessenger(doing.DoDoer):
 
             yield self.tock
 
-    def responseDo(self, tymth=None, tock=0.0):
+    def responseDo(self, tymth=None, tock=0.0, **kwa):
         """
         Processes responses from client and adds them to sent cue
 

--- a/src/keri/app/apping.py
+++ b/src/keri/app/apping.py
@@ -28,9 +28,9 @@ class Consoler(doing.Doer):
         self.db = db if db is not None else basing.Baser()
         self.console = console if console is not None else serialing.Console()
 
-    def enter(self):
+    def enter(self, *, temp=None):
         """"""
-        if not self.console.reopen():
+        if not self.console.reopen(): # reopen(temp=temp)
             raise IOError("Unable to open serial console.")
 
     def recur(self, tyme):

--- a/src/keri/app/cli/commands/incept.py
+++ b/src/keri/app/cli/commands/incept.py
@@ -150,7 +150,7 @@ class InceptDoer(doing.DoDoer):
         self.alias = alias
         super(InceptDoer, self).__init__(doers=doers)
 
-    def inceptDo(self, tymth, tock=0.0):
+    def inceptDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of

--- a/src/keri/app/cli/commands/init.py
+++ b/src/keri/app/cli/commands/init.py
@@ -67,7 +67,7 @@ class InitDoer(doing.DoDoer):
         self.args = args
         super(InitDoer, self).__init__(doers=[doing.doify(self.initialize)])
 
-    def initialize(self, tymth, tock=0.0):
+    def initialize(self, tymth, tock=0.0, **kwa):
 
         # enter context
         self.wind(tymth)

--- a/src/keri/app/cli/commands/multisig/incept.py
+++ b/src/keri/app/cli/commands/multisig/incept.py
@@ -105,7 +105,7 @@ class GroupMultisigIncept(doing.DoDoer):
 
         super(GroupMultisigIncept, self).__init__(doers=doers)
 
-    def inceptDo(self, tymth, tock=0.0):
+    def inceptDo(self, tymth, tock=0.0, **kwa):
         """ Create or participate in an inception event for a distributed multisig identifier
 
         Parameters:

--- a/src/keri/app/cli/commands/rotate.py
+++ b/src/keri/app/cli/commands/rotate.py
@@ -167,7 +167,7 @@ class RotateDoer(doing.DoDoer):
 
         super(RotateDoer, self).__init__(doers=doers)
 
-    def rotateDo(self, tymth, tock=0.0):
+    def rotateDo(self, tymth, tock=0.0, **kwa):
         """
         Returns:  doifiable Doist compatible generator method
         Usage:

--- a/src/keri/app/configing.py
+++ b/src/keri/app/configing.py
@@ -225,10 +225,10 @@ class ConfigerDoer(doing.Doer):
         super(ConfigerDoer, self).__init__(**kwa)
         self.configer = configer
 
-    def enter(self):
+    def enter(self, *, temp=None):
         """"""
         if not self.configer.opened:
-            self.configer.reopen()
+            self.configer.reopen()  # reopen(temp=temp)
 
     def exit(self):
         """"""

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -95,7 +95,7 @@ class Anchorer(doing.DoDoer):
 
         return True
 
-    def escrowDo(self, tymth, tock=1.0):
+    def escrowDo(self, tymth, tock=1.0, **kwa):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -39,7 +39,7 @@ class Poster(doing.DoDoer):
         doers = [doing.doify(self.deliverDo)]
         super(Poster, self).__init__(doers=doers, **kwa)
 
-    def deliverDo(self, tymth=None, tock=0.0):
+    def deliverDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:  doifiable Doist compatible generator method that processes
                    a queue of messages and envelopes them in a `fwd` message

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -72,7 +72,7 @@ class Counselor(doing.DoDoer):
 
         return True
 
-    def escrowDo(self, tymth, tock=1.0):
+    def escrowDo(self, tymth, tock=1.0, **kwa):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -900,7 +900,7 @@ class HaberyDoer(doing.Doer):
         super(HaberyDoer, self).__init__(**kwa)
         self.habery = habery
 
-    def enter(self):
+    def enter(self, *, temp=False):
         """ Enter context and set up Habery """
         if not self.habery.inited:
             self.habery.setup(**self.habery._inits)

--- a/src/keri/app/httping.py
+++ b/src/keri/app/httping.py
@@ -259,7 +259,7 @@ class Clienter(doing.DoDoer):
         (_, doer, _) = tup
         super(Clienter, self).remove([doer])
 
-    def clientDo(self, tymth, tock=0.0):
+    def clientDo(self, tymth, tock=0.0, **kwa):
         """ Periodically prune stale clients
 
         Process existing clients and prune any that have receieved a response longer than timeout

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -161,7 +161,7 @@ class WitnessStart(doing.DoDoer):
         doers = [doing.doify(self.start), doing.doify(self.msgDo), doing.doify(self.escrowDo), doing.doify(self.cueDo)]
         super().__init__(doers=doers, **opts)
 
-    def start(self, tymth=None, tock=0.0):
+    def start(self, tymth=None, tock=0.0, **kwa):
         """ Prints witness name and prefix
 
         Parameters:
@@ -179,7 +179,7 @@ class WitnessStart(doing.DoDoer):
 
         print("Witness", self.hab.name, ":", self.hab.pre)
 
-    def msgDo(self, tymth=None, tock=0.0):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -201,7 +201,7 @@ class WitnessStart(doing.DoDoer):
         done = yield from self.parser.parsator(local=True)  # process messages continuously
         return done  # should nover get here except forced close
 
-    def escrowDo(self, tymth=None, tock=0.0):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery and .tevery escrows.
@@ -227,7 +227,7 @@ class WitnessStart(doing.DoDoer):
 
             yield
 
-    def cueDo(self, tymth=None, tock=0.0):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -363,7 +363,7 @@ class Indirector(doing.DoDoer):
         super(Indirector, self).wind(tymth)
         self.client.wind(tymth)
 
-    def msgDo(self, tymth=None, tock=0.0):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -390,7 +390,7 @@ class Indirector(doing.DoDoer):
         done = yield from self.parser.parsator(local=True)  # process messages continuously
         return done  # should nover get here except forced close
 
-    def cueDo(self, tymth=None, tock=0.0):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -418,7 +418,7 @@ class Indirector(doing.DoDoer):
                 yield  # throttle just do one cue at a time
             yield
 
-    def escrowDo(self, tymth=None, tock=0.0):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -578,7 +578,7 @@ class MailboxDirector(doing.DoDoer):
         """
         super(MailboxDirector, self).wind(tymth)
 
-    def pollDo(self, tymth=None, tock=0.0):
+    def pollDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:
            doifiable Doist compatible generator method
@@ -656,7 +656,7 @@ class MailboxDirector(doing.DoDoer):
             msg = mail.pop(0)
             yield msg
 
-    def msgDo(self, tymth=None, tock=0.0):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -681,7 +681,7 @@ class MailboxDirector(doing.DoDoer):
         done = yield from self.parser.parsator(local=True)  # process messages continuously
         return done  # should nover get here except forced close
 
-    def escrowDo(self, tymth=None, tock=0.0):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -754,7 +754,7 @@ class Poller(doing.DoDoer):
 
         super(Poller, self).__init__(doers=doers, **kwa)
 
-    def eventDo(self, tymth=None, tock=0.0):
+    def eventDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:
            doifiable Doist compatible generator method
@@ -1152,7 +1152,7 @@ class ReceiptEnd(doing.DoDoer):
         rep.status = falcon.HTTP_200
         rep.data = rct
 
-    def interceptDo(self, tymth=None, tock=0.0):
+    def interceptDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             Kevery and Tevery cues deque

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -343,10 +343,10 @@ class KeeperDoer(doing.Doer):
         self.keeper = keeper
 
 
-    def enter(self):
+    def enter(self, *, temp=False):
         """"""
         if not self.keeper.opened:
-            self.keeper.reopen()
+            self.keeper.reopen()  # reopen(temp=temp)
 
 
     def exit(self):
@@ -1756,7 +1756,7 @@ class ManagerDoer(doing.Doer):
         self.manager = manager
 
 
-    def enter(self):
+    def enter(self, *, temp=False):
         """"""
         if not self.manager.inited:
             self.manager.setup(**self.manager._inits)

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -386,7 +386,7 @@ class Oobiery:
         obr = basing.OobiRecord(cid=cid, date=dt)
         self.hby.db.oobis.put(keys=(oobi,), val=obr)
 
-    def scoobiDo(self, tymth=None, tock=0.0):
+    def scoobiDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             .exc responses and pass them on to the HTTPRespondant
@@ -661,7 +661,7 @@ class Authenticator:
         wkan = basing.WellKnownAuthN(url=url, dt=now)
         self.hby.db.wkas.add(keys=(cid,), val=wkan)
 
-    def authzDo(self, tymth=None, tock=0.0):
+    def authzDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             .exc responses and pass them on to the HTTPRespondant

--- a/src/keri/app/signaling.py
+++ b/src/keri/app/signaling.py
@@ -128,7 +128,7 @@ class Signaler(doing.DoDoer):
 
         self.signals.append(sig)
 
-    def expireDo(self, tymth=None, tock=0.0):
+    def expireDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatible generator method (doer dog)
 

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -186,7 +186,7 @@ class Respondant(doing.DoDoer):
         doers = [self.postman, doing.doify(self.responseDo), doing.doify(self.cueDo)]
         super(Respondant, self).__init__(doers=doers, **kwa)
 
-    def responseDo(self, tymth=None, tock=0.0):
+    def responseDo(self, tymth=None, tock=0.0, **kwa):
         """
         Doifiable Doist compatibile generator method to process response messages from `exn` handlers.
         If dest is not in local environment, ignore the response (for now).  If dest has witnesses,
@@ -232,7 +232,7 @@ class Respondant(doing.DoDoer):
 
             yield self.tock
 
-    def cueDo(self, tymth=None, tock=0.0):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             Kevery and Tevery cues deque

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -3277,10 +3277,10 @@ class BaserDoer(doing.Doer):
         super(BaserDoer, self).__init__(**kwa)
         self.baser = baser
 
-    def enter(self):
+    def enter(self, *, temp=False):
         """"""
         if not self.baser.opened:
-            self.baser.reopen()
+            self.baser.reopen()  # reopen(temp=temp)
 
     def exit(self):
         """"""

--- a/src/keri/vc/walleting.py
+++ b/src/keri/vc/walleting.py
@@ -72,7 +72,7 @@ class WalletDoer(doing.DoDoer):
 
         super(WalletDoer, self).__init__(doers=doers, **kwa)
 
-    def escrowDo(self, tymth, tock=0.0):
+    def escrowDo(self, tymth, tock=0.0, **kwa):
         """ Processes the escrows for group icp, rot and ixn request messages.
 
         Parameters:

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -652,7 +652,7 @@ class Registrar(doing.DoDoer):
         said = self.rgy.reger.ctel.get(keys=(pre, seqner.qb64))
         return said is not None and self.witPub.sent(said=pre)
 
-    def escrowDo(self, tymth, tock=1.0):
+    def escrowDo(self, tymth, tock=1.0, **kwa):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:
@@ -878,7 +878,7 @@ class Credentialer(doing.DoDoer):
     def complete(self, said):
         return self.rgy.reger.ccrd.get(keys=(said,)) is not None
 
-    def escrowDo(self, tymth, tock=1.0):
+    def escrowDo(self, tymth, tock=1.0, **kwa):
         """ Process escrows of group multisig identifiers waiting to be completed.
 
         Steps involve:

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -60,7 +60,7 @@ class ReceiptDoer(doing.DoDoer):
 
         super(ReceiptDoer, self).__init__(doers=[doing.doify(self.testDo)])
 
-    def testDo(self, tymth, tock=0.0):
+    def testDo(self, tymth, tock=0.0, **kwa):
         """ Execute a series of kli commands for this test scenario """
         # enter context
         self.wind(tymth)
@@ -145,7 +145,7 @@ class PublishDoer(doing.DoDoer):
 
         super(PublishDoer, self).__init__(doers=doers)
 
-    def testDo(self, tymth, tock=0.0):
+    def testDo(self, tymth, tock=0.0, **kwa):
         """ Run the test and exit and remove all child doers when done """
         self.wind(tymth)
         self.tock = tock


### PR DESCRIPTION
Ported from Sam's commit to main in PR #945.

These changes are required in order to upgrade to HIO 0.6.18 or higher. Without these, or similar changes, then some KLI commands break.

Third time's a charm.