### PR TITLE
Fixed Mapper to round trip correctly even when field value is a string that is verbatim a special value qb64

### DIFF
--- a/src/keri/core/__init__.py
+++ b/src/keri/core/__init__.py
@@ -15,5 +15,5 @@ from .coring import (Matter, MtrDex, Number, NumDex, Dater, DecDex, Decimer,
 from .indexing import Indexer, Siger, IdrDex, IdxSigDex
 from .signing import Signer, Salter, Cipher, CiXDex, Encrypter, Decrypter
 from .counting import Counter, Codens, GenDex, CtrDex_1_0, CtrDex_2_0
-from .mapping import Mapper
+from .mapping import Mapper, EscapeDex
 from .streaming import Streamer

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -342,6 +342,7 @@ class MatterCodex:
     No:                   str = '1AAL'  # No Falsey Boolean value
     Yes:                  str = '1AAM'  # Yes Truthy Boolean value
     Tag8:                 str = '1AAN'  # Tag8 8 B64 encoded chars for special values
+    Escape:               str = '1AAO'  # Escape code for excaping special map fields
     TBD0S:                str = '1__-'  # Testing purposes only, fixed special values with non-empty raw lead size 0
     TBD0:                 str = '1___'  # Testing purposes only, fixed with lead size 0
     TBD1S:                str = '2__-'  # Testing purposes only, fixed special values with non-empty raw lead size 1
@@ -586,8 +587,8 @@ TagDex = TagCodex()  # Make instance
 
 @dataclass(frozen=True)
 class LabelCodex:
-    """
-    LabelCodex is codex of.
+    """LabelCodex is codex of codes to compactly ser/des labels and string values
+    in maps or lists.
 
     Only provide defined codes.
     Undefined are left out so that inclusion(exclusion) via 'in' operator works.
@@ -847,6 +848,7 @@ class Matter:
         '1AAL': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1AAM': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1AAN': Sizage(hs=4, ss=8, xs=0, fs=12, ls=0),
+        '1AAO': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1__-': Sizage(hs=4, ss=2, xs=0, fs=12, ls=0),
         '1___': Sizage(hs=4, ss=0, xs=0, fs=8, ls=0),
         '2__-': Sizage(hs=4, ss=2, xs=1, fs=12, ls=1),

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -271,6 +271,7 @@ def test_matter_class():
         'No': '1AAL',
         'Yes': '1AAM',
         'Tag8': '1AAN',
+        'Escape': '1AAO',
         'TBD0S': '1__-',
         'TBD0': '1___',
         'TBD1S': '2__-',
@@ -389,6 +390,7 @@ def test_matter_class():
         '1AAL': 'No',
         '1AAM': 'Yes',
         '1AAN': 'Tag8',
+        '1AAO': 'Escape',
         '1__-': 'TBD0S',
         '1___': 'TBD0',
         '2__-': 'TBD1S',
@@ -521,6 +523,7 @@ def test_matter_class():
         '1AAL': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1AAM': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1AAN': Sizage(hs=4, ss=8, xs=0, fs=12, ls=0),
+        '1AAO': Sizage(hs=4, ss=0, xs=0, fs=4, ls=0),
         '1__-': Sizage(hs=4, ss=2, xs=0, fs=12, ls=0),
         '1___': Sizage(hs=4, ss=0, xs=0, fs=8, ls=0),
         '2__-': Sizage(hs=4, ss=2, xs=1, fs=12, ls=1),
@@ -2219,6 +2222,42 @@ def test_matter_special():
     assert matter.special
     assert matter.composable
 
+    # Test escape code
+    code = MtrDex.Escape
+    rs = Matter._rawSize(code)  # raw size
+    soft = ''
+    qb64 = '1AAO'
+    qb2 = b'\xd4\x00\x0e'
+    raw = b''
+
+    assert rs == 0  # empty raw only hard code
+
+    matter = Matter(raw=raw, code=code)
+    assert matter.code == matter.hard == code
+    assert matter.soft == soft
+    assert matter.raw == raw
+    assert matter.qb64 == qb64
+    assert matter.qb2 == qb2
+    assert not matter.special
+    assert matter.composable
+
+    matter = Matter(qb2=qb2)
+    assert matter.code == matter.hard == code
+    assert matter.soft == soft
+    assert matter.raw == raw
+    assert matter.qb64 == qb64
+    assert matter.qb2 == qb2
+    assert not matter.special
+    assert matter.composable
+
+    matter = Matter(qb64=qb64)
+    assert matter.code == matter.hard == code
+    assert matter.soft == soft
+    assert matter.raw == raw
+    assert matter.qb64 == qb64
+    assert matter.qb2 == qb2
+    assert not matter.special
+    assert matter.composable
 
 
     # Test TBD0S  '1__-'

--- a/tests/core/test_mapping.py
+++ b/tests/core/test_mapping.py
@@ -8,9 +8,54 @@ import cbor2 as cbor
 
 import pytest
 
-from keri.kering import Colds, SerializeError, DeserializeError
-from keri.core import Mapper, Diger
+from dataclasses import dataclass, astuple, asdict
 
+from keri.kering import Colds, SerializeError, DeserializeError
+from keri.core import EscapeDex, Mapper, Diger, Decimer, Labeler
+
+
+def test_special_dex():
+    """Test SpecialCodex"""
+    assert asdict(EscapeDex) == \
+    {
+        'Escape': '1AAO',
+        'Null': '1AAK',
+        'No': '1AAL',
+        'Yes': '1AAM',
+        'Decimal_L0': '4H',
+        'Decimal_L1': '5H',
+        'Decimal_L2': '6H',
+        'Decimal_Big_L0': '7AAH',
+        'Decimal_Big_L1': '8AAH',
+        'Decimal_Big_L2': '9AAH',
+        'Tag1': '0J',
+        'Tag2': '0K',
+        'Tag3': 'X',
+        'Tag4': '1AAF',
+        'Tag5': '0L',
+        'Tag6': '0M',
+        'Tag7': 'Y',
+        'Tag8': '1AAN',
+        'Tag9': '0N',
+        'Tag10': '0O',
+        'Tag11': 'Z',
+        'StrB64_L0': '4A',
+        'StrB64_L1': '5A',
+        'StrB64_L2': '6A',
+        'StrB64_Big_L0': '7AAA',
+        'StrB64_Big_L1': '8AAA',
+        'StrB64_Big_L2': '9AAA',
+        'Label1': 'V',
+        'Label2': 'W',
+        'Bytes_L0': '4B',
+        'Bytes_L1': '5B',
+        'Bytes_L2': '6B',
+        'Bytes_Big_L0': '7AAB',
+        'Bytes_Big_L1': '8AAB',
+        'Bytes_Big_L2': '9AAB'
+    }
+
+    """Done Test"""
 
 def test_mapper_basic():
     """Test Mapper class"""
@@ -308,6 +353,7 @@ def test_mapper_basic():
     assert mapper.mad == mad
     assert mapper.qb64 == qb64
     assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
     assert mapper.count == count
     assert mapper.size ==size
     assert mapper.byteCount() == size
@@ -317,7 +363,161 @@ def test_mapper_basic():
     with pytest.raises(DeserializeError):
         mapper = Mapper(qb64=bad)
 
+
+    # test escape values of field map
+    # value is verbatim qb64 of escape code
+    mad = dict(a=EscapeDex.Escape)
+    assert mad['a'] == '1AAO'
+    qb64 =  '-IAD0J_a1AAO1AAO'
+    qb64b =  b'-IAD0J_a1AAO1AAO'
+    qb2 = b'\xf8\x80\x03\xd0\x9f\xda\xd4\x00\x0e\xd4\x00\x0e'
+
+    count = 4
+    size = 16
+    bc = 12
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of null code
+    mad = dict(a=EscapeDex.Null)
+    assert mad['a'] == '1AAK'
+    qb64 =  '-IAD0J_a1AAO1AAK'
+    qb64b =  b'-IAD0J_a1AAO1AAK'
+    qb2 = b'\xf8\x80\x03\xd0\x9f\xda\xd4\x00\x0e\xd4\x00\n'
+
+    count = 4
+    size = 16
+    bc = 12
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of No code i.e. boolean False
+    mad = dict(a=EscapeDex.No)
+    assert mad['a'] == '1AAL'
+    qb64 =  '-IAD0J_a1AAO1AAL'
+    qb64b =  b'-IAD0J_a1AAO1AAL'
+    qb2 = b'\xf8\x80\x03\xd0\x9f\xda\xd4\x00\x0e\xd4\x00\x0b'
+
+    count = 4
+    size = 16
+    bc = 12
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of Yes code i.e. boolean True
+    mad = dict(a=EscapeDex.Yes)
+    assert mad['a'] == '1AAM'
+    qb64 =  '-IAD0J_a1AAO1AAM'
+    qb64b =  b'-IAD0J_a1AAO1AAM'
+    qb2 = b'\xf8\x80\x03\xd0\x9f\xda\xd4\x00\x0e\xd4\x00\x0c'
+
+    count = 4
+    size = 16
+    bc = 12
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of Decimer qb64
+    dqb64 = Decimer(decimal=1).qb64
+    mad = dict(a=dqb64)
+    assert mad['a'] == '6HABAAA1'
+    qb64 =  '-IAE0J_a1AAO6HABAAA1'
+    qb64b =  b'-IAE0J_a1AAO6HABAAA1'
+    qb2 = b'\xf8\x80\x04\xd0\x9f\xda\xd4\x00\x0e\xe8p\x01\x00\x005'
+
+    count = 5
+    size = 20
+    bc = 15
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of Labeler qb64 as Tag3
+    lqb64 = Labeler(text="Pet").qb64
+    mad = dict(a=lqb64)
+    assert mad['a'] == 'XPet'
+    qb64 =  '-IAD0J_a1AAOXPet'
+    qb64b =  b'-IAD0J_a1AAOXPet'
+    qb2 = b'\xf8\x80\x03\xd0\x9f\xda\xd4\x00\x0e\\\xf7\xad'
+
+    count = 4
+    size = 16
+    bc = 12
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+    # value is verbatim qb64 of Labeler qb64 as Bytes variable length
+    lqb64 = Labeler(text="@home").qb64
+    mad = dict(a=lqb64)
+    assert mad['a'] == '5BACAEBob21l'
+    qb64 =  '-IAF0J_a1AAO5BACAEBob21l'
+    qb64b =  b'-IAF0J_a1AAO5BACAEBob21l'
+    qb2 = b'\xf8\x80\x05\xd0\x9f\xda\xd4\x00\x0e\xe4\x10\x02\x00@home'
+
+    count = 6
+    size = 24
+    bc = 18
+
+    mapper = Mapper(mad=mad)
+    assert mapper.mad == mad
+    assert mapper.qb64 == qb64
+    assert mapper.qb64b == qb64b
+    assert mapper.qb2 == qb2
+    assert mapper.count == count
+    assert mapper.size ==size
+    assert mapper.byteCount() == size
+    assert mapper.byteCount(Colds.bny) == bc
+
+
     """Done Test"""
 
 if __name__ == "__main__":
+    test_special_dex()
     test_mapper_basic()


### PR DESCRIPTION
…g that is verbatim the qb64 of a special type value

such as None, bool, int, float, string or escape. This required adding an special primitive code for Escape So matter serilizer will escape any string field values with new escape code, include the escape code itself.