### PR TITLE
fix: multisig join should use icp ked not exn ked

### DIFF
--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -187,7 +187,7 @@ class JoinDoer(doing.DoDoer):
 
         inits["toad"] = oicp.ked["bt"]
         inits["wits"] = oicp.ked["b"]
-        inits["delpre"] = oicp.ked["di"] if "di" in ked else None
+        inits["delpre"] = oicp.ked["di"] if "di" in oicp.ked else None
 
         print()
         print("Group Multisig Inception proposed:")


### PR DESCRIPTION
This fixes a bug where "kli multisig join" would fail due to accidentally checking for a delegator identifier in an EXN ked instead of an inception event KED