### PR TITLE
feat: configure LMDB db sizes in config file

### DIFF
--- a/scripts/keri/cf/main/wan.json
+++ b/scripts/keri/cf/main/wan.json
@@ -1,5 +1,25 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wan": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5632/", "http://127.0.0.1:5642/"]

--- a/scripts/keri/cf/main/wan.json
+++ b/scripts/keri/cf/main/wan.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wan": {

--- a/scripts/keri/cf/main/wes.json
+++ b/scripts/keri/cf/main/wes.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wes": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5634/", "http://127.0.0.1:5644/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wes.json
+++ b/scripts/keri/cf/main/wes.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wes": {

--- a/scripts/keri/cf/main/wil.json
+++ b/scripts/keri/cf/main/wil.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wil": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5633/", "http://127.0.0.1:5643/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wil.json
+++ b/scripts/keri/cf/main/wil.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wil": {

--- a/scripts/keri/cf/main/wit.json
+++ b/scripts/keri/cf/main/wit.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wit": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5635/", "http://127.0.0.1:5645/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wit.json
+++ b/scripts/keri/cf/main/wit.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wit": {

--- a/scripts/keri/cf/main/wub.json
+++ b/scripts/keri/cf/main/wub.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wub": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5636/", "http://127.0.0.1:5646/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wub.json
+++ b/scripts/keri/cf/main/wub.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wub": {

--- a/scripts/keri/cf/main/wyz.json
+++ b/scripts/keri/cf/main/wyz.json
@@ -1,9 +1,29 @@
 {
+  "dt": "2022-01-20T12:57:59.823350+00:00",
+  "baser": {
+    // LMDB Map size - 1 GB
+    "mapSize": 1073741824
+  },
+  "keeper": {
+    // LMDB Map Size - 25 MB
+    "mapSize": 26214400
+  },
+  "mailboxer": {
+    // LMDB Map Size - 16.384 GB
+    "mapSize": 17179869184
+  },
+  "reger": {
+    // LMDB Map Size - 512 MB
+    "mapSize": 536870912
+  },
+  "noter": {
+    // LMDB Map Size - 128 MB
+    "mapSize": 134217728
+  },
   "wyz": {
     "dt": "2022-01-20T12:57:59.823350+00:00",
     "curls": ["tcp://127.0.0.1:5637/", "http://127.0.0.1:5647/"]
   },
-  "dt": "2022-01-20T12:57:59.823350+00:00",
   "iurls": [
   ]
 }

--- a/scripts/keri/cf/main/wyz.json
+++ b/scripts/keri/cf/main/wyz.json
@@ -1,23 +1,18 @@
 {
   "dt": "2022-01-20T12:57:59.823350+00:00",
   "baser": {
-    // LMDB Map size - 1 GB
     "mapSize": 1073741824
   },
   "keeper": {
-    // LMDB Map Size - 25 MB
     "mapSize": 26214400
   },
   "mailboxer": {
-    // LMDB Map Size - 16.384 GB
     "mapSize": 17179869184
   },
   "reger": {
-    // LMDB Map Size - 512 MB
     "mapSize": 536870912
   },
   "noter": {
-    // LMDB Map Size - 128 MB
     "mapSize": 134217728
   },
   "wyz": {

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -203,23 +203,25 @@ class Habery:
         self.base = base
         self.temp = temp
 
-        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
-                                                           base=self.base,
-                                                           temp=self.temp,
-                                                           reopen=True,
-                                                           clear=clear,
-                                                           headDirPath=headDirPath)
-        self.db = db if db is not None else basing.Baser(name=self.name,
-                                                         base=self.base,
-                                                         temp=self.temp,
-                                                         reopen=True,
-                                                         clear=clear,
-                                                         headDirPath=headDirPath)
         self.cf = cf if cf is not None else configing.Configer(name=self.name,
                                                                base=self.base,
                                                                temp=self.temp,
                                                                reopen=True,
                                                                clear=clear)
+        self.ks = ks if ks is not None else keeping.Keeper(name=self.name,
+                                                           base=self.base,
+                                                           temp=self.temp,
+                                                           reopen=True,
+                                                           clear=clear,
+                                                           headDirPath=headDirPath,
+                                                           cf=cf)
+        self.db = db if db is not None else basing.Baser(name=self.name,
+                                                         base=self.base,
+                                                         temp=self.temp,
+                                                         reopen=True,
+                                                         clear=clear,
+                                                         headDirPath=headDirPath,
+                                                         cf=cf)
 
         self.mgr = None  # wait to setup until after ks is known to be opened
         self.rtr = routing.Router()

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -262,7 +262,7 @@ class Keeper(dbing.LMDBer):
         Open sub databases
         """
         opened = super(Keeper, self).reopen(**kwa)
-        logger.info("[%s] Keeper map size set to %s", self.name, self.mapSize)
+        logger.debug("[%s] Keeper map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/app/keeping.py
+++ b/src/keri/app/keeping.py
@@ -29,11 +29,12 @@ from dataclasses import dataclass, asdict, field
 import pysodium
 from hio.base import doing
 
-from .. import kering
-from .. import core
+from .. import kering, core, help
 from ..core import coring
 from ..db import dbing, subing, koming
 from ..help import helping
+
+logger = help.ogler.getLogger()
 
 Algoage = namedtuple("Algoage", 'randy salty group extern')
 Algos = Algoage(randy='randy', salty='salty', group="group", extern="extern")  # randy is rerandomize, salty is use salt
@@ -214,6 +215,7 @@ class Keeper(dbing.LMDBer):
     AltTailDirPath = ".keri/ks"
     TempPrefix = "keri_ks_"
     MaxNamedDBs = 10
+    ConfigKey = "keeper"
 
     def __init__(self, headDirPath=None, perm=None, reopen=False, **kwa):
         """
@@ -235,6 +237,7 @@ class Keeper(dbing.LMDBer):
                 default perm=None so do not set mode
             reopen is boolean, IF True then database will be reopened by this init
                 default reopen=True
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
 
         Notes:
 
@@ -259,6 +262,7 @@ class Keeper(dbing.LMDBer):
         Open sub databases
         """
         opened = super(Keeper, self).reopen(**kwa)
+        logger.info("[%s] Keeper map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -7,11 +7,13 @@ import os
 from collections.abc import Iterable
 from typing import Union, Type
 
-from keri import kering
+from keri import kering, help
 from keri.help import helping
 from keri.app import signaling
 from keri.core import coring
 from keri.db import dbing, subing
+
+logger = help.ogler.getLogger()
 
 
 def notice(attrs, dt=None, read=False):
@@ -208,15 +210,19 @@ class Noter(dbing.LMDBer):
     TailDirPath = os.path.join("keri", "not")
     AltTailDirPath = os.path.join(".keri", "not")
     TempPrefix = "keri_not_"
+    ConfigKey = "noter"
 
     def __init__(self, name="not", headDirPath=None, reopen=True, **kwa):
         """
+        Sets up a named notification database where all notifications for a controller are stored.
 
         Parameters:
-            headDirPath:
-            perm:
-            reopen:
-            kwa:
+            headDirPath(str): optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+            perm(int): is numeric os permissions for directory and/or file(s)
+            reopen(bool): True means database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
+            kwa: pass through init args to reopen and LMDBer
         """
         self.notes = None
         self.nidx = None
@@ -226,11 +232,13 @@ class Noter(dbing.LMDBer):
 
     def reopen(self, **kwa):
         """
+        Sets up specific named LMDB sub databases to be opened.
 
-        :param kwa:
+        :param kwa: pass through init args to reopen and LMDBer
         :return:
         """
         super(Noter, self).reopen(**kwa)
+        logger.info("[%s] Noter map size set to %s", self.name, self.mapSize)
 
         self.notes = DicterSuber(db=self, subkey='nots.', sep='/', klas=Notice)
         self.nidx = subing.Suber(db=self, subkey='nidx.')

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -25,15 +25,19 @@ class Mailboxer(dbing.LMDBer):
     TailDirPath = "keri/mbx"
     AltTailDirPath = ".keri/mbx"
     TempPrefix = "keri_mbx_"
+    ConfigKey = "mailboxer"
 
     def __init__(self, name="mbx", headDirPath=None, reopen=True, **kwa):
         """
+        Sets up the mailbox named sub database where all mailbox messages are stored.
 
         Parameters:
-            headDirPath:
-            perm:
-            reopen:
-            kwa:
+            headDirPath(str): optional str head directory pathname for main database
+                If not provided use default .HeadDirpath
+            perm(int): is numeric os permissions for directory and/or file(s)
+            reopen(bool): True means database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
+            kwa: pass through init args to reopen and LMDBer
 
         Mailboxer uses two dbs for mailbox messages these are .tpcs and .msgs.
         The message index is in .tpcs (topics).
@@ -58,6 +62,7 @@ class Mailboxer(dbing.LMDBer):
         :return:
         """
         super(Mailboxer, self).reopen(**kwa)
+        logger.info("[%s] Mailboxer map size set to %s", self.name, self.mapSize)
         self.tpcs = subing.OnSuber(db=self, subkey='tpcs.')
         self.msgs = subing.Suber(db=self, subkey='msgs.')  # key states
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -944,6 +944,7 @@ class Baser(dbing.LMDBer):
         kevers (dbdict): read through cache of kevers of states for KELs in db
 
     """
+    ConfigKey = "baser"
 
     def __init__(self, headDirPath=None, reopen=False, **kwa):
         """
@@ -960,17 +961,17 @@ class Baser(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode is int numeric os dir permissions for database directory
             reopen (bool): True means database will be reopened by this init
-
-
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
         """
         self.prefixes = oset()  # should change to hids for hab ids
         self.groups = oset()  # group hab ids
         self._kevers = dbdict()
         self._kevers.db = self  # assign db for read through cache of kevers
 
+        # Alternate way to set map size by environment variable
         if (mapSize := os.getenv(KERIBaserMapSizeKey)) is not None:
             try:
-                self.MapSize = int(mapSize)
+                self.mapSize = int(mapSize)
             except ValueError:
                 logger.error("KERI_BASER_MAP_SIZE must be an integer value >1!")
                 raise
@@ -1001,6 +1002,7 @@ class Baser(dbing.LMDBer):
 
         """
         super(Baser, self).reopen(**kwa)
+        logger.info("[%s] Baser map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -345,7 +345,7 @@ class LMDBer(filing.Filer):
     MaxNamedDBs = 96
     ConfigKey = 'lmdber'
 
-    def __init__(self, readonly=False, **kwa):
+    def __init__(self, readonly=False, cf=None, **kwa):
         """
         Setup main database directory at .dirpath.
         Create main database environment at .env using .path.
@@ -386,10 +386,10 @@ class LMDBer(filing.Filer):
         self._version = None
         self.readonly = True if readonly else False
         self._mapSize = 104_857_600  # 10MB fallback default
-        self.cf = kwa["cf"] if "cf" in kwa else None
+        self.cf = cf
         super(LMDBer, self).__init__(**kwa)
 
-    def reopen(self, readonly=False, **kwa):
+    def reopen(self, readonly=False, cf=None, **kwa):
         """
         Open if closed or close and reopen if opened or create and open if not
         preexistent, directory path for lmdb at .path and then
@@ -420,9 +420,13 @@ class LMDBer(filing.Filer):
         if readonly is not None:
             self.readonly = readonly
 
-        config = self.cf.get() if self.cf is not None else None
-        lmdberConf = config.get(self.ConfigKey, None) if config is not None else None
-        if lmdberConf is not None:
+        cf = cf if cf is not None else self.cf
+        config = cf.get() if cf is not None else None
+        lmdberConf = config.get(LMDBer.ConfigKey) if config is not None else None
+        dbconf = config.get(self.ConfigKey, None) if config is not None else None
+        if dbconf is not None:
+            self.mapSize = dbconf.get("mapSize", 104_857_600)  # 10MB default
+        elif config and lmdberConf: # fall back to LMDBer size if present
             self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
 
         # open lmdb major database instance

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -426,8 +426,6 @@ class LMDBer(filing.Filer):
         dbconf = config.get(self.ConfigKey, None) if config is not None else None
         if dbconf is not None:
             self.mapSize = dbconf.get("mapSize", 104_857_600)  # 10MB default
-        elif config and lmdberConf: # fall back to LMDBer size if present
-            self.mapSize = lmdberConf.get("mapSize", 104_857_600)  # 10MB default
 
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -13,14 +13,13 @@ from  ordered_set import OrderedSet as oset
 
 from ..db import koming, subing, escrowing
 
-from .. import kering, core
+from .. import kering, core, help
 from ..app import signing
 from ..core import coring, serdering, indexing, counting
 from ..db import dbing, basing
-from ..db.dbing import snKey
-from ..help import helping
-from ..vc import proving
 from ..vdr import eventing
+
+logger = help.ogler.getLogger()
 
 
 class rbdict(dict):
@@ -238,6 +237,7 @@ class Reger(dbing.LMDBer):
     TailDirPath = "keri/reg"
     AltTailDirPath = ".keri/reg"
     TempPrefix = "keri_reg_"
+    ConfigKey = "reger"
 
     def __init__(self, headDirPath=None, reopen=True, **kwa):
         """
@@ -254,6 +254,7 @@ class Reger(dbing.LMDBer):
                 If not provided use default .HeadDirpath
             mode (int): numeric os dir permissions for database directory
             reopen (boolean,): IF True then database will be reopened by this init
+            cf (Configer): optional Configer to configure the opened LMDB database via kwa
 
         Notes:
 
@@ -294,6 +295,7 @@ class Reger(dbing.LMDBer):
 
         """
         super(Reger, self).reopen(**kwa)
+        logger.info("[%s] Reger map size set to %s", self.name, self.mapSize)
 
         # Create by opening first time named sub DBs within main DB instance
         # Names end with "." as sub DB name must include a non Base64 character

--- a/tests/app/test_keeping.py
+++ b/tests/app/test_keeping.py
@@ -20,6 +20,7 @@ import pysodium
 from hio.base import doing
 
 from keri import kering
+from keri.app.keeping import Keeper
 from keri.help import helping
 
 from keri import core
@@ -27,7 +28,7 @@ from keri import core
 from keri.core import coring, indexing
 from keri.core.indexing import IdrDex
 
-from keri.app import keeping
+from keri.app import keeping, configing
 
 
 def test_dataclasses():
@@ -2007,6 +2008,19 @@ def test_manager_sign_dual_indices():
     assert not os.path.exists(manager.ks.path)
     assert not manager.ks.opened
     """End Test"""
+
+
+def test_keeper_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        keeper=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    keeper = Keeper(reopen=True,cf=cf)  # default is to not reopen
+    assert keeper.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 if __name__ == "__main__":
     test_manager_sign_dual_indices()

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -11,7 +11,8 @@ import time
 import pytest
 import os
 
-from keri.app import notifying, habbing
+from keri.app import notifying, habbing, configing
+from keri.app.notifying import Noter
 from keri.core import coring
 from keri.db import dbing
 from keri.help import helping
@@ -230,3 +231,16 @@ def test_notifier(mockHelpingNowUTC):
 
     assert notifier.mar(note.rid) is False
     assert notifier.rem(note.rid) is True
+
+
+def test_noter_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        noter=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    noter = Noter(reopen=True,cf=cf)  # default is to not reopen
+    assert noter.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -7,7 +7,7 @@ import os
 
 import lmdb
 
-from keri.app import keeping
+from keri.app import keeping, configing
 from keri.core import coring, serdering
 from keri.db import dbing, basing, subing
 from keri.peer import exchanging
@@ -109,6 +109,18 @@ def test_mailboxing():
         #assert(len(msgs)) == 6
         #assert msgs[0][0] == 4
 
+
+def test_mailboxer_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        mailboxer=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    mailboxer = Mailboxer(reopen=True,cf=cf)  # default is to not reopen
+    assert mailboxer.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 
 if __name__ == '__main__':

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -14,7 +14,7 @@ import pytest
 import lmdb
 from hio.base import doing
 from keri import core
-from keri.app import habbing
+from keri.app import habbing, configing
 from keri.core import coring, eventing, serdering
 from keri.core.coring import Kinds, versify, Seqner
 from keri.core.eventing import incept, rotate, interact, Kever
@@ -1912,6 +1912,20 @@ def test_clear_escrows():
         assert db.udes.cntAll() == 0
         assert db.epsd.cntAll() == 0
         assert db.dpub.cntAll() == 0
+
+
+def test_baser_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        baser=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    baser = Baser(reopen=True,cf=cf)  # default is to not reopen
+    assert baser.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
+
 
 if __name__ == "__main__":
     test_baser()

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -11,6 +11,7 @@ import tempfile
 
 import lmdb
 
+from keri.app import configing
 from keri.core.coring import Diger, versify, Kinds
 from keri.db.dbing import openLMDB, dgKey, snKey
 from keri.vdr.viring import Reger
@@ -343,6 +344,19 @@ def test_clone():
           b'n_1wWjlUslGkXfs0KyoNOEAAC_6PB5Zre_E_7YLkM9OtRo-uYmwRyFmOH3Xo4JDi'
           b'PjioY7Ycna6ouhSSH0QcKsEjce10HCXIW_XtmEYr9SrB5BA-GAB0AAAAAAAAAAAA'
           b'AAAAAAAAABCEzpq06UecHwzy-K9FpNoRxCJp2wIGM9u2Edk-PLMZ1H4')
+
+
+def test_reger_config_with_file():
+    cf = configing.Configer()
+    configDict = dict(
+        reger=dict(
+            mapSize="1_073_741_824"
+        )
+    )
+    cf.put(configDict)
+
+    reger = Reger(reopen=True,cf=cf)  # default is to not reopen
+    assert reger.mapSize == 1_073_741_824, "Map Size should be 1GB"  # 1024*1024*1024 = 1GB
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds ability to configure LMDB sizes using the bootstrap configuration file.
Also adds some INFO level logging on the config file location and database sizes set.

Adds the `.mapSize` property to LMDBer and the `LMDBer.ConfigKey` that is overridden in each subclass. This config key is used to select a subset of the overall config file to use to configure each LMDBer subclass.

For backwards compatibility the `KERI_BASER_MAP_SIZE` environment variable still works, yet may be deprecated in the future. Moving forward using the configuration file as the single source of truth for configuration is the recommended path.