### PR TITLE
feat: configure LMDB db sizes in config file

### DIFF
--- a/scripts/keri/cf/main/wan.json
+++ b/scripts/keri/cf/main/wan.json
@@ -1,5 +1,25 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wan": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5632/", "http://127.0.0.1:5642/"]

--- a/scripts/keri/cf/main/wan.json
+++ b/scripts/keri/cf/main/wan.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wan": {

--- a/scripts/keri/cf/main/wes.json
+++ b/scripts/keri/cf/main/wes.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wes": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5634/", "http://127.0.0.1:5644/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wes.json
+++ b/scripts/keri/cf/main/wes.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wes": {

--- a/scripts/keri/cf/main/wil.json
+++ b/scripts/keri/cf/main/wil.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wil": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5633/", "http://127.0.0.1:5643/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wil.json
+++ b/scripts/keri/cf/main/wil.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wil": {

--- a/scripts/keri/cf/main/wit.json
+++ b/scripts/keri/cf/main/wit.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wit": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5635/", "http://127.0.0.1:5645/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wit.json
+++ b/scripts/keri/cf/main/wit.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wit": {

--- a/scripts/keri/cf/main/wub.json
+++ b/scripts/keri/cf/main/wub.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wub": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5636/", "http://127.0.0.1:5646/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wub.json
+++ b/scripts/keri/cf/main/wub.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wub": {

--- a/scripts/keri/cf/main/wyz.json
+++ b/scripts/keri/cf/main/wyz.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wyz": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5637/", "http://127.0.0.1:5647/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wyz.json
+++ b/scripts/keri/cf/main/wyz.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wyz": {

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -14,9 +14,7 @@ from hio.help import hicting
 
 from keri.peer import exchanging
 from . import keeping, configing
-from .. import help
-from .. import kering
-from .. import core
+from .. import help, kering, core
 from ..core import (coring, eventing, parsing, routing, serdering, indexing,
                     Counter, Codens)
 from ..db import dbing, basing
@@ -203,23 +201,27 @@ class Habery:
         self.base = base
         self.temp = temp
 
-        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
-                                                           base=self.base,
-                                                           temp=self.temp,
-                                                           reopen=True,
-                                                           clear=clear,
-                                                           headDirPath=headDirPath)
-        self.db = db if db is not None else basing.Baser(name=self.name,
-                                                         base=self.base,
-                                                         temp=self.temp,
-                                                         reopen=True,
-                                                         clear=clear,
-                                                         headDirPath=headDirPath)
         self.cf = cf if cf is not None else configing.Configer(name=self.name,
                                                                base=self.base,
                                                                temp=self.temp,
                                                                reopen=True,
                                                                clear=clear)
+        logger.info("[%s] Habery config file %s at %s", self.name, self.cf.name, self.cf.path)
+
+        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
+                                                           base=self.base,
+                                                           temp=self.temp,
+                                                           reopen=True,
+                                                           clear=clear,
+                                                           headDirPath=headDirPath,
+                                                           cf=cf)
+        self.db = db if db is not None else basing.Baser(name=self.name,
+                                                         base=self.base,
+                                                         temp=self.temp,
+                                                         reopen=True,
+                                                         clear=clear,
+                                                         headDirPath=headDirPath,
+                                                         cf=cf)
 
         self.mgr = None  # wait to setup until after ks is known to be opened
         self.rtr = routing.Router()

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -262,7 +262,7 @@ class Keeper(dbing.LMDBer):
         Open sub databases
         """
         opened = super(Keeper, self).reopen(**kwa)
-        logger.info("[%s] Keeper map size set to %s", self.name, self.mapSize)
+        logger.debug("[%s] Keeper map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -29,11 +29,12 @@ from dataclasses import dataclass, asdict, field
 import pysodium
 from hio.base import doing
 
-from .. import kering
-from .. import core
+from .. import core, help, kering
 from ..core import coring
 from ..db import dbing, subing, koming
 from ..help import helping
+
+logger = help.ogler.getLogger()
 
 Algoage = namedtuple("Algoage", 'randy salty group extern')
 Algos = Algoage(randy='randy', salty='salty', group="group", extern="extern")  # randy is rerandomize, salty is use salt
@@ -214,6 +215,7 @@ class Keeper(dbing.LMDBer):
     AltTailDirPath = ".keri/ks"
     TempPrefix = "keri_ks_"
     MaxNamedDBs = 10
+    ConfigKey = "keeper"
 
     def __init__(self, headDirPath=None, perm=None, reopen=False, **kwa):
         """
@@ -235,6 +237,7 @@ class Keeper(dbing.LMDBer):
                 default perm=None so do not set mode
             reopen is boolean, IF True then database will be reopened by this init
                 default reopen=True
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
 
         Notes:
 
@@ -259,6 +262,7 @@ class Keeper(dbing.LMDBer):
         Open sub databases
         """
         opened = super(Keeper, self).reopen(**kwa)
+        logger.info("[%s] Keeper map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -6,11 +6,13 @@ keri.app.notifying module
 from collections.abc import Iterable
 from typing import Union, Type
 
-from keri import kering
+from keri import kering, help
 from keri.help import helping
 from keri.app import signaling
 from keri.core import coring
 from keri.db import dbing, subing
+
+logger = help.ogler.getLogger()
 
 
 def notice(attrs, dt=None, read=False):
@@ -207,15 +209,18 @@ class Noter(dbing.LMDBer):
     TailDirPath = "keri/not"
     AltTailDirPath = ".keri/not"
     TempPrefix = "keri_not_"
+    ConfigKey = "noter"
 
     def __init__(self, name="not", headDirPath=None, reopen=True, **kwa):
         """
+        Sets up a named notification database where all notifications for a controller are stored.
 
-        Parameters:
-            headDirPath:
-            perm:
-            reopen:
-            kwa:
+        headDirPath(str): optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+            perm(int): is numeric os permissions for directory and/or file(s)
+            reopen(bool): True means database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
+            kwa: pass through init args to reopen and LMDBer
         """
         self.notes = None
         self.nidx = None
@@ -225,11 +230,13 @@ class Noter(dbing.LMDBer):
 
     def reopen(self, **kwa):
         """
+        Sets up specific named LMDB sub databases to be opened.
 
-        :param kwa:
+        :param kwa: pass through init args to reopen and LMDBer
         :return:
         """
         super(Noter, self).reopen(**kwa)
+        logger.info("[%s] Noter map size set to %s", self.name, self.mapSize)
 
         self.notes = DicterSuber(db=self, subkey='nots.', sep='/', klas=Notice)
         self.nidx = subing.Suber(db=self, subkey='nidx.')

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -25,15 +25,19 @@ class Mailboxer(dbing.LMDBer):
     TailDirPath = "keri/mbx"
     AltTailDirPath = ".keri/mbx"
     TempPrefix = "keri_mbx_"
+    ConfigKey = "mailboxer"
 
     def __init__(self, name="mbx", headDirPath=None, reopen=True, **kwa):
         """
+        Sets up the mailbox named sub database where all mailbox messages are stored.
 
         Parameters:
-            headDirPath:
-            perm:
-            reopen:
-            kwa:
+            headDirPath(str): optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+            perm(int): is numeric os permissions for directory and/or file(s)
+            reopen(bool): True means database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
+            kwa: pass through init args to reopen and LMDBer
 
         Mailboxer uses two dbs for mailbox messages these are .tpcs and .msgs.
         The message index is in .tpcs (topics).
@@ -58,6 +62,7 @@ class Mailboxer(dbing.LMDBer):
         :return:
         """
         super(Mailboxer, self).reopen(**kwa)
+        logger.info("[%s] Mailboxer map size set to %s", self.name, self.mapSize)
         self.tpcs = subing.OnSuber(db=self, subkey='tpcs.')
         self.msgs = subing.Suber(db=self, subkey='msgs.')  # key states
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -943,6 +943,7 @@ class Baser(dbing.LMDBer):
         kevers (dbdict): read through cache of kevers of states for KELs in db
 
     """
+    ConfigKey = "baser"
 
     def __init__(self, headDirPath=None, reopen=False, **kwa):
         """
@@ -959,17 +960,17 @@ class Baser(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode is int numeric os dir permissions for database directory
             reopen (bool): True means database will be reopened by this init
-
-
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
         """
         self.prefixes = oset()  # should change to hids for hab ids
         self.groups = oset()  # group hab ids
         self._kevers = dbdict()
         self._kevers.db = self  # assign db for read through cache of kevers
 
+        # Alternate way to set map size by environment variable
         if (mapSize := os.getenv(KERIBaserMapSizeKey)) is not None:
             try:
-                self.MapSize = int(mapSize)
+                self.mapSize = int(mapSize)
             except ValueError:
                 logger.error("KERI_BASER_MAP_SIZE must be an integer value >1!")
                 raise
@@ -1000,6 +1001,7 @@ class Baser(dbing.LMDBer):
 
         """
         super(Baser, self).reopen(**kwa)
+        logger.debug("[%s] Baser map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -421,12 +421,9 @@ class LMDBer(filing.Filer):
 
         cf = cf if cf is not None else self.cf
         config = cf.get() if cf is not None else None
-        lmdberConf = config.get(LMDBer.ConfigKey) if config is not None else None
         dbconf = config.get(self.ConfigKey, None) if config is not None else None
         if dbconf is not None:
             self.mapSize = dbconf.get("mapSize", 104_857_600)  # 10MB default
-        elif config and lmdberConf: # fall back to LMDBer size if present
-            self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
 
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -313,6 +313,7 @@ class LMDBer(filing.Filer):
     Attributes:
         env (lmdb.env): LMDB main (super) database environment
         readonly (bool): True means open LMDB env as readonly
+        cf (Configer): optional Configer to configure the opened LMDB database
 
     Properties:
 
@@ -340,7 +341,7 @@ class LMDBer(filing.Filer):
     TempSuffix = "_test"
     Perm = stat.S_ISVTX | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR  # 0o1700==960
     MaxNamedDBs = 96
-    MapSize = 104857600
+    ConfigKey = 'lmdber'
 
     def __init__(self, readonly=False, **kwa):
         """
@@ -376,18 +377,21 @@ class LMDBer(filing.Filer):
 
             readonly (bool): True means open database in readonly mode
                                 False means open database in read/write mode
+            cf (Configer): optional Configer to configure the opened LMDB database
 
         """
 
         self.env = None
         self._version = None
         self.readonly = True if readonly else False
+        self._mapSize = 104_857_600  # 10MB fallback default
+        self.cf = kwa["cf"] if "cf" in kwa else None
         super(LMDBer, self).__init__(**kwa)
 
     def reopen(self, readonly=False, **kwa):
         """
         Open if closed or close and reopen if opened or create and open if not
-        if not preexistent, directory path for lmdb at .path and then
+        preexistent, directory path for lmdb at .path and then
         Open lmdb and assign to .env
 
         Parameters:
@@ -408,15 +412,21 @@ class LMDBer(filing.Filer):
             fext (str): File extension when .filed
             readonly (bool): True means open database in readonly mode
                                 False means open database in read/write mode
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
         """
         exists = self.exists(name=self.name, base=self.base)
         opened = super(LMDBer, self).reopen(**kwa)
         if readonly is not None:
             self.readonly = readonly
 
+        config = self.cf.get() if self.cf is not None else None
+        lmdberConf = config.get(self.ConfigKey, None) if config is not None else None
+        if lmdberConf is not None:
+            self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
+
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
-        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.MapSize,
+        self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.mapSize,
                              mode=self.perm, readonly=self.readonly)
 
         self.opened = True if opened and self.env else False
@@ -454,6 +464,34 @@ class LMDBer(filing.Filer):
 
         self._version = val
         self.setVer(self._version)
+
+    @property
+    def mapSize(self):
+        """
+        Get LMDB map size (database file size) limit for this instance.
+        Returns:
+            int: the map size limit for this instance
+        """
+        if self._mapSize is None:
+            self._mapSize = 104_857_600  # 512MB fallback default
+        return self._mapSize
+
+    @mapSize.setter
+    def mapSize(self, val):
+        """
+        Set LMDB map size (database file size) limit for this instance.
+        Parameters:
+            val (int): the new map size limit for this instance
+        """
+        if val is None:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        try:
+            val = int(val)
+        except ValueError:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        if val <= 0:
+            raise ValueError(f"Invalid map size {val=}. Must be positive integer.")
+        self._mapSize = val
 
     def close(self, clear=False):
         """

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -238,6 +238,7 @@ class Reger(dbing.LMDBer):
     TailDirPath = "keri/reg"
     AltTailDirPath = ".keri/reg"
     TempPrefix = "keri_reg_"
+    ConfigKey = "reger"
 
     def __init__(self, headDirPath=None, reopen=True, **kwa):
         """
@@ -254,6 +255,7 @@ class Reger(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode (int): numeric os dir permissions for database directory
             reopen (boolean,): IF True then database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
 
         Notes:
 
@@ -294,6 +296,7 @@ class Reger(dbing.LMDBer):
 
         """
         super(Reger, self).reopen(**kwa)
+        logger.info("[%s] Reger map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/tests/app/test_keeping.py
+++ b/tests/app/test_keeping.py
@@ -7,16 +7,14 @@ import pytest
 
 import os
 import stat
-import json
 from dataclasses import asdict
-from math import ceil
 
 import lmdb
-import pysodium
 
 from hio.base import doing
 
 from keri import kering
+from keri.app.keeping import Keeper
 from keri.help import helping
 
 from keri import core
@@ -24,7 +22,7 @@ from keri import core
 from keri.core import coring, indexing
 from keri.core.indexing import IdrDex
 
-from keri.app import keeping
+from keri.app import keeping, configing
 
 
 def test_dataclasses():
@@ -1996,6 +1994,18 @@ def test_manager_sign_dual_indices():
     assert not os.path.exists(manager.ks.path)
     assert not manager.ks.opened
     """End Test"""
+
+def test_keeper_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        keeper=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    keeper = Keeper(reopen=True,cf=cf)  # default is to not reopen
+    assert keeper.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 if __name__ == "__main__":
     test_manager_sign_dual_indices()

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -7,7 +7,8 @@ import datetime
 
 import pytest
 
-from keri.app import notifying, habbing
+from keri.app import notifying, habbing, configing
+from keri.app.notifying import Noter
 from keri.core import coring
 from keri.db import dbing
 from keri.help import helping
@@ -221,3 +222,16 @@ def test_notifier(mockHelpingNowUTC):
 
     assert notifier.mar(note.rid) is False
     assert notifier.rem(note.rid) is True
+
+
+def test_noter_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        noter=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    noter = Noter(reopen=True,cf=cf)  # default is to not reopen
+    assert noter.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -7,7 +7,7 @@ import os
 
 import lmdb
 
-from keri.app import keeping
+from keri.app import keeping, configing
 from keri.core import coring, serdering
 from keri.db import dbing, basing, subing
 from keri.peer import exchanging
@@ -110,6 +110,17 @@ def test_mailboxing():
         #assert msgs[0][0] == 4
 
 
+def test_mailboxer_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        mailboxer=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    mailboxer = Mailboxer(reopen=True,cf=cf)  # default is to not reopen
+    assert mailboxer.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 if __name__ == '__main__':
     test_mailboxing()

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -12,7 +12,7 @@ import pytest
 import lmdb
 from hio.base import doing
 from keri import core
-from keri.app import habbing
+from keri.app import habbing, configing
 from keri.core import coring, eventing, serdering
 from keri.core.coring import Kinds, versify, Seqner
 from keri.core.eventing import incept, rotate, interact, Kever
@@ -1906,6 +1906,19 @@ def test_clear_escrows():
         assert db.udes.cntAll() == 0
         assert db.epsd.cntAll() == 0
         assert db.dpub.cntAll() == 0
+
+def test_baser_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        baser=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    baser = Baser(reopen=True,cf=cf)  # default is to not reopen
+    assert baser.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
+
 
 if __name__ == "__main__":
     test_baser()

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -6,18 +6,15 @@ tests.db.dbing module
 import pytest
 
 import os
-import json
-import datetime
 
 import lmdb
 from  ordered_set import OrderedSet as oset
 
-from hio.base import doing
-
+from keri.app import configing
 from keri.db import dbing
-from keri.db.dbing import clearDatabaserDir, openLMDB
-from keri.db.dbing import (dgKey, onKey, fnKey, snKey, dtKey, splitKey,
-                           splitOnKey, splitKeyFN, splitSnKey, splitKeyDT)
+from keri.db.dbing import openLMDB
+from keri.db.dbing import (dgKey, onKey, snKey, dtKey, splitKey,
+                           splitOnKey, splitSnKey, splitKeyDT)
 from keri.db.dbing import LMDBer
 
 
@@ -1152,6 +1149,46 @@ def test_lmdber():
     assert not os.path.exists(dber.path)
 
     """ End Test """
+
+
+def test_lmdber_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        lmdber=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    databaser = LMDBer(cf=cf)
+    assert databaser.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
+
+    badConfigStr = dict(
+        lmdber=dict(
+            mapSize="somestr"
+        )
+    )
+    cf.put(badConfigStr)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
+
+    badConfigNone = dict(
+        lmdber=dict(
+            mapSize=None
+        )
+    )
+    cf.put(badConfigNone)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
+
+    badConfigNeg = dict(
+        lmdber=dict(
+            mapSize=-1
+        )
+    )
+    cf.put(badConfigNeg)
+    with pytest.raises(ValueError):
+        LMDBer(cf=cf)
 
 
 if __name__ == "__main__":

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -10,6 +10,7 @@ import os
 import lmdb
 
 from keri import kering
+from keri.app import configing
 from keri.core import coring
 from keri.core.coring import Diger, versify, Kinds
 from keri.core.serdering import SerderACDC
@@ -400,6 +401,18 @@ def test_clearEscrows():
         assert db.tpwe.cntAll() == 0
         assert db.tmse.cntAll() == 0
         assert db.tede.cntAll() == 0
+
+def test_reger_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        reger=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    reger = Reger(reopen=True,cf=cf)  # default is to not reopen
+    assert reger.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 if __name__ == "__main__":
     test_issuer()


### PR DESCRIPTION
Adds ability to configure LMDB sizes using the bootstrap configuration file.
Also adds some INFO level logging on the config file location and database sizes set.

Adds the `.mapSize` property to LMDBer and the `LMDBer.ConfigKey` that is overridden in each subclass. This config key is used to select a subset of the overall config file to use to configure each LMDBer subclass.

For backwards compatibility the `KERI_BASER_MAP_SIZE` environment variable still works, yet may be deprecated in the future. Moving forward using the configuration file as the single source of truth for configuration is the recommended path.