### PR TITLE
A few bug fixes for exchange events

### DIFF
--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -112,6 +112,7 @@ class Exchanger:
                                                 " for evt = {}.".format(cigar,
                                                                         serder.ked))
         else:
+            self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed, essrs=essrs)
             raise MissingSignatureError("Failure satisfying exn, no cigs or sigs"
                                         " for evt = {}.".format(serder.ked))
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -80,19 +80,15 @@ class Exchanger:
         if tsgs:
             for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
                 if sender != prefixer.qb64:  # sig not by aid
-                    msg = (f"Skipped signature not from aid = "
-                           f"{sender}, from {prefixer.qb64} on exn msg = {serder.said}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                    raise MissingSignatureError(f"Exchange process: skipped signature not from aid="
+                                                f"{sender}, from {prefixer.qb64} on exn msg=\n{serder.pretty()}\n")
 
                 if prefixer.qb64 not in self.kevers or self.kevers[prefixer.qb64].sn < seqner.sn:
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
+                        logger.info(f"Unable to find sender {prefixer.qb64} or sn={seqner.sn} in kevers, escrowing event and cueing.")
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
-                    msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                    raise MissingSignatureError(f"Unable to find sender {prefixer.qb64} in kevers"
+                                                f" for evt = {serder.ked}.")
 
                 # Verify the signatures are valid and that the signature threshold as of the signing event is met
                 tholder, verfers = self.hby.db.resolveVerifiers(pre=prefixer.qb64, sn=seqner.sn, dig=ssaider.qb64)
@@ -101,35 +97,22 @@ class Exchanger:
                 if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
-                    msg = (f"Not enough signatures in idx={indices} route={route} "
-                           f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                    raise MissingSignatureError(f"Not enough signatures in  {indices}"
+                                                f" for evt = {serder.ked}.")
 
         elif cigars:
             for cigar in cigars:
                 if sender != cigar.verfer.qb64:  # cig not by aid
-                    msg = (f"Skipped cig not from aid={sender} route={route} "
-                           f"for exn evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                    raise MissingSignatureError(" process: skipped cig not from aid="
+                                                "%s on exn msg=\n%s\n", sender, serder.pretty())
 
                 if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-                    msg = (f"Failure satisfying exn on cigs for {cigar} route={route} "
-                           f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                    raise MissingSignatureError("Failure satisfying exn on cigs for {}"
+                                                " for evt = {}.".format(cigar,
+                                                                        serder.ked))
         else:
-            self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed)
-            msg = (
-                f"Failure satisfying exn, no cigs or sigs for evt = {serder.said} "
-                f"on route {route} recipient = {serder.ked.get('rp', '')}")
-            logger.info(msg)
-            logger.debug("Exchange message body=\n%s\n", serder.pretty())
-            raise MissingSignatureError(msg)
+            raise MissingSignatureError("Failure satisfying exn, no cigs or sigs"
+                                        " for evt = {}.".format(serder.ked))
 
         e = coring.Pather(path=["e"])
 

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -262,7 +262,7 @@ class Registry(BaseRegistry):
 
     """
 
-    def make(self, *, nonce=None, noBackers=True, baks=None, toad=None, estOnly=False, vcp=None):
+    def make(self, *, nonce=None, noBackers=True, baks=None, toad=None, estOnly=False, vcp=None, temp=None):
         """ Delayed initialization of Issuer.
 
         Actual initialization of Issuer from properties or loaded from .reger.  Should


### PR DESCRIPTION
This PR includes:

* Bug fix for exchanger, to make sure that ESSR attachments survive an escrowed event.
* Bug fix to ensure one exchanger does not poach another exchanger's escrowed events.
* Fix registry inception to match hio changes.
* Removing log messages that are in the direct line of fire of escrow processing