### PR TITLE
fix: lmdb.MapFullError: mdb_txn_commit: MDB_MAP_FULL on Mailboxer

### DIFF
--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -23,6 +23,7 @@ raw = json.dumps(ked, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 """
 import math
+import os
 from collections import namedtuple, deque
 from dataclasses import dataclass, asdict, field
 
@@ -30,10 +31,13 @@ import pysodium
 from hio.base import doing
 
 from .. import kering
-from .. import core
+from .. import core, help
 from ..core import coring
 from ..db import dbing, subing, koming
+from ..db.basing import KERIBaserMapSizeKey
 from ..help import helping
+
+logger = help.ogler.getLogger()
 
 Algoage = namedtuple("Algoage", 'randy salty group extern')
 Algos = Algoage(randy='randy', salty='salty', group="group", extern="extern")  # randy is rerandomize, salty is use salt
@@ -128,6 +132,9 @@ def openKS(name="test", **kwa):
             Otherwise open in persistent directory, do not clear on close
     """
     return dbing.openLMDB(cls=Keeper, name=name, **kwa)
+
+# Env var for configuring LMDB size for the Keeper database
+KERIKeeperMapSizeKey = "KERI_KEEPER_MAP_SIZE"
 
 
 class Keeper(dbing.LMDBer):
@@ -250,6 +257,17 @@ class Keeper(dbing.LMDBer):
         """
         if perm is None:
             perm = self.Perm  # defaults to restricted permissions for non temp
+
+        # support separate Keeper size config yet fall back to baser size if not set
+        keeperSize = os.getenv(KERIKeeperMapSizeKey, None)
+        baserSize = os.getenv(KERIBaserMapSizeKey, None)
+        mapSize = keeperSize if (keeperSize is not None and keeperSize != '') else baserSize
+        if mapSize:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                logger.error("KERI_KEEPER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(Keeper, self).__init__(headDirPath=headDirPath, perm=perm,
                                      reopen=reopen, **kwa)

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -3,14 +3,18 @@
 keri.app.notifying module
 
 """
+import os
 from collections.abc import Iterable
 from typing import Union, Type
 
-from keri import kering
+from keri import kering, help
+from keri.db.basing import KERIBaserMapSizeKey
 from keri.help import helping
 from keri.app import signaling
 from keri.core import coring
 from keri.db import dbing, subing
+
+logger = help.ogler.getLogger()
 
 
 def notice(attrs, dt=None, read=False):
@@ -197,6 +201,9 @@ class DicterSuber(subing.Suber):
         """
         return self.db.cnt(db=self.sdb)
 
+# Env var for configuring LMDB size for the Noter database
+KERINoterMapSizeKey = "KERI_NOTER_MAP_SIZE"
+
 
 class Noter(dbing.LMDBer):
     """
@@ -220,6 +227,17 @@ class Noter(dbing.LMDBer):
         self.notes = None
         self.nidx = None
         self.ncigs = None
+
+        # support separate mailbox size config yet fall back to baser size if not set
+        noterSize = os.getenv(KERINoterMapSizeKey, None)
+        baserSize = os.getenv(KERIBaserMapSizeKey, None)
+        mapSize = noterSize if (noterSize is not None and noterSize != '') else baserSize
+        if mapSize:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                logger.error("KERI_NOTER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(Noter, self).__init__(name=name, headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -3,6 +3,7 @@
 keri.app.storing module
 
 """
+import os
 
 from hio.base import doing
 from hio.help import decking
@@ -13,8 +14,12 @@ from .. import help
 from ..core import coring, serdering
 from ..core.coring import MtrDex
 from ..db import dbing, subing
+from ..db.basing import KERIBaserMapSizeKey
 
 logger = help.ogler.getLogger()
+
+# Env var for configuring LMDB size for the Mailbox database
+KERIMailboxerMapSizeKey = "KERI_MAILBOXER_MAP_SIZE"
 
 
 class Mailboxer(dbing.LMDBer):
@@ -48,6 +53,17 @@ class Mailboxer(dbing.LMDBer):
         """
         self.tpcs = None
         self.msgs = None
+
+        # support separate mailbox size config yet fall back to baser size if not set
+        mailboxerSize = os.getenv(KERIMailboxerMapSizeKey, None)
+        baserSize = os.getenv(KERIBaserMapSizeKey, None)
+        mapSize = mailboxerSize if (mailboxerSize is not None and mailboxerSize != '') else baserSize
+        if mapSize:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                logger.error("KERI_MAILBOXER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(Mailboxer, self).__init__(name=name, headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -594,7 +594,7 @@ def reopenDB(db, clear=False, **kwa):
     finally:
         db.close(clear=clear)
 
-
+# Env var for configuring LMDB size for the main Baser database
 KERIBaserMapSizeKey = "KERI_BASER_MAP_SIZE"
 
 

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -6,10 +6,12 @@ tests.app.storing
 import os
 
 import lmdb
+import pytest
 
 from keri.app import keeping
 from keri.core import coring, serdering
 from keri.db import dbing, basing, subing
+from keri.db.dbing import LMDBer
 from keri.peer import exchanging
 from keri.app.storing import Mailboxer
 
@@ -109,7 +111,32 @@ def test_mailboxing():
         #assert(len(msgs)) == 6
         #assert msgs[0][0] == 4
 
+def test_mailbox_db_size_set_from_env_var():
+    new_map_size = 10737418240
+    # Default map size works
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert mber.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
 
+    # Specific map size works
+    os.environ["KERI_MAILBOXER_MAP_SIZE"] = f"{new_map_size}"
+
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ["KERI_MAILBOXER_MAP_SIZE"] = ''
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ["KERI_BASER_MAP_SIZE"] = f"{baser_map_size}"
+
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # Bad map size throws
+    os.environ["KERI_MAILBOXER_MAP_SIZE"] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        Mailboxer()
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
 
 if __name__ == '__main__':
     test_mailboxing()

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -8,12 +8,13 @@ import json
 import os
 
 import lmdb
+import pytest
 
 from keri import kering
 from keri.core import coring
 from keri.core.coring import Diger, versify, Kinds
 from keri.core.serdering import SerderACDC
-from keri.db.dbing import openLMDB, dgKey, snKey
+from keri.db.dbing import openLMDB, dgKey, snKey, LMDBer
 from keri.vdr.viring import Reger
 
 
@@ -400,6 +401,33 @@ def test_clearEscrows():
         assert db.tpwe.cntAll() == 0
         assert db.tmse.cntAll() == 0
         assert db.tede.cntAll() == 0
+
+def test_mailbox_db_size_set_from_env_var():
+    new_map_size = 10737418240
+    # Default map size works
+    reger = Reger()
+    assert reger.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert reger.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+
+    # Specific map size works
+    os.environ["KERI_REGER_MAP_SIZE"] = f"{new_map_size}"
+
+    reger = Reger()
+    assert reger.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ["KERI_REGER_MAP_SIZE"] = ''
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ["KERI_BASER_MAP_SIZE"] = f"{baser_map_size}"
+
+    reger = Reger()
+    assert reger.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # Bad map size throws
+    os.environ["KERI_REGER_MAP_SIZE"] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        Reger()
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
 
 if __name__ == "__main__":
     test_issuer()


### PR DESCRIPTION
The default 10MB size limit on the Mailboxer LMDB database has been hit regularly for quite some time now, which has been causing odd behavior with witnesses. The stack trace shows the error coming up through `storing.py` as shown in the stack trace below. This PR adds configurability on a database by database basis as well as piggybacking off of the KERI_BASER_MAP_SIZE env var for simplicity. This problem exists on all major branches so there will be corresponding PRs to both `1.1.32` and `main`.

### Stack Trace

```python
Traceback (most recent call last):
  File "/keripy/src/keri/app/cli/kli.py", line 24, in main
    doers = args.handler(args)
            ^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 19, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
                                             ^^^^^^^^^^^^
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 66, in launch
    runWitness(name=args.name,
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 115, in runWitness
    directing.runController(doers=doers, expire=expire)
  File "/keripy/src/keri/app/directing.py", line 665, in runController
    doist.do(doers=doers)
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 156, in do
    self.recur()  # increments .tyme runs recur context
    ^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 275, in recur
    tock = dog.send(self.tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
                ^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
                ^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^
  File "/keripy/src/keri/app/forwarding.py", line 86, in deliverDo
    yield from self.forwardToWitness(hab, ends[Roles.witness], recp=recp, serder=srdr, atc=atc, topic=tpc)
  File "/keripy/src/keri/app/forwarding.py", line 211, in forwardToWitness
    self.mbx.storeMsg(topic=f"{recp}/{topic}".encode("utf-8"), msg=msg)
  File "/keripy/src/keri/app/storing.py", line 131, in storeMsg
    return self.msgs.pin(keys=digb, val=msg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/db/subing.py", line 388, in pin
    return (self.db.setVal(db=self.sdb,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/db/dbing.py", line 534, in setVal
    with self.env.begin(db=db, write=True, buffers=True) as txn:
lmdb.MapFullError: mdb_txn_commit: MDB_MAP_FULL: Environment mapsize limit reached

```