### PR TITLE
fix: lmdb.MapFullError: mdb_txn_commit: MDB_MAP_FULL on Mailboxer

### DIFF
--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -3,9 +3,11 @@
 keri.app.storing module
 
 """
+import os
 
 from hio.base import doing
 from hio.help import decking
+from keri.db.basing import KERIBaserMapSizeKey
 from ordered_set import OrderedSet as oset
 
 from . import forwarding
@@ -15,6 +17,9 @@ from ..core.coring import MtrDex
 from ..db import dbing, subing
 
 logger = help.ogler.getLogger()
+
+# Env var for configuring LMDB size for the Mailbox database
+KERIMailboxerMapSizeKey = "KERI_MAILBOXER_MAP_SIZE"
 
 
 class Mailboxer(dbing.LMDBer):
@@ -37,6 +42,17 @@ class Mailboxer(dbing.LMDBer):
         """
         self.tpcs = None
         self.msgs = None
+
+        # support separate mailbox size config yet fall back to baser size if not set
+        mailboxerSize = os.getenv(KERIMailboxerMapSizeKey, None)
+        baserSize = os.getenv(KERIBaserMapSizeKey, None)
+        mapSize = mailboxerSize if (mailboxerSize is not None and mailboxerSize != '') else baserSize
+        if mapSize:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                logger.error("KERI_MAILBOXER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(Mailboxer, self).__init__(name=name, headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -501,6 +501,8 @@ def reopenDB(db, clear=False, **kwa):
     finally:
         db.close(clear=clear)
 
+# Env var for configuring LMDB size for the main Baser database
+KERIBaserMapSizeKey = "KERI_BASER_MAP_SIZE"
 
 class Baser(dbing.LMDBer):
     """

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -7,7 +7,7 @@ VIR  Verifiable Issuance(Revocation) Registry
 Provides public simple Verifiable Credential Issuance/Revocation Registry
 A special purpose Verifiable Data Registry (VDR)
 """
-
+import os
 from dataclasses import dataclass, field, asdict
 from  ordered_set import OrderedSet as oset
 
@@ -17,6 +17,7 @@ from .. import kering
 from ..app import signing
 from ..core import coring, serdering
 from ..db import dbing, basing
+from ..db.basing import KERIBaserMapSizeKey
 from ..vdr import eventing
 
 from keri import help
@@ -171,6 +172,9 @@ def openReger(name="test", **kwa):
     """
     return dbing.openLMDB(cls=Reger, name=name, **kwa)
 
+# Env var for configuring LMDB size for the Keeper database
+KERIRegerMapSizeKey = "KERI_REGER_MAP_SIZE"
+
 
 class Reger(dbing.LMDBer):
     """ Reger sets up named sub databases for TEL registry
@@ -276,6 +280,17 @@ class Reger(dbing.LMDBer):
             self._tevers.db = kwa["db"]
         else:
             self._tevers = dict()
+
+        # support separate Reger size config yet fall back to baser size if not set
+        regerSize = os.getenv(KERIRegerMapSizeKey, None)
+        baserSize = os.getenv(KERIBaserMapSizeKey, None)
+        mapSize = regerSize if (regerSize is not None and regerSize != '') else baserSize
+        if mapSize:
+            try:
+                self.MapSize = int(mapSize)
+            except ValueError:
+                logger.error("KERI_REGER_MAP_SIZE and KERI_BASER_MAP_SIZE must be an integer value >1!")
+                raise
 
         super(Reger, self).__init__(headDirPath=headDirPath, reopen=reopen, **kwa)
 

--- a/tests/app/test_keeping.py
+++ b/tests/app/test_keeping.py
@@ -16,6 +16,9 @@ import pysodium
 
 from hio.base import doing
 
+from keri.app.keeping import Keeper, KERIKeeperMapSizeKey
+from keri.db.basing import KERIBaserMapSizeKey
+from keri.db.dbing import LMDBer
 from keri.help import helping
 from keri.core import coring
 from keri.core.coring import IdrDex
@@ -1991,6 +1994,43 @@ def test_manager_sign_dual_indices():
     assert not os.path.exists(manager.ks.path)
     assert not manager.ks.opened
     """End Test"""
+
+def test_keeper_db_size_set_from_env_var():
+    # Clear environment before test
+    if KERIBaserMapSizeKey in os.environ:
+        os.environ.pop(KERIBaserMapSizeKey)
+    if KERIKeeperMapSizeKey in os.environ:
+        os.environ.pop(KERIKeeperMapSizeKey)
+
+    new_map_size = 10737418240
+
+    # Default map size works
+    kpr = Keeper(reopen=True)
+    assert kpr.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert kpr.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+
+    # Specific map size works
+    os.environ[KERIKeeperMapSizeKey] = f"{new_map_size}"
+
+    kpr = Keeper(reopen=True)
+    assert kpr.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ.pop(KERIKeeperMapSizeKey)
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ[KERIBaserMapSizeKey] = f"{baser_map_size}"
+
+    kpr = Keeper(reopen=True)
+    assert kpr.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # Bad map size throws
+    os.environ[KERIKeeperMapSizeKey] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        kpr = Keeper(reopen=True)
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
+    os.environ.pop(KERIBaserMapSizeKey)
+    os.environ.pop(KERIKeeperMapSizeKey)
+
 
 if __name__ == "__main__":
     test_manager_sign_dual_indices()

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -4,12 +4,16 @@ tests.app.test_multisig module
 
 """
 import datetime
+import os
 
 import pytest
 
 from keri.app import notifying, habbing
+from keri.app.notifying import Noter, KERINoterMapSizeKey
 from keri.core import coring
 from keri.db import dbing
+from keri.db.basing import KERIBaserMapSizeKey
+from keri.db.dbing import LMDBer
 from keri.help import helping
 
 
@@ -216,3 +220,38 @@ def test_notifier():
 
     assert notifier.mar(note.rid) is False
     assert notifier.rem(note.rid) is True
+
+def test_noter_db_size_set_from_env_var():
+    # Clear environment before test
+    if KERIBaserMapSizeKey in os.environ:
+        os.environ.pop(KERIBaserMapSizeKey)
+    if KERINoterMapSizeKey in os.environ:
+        os.environ.pop(KERINoterMapSizeKey)
+
+    new_map_size = 10737418240 # 10GB
+    # Default map size works
+    noter = Noter()
+    assert noter.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert noter.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+
+    # Specific map size works
+    os.environ[KERINoterMapSizeKey] = f"{new_map_size}"
+
+    noter = Noter()
+    assert noter.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ.pop(KERINoterMapSizeKey)
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ[KERIBaserMapSizeKey] = f"{baser_map_size}"
+
+    noter = Noter()
+    assert noter.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # bad map size throws
+    os.environ[KERINoterMapSizeKey] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        Noter()
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
+    os.environ.pop(KERIBaserMapSizeKey)
+    os.environ.pop(KERINoterMapSizeKey)

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -6,12 +6,15 @@ tests.peer.mailboxing
 import os
 
 import lmdb
+import pytest
 
 from keri.app import keeping
 from keri.core import coring, serdering
 from keri.db import dbing, basing
+from keri.db.basing import KERIBaserMapSizeKey
+from keri.db.dbing import LMDBer
 from keri.peer import exchanging
-from keri.app.storing import Mailboxer
+from keri.app.storing import Mailboxer, KERIMailboxerMapSizeKey
 
 
 def test_mailboxing():
@@ -108,6 +111,41 @@ def test_mailboxing():
         assert(len(msgs)) == 6
         assert msgs[0][0] == 4
 
+
+def test_mailbox_db_size_set_from_env_var():
+    # Clear environment before test
+    if KERIBaserMapSizeKey in os.environ:
+        os.environ.pop(KERIBaserMapSizeKey)
+    if KERIMailboxerMapSizeKey in os.environ:
+        os.environ.pop(KERIMailboxerMapSizeKey)
+
+    new_map_size = 10737418240
+    # Default map size works
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert mber.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+
+    # Specific map size works
+    os.environ[KERIMailboxerMapSizeKey] = f"{new_map_size}"
+
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ.pop(KERIMailboxerMapSizeKey)
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ[KERIBaserMapSizeKey] = f"{baser_map_size}"
+
+    mber = Mailboxer()
+    assert mber.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # Bad map size throws
+    os.environ[KERIMailboxerMapSizeKey] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        Mailboxer()
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
+    os.environ.pop(KERIBaserMapSizeKey)
+    os.environ.pop(KERIMailboxerMapSizeKey)
 
 
 if __name__ == '__main__':

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -231,11 +231,14 @@ def test_lmdber():
     databaser.reopen()
     assert databaser.opened
     assert databaser.env.info()['map_size'] == 2 * 1024**3  # 2GB
+    os.environ.pop('KERI_LMDB_MAP_SIZE')
 
     os.environ['KERI_LMDB_MAP_SIZE'] = f'invalid-size'  # will trigger default
     databaser.reopen()
     assert databaser.opened
-    assert databaser.env.info()['map_size'] == 4 * 1024 ** 3  # 4GB default value
+    assert databaser.env.info()['map_size'] == LMDBer.MapSize  # 10MB default value
+    os.environ.pop('KERI_LMDB_MAP_SIZE')
+
     assert isinstance(databaser.env, lmdb.Environment)
     assert databaser.path.endswith("keri/db/main")
     assert databaser.env.path() == databaser.path

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -8,10 +8,12 @@ import json
 import os
 
 import lmdb
+import pytest
 
 from keri.core.coring import Diger, versify, Serials
-from keri.db.dbing import openLMDB, dgKey, snKey
-from keri.vdr.viring import Reger
+from keri.db.basing import KERIBaserMapSizeKey
+from keri.db.dbing import openLMDB, dgKey, snKey, LMDBer
+from keri.vdr.viring import Reger, KERIRegerMapSizeKey
 
 
 def test_issuer():
@@ -340,6 +342,42 @@ def test_clone():
           b'n_1wWjlUslGkXfs0KyoNOEAAC_6PB5Zre_E_7YLkM9OtRo-uYmwRyFmOH3Xo4JDi'
           b'PjioY7Ycna6ouhSSH0QcKsEjce10HCXIW_XtmEYr9SrB5BA-GAB0AAAAAAAAAAAA'
           b'AAAAAAAAABCEzpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-PLMZ1H4')
+
+
+def test_mailbox_db_size_set_from_env_var():
+    # Clear environment before test
+    if KERIBaserMapSizeKey in os.environ:
+        os.environ.pop(KERIBaserMapSizeKey)
+    if KERIRegerMapSizeKey in os.environ:
+        os.environ.pop(KERIRegerMapSizeKey)
+
+    new_map_size = 10737418240
+    # Default map size works
+    reger = Reger()
+    assert reger.env.info()['map_size'] != new_map_size, "Expected map size to be the default 10MB"
+    assert reger.env.info()['map_size'] == LMDBer.MapSize, "Expected map size to be the default 10MB"
+
+    # Specific map size works
+    os.environ[KERIRegerMapSizeKey] = f"{new_map_size}"
+
+    reger = Reger()
+    assert reger.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+    os.environ.pop(KERIRegerMapSizeKey)
+
+    # generic map size works
+    baser_map_size = 10737418240
+    os.environ[KERIBaserMapSizeKey] = f"{baser_map_size}"
+
+    reger = Reger()
+    assert reger.env.info()['map_size'] == new_map_size, "Expected map size to be set from environment variable to 10GB"
+
+    # Bad map size throws
+    os.environ[KERIRegerMapSizeKey] = f"bad_map_size"
+    with pytest.raises(ValueError) as excinfo:
+        Reger()
+    assert "invalid literal for int" in str(excinfo.value), "Expected ValueError when map size is not an integer"
+    os.environ.pop(KERIBaserMapSizeKey)
+    os.environ.pop(KERIRegerMapSizeKey)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The default 10MB size limit on the Mailboxer LMDB database has been hit regularly for quite some time now, which has been causing odd behavior with witnesses. The stack trace shows the error coming up through `storing.py` as shown in the stack trace below. This PR adds configurability on a database by database basis as well as piggybacking off of the KERI_BASER_MAP_SIZE env var for simplicity. This problem exists on all major branches so there will be corresponding PRs to both `1.2.6` and `main`.

### Stack Trace

```python
Traceback (most recent call last):
  File "/keripy/src/keri/app/cli/kli.py", line 24, in main
    doers = args.handler(args)
            ^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 19, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
                                             ^^^^^^^^^^^^
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 66, in launch
    runWitness(name=args.name,
  File "/keripy/src/keri/app/cli/commands/witness/start.py", line 115, in runWitness
    directing.runController(doers=doers, expire=expire)
  File "/keripy/src/keri/app/directing.py", line 665, in runController
    doist.do(doers=doers)
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 156, in do
    self.recur()  # increments .tyme runs recur context
    ^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 275, in recur
    tock = dog.send(self.tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
                ^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
                ^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/venv/lib/python3.12/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
           ^^^^^^^^^^^^^^
  File "/keripy/src/keri/app/forwarding.py", line 86, in deliverDo
    yield from self.forwardToWitness(hab, ends[Roles.witness], recp=recp, serder=srdr, atc=atc, topic=tpc)
  File "/keripy/src/keri/app/forwarding.py", line 211, in forwardToWitness
    self.mbx.storeMsg(topic=f"{recp}/{topic}".encode("utf-8"), msg=msg)
  File "/keripy/src/keri/app/storing.py", line 131, in storeMsg
    return self.msgs.pin(keys=digb, val=msg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/db/subing.py", line 388, in pin
    return (self.db.setVal(db=self.sdb,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/keripy/src/keri/db/dbing.py", line 534, in setVal
    with self.env.begin(db=db, write=True, buffers=True) as txn:
lmdb.MapFullError: mdb_txn_commit: MDB_MAP_FULL: Environment mapsize limit reached

```