### PR TITLE
Updated Temp File for Windows in Tests and CI/CD

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -37,16 +37,6 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
         shell: pwsh
-      - name: Create \tmp directory on Windows
-        if: runner.os == 'Windows'
-        run: |
-          if (-not (Test-Path -Path '\tmp')) {
-            New-Item -Path '\tmp' -ItemType Directory -Force
-            Write-Host "Created \tmp directory for testing"
-          } else {
-            Write-Host "\tmp directory already exists"
-          }
-        shell: pwsh
       - name: Run core KERI tests
         run: |
           pytest tests/ --ignore tests/demo/ --ignore test/scripts

--- a/tests/app/test_configing.py
+++ b/tests/app/test_configing.py
@@ -5,6 +5,7 @@ tests.app.configin module
 import os
 import platform
 import shutil
+import tempfile
 
 import pytest
 
@@ -17,6 +18,7 @@ def test_configer():
     Test Configer class
     """
     # Test Filer with file not dir
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     filepath = os.path.join(os.path.sep, 'usr', 'local', 'var', 'keri', 'cf', 'main', 'conf.json')
     if os.path.exists(filepath):
         os.remove(filepath)
@@ -214,9 +216,9 @@ def test_configer():
 
     #test openCF hjson
     with configing.openCF() as cfr:  # default uses json and temp==True
-        filepath = os.path.join(os.path.sep, 'tmp', 'keri_cf_2_zu01lb_test', 'keri', 'cf', 'main', 'test.json')
+        filepath = os.path.join(tempDirPath, 'keri_cf_2_zu01lb_test', 'keri', 'cf', 'main', 'test.json')
         _, path = os.path.splitdrive(os.path.normpath(cfr.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert path.startswith(os.path.join(tempDirPath, 'keri_'))
         assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.json'))
         assert cfr.opened
         assert cfr.human
@@ -231,9 +233,9 @@ def test_configer():
 
     #test openCF json
     with configing.openCF(human=False) as cfr:  # default uses json and temp==True
-        filepath = '/tmp/keri_cf_2_zu01lb_test/keri/cf/main/test.json'
+        filepath = os.path.join(tempDirPath,'keri_cf_2_zu01lb_test/keri/cf/main/test.json')
         _, path = os.path.splitdrive(os.path.normpath(cfr.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert path.startswith(os.path.join(tempDirPath, 'keri_'))
         assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.json'))
         assert cfr.opened
         assert not cfr.human
@@ -249,7 +251,7 @@ def test_configer():
     #test openCF mgpk
     with configing.openCF(fext='mgpk') as cfr:  # default uses temp==True
         _, path = os.path.splitdrive(os.path.normpath(cfr.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert path.startswith(os.path.join(tempDirPath, 'keri_'))
         assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.mgpk'))
         assert cfr.opened
         assert os.path.exists(cfr.path)
@@ -264,7 +266,7 @@ def test_configer():
     # test openCF cbor
     with configing.openCF(fext='cbor') as cfr:  # default uses temp==True
         _, path = os.path.splitdrive(os.path.normpath(cfr.path))
-        assert path.startswith(os.path.join(os.path.sep, 'tmp', 'keri_'))
+        assert path.startswith(os.path.join(tempDirPath, 'keri_'))
         assert cfr.path.endswith(os.path.join('_test', 'keri', 'cf', 'main', 'test.cbor'))
         assert cfr.opened
         assert os.path.exists(cfr.path)

--- a/tests/app/test_keeping.py
+++ b/tests/app/test_keeping.py
@@ -4,6 +4,7 @@ tests.app.keeping module
 
 """
 import platform
+import tempfile
 
 import pytest
 
@@ -183,12 +184,13 @@ def test_openkeeper():
     """
     test contextmanager decorator for test Keeper databases
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     with keeping.openKS() as ks:
         assert isinstance(ks, keeping.Keeper)
         assert ks.name == "test"
         assert isinstance(ks.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(ks.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_ks_"))
         assert ks.path.endswith(os.path.join("_test", "keri", "ks", "test"))
         assert ks.env.path() == ks.path
         assert os.path.exists(ks.path)
@@ -202,7 +204,7 @@ def test_openkeeper():
         assert ks.name == "blue"
         assert isinstance(ks.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(ks.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_ks_"))
         assert ks.path.endswith(os.path.join("_test", "keri", "ks", "blue"))
         assert ks.env.path() == ks.path
         assert os.path.exists(ks.path)
@@ -246,6 +248,7 @@ def test_keeper():
     stat.S_IWUSR Owner has write permission.
     stat.S_IXUSR Owner has execute permission.
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
     assert perm == 0o1700
 
@@ -326,7 +329,7 @@ def test_keeper():
         assert keeper.temp == True
         assert isinstance(keeper.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(keeper.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_ks_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_ks_"))
         assert keeper.path.endswith(os.path.join("_test", "keri", "ks", "test"))
         assert keeper.env.path() == keeper.path
         assert os.path.exists(keeper.path)

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -4,6 +4,8 @@ tests.app.test_multisig module
 
 """
 import datetime
+import platform
+import tempfile
 
 import time
 import pytest
@@ -119,7 +121,8 @@ def test_noter(mockHelpingNowUTC):
 
     noter = notifying.Noter(temp=True)
     _, path = os.path.splitdrive(os.path.normpath(noter.path))
-    assert path.startswith(os.path.join(os.path.sep, "tmp"))
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+    assert path.startswith(tempDirPath)
 
     payload = dict(name="John", email="john@example.com", msg="test")
     dt = helping.fromIso8601("2022-07-08T15:01:05.453632")

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -5,6 +5,8 @@ tests.db.dbing module
 """
 import json
 import os
+import platform
+import tempfile
 from dataclasses import dataclass, asdict
 
 import pytest
@@ -35,6 +37,7 @@ def test_baser():
     """
     Test Baser class
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     baser = Baser(reopen=True)  # default is to not reopen
     assert isinstance(baser, Baser)
     assert baser.name == "main"
@@ -99,7 +102,7 @@ def test_baser():
         assert baser.temp == True
         assert isinstance(baser.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(baser.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_lmdb_"))
         assert baser.path.endswith(os.path.join("_test", "keri", "db", "test"))
         assert baser.env.path() == baser.path
         assert os.path.exists(baser.path)

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -3,6 +3,9 @@
 tests.db.dbing module
 
 """
+import platform
+import tempfile
+
 import pytest
 
 import os
@@ -174,12 +177,13 @@ def test_opendatabaser():
     """
     test contextmanager decorator for test databases
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     with openLMDB() as databaser:
         assert isinstance(databaser, LMDBer)
         assert databaser.name == "test"
         assert isinstance(databaser.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(databaser.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_lmdb_"))
         assert databaser.path.endswith(os.path.join("_test", "keri", "db", "test"))
         assert databaser.env.path() == databaser.path
         assert os.path.exists(databaser.path)
@@ -193,7 +197,7 @@ def test_opendatabaser():
         assert databaser.name == "blue"
         assert isinstance(databaser.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(databaser.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_lmdb_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_lmdb_"))
         assert databaser.path.endswith(os.path.join("_test", "keri", "db", "blue"))
         assert databaser.env.path() == databaser.path
         assert os.path.exists(databaser.path)

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -3,6 +3,8 @@
 tests.help.test_ogling module
 
 """
+import tempfile
+
 import pytest
 
 import os
@@ -21,6 +23,8 @@ def test_openogler():
     # used context manager to directly open an ogler  Because loggers are singletons
     # it still affects loggers.
 
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
+
     with ogling.openOgler(prefix='keri', level=logging.DEBUG) as ogler:  # default is temp = True
         assert isinstance(ogler, ogling.Ogler)
         assert ogler.name == "test"
@@ -29,7 +33,7 @@ def test_openogler():
         assert ogler.prefix == 'keri'
         assert ogler.headDirPath == ogler.HeadDirPath == os.path.join(os.path.sep, "usr", "local", "var")
         _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
         assert ogler.dirPath.endswith("_temp")
         assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
         assert ogler.opened
@@ -140,6 +144,7 @@ def test_ogler():
     """
     Test Ogler class instance that builds loggers
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     ogler = ogling.Ogler(name="test", prefix="keri")
     assert ogler.path is None
     assert ogler.opened == False
@@ -172,7 +177,7 @@ def test_ogler():
                          prefix='keri', reopen=True, clear=True)
     assert ogler.level == logging.DEBUG
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -206,7 +211,7 @@ def test_ogler():
     # Test reopen but not clear so file still there
     ogler.reopen(temp=True)
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     assert ogler.opened == True
@@ -251,6 +256,7 @@ def test_init_ogler():
     Test initOgler function for ogler global
     """
     #defined by default in help.__init__ on import of ogling
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     assert isinstance(help.ogler, ogling.Ogler)
     assert not help.ogler.opened
     assert help.ogler.level == logging.CRITICAL  # default
@@ -289,7 +295,7 @@ def test_init_ogler():
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
     _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
@@ -312,7 +318,7 @@ def test_init_ogler():
     assert ogler.opened
     assert ogler.level == logging.DEBUG
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     with open(ogler.path, 'r') as logfile:
@@ -350,6 +356,7 @@ def test_reset_levels():
     Test resetLevel on preexisting loggers
     """
     #defined by default in help.__init__ on import of ogling
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     assert isinstance(help.ogler, ogling.Ogler)
     assert not help.ogler.opened
     assert help.ogler.level == logging.CRITICAL  # default
@@ -380,7 +387,7 @@ def test_reset_levels():
     assert help.ogler.opened
     assert help.ogler.level == logging.DEBUG
     _, path = os.path.splitdrive(os.path.normpath(help.ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
@@ -409,7 +416,7 @@ def test_reset_levels():
     assert ogler.opened
     assert ogler.level == logging.DEBUG
     _, path = os.path.splitdrive(os.path.normpath(ogler.dirPath))
-    assert path.startswith(os.path.join(os.path.sep, "tmp", "keri", "logs", "test_"))
+    assert path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
     # Still have 3 handlers

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -6,6 +6,8 @@ tests.vdr.viring module
 
 import json
 import os
+import platform
+import tempfile
 
 import lmdb
 
@@ -18,6 +20,7 @@ def test_issuer():
     """
     Test Issuer Class
     """
+    tempDirPath = os.path.join(os.path.sep, "tmp") if platform.system() == "Darwin" else tempfile.gettempdir()
     issuer = Reger()
 
     assert isinstance(issuer, Reger)
@@ -63,7 +66,7 @@ def test_issuer():
         assert issuer.temp is True
         assert isinstance(issuer.env, lmdb.Environment)
         _, path = os.path.splitdrive(os.path.normpath(issuer.path))
-        assert path.startswith(os.path.join(os.path.sep, "tmp", "keri_reg_"))
+        assert path.startswith(os.path.join(tempDirPath, "keri_reg_"))
         assert issuer.path.endswith(os.path.join("_test", "keri", "reg", "test"))
         assert issuer.env.path() == issuer.path
         assert os.path.exists(issuer.path)


### PR DESCRIPTION
### This PR is dependent on https://github.com/ioflo/hio/pull/80
- Updated temp file access such that it is os agnostic
- Removed \tmp file creation in windows CI/CD