### PR TITLE
add test script for multisig delegator to single sig delegatee

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -1,90 +1,45 @@
 #!/bin/bash
-set -e
+kli init --name delegate --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9aBc
+kli init --name delegator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWdoaWpsaw
+kli incept --name delegator --alias delegator --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
+kli oobi resolve --name delegate --oobi-alias delegator --oobi http://127.0.0.1:5642/oobi/EHpD0-CDWOdu5RJ8jHBSUkOqBZ3cXeDVHWNb_Ul89VI7/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
-. "$(dirname "$0")/../demo-scripts.sh"
-. "$(dirname "$0")/script-utils.sh"
+kli incept --name delegate --alias proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
+kli incept --name delegate --alias delegate --proxy proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegatee.json &
+pid=$!
+PID_LIST+=" $pid"
 
-delegator=$(random_name delegator)
-delegate=$(random_name delegate)
-validator=$(random_name validator)
+kli delegate confirm --name delegator --alias delegator -Y &
+pid=$!
+PID_LIST+=" $pid"
 
-background_start kli init --name "$delegator" --nopasscode
-background_start kli init --name "$delegate" --nopasscode
-background_start kli init --name "$validator" --nopasscode
-background_wait
+wait $PID_LIST
 
-background_start kli oobi resolve --name "$delegator" --oobi http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller
-background_start kli oobi resolve --name "$delegate" --oobi http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller
-background_start kli oobi resolve --name "$validator" --oobi http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller
-background_wait
+kli status --name delegate --alias delegate
 
-kli incept --name "$delegator" --alias delegator \
-    --wit BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
+echo "Now rotating delegate..."
+kli rotate --name delegate --alias delegate --proxy proxy &
+pid=$!
+PID_LIST="$pid"
 
-kli incept --name "$delegate" --alias proxy \
-    --wit BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
+echo "Checking for delegate rotate..."
+kli delegate confirm --name delegator --alias delegator -Y &
+pid=$!
+PID_LIST+=" $pid"
 
-kli incept --name "$validator" --alias validator \
-    --wit BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
+wait $PID_LIST
 
-kli ends add --name "$delegate" --alias proxy --eid "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha" --role mailbox
+kli status --name delegate --alias delegate
 
-delegator_oobi=$(kli oobi generate --name "$delegator" --alias delegator --role witness | tail -n 1)
-delegator_aid=$(kli aid --name "$delegator" --alias delegator)
-proxy_oobi=$(kli oobi generate --name "$delegate" --alias proxy --role witness | tail -n 1)
+kli init --name validator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9vAl
 
-kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
-kli oobi resolve --name "$delegator" --oobi-alias proxy --oobi "${proxy_oobi}"
+OOBI=$(kli oobi generate --name delegator --alias delegator --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegator --oobi "${OOBI}"
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegate --oobi "${OOBI}"
 
-delegate_json=$(mktemp)
-cat << EOF > "$delegate_json"
-{
-    "transferable": true,
-    "toad": 1,
-    "wits": ["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"],
-    "icount": 1,
-    "ncount": 1,
-    "isith": "1",
-    "nsith": "1",
-    "delpre": "$delegator_aid"
-}
-EOF
+AID=$(kli aid --name delegate --alias delegate)
+kli kevers --name validator --prefix "${AID}"
 
-# Create delegated identifier
-background_start kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json"
-background_start kli delegate confirm --name "$delegator" --alias delegator --interact -Y
-background_wait
 
-kli status --name "$delegate" --alias delegate
-delegate_oobi=$(kli oobi generate --name "$delegate" --alias delegate --role witness | tail -n 1)
-delegate_aid=$(kli aid --name "$delegate" --alias delegate)
 
-# Rotate delegated identifier
-background_start kli rotate --name "$delegate" --alias delegate --proxy proxy
-background_start kli delegate confirm --name "$delegator" --alias delegator --interact -Y
-background_wait
-
-kli status --name "$delegate" --alias delegate
-
-# 3rd party validated delegated identifier
-kli oobi resolve --name "$validator" --oobi-alias delegate --oobi "$delegate_oobi"
-kli oobi resolve --name "$validator" --oobi-alias delegator --oobi "$delegator_oobi"
-kli kevers --name "$validator" --prefix "$delegate_aid" --poll

--- a/scripts/demo/basic/multisig-delegator.sh
+++ b/scripts/demo/basic/multisig-delegator.sh
@@ -1,27 +1,24 @@
 #!/bin/bash
 set -e
 
-. "$(dirname "$0")/../demo-scripts.sh"
 . "$(dirname "$0")/script-utils.sh"
 
 delegator_1=$(random_name delegator_1)
 delegator_2=$(random_name delegator_2)
 delegate=$(random_name delegate)
 
-background_start kli init --name "$delegator_1" --nopasscode
-background_start kli init --name "$delegator_2" --nopasscode
-background_start kli init --name "$delegate" --nopasscode
-background_wait
+kli init --name "$delegator_1" --nopasscode
+kli init --name "$delegator_2" --nopasscode
+kli init --name "$delegate" --nopasscode
 
 delegator_witness_aid="BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM"
 delegator_witness_url="http://127.0.0.1:5643/oobi/$delegator_witness_aid/controller"
 delegate_witness_aid="BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"
 delegate_witness_url="http://127.0.0.1:5642/oobi/$delegate_witness_aid/controller"
 
-background_start kli oobi resolve --name "$delegator_1" --oobi "$delegator_witness_url"
-background_start kli oobi resolve --name "$delegator_2" --oobi "$delegator_witness_url"
-background_start kli oobi resolve --name "$delegate" --oobi "$delegate_witness_url"
-background_wait
+kli oobi resolve --name "$delegator_1" --oobi "$delegator_witness_url"
+kli oobi resolve --name "$delegator_2" --oobi "$delegator_witness_url"
+kli oobi resolve --name "$delegate" --oobi "$delegate_witness_url"
 
 kli incept --name "$delegator_1" --alias member --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegator_witness_aid"
 kli incept --name "$delegator_2" --alias member --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegator_witness_aid"
@@ -33,9 +30,8 @@ delegator_1_oobi=$(kli oobi generate --name "$delegator_1" --alias member --role
 delegator_2_aid=$(kli aid --name "$delegator_2" --alias member)
 delegator_2_oobi=$(kli oobi generate --name "$delegator_2" --alias member --role witness | tail -n 1)
 
-background_start kli oobi resolve --name "$delegator_1" --oobi "$delegator_2_oobi"
-background_start kli oobi resolve --name "$delegator_2" --oobi "$delegator_1_oobi"
-background_wait
+kli oobi resolve --name "$delegator_1" --oobi "$delegator_2_oobi"
+kli oobi resolve --name "$delegator_2" --oobi "$delegator_1_oobi"
 
 delegator_json=$(mktemp)
 cat << EOF > "$delegator_json"
@@ -49,9 +45,10 @@ cat << EOF > "$delegator_json"
 }
 EOF
 
-background_start kli multisig incept --name "$delegator_1" --alias member --group delegator --file "$delegator_json"
-background_start kli multisig incept --name "$delegator_2" --alias member --group delegator --file "$delegator_json"
-background_wait
+kli multisig incept --name "$delegator_1" --alias member --group delegator --file "$delegator_json" &
+pid=$!
+kli multisig incept --name "$delegator_2" --alias member --group delegator --file "$delegator_json"
+wait $pid
 
 # Create proxy and resolve OOBIs
 kli incept --name "$delegate" --alias proxy --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegate_witness_aid"
@@ -60,10 +57,9 @@ proxy_oobi=$(kli oobi generate --name "$delegate" --alias proxy --role witness |
 delegator_oobi=$(kli oobi generate --name "$delegator_1" --alias delegator --role witness | tail -n 1)
 delegator_aid=$(kli aid --name "$delegator_1" --alias delegator)
 
-background_start kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
-background_start kli oobi resolve --name "$delegator_1" --oobi-alias proxy --oobi "${proxy_oobi}"
-background_start kli oobi resolve --name "$delegator_2" --oobi-alias proxy --oobi "${proxy_oobi}"
-background_wait
+kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
+kli oobi resolve --name "$delegator_1" --oobi-alias proxy --oobi "${proxy_oobi}"
+kli oobi resolve --name "$delegator_2" --oobi-alias proxy --oobi "${proxy_oobi}"
 
 delegate_json=$(mktemp)
 cat << EOF > "$delegate_json"
@@ -80,9 +76,12 @@ cat << EOF > "$delegate_json"
 EOF
 
 # Create delegated identifier
-background_start kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json"
-background_start kli delegate confirm --name "$delegator_1" --alias delegator --interact -Y
-background_start kli delegate confirm --name "$delegator_2" --alias delegator --interact -Y
-background_wait
+kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json" &
+PID_LIST="$!"
+kli delegate confirm --name "$delegator_1" --alias delegator --interact -Y &
+PID_LIST+=" $!"
+kli delegate confirm --name "$delegator_2" --alias delegator --interact -Y &
+PID_LIST+=" $!"
+wait $PID_LIST
 
 kli status --name "$delegate" --alias delegate

--- a/scripts/demo/basic/multisig-delegator.sh
+++ b/scripts/demo/basic/multisig-delegator.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -e
+
+. "$(dirname "$0")/../demo-scripts.sh"
+. "$(dirname "$0")/script-utils.sh"
+
+delegator_1=$(random_name delegator_1)
+delegator_2=$(random_name delegator_2)
+delegate=$(random_name delegate)
+
+background_start kli init --name "$delegator_1" --nopasscode
+background_start kli init --name "$delegator_2" --nopasscode
+background_start kli init --name "$delegate" --nopasscode
+background_wait
+
+delegator_witness_aid="BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM"
+delegator_witness_url="http://127.0.0.1:5643/oobi/$delegator_witness_aid/controller"
+delegate_witness_aid="BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"
+delegate_witness_url="http://127.0.0.1:5642/oobi/$delegate_witness_aid/controller"
+
+background_start kli oobi resolve --name "$delegator_1" --oobi "$delegator_witness_url"
+background_start kli oobi resolve --name "$delegator_2" --oobi "$delegator_witness_url"
+background_start kli oobi resolve --name "$delegate" --oobi "$delegate_witness_url"
+background_wait
+
+kli incept --name "$delegator_1" --alias member --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegator_witness_aid"
+kli incept --name "$delegator_2" --alias member --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegator_witness_aid"
+kli ends add --name "$delegator_1" --alias member --eid "$delegator_witness_aid" --role mailbox
+kli ends add --name "$delegator_2" --alias member --eid "$delegator_witness_aid" --role mailbox
+
+delegator_1_aid=$(kli aid --name "$delegator_1" --alias member)
+delegator_1_oobi=$(kli oobi generate --name "$delegator_1" --alias member --role witness | tail -n 1)
+delegator_2_aid=$(kli aid --name "$delegator_2" --alias member)
+delegator_2_oobi=$(kli oobi generate --name "$delegator_2" --alias member --role witness | tail -n 1)
+
+background_start kli oobi resolve --name "$delegator_1" --oobi "$delegator_2_oobi"
+background_start kli oobi resolve --name "$delegator_2" --oobi "$delegator_1_oobi"
+background_wait
+
+delegator_json=$(mktemp)
+cat << EOF > "$delegator_json"
+{
+  "transferable": true,
+  "wits": ["$delegator_witness_aid"],
+  "aids": ["$delegator_1_aid", "$delegator_2_aid"],
+  "toad": 1,
+  "isith": "2",
+  "nsith": "2"
+}
+EOF
+
+background_start kli multisig incept --name "$delegator_1" --alias member --group delegator --file "$delegator_json"
+background_start kli multisig incept --name "$delegator_2" --alias member --group delegator --file "$delegator_json"
+background_wait
+
+# timestamp=$(kli time)
+# background_start kli ends add --name "$delegator_1" --alias delegator --eid "$delegator_witness_aid" --role mailbox --time "$timestamp"
+# background_start kli ends add --name "$delegator_2" --alias delegator --eid "$delegator_witness_aid" --role mailbox --time "$timestamp"
+# background_wait
+
+# Create proxy and resolve OOBIs
+kli incept --name "$delegate" --alias proxy --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegate_witness_aid"
+kli ends add --name "$delegate" --alias proxy --eid "$delegate_witness_aid" --role mailbox
+proxy_oobi=$(kli oobi generate --name "$delegate" --alias proxy --role witness | tail -n 1)
+delegator_oobi=$(kli oobi generate --name "$delegator_1" --alias delegator --role witness | tail -n 1)
+delegator_aid=$(kli aid --name "$delegator_1" --alias delegator)
+
+background_start kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
+background_start kli oobi resolve --name "$delegate" --oobi-alias delegator_1 --oobi "${delegator_1_oobi}"
+background_start kli oobi resolve --name "$delegate" --oobi-alias delegator_2 --oobi "${delegator_2_oobi}"
+background_start kli oobi resolve --name "$delegator_1" --oobi-alias proxy --oobi "${proxy_oobi}"
+background_start kli oobi resolve --name "$delegator_2" --oobi-alias proxy --oobi "${proxy_oobi}"
+background_wait
+
+delegate_json=$(mktemp)
+cat << EOF > "$delegate_json"
+{
+    "transferable": true,
+    "toad": 1,
+    "wits": ["$delegate_witness_aid"],
+    "icount": 1,
+    "ncount": 1,
+    "isith": "1",
+    "nsith": "1",
+    "delpre": "$delegator_aid"
+}
+EOF
+
+# Create delegated identifier
+background_start kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json"
+sleep 2
+background_start kli delegate confirm --name "$delegator_1" --alias delegator --interact -Y
+background_start kli delegate confirm --name "$delegator_2" --alias delegator --interact -Y
+background_wait
+
+kli status --name "$delegate" --alias delegate

--- a/scripts/demo/basic/multisig-delegator.sh
+++ b/scripts/demo/basic/multisig-delegator.sh
@@ -53,11 +53,6 @@ background_start kli multisig incept --name "$delegator_1" --alias member --grou
 background_start kli multisig incept --name "$delegator_2" --alias member --group delegator --file "$delegator_json"
 background_wait
 
-# timestamp=$(kli time)
-# background_start kli ends add --name "$delegator_1" --alias delegator --eid "$delegator_witness_aid" --role mailbox --time "$timestamp"
-# background_start kli ends add --name "$delegator_2" --alias delegator --eid "$delegator_witness_aid" --role mailbox --time "$timestamp"
-# background_wait
-
 # Create proxy and resolve OOBIs
 kli incept --name "$delegate" --alias proxy --icount 1 --ncount 1 --isith 1 --nsith 1 --transferable --toad 1 --wit "$delegate_witness_aid"
 kli ends add --name "$delegate" --alias proxy --eid "$delegate_witness_aid" --role mailbox
@@ -88,7 +83,6 @@ EOF
 
 # Create delegated identifier
 background_start kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json"
-sleep 2
 background_start kli delegate confirm --name "$delegator_1" --alias delegator --interact -Y
 background_start kli delegate confirm --name "$delegator_2" --alias delegator --interact -Y
 background_wait

--- a/scripts/demo/basic/multisig-delegator.sh
+++ b/scripts/demo/basic/multisig-delegator.sh
@@ -61,8 +61,6 @@ delegator_oobi=$(kli oobi generate --name "$delegator_1" --alias delegator --rol
 delegator_aid=$(kli aid --name "$delegator_1" --alias delegator)
 
 background_start kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
-background_start kli oobi resolve --name "$delegate" --oobi-alias delegator_1 --oobi "${delegator_1_oobi}"
-background_start kli oobi resolve --name "$delegate" --oobi-alias delegator_2 --oobi "${delegator_2_oobi}"
 background_start kli oobi resolve --name "$delegator_1" --oobi-alias proxy --oobi "${proxy_oobi}"
 background_start kli oobi resolve --name "$delegator_2" --oobi-alias proxy --oobi "${proxy_oobi}"
 background_wait

--- a/scripts/demo/basic/script-utils.sh
+++ b/scripts/demo/basic/script-utils.sh
@@ -20,3 +20,44 @@ print_lcyan() {
   text=$1
   printf "\e[96m${text}\e[0m\n"
 }
+
+random_name () {
+   suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c4)
+   prefix="${1:-test}"
+   echo "${prefix}_${suffix}"
+}
+
+teardown () {
+    echo "Teardown"
+    trap - SIGTERM && kill -- -$$
+}
+
+background_pids=()
+background_waiting=0
+background_start () {
+    if [[ $background_waiting -ne 0 ]]; then
+        echo "Currently waiting for background processes, cannot start new process" 1>&2
+        return 1
+    fi
+
+    "$@" &
+    background_pids+=("$!")
+}
+
+background_wait() {
+    if [[ $background_waiting -ne 0 ]]; then
+        echo "Already waiting for background processes, cannot wait again" 1>&2
+        return 1
+    fi
+
+    background_waiting=1
+    for p in "${background_pids[@]}"; do
+        if  [[ -n "$p" ]]; then
+            wait "$p"
+            background_pids=("${background_pids[@]/$p}")
+        fi
+    done
+    background_pids=()
+    background_waiting=0
+}
+

--- a/scripts/demo/basic/script-utils.sh
+++ b/scripts/demo/basic/script-utils.sh
@@ -26,38 +26,3 @@ random_name () {
    prefix="${1:-test}"
    echo "${prefix}_${suffix}"
 }
-
-teardown () {
-    echo "Teardown"
-    trap - SIGTERM && kill -- -$$
-}
-
-background_pids=()
-background_waiting=0
-background_start () {
-    if [[ $background_waiting -ne 0 ]]; then
-        echo "Currently waiting for background processes, cannot start new process" 1>&2
-        return 1
-    fi
-
-    "$@" &
-    background_pids+=("$!")
-}
-
-background_wait() {
-    if [[ $background_waiting -ne 0 ]]; then
-        echo "Already waiting for background processes, cannot wait again" 1>&2
-        return 1
-    fi
-
-    background_waiting=1
-    for p in "${background_pids[@]}"; do
-        if  [[ -n "$p" ]]; then
-            wait "$p"
-            background_pids=("${background_pids[@]/$p}")
-        fi
-    done
-    background_pids=()
-    background_waiting=0
-}
-

--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -59,9 +59,13 @@ printf "\n************************************\n"
 "${script_dir}/basic/multisig-rotate-three-stooges.sh"
 isSuccess
 
+printf "Running multisig-delegator.sh"
+printf "\n************************************\n"
+"${script_dir}/basic/multisig-delegator.sh"
+isSuccess
+
 printf "\n************************************\n"
 printf "Running multisig-delegate-delegator.sh"
-printf "\n************************************\n"
 "${script_dir}/basic/multisig-delegate-delegator.sh"
 isSuccess
 


### PR DESCRIPTION
~~The `dip` event never ended up in the delegables escrow. See change in eventing.py.~~

Same fix was merged in #997.

This PR now only adds a test script for multisig delegator to single sig delegatee using _separate_ witnesses for delegator and delegatee.

See also #992, I use the same utility functions and approach to test script here. I can change the other scripts to be implemented this way as well. I can also just put these scripts in a separate repository. Let me know.