### PR TITLE
chore: bump version to 1.2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: build-keri
 
-VERSION=1.2.6
+VERSION=1.2.7
 
 define DOCKER_WARNING
 In order to use the multi-platform build enable the containerd image store

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from os.path import splitext
 from setuptools import find_packages, setup
 setup(
     name='keri',
-    version='1.2.6',  # also change in src/keri/__init__.py
+    version='1.2.7',  # also change in src/keri/__init__.py
     license='Apache Software License 2.0',
     description='Key Event Receipt Infrastructure',
     long_description="KERI Decentralized Key Management Infrastructure",

--- a/src/keri/__init__.py
+++ b/src/keri/__init__.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
-__version__ = '1.2.6'  # also change in setup.py
+__version__ = '1.2.7'  # also change in setup.py
 
 


### PR DESCRIPTION
Looks like the version number was missed from the 1.2.7 release.