### PR TITLE
refactor delegate script to use separate witnesses

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-. "$(dirname "$0")/../demo-scripts.sh"
-. "$(dirname "$0")/script-utils.sh"
+source "$(dirname "$0")/script-utils.sh"
 
 delegator=$(random_name delegator)
 delegate=$(random_name delegate)

--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -8,15 +8,13 @@ delegator=$(random_name delegator)
 delegate=$(random_name delegate)
 validator=$(random_name validator)
 
-background_start kli init --name "$delegator" --nopasscode
-background_start kli init --name "$delegate" --nopasscode
-background_start kli init --name "$validator" --nopasscode
-background_wait
+kli init --name "$delegator" --nopasscode
+kli init --name "$delegate" --nopasscode
+kli init --name "$validator" --nopasscode
 
-background_start kli oobi resolve --name "$delegator" --oobi http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller
-background_start kli oobi resolve --name "$delegate" --oobi http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller
-background_start kli oobi resolve --name "$validator" --oobi http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller
-background_wait
+kli oobi resolve --name "$delegator" --oobi http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller
+kli oobi resolve --name "$delegate" --oobi http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller
+kli oobi resolve --name "$validator" --oobi http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller
 
 kli incept --name "$delegator" --alias delegator \
     --wit BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM \
@@ -69,18 +67,19 @@ cat << EOF > "$delegate_json"
 EOF
 
 # Create delegated identifier
-background_start kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json"
-background_start kli delegate confirm --name "$delegator" --alias delegator --interact -Y
-background_wait
+kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json" &
+pid=$!
+kli delegate confirm --name "$delegator" --alias delegator --interact -Y
+wait $pid
 
 kli status --name "$delegate" --alias delegate
 delegate_oobi=$(kli oobi generate --name "$delegate" --alias delegate --role witness | tail -n 1)
 delegate_aid=$(kli aid --name "$delegate" --alias delegate)
 
 # Rotate delegated identifier
-background_start kli rotate --name "$delegate" --alias delegate --proxy proxy
-background_start kli delegate confirm --name "$delegator" --alias delegator --interact -Y
-background_wait
+kli rotate --name "$delegate" --alias delegate --proxy proxy &
+pid=$!
+kli delegate confirm --name "$delegator" --alias delegator --interact -Y
 
 kli status --name "$delegate" --alias delegate
 

--- a/scripts/demo/basic/script-utils.sh
+++ b/scripts/demo/basic/script-utils.sh
@@ -20,3 +20,44 @@ print_lcyan() {
   text=$1
   printf "\e[96m${text}\e[0m\n"
 }
+
+random_name () {
+   suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c4)
+   prefix="${1:-test}"
+   echo "${prefix}_${suffix}"
+}
+
+teardown () {
+    echo "Teardown"
+    trap - SIGTERM && kill -- -$$
+}
+
+background_pids=()
+background_waiting=0
+background_start () {
+    if [[ $background_waiting -ne 0 ]]; then
+        echo "Currently waiting for background processes, cannot start new process" 1>&2
+        return 1
+    fi
+
+    "$@" &
+    background_pids+=("$!")
+}
+
+background_wait() {
+    if [[ $background_waiting -ne 0 ]]; then
+        echo "Already waiting for background processes, cannot wait again" 1>&2
+        return 1
+    fi
+
+    background_waiting=1
+    for p in "${background_pids[@]}"; do
+        if  [[ -n "$p" ]]; then
+            wait "$p"
+            background_pids=("${background_pids[@]/$p}")
+        fi
+    done
+    background_pids=()
+    background_waiting=0
+}
+

--- a/scripts/demo/basic/script-utils.sh
+++ b/scripts/demo/basic/script-utils.sh
@@ -26,38 +26,3 @@ random_name () {
    prefix="${1:-test}"
    echo "${prefix}_${suffix}"
 }
-
-teardown () {
-    echo "Teardown"
-    trap - SIGTERM && kill -- -$$
-}
-
-background_pids=()
-background_waiting=0
-background_start () {
-    if [[ $background_waiting -ne 0 ]]; then
-        echo "Currently waiting for background processes, cannot start new process" 1>&2
-        return 1
-    fi
-
-    "$@" &
-    background_pids+=("$!")
-}
-
-background_wait() {
-    if [[ $background_waiting -ne 0 ]]; then
-        echo "Already waiting for background processes, cannot wait again" 1>&2
-        return 1
-    fi
-
-    background_waiting=1
-    for p in "${background_pids[@]}"; do
-        if  [[ -n "$p" ]]; then
-            wait "$p"
-            background_pids=("${background_pids[@]/$p}")
-        fi
-    done
-    background_pids=()
-    background_waiting=0
-}
-


### PR DESCRIPTION
This illustrates the issue encountered in #975 and adds the steps needed to resolve it.

I have added some utility functions to make it easier to create isolated keystores and avoid creating config files for each AID. Please advice if you like this approach.

Closes #975 