### PR TITLE
Update exchanging code to use rparts for attachment paths.

### DIFF
--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -790,6 +790,7 @@ class Parser:
             raise  # no enclosing message group so can't preflush, must flush stream
 
         finally:  # restore version at top level
+            done = True
             while stack:  # when tail end of group has validation error
                 svrsn, _ = stack.pop()
                 if svrsn:

--- a/src/keri/help/helping.py
+++ b/src/keri/help/helping.py
@@ -8,7 +8,9 @@ import dataclasses
 import datetime
 import re
 from collections import deque
-from collections.abc import Iterable, Sequence, Mapping, ABCMeta
+from collections.abc import Iterable, Sequence, Mapping
+
+from abc import ABCMeta
 
 import pysodium
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -452,7 +452,7 @@ def cloneMessage(hby, said):
         pather = coring.Pather(qb64b=pb, strip=True)
         if pather.startswith(e):
             np = pather.strip(e)
-            nesting(np.parts, pathed, pb)
+            nesting(np.rparts, pathed, pb)
 
     return exn, pathed
 


### PR DESCRIPTION
Update import of ABCMeta so it works with Python 3.12.6

Set "done" in groupParsator to fix bug when exiting.