### PR TITLE
Change GenusCodex to reserve the four relevant protocols so have the flexibility to go to a one-to-one instead of shared relationship

### DIFF
--- a/src/keri/core/counting.py
+++ b/src/keri/core/counting.py
@@ -28,10 +28,10 @@ class GenusCodex(IceMapDom):
     Only provide defined codes.
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
     """
-    KERI_ACDC_SPAC: str = '-_AAA'  # KERI, ACDC, and  SPAC Protocol Stacks share the same tables
-    KERI: str = '-_AAA'  # KERI and ACDC Protocol Stacks share the same tables
-    ACDC: str = '-_AAA'  # KERI and ACDC Protocol Stacks share the same tables
-    SPAC: str = '-_AAA'  # KERI and ACDC Protocol Stacks share the same tables
+    KERI: str = '-_AAA'  # KERI Tables may be shared by ACDC and SPAC and TSP_
+    ACDC: str = '-_AAB'  # Reserved in case ACDC can no longer share with KERI
+    SPAC: str = '-_AAC'  # Reserved in case SPAC can no longer share with KERI
+    TSP_: str = '-_AAD'  # Reserved in case TSP_ can no longer share with KERI
 
 
     def __iter__(self):
@@ -40,6 +40,12 @@ class GenusCodex(IceMapDom):
         # in inclusion still works
 
 GenDex = GenusCodex()  # Make instance
+
+
+#ToDo. ProtoGenus table that maps protocol code to Genus Code in cases
+# where protocol code name and genus code name are different as would be
+# the case where a protocol is using a shared genus table with some other protocal
+
 
 
 @dataclass(frozen=True)

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -162,7 +162,7 @@ class Parser:
         self.vry = vry
         self.local = True if local else False
 
-        self._genus = GenDex.KERI_ACDC_SPAC  # only supports KERI_ACDC_SPAC
+        self._genus = GenDex.KERI  # only supports KERI
         self.version = version  # provided version may be earlier than supported version
         # version sets  .methods, .codes, .sucodes, and .mucodes
 

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -245,9 +245,9 @@ class Serdery:
             raise SerializeError(f"Incompatible major protocol version="
                                  f"{smellage.pvrsn} with stream major genus "
                                  f"version={svrsn}.")
-        if getattr(GenDex, smellage.proto, None) != genus:
-            raise SerializeError(f"Incompatible protocol={smellage.proto} with "
-                                 f"genus={genus}.")
+        #if getattr(GenDex, smellage.proto, None) != genus:
+            #raise SerializeError(f"Incompatible protocol={smellage.proto} with "
+                                 #f"genus={genus}.")
 
         if smellage.proto == Protocols.keri:
             return SerderKERI(raw=ims, strip=True, smellage=smellage)
@@ -722,9 +722,9 @@ class Serder:
         if self.genus not in GenDex:  # ensures self.genus != None
             raise ValidationError(f"Invalid genus={self.genus}.")
 
-        if getattr(GenDex, self.proto, None) != self.genus:
-            raise ValidationError(f"Incompatible protocol={self.proto} with "
-                                 f"genus={self.genus}.")
+        #if getattr(GenDex, self.proto, None) != self.genus:
+            #raise ValidationError(f"Incompatible protocol={self.proto} with "
+                                 #f"genus={self.genus}.")
 
         if self.gvrsn is not None and self.pvrsn.major > self.gvrsn.major:
             raise ValidationError(f"Incompatible major protocol version={self.pvrsn}"
@@ -911,9 +911,9 @@ class Serder:
         if genus not in GenDex:  # ensures valid genus != None
             raise SerializeError(f"Invalid genus={self.genus}.")
 
-        if getattr(GenDex, proto, None) != genus:  # ensure compatible proto
-            raise SerializeError(f"Incompatible protocol={proto} with "
-                                 f"{genus=}.")
+        #if getattr(GenDex, proto, None) != genus:  # ensure compatible proto
+            #raise SerializeError(f"Incompatible protocol={proto} with "
+                                 #f"{genus=}.")
 
         if pvrsn is None:
             pvrsn = svrsn if svrsn is not None else self.Vrsn

--- a/src/keri/help/__init__.py
+++ b/src/keri/help/__init__.py
@@ -29,4 +29,4 @@ logging.Logger.trace = trace
 ogler = ogling.initOgler(prefix='keri', syslogged=False)  # inits once only on first import
 
 from .helping import (nowIso8601, toIso8601, fromIso8601,
-                      nonStringSequence, nonStringIterable, Reb64)
+                      nonStringSequence, nonStringIterable, Reb64, Reat)

--- a/src/keri/help/helping.py
+++ b/src/keri/help/helping.py
@@ -431,3 +431,7 @@ def verify64uEd25519(signature, message, verkey):
     return (verifyEd25519(sig, msg, vk))
 
 
+# Regular expression to detect valid attributish names as bytes
+ATREX = rb'^[a-zA-Z_][a-zA-Z0-9_]*$'  # bytes
+# Usage: if Reat.match(name): or if not Reat.match(name):
+Reat = re.compile(ATREX)  # compile is faster

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -4988,20 +4988,28 @@ def test_labeler():
 
     labeler = Labeler(label=label)
     assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     assert labeler.soft == label
     assert labeler.raw == raw
     assert labeler.qb64 == qb64
     assert labeler.qb2 == qb2
 
+    labeler = Labeler(text=label)
+    assert labeler.label == label
+    assert labeler.text == label
+
     labeler = Labeler(raw=raw, code=code, soft=label)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
     assert labeler.label == label
+    assert labeler.text == label
 
 
     # Test all sizes taggable labels
@@ -5017,21 +5025,28 @@ def test_labeler():
 
         labeler = Labeler(label=label)
         assert labeler.label == label
+        assert labeler.text == label
         assert labeler.code == code
         assert labeler.soft == label
         assert labeler.raw == raw
         assert labeler.qb64 == qb64
         assert labeler.qb2 == qb2
 
+        labeler = Labeler(text=label)
+        assert labeler.label == label
+        assert labeler.text == label
+
         labeler = Labeler(raw=raw, code=code, soft=label)
         assert labeler.label == label
+        assert labeler.text == label
 
         labeler = Labeler(qb64=qb64)
         assert labeler.label == label
+        assert labeler.text == label
 
         labeler = Labeler(qb2=qb2)
         assert labeler.label == label
-
+        assert labeler.text == label
 
     # test bextable labels
     label = 'zyxwvutsrqponm'
@@ -5042,6 +5057,7 @@ def test_labeler():
 
     labeler = Labeler(label=label)
     assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     rs = (len(label) + len(label) % 4) // 4
     assert labeler.soft == intToB64(rs, 2) == 'AE'
@@ -5049,14 +5065,21 @@ def test_labeler():
     assert labeler.qb64 == qb64
     assert labeler.qb2 == qb2
 
+    labeler = Labeler(text=label)
+    assert labeler.label == label
+    assert labeler.text == label
+
     labeler = Labeler(raw=raw, code=code, soft=label)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
     assert labeler.label == label
+    assert labeler.text == label
 
     # test textable labels
     # fixed size short
@@ -5066,8 +5089,13 @@ def test_labeler():
     qb64 = 'VABA'
     qb2 = decodeB64(qb64) # b'T\x00@'
 
-    labeler = Labeler(label=label)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        labeler = Labeler(label=label)
+
+    labeler = Labeler(text=label)
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     assert labeler.soft == ''
     assert labeler.raw == raw
@@ -5075,13 +5103,19 @@ def test_labeler():
     assert labeler.qb2 == qb2
 
     labeler = Labeler(raw=raw, code=code)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     label = '!$'
     code = LabelDex.Label2
@@ -5089,8 +5123,13 @@ def test_labeler():
     qb64 = 'WCEk'
     qb2 = decodeB64(qb64) # b'X!$'
 
-    labeler = Labeler(label=label)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        labeler = Labeler(label=label)
+
+    labeler = Labeler(text=label)
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     assert labeler.soft == ''
     assert labeler.raw == raw
@@ -5098,13 +5137,19 @@ def test_labeler():
     assert labeler.qb2 == qb2
 
     labeler = Labeler(raw=raw, code=code)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
 
     # variable sized
@@ -5115,8 +5160,13 @@ def test_labeler():
     qb2 = decodeB64(qb64)
 
 
-    labeler = Labeler(label=label)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        labeler = Labeler(label=label)
+
+    labeler = Labeler(text=label)
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     assert labeler.soft == 'AF'
     assert labeler.raw == raw
@@ -5124,13 +5174,19 @@ def test_labeler():
     assert labeler.qb2 == qb2
 
     labeler = Labeler(raw=raw, code=code)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
-    assert labeler.label == label
+    with pytest.raises(InvalidValueError):
+        assert labeler.label == label
+    assert labeler.text == label
 
     # test base64 that starts with 'A' get encoded as textable, is not bextable
     label = 'Ayxwvutsrqponm'
@@ -5142,6 +5198,7 @@ def test_labeler():
 
     labeler = Labeler(label=label)
     assert labeler.label == label
+    assert labeler.text == label
     assert labeler.code == code
     assert labeler.soft == 'AF'
     assert labeler.raw == raw
@@ -5150,12 +5207,15 @@ def test_labeler():
 
     labeler = Labeler(raw=raw, code=code)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb64=qb64)
     assert labeler.label == label
+    assert labeler.text == label
 
     labeler = Labeler(qb2=qb2)
     assert labeler.label == label
+    assert labeler.text == label
 
     """ Done Test """
 

--- a/tests/core/test_counting.py
+++ b/tests/core/test_counting.py
@@ -36,23 +36,27 @@ def test_genus_codex():
 
     assert asdict(GenDex) == \
     {
-        'KERI_ACDC_SPAC': '-_AAA',
         'KERI': '-_AAA',
-        'ACDC': '-_AAA',
-        'SPAC': '-_AAA'
+        'ACDC': '-_AAB',
+        'SPAC': '-_AAC',
+        'TSP_': '-_AAD',
     }
 
     assert '-_AAA' in GenDex
+    assert '-_AAB' in GenDex
+    assert '-_AAC' in GenDex
+    assert '-_AAD' in GenDex
+
     assert GenDex.KERI == "-_AAA"
-    assert GenDex.ACDC == "-_AAA"
-    assert GenDex.SPAC == "-_AAA"
-    assert GenDex.KERI_ACDC_SPAC == "-_AAA"
-    assert GenDex.KERI == GenDex.ACDC
+    assert GenDex.ACDC == "-_AAB"
+    assert GenDex.SPAC == "-_AAC"
+    assert GenDex.TSP_ == "-_AAD"
+
 
     assert hasattr(GenDex, "KERI")
     assert hasattr(GenDex, "ACDC")
     assert hasattr(GenDex, "SPAC")
-    assert hasattr(GenDex, "KERI_ACDC_SPAC")
+    assert hasattr(GenDex, "TSP_")
 
     """End Test"""
 

--- a/tests/core/test_mapping.py
+++ b/tests/core/test_mapping.py
@@ -8,7 +8,7 @@ import cbor2 as cbor
 
 import pytest
 
-from keri.kering import Colds
+from keri.kering import Colds, SerializeError, DeserializeError
 from keri.core import Mapper, Diger
 
 
@@ -287,6 +287,35 @@ def test_mapper_basic():
     assert mapper.byteCount() == size
     assert mapper.byteCount(Colds.bny) == bc
 
+
+
+    # test bad label
+    mad = {"1abc": "Hello",}
+    with pytest.raises(SerializeError):
+        mapper = Mapper(mad=mad)
+
+    # test bad qb64 due to bad label
+    mad = dict(a="bye")
+    qb64 =  '-IAC0J_aXbye'
+    qb64b =  b'-IAC0J_aXbye'
+    qb2 = b'\xf8\x80\x02\xd0\x9f\xda]\xbc\x9e'
+
+    count = 3
+    size = 12
+    bc = 9
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    bad = '-IAC0J_1Xbye'
+    with pytest.raises(DeserializeError):
+        mapper = Mapper(qb64=bad)
 
     """Done Test"""
 

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -32,7 +32,7 @@ def test_parser_v1_basic():
 
     """
     parser = Parser()  # test defaults
-    assert parser.genus == GenDex.KERI_ACDC_SPAC
+    assert parser.genus == GenDex.KERI
     assert parser.version == Vrsn_2_0
     assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
     assert parser.codes == Parser.Codes[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -361,7 +361,7 @@ def test_parser_v1_basic():
         kevery = Kevery(db=valDB)
 
         parser = Parser(kvy=kevery, version=Vrsn_1_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -571,7 +571,7 @@ def test_parser_v1_version():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -905,7 +905,7 @@ def test_parser_v1_enclosed_attachments():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -1318,7 +1318,7 @@ def test_parser_v1_enclosed_message():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -1670,7 +1670,7 @@ def test_parser_v1_non_native_message():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -1704,7 +1704,7 @@ def test_parser_v2_basic():
 
     """
     parser = Parser()  # test defaults
-    assert parser.genus == GenDex.KERI_ACDC_SPAC
+    assert parser.genus == GenDex.KERI
     assert parser.version == Vrsn_2_0
     assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
     assert parser.codes == Parser.Codes[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -2090,7 +2090,7 @@ def test_parser_v2_basic():
         kevery = Kevery(db=valDB)
 
         parser = Parser(kvy=kevery, version=Vrsn_2_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_2_0
         assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -2131,7 +2131,7 @@ def test_parser_v2_mix():
 
     """
     parser = Parser()  # test defaults
-    assert parser.genus == GenDex.KERI_ACDC_SPAC
+    assert parser.genus == GenDex.KERI
     assert parser.version == Vrsn_2_0
     assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
     assert parser.codes == Parser.Codes[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -2538,7 +2538,7 @@ def test_parser_v2_mix():
         kevery = Kevery(db=valDB)
 
         parser = Parser(kvy=kevery, version=Vrsn_2_0)
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_2_0
         assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -2925,7 +2925,7 @@ def test_parser_v2_enclosed_attachments():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery)  # default is Vrsn_2_0_
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_2_0
         assert parser.version == Vrsn_2_0
         assert parser.methods == Parser.Methods[Vrsn_2_0.major][Vrsn_2_0.minor]
@@ -3373,7 +3373,7 @@ def test_parser_v2_enclosed_message():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)  # default v1 but override at top level above
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -3822,7 +3822,7 @@ def test_parse_generic_group():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)  # default v1 but override at top level above
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -4272,7 +4272,7 @@ def test_group_parsator():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)  # default v1 but override at top level above
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]
@@ -4741,7 +4741,7 @@ def test_parse_native_cesr_fixed_field():
 
         kevery = Kevery(db=valDB)
         parser = Parser(kvy=kevery, version=Vrsn_1_0)  # default v1 but override at top level above
-        assert parser.genus == GenDex.KERI_ACDC_SPAC
+        assert parser.genus == GenDex.KERI
         assert parser.version == Vrsn_1_0
         assert parser.methods == Parser.Methods[Vrsn_1_0.major][Vrsn_1_0.minor]
         assert parser.codes == Parser.Codes[Vrsn_1_0.major][Vrsn_1_0.minor]

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -17,7 +17,8 @@ from keri.help.helping import isign, sceil
 from keri.help.helping import extractValues
 from keri.help.helping import dictify, datify, klasify
 from keri.help.helping import (intToB64, intToB64b, b64ToInt, B64_CHARS,
-                               codeB64ToB2, codeB2ToB64, Reb64, nabSextets)
+                               codeB64ToB2, codeB2ToB64, Reb64, nabSextets,
+                               Reat)
 
 def test_utilities():
     """
@@ -243,10 +244,10 @@ def test_iso8601():
 
     dts1 = helping.nowIso8601()
     dt1 = helping.fromIso8601(dts1)
-    
+
     # Add a small delay to ensure timestamps are different
     time.sleep(0.001)
-    
+
     dts2 = helping.nowIso8601()
     dt2 = helping.fromIso8601(dts2)
 
@@ -256,7 +257,7 @@ def test_iso8601():
     assert dts2 == helping.toIso8601(dt2)
 
     time.sleep(0.001)
-    
+
     dts3 = helping.toIso8601()
     dt3 = helping.fromIso8601(dts3)
 
@@ -443,6 +444,27 @@ def test_b64_conversions():
     """End Test"""
 
 
+
+
+def test_reat():
+    """Test regular expression Reat for attribute name """
+    name = b"hello"
+    assert Reat.match(name)
+
+    name = b"_hello"
+    assert Reat.match(name)
+
+    name = b"hell1"
+    assert Reat.match(name)
+
+    name = b"1hello"
+    assert not Reat.match(name)
+
+    name = b"hello.hello"
+    assert not Reat.match(name)
+    """Done Test"""
+
+
 if __name__ == "__main__":
     test_utilities()
     test_datify()
@@ -451,3 +473,4 @@ if __name__ == "__main__":
     test_extractvalues()
     test_iso8601()
     test_b64_conversions()
+    test_reat()


### PR DESCRIPTION
… ACDC, SPAC, and TSP_ incase some time infuture

they need to not share the KERI CESR code table.