### PR TITLE
KLI export  --ends Fix Main

### DIFF
--- a/src/keri/app/cli/commands/export.py
+++ b/src/keri/app/cli/commands/export.py
@@ -102,11 +102,7 @@ class ExportDoer(doing.DoDoer):
             f = open(f"{pre}-ends.cesr", "w")
 
         msgs = self.hab.replyToOobi(aid=pre, role="controller")
-        for msg in msgs:
-            if f is not None:
-                f.write(msg.decode("utf-8"))
-            else:
-                serder = serdering.SerderKERI(raw=msg)
-                atc = msg[serder.size:]
-                sys.stdout.write(serder.raw.decode("utf-8"))
-                sys.stdout.write(atc.decode("utf-8"))
+        if f is not None:
+            f.write(msgs.decode("utf-8"))
+        else:
+            sys.stdout.write(msgs.decode("utf-8"))


### PR DESCRIPTION
Running the export command with the --ends flag would result in the following error being appended to the output:

ERR: object of type 'int' has no len()
The outputEnds method was incorrectly treating the bytearray returned by replyToOobi() as a list of messages. When iterating over a bytearray, Python yields integers (0-255), not byte strings. The code then tried to slice these integers with msg[serder.size:], resulting in the error.

Fixed by treating the entire bytearray as a single message stream.