### PR TITLE
docs: clean up and add agenting docs

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -26,8 +26,21 @@ logger = help.ogler.getLogger()
 
 
 class Receiptor(doing.DoDoer):
+    """DoDoer for synchronous witness receipting and receipt queries over HTTP.
+
+    Drains `msgs` for witness receipt submissions and `gets` for receipt
+    queries, pushing processed request dicts to `cues`.
+    """
 
     def __init__(self, hby, msgs=None, gets=None, cues=None):
+        """Initialize with shared queues and an HTTP client.
+
+        Parameters:
+            hby (Habery): Habitat environment for identifier lookups.
+            msgs (Deck): receipt requests with `pre`, optional `sn`, optional `auths`.
+            gets (Deck): receipt query requests with `pre`, optional `sn`.
+            cues (Deck): completed request cues.
+        """
 
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.gets = gets if gets is not None else decking.Deck()
@@ -40,20 +53,18 @@ class Receiptor(doing.DoDoer):
         super(Receiptor, self).__init__(doers=doers)
 
     def receipt(self, pre, sn=None, auths=None):
-        """ Returns a generator for witness receipting
+        """Yield while witnessing an event and returning witness receipt couples.
 
-        The returns a generator that will submit the designated event to witnesses for receipts using
-        the synchronous witness API, then propogate the receipts to each of the other witnesses.
-
+        Sends the event to all witnesses, optionally catches new witnesses up,
+        then propagates the collected non-transferable receipts to each witness.
 
         Parameters:
-            pre (str): qualified base64 identifier to gather receipts for
-            sn: (Optiona[int]): sequence number of event to gather receipts for, latest is used if not provided
-            auths: (Options[dict]): map of witness AIDs to (time,auth) tuples for providing TOTP auth for witnessing
+            pre (str): qb64 identifier to receipt for.
+            sn (int | None): sequence number, defaults to latest.
+            auths (dict | None): optional map of wit AID to 2FA auth header value.
 
         Returns:
-            list: identifiers of witnesses that returned receipts.
-
+            iterable: witness identifiers that returned receipts.
         """
         auths = auths if auths is not None else dict()
         if pre not in self.hby.prefixes:
@@ -140,18 +151,13 @@ class Receiptor(doing.DoDoer):
         return rcts.keys()
 
     def get(self, pre, sn=None):
-        """ Returns a generator for witness querying
+        """Yield while querying a witness for receipts of an event identified by pre and sn.
 
-        The returns a generator that will request receipts for event identified by pre and sn
-
-
-        Parameters:
-            pre (str): qualified base64 identifier to gather receipts for
-            sn: (Optiona[int]): sequence number of event to gather receipts for, latest is used if not provided
+        Picks one witness and issues GET /receipts?pre=&sn=. Parses any
+        returned receipts into the local parser.
 
         Returns:
-            list: identifiers of witnesses that returned receipts.
-
+            bool: True if the witness returned HTTP 200.
         """
         if pre not in self.hby.prefixes:
             raise kering.MissingEntryError(f"{pre} not a valid AID")
@@ -184,12 +190,13 @@ class Receiptor(doing.DoDoer):
         return rep.status == 200
 
     def catchup(self, pre, wit):
-        """ When adding a new Witness, use this method to catch the witness up to the current state of the KEL
+        """
+        Yield while replaying the full KEL for `pre` to the witness.
+        When adding a new Witness, use this method to catch the witness up to the current state of the KEL
 
         Parameters:
             pre (str): qualified base64 AID of the KEL to send
             wit (str): qualified base64 AID of the witness to send the KEL to
-
         """
         if pre not in self.hby.prefixes:
             raise kering.MissingEntryError(f"{pre} not a valid AID")
@@ -207,18 +214,7 @@ class Receiptor(doing.DoDoer):
         self.remove([clientDoer])
 
     def witDo(self, tymth=None, tock=0.0, **kwa):
-        """
-         Returns doifiable Doist compatibile generator method (doer dog) to process
-            .kevery and .tevery escrows.
-
-        Parameters:
-            tymth (function): injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock (float): injected initial tock value
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that drains `msgs` and runs witness receipt flow."""
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -236,18 +232,7 @@ class Receiptor(doing.DoDoer):
             yield self.tock
 
     def gitDo(self, tymth=None, tock=0.0, **kwa):
-        """
-         Returns doifiable Doist compatibile generator method (doer dog) to process
-            .kevery and .tevery escrows.
-
-        Parameters:
-            tymth (function): injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock (float): injected initial tock value
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that drains `gets` and runs witness receipt queries."""
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -264,28 +249,25 @@ class Receiptor(doing.DoDoer):
 
 
 class WitnessReceiptor(doing.DoDoer):
-    """
-    Sends messages to all current witnesses of given identifier (from hab) and waits
-    for receipts from each of those witnesses and propagates those receipts to each
-    of the other witnesses after receiving the complete set.
+    """Witness receipt doer that sends events and propagates receipts.
 
-    Removes all Doers and exits as Done once all witnesses have been sent the entire
-    receipt set.  Could be enhanced to have a `once` method that runs once and cleans up
+    Uses messenger doers to asynchronously send the event to each witness,
+    waits for receipts to arrive in `hab.db` (via mailbox processing), then
+    propagates the full receipt set across the witness group.
+
+    Could be enhanced to have a `once` method that runs once and cleans up
     and an `all` method that runs and waits for more messages to receipt.
-
     """
 
     def __init__(self, hby, msgs=None, cues=None, force=False, auths=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize with queues and optional auth for witness endpoints.
 
         Parameters:
-            hby (Habery): Habitat of the identifier to receipt witnesses
-            msgs (Deck): incoming messages to publish to witnesses
-            cues (Deck): outgoing cues of successful messages
-            force (bool): True means to send witnesses all receipts even if we have a full compliment.
-
+            hby (Habery): Habitat environment for identifier lookups.
+            msgs (Deck): receipt requests with `pre` and optional `sn`.
+            cues (Deck): completed request cues.
+            force (bool): resend receipts even if already complete.
+            auths (dict | None): optional map of wit AID to auth header value.
         """
         self.hby = hby
         self.force = force
@@ -296,17 +278,15 @@ class WitnessReceiptor(doing.DoDoer):
         super(WitnessReceiptor, self).__init__(doers=[doing.doify(self.receiptDo)], **kwa)
 
     def receiptDo(self, tymth=None, tock=0.0, **kwa):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
+        """Doer loop that sends events to witnesses and propagates receipts.
+        
 
-        Usage:
-            add result of doify on this method to doers list
-
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-
+        Asynchronously processes witness receipt requests from self.msgs queue. 
+        Sends any required delegation context, replays KEL for new witnesses,
+        posts the event, waits for receipts to be stored in `hab.db`, then
+        shares the full receipt set across witnesses. If `force` is false and
+        all receipts already exist, it skips resubmission.
+        Pushes the original request to self.cues to signal completion
         """
         self.wind(tymth)
         self.tock = tock
@@ -358,13 +338,13 @@ class WitnessReceiptor(doing.DoDoer):
                         witer.msgs.append(bytearray(msg))  # make a copy
                         _ = (yield self.tock)
 
-                    while True:
+                    while True: # wait for all receipts to arrive
                         wigs = hab.db.getWigs(dgkey)
                         if len(wigs) == len(wits):
                             break
                         _ = yield self.tock
 
-                # If we started with all our recipts, exit unless told to force resubmit of all receipts
+                # If we started with all our receipts, exit unless told to force resubmit of all receipts
                 if completed and not self.force:
                     self.cues.push(evt)
                     continue
@@ -426,21 +406,21 @@ class WitnessInquisitor(doing.DoDoer):
     for receipts from each of those witnesses and propagates those receipts to each
     of the other witnesses after receiving the complete set.
 
-    Removes all Doers and exits as Done once all witnesses have been sent the entire
-    receipt set.  Could be enhanced to have a `once` method that runs once and cleans up
-    and an `all` method that runs and waits for more messages to receipt.
+    Builds and sends qry/tel queries, pushing the raw sent message to `sent`.
+    The response parsing happens elsewhere (e.g. mailbox or HTTP response handlers).
 
+    Could be enhanced to have a `once` method that runs once and cleans up
+    and an `all` method that runs and waits for more messages to receipt.
     """
 
     def __init__(self, hby, reger=None, msgs=None, klas=None, **kwa):
-        """
-        For all msgs, select a random witness from Habitat's current set of witnesses
-        send the msg and process all responses (KEL replays, RCTs, etc)
+        """Initialize with a message queue and optional messenger class.
 
         Parameters:
-            hby (Habitat): Habitat of the identifier to use to identify witnesses
-            msgs: is the message buffer to process and send to one random witness.
-
+            hby (Habery): Habitat environment for endpoint and kever lookup.
+            reger (Reger | None): optional registry database handle.
+            msgs (Deck): query requests built by `query`/`telquery`.
+            klas (type | None): messenger class, defaults to `HTTPMessenger`.
         """
         self.hby = hby
         self.reger = reger
@@ -452,10 +432,11 @@ class WitnessInquisitor(doing.DoDoer):
 
     def msgDo(self, tymth=None, tock=1.0, **opts):
         """
-        Returns doifiable Doist compatible generator method (doer dog)
+        Doer loop that sends one query to one selected endpoint.
 
-        Usage:
-            add result of doify on this method to doers list
+        For all msgs, select a random witness from Habitat's current set of witnesses
+        send the msg and process all responses (KEL replays, RCTs, etc)
+        Pushes the raw sent message to self.sent to signal completion.
         """
         self.wind(tymth)
         self.tock = tock
@@ -526,21 +507,17 @@ class WitnessInquisitor(doing.DoDoer):
             yield self.tock
 
     def query(self, pre, r="logs", sn='0', fn='0', src=None, hab=None, anchor=None, wits=None, **kwa):
-        """ Create, sign and return a `qry` message against the attester for the prefix
+        """Create, sign, and queue a `qry` KEL query request against the attester for the prefix for later sending.
 
         Parameters:
-            src (str): qb64 identifier prefix of source of query
-            hab (Hab): Hab to use instead of src if provided
-            pre (str): qb64 identifier prefix being queried for
-            r (str): query route
-            sn (str): optional specific hex str of sequence number to query for
-            fn (str): optional specific hex str of sequence number to start with
-            anchor (Seal): anchored Seal to search for
-            wits (list) witnesses to query
-
-        Returns:
-            bytearray: signed query event
-
+            pre (str): qb64 identifier being queried.
+            r (str): query route (e.g. "logs").
+            sn (str): optional hex sequence number to query for.
+            fn (str): optional hex start sequence number.
+            src (str | None): qb64 source identifier (ignored if `hab` provided).
+            hab (Hab | None): habitat used to sign and route the query.
+            anchor (Seal | None): anchored seal to search for.
+            wits (list | None): explicit witnesses to target; otherwise uses endpoints.
         """
         qry = dict(s=sn, fn=fn)
         if anchor is not None:
@@ -553,6 +530,7 @@ class WitnessInquisitor(doing.DoDoer):
         self.msgs.append(msg)
 
     def telquery(self, ri, src=None, i=None, r="tels", hab=None, pre=None, wits=None, **kwa):
+        """Queue a TEL query request for later sending."""
         qry = dict(ri=ri)
         msg = dict(src=src, pre=pre, target=i, r=r, wits=wits, q=qry)
         if hab is not None:
@@ -562,25 +540,19 @@ class WitnessInquisitor(doing.DoDoer):
 
 
 class WitnessPublisher(doing.DoDoer):
-    """
-    Sends messages to all current witnesses of given identifier (from hab) and exits.
-
-    Removes all Doers and exits as Done once all witnesses have been sent the message.
+    """DoDoer that publishes messages to all witnesses for an identifier.
+    
     Could be enhanced to have a `once` method that runs once and cleans up
     and an `all` method that runs and waits for more messages to receipt.
-
     """
 
     def __init__(self, hby, msgs=None, cues=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize with publish queue and completion cues.
 
         Parameters:
-            hby (Habery): Habitat of the identifier to populate witnesses
-            msgs (Deck): incoming messages to publish to witnesses
-            cues (Deck): outgoing cues of successful messages
-
+            hby (Habery): Habitat environment for identifier lookups.
+            msgs (Deck): publish requests with `pre` and `msg`.
+            cues (Deck): completed request cues.
         """
         self.hby = hby
         self.posted = 0
@@ -589,11 +561,9 @@ class WitnessPublisher(doing.DoDoer):
         super(WitnessPublisher, self).__init__(doers=[doing.doify(self.sendDo)], **kwa)
 
     def sendDo(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
-
-        Usage:
-            add result of doify on this method to doers list
+        """Doer loop that sends queued messages to each witness.
+        
+        Pushes the original request to self.cues to signal completion
         """
         self.wind(tymth)
         self.tock = tock
@@ -652,18 +622,17 @@ class WitnessPublisher(doing.DoDoer):
 
 
 class TCPMessenger(doing.DoDoer):
-    """ Send events to witnesses for receipting using TCP direct connection
-
-    """
+    """Send outbound CESR messages to a witness via TCP and parse inbound receipts."""
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize TCP messenger with queues and parser wiring.
 
         Parameters:
-            hab: Habitat of the identifier to populate witnesses
-
+            hab (Hab): habitat for KEL parsing and db access.
+            wit (str): qb64 witness identifier.
+            url (str): tcp endpoint URL for the witness.
+            msgs (Deck | None): outbound message queue.
+            sent (Deck | None): sent message queue.
         """
         self.hab = hab
         self.wit = wit
@@ -681,12 +650,7 @@ class TCPMessenger(doing.DoDoer):
         super(TCPMessenger, self).__init__(doers=doers)
 
     def receiptDo(self, tymth=None, tock=0.0, **kwa):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that sends queued messages over TCP."""
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -719,25 +683,7 @@ class TCPMessenger(doing.DoDoer):
             yield self.tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns doifiable Doist compatible generator method (doer dog) to process
-            incoming message stream of .kevery
-
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
-
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
-
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that parses inbound TCP messages into the Kevery."""
         yield from self.parser.parsator(local=True)  # process messages continuously
 
     @property
@@ -746,18 +692,17 @@ class TCPMessenger(doing.DoDoer):
 
 
 class TCPStreamMessenger(doing.DoDoer):
-    """ Send events to witnesses for receipting using TCP direct connection
-
-    """
+    """Stream a CESR message to a witness via TCP and parse inbound receipts."""
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize TCP stream messenger with queues and parser wiring.
 
         Parameters:
-            hab: Habitat of the identifier to populate witnesses
-
+            hab (Hab): habitat for KEL parsing and db access.
+            wit (str): qb64 witness identifier.
+            url (str): tcp endpoint URL for the witness.
+            msgs (Deck | None): outbound message queue.
+            sent (Deck | None): sent message queue.
         """
         self.hab = hab
         self.wit = wit
@@ -775,11 +720,9 @@ class TCPStreamMessenger(doing.DoDoer):
         super(TCPStreamMessenger, self).__init__(doers=doers)
 
     def receiptDo(self, tymth=None, tock=0.0, **kwa):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
-
-        Usage:
-            add result of doify on this method to doers list
+        """Doer loop that sends queued messages over TCP.
+        
+        Pushes the original request to self.sent to signal completion
         """
         self.wind(tymth)
         self.tock = tock
@@ -813,25 +756,7 @@ class TCPStreamMessenger(doing.DoDoer):
             yield self.tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns doifiable Doist compatible generator method (doer dog) to process
-            incoming message stream of .kevery
-
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
-
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
-
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that parses inbound TCP messages into the Kevery."""
         yield from self.parser.parsator(local=True)  # process messages continuously
 
     @property
@@ -840,19 +765,18 @@ class TCPStreamMessenger(doing.DoDoer):
 
 
 class HTTPMessenger(doing.DoDoer):
-    """
-    Interacts with Recipients on HTTP and SSE for sending events and receiving receipts
-
-    """
+    """Send CESR messages to a witness over HTTP and capture responses."""
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, auth=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize HTTP messenger with queues and optional auth.
 
         Parameters:
-            hab: Habitat of the identifier to populate witnesses
-
+            hab (Hab): habitat for KEL parsing and db access.
+            wit (str): qb64 witness identifier.
+            url (str): http/https endpoint URL for the witness.
+            msgs (Deck | None): outbound message queue.
+            sent (Deck | None): response queue.
+            auth (str | None): optional 2FA auth codes for witnesses.
         """
         self.hab = hab
         self.wit = wit
@@ -876,12 +800,7 @@ class HTTPMessenger(doing.DoDoer):
         super(HTTPMessenger, self).__init__(doers=doers, **kwa)
 
     def msgDo(self, tymth=None, tock=0.0, **kwa):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Doer loop that sends queued messages over HTTP."""
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -902,10 +821,7 @@ class HTTPMessenger(doing.DoDoer):
             yield self.tock
 
     def responseDo(self, tymth=None, tock=0.0, **kwa):
-        """
-        Processes responses from client and adds them to sent cue
-
-        """
+        """Doer loop that processes HTTP responses from the client and adds them into `sent` cues."""
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -923,19 +839,17 @@ class HTTPMessenger(doing.DoDoer):
 
 
 class HTTPStreamMessenger(doing.DoDoer):
-    """
-    Interacts with Recipients on HTTP and SSE for sending events and receiving receipts
-
-    """
+    """Send a single CESR message via HTTP PUT and capture the response."""
 
     def __init__(self, hab, wit, url, msg=b'', headers=None, **kwa):
-        """
-        For the current event, gather the current set of witnesses, send the event,
-        gather all receipts and send them to all other witnesses
+        """Initialize a single-request HTTP messenger.
 
         Parameters:
-            hab: Habitat of the identifier to populate witnesses
-
+            hab (Hab): habitat for KEL parsing and db access.
+            wit (str): qb64 witness identifier.
+            url (str): http/https endpoint URL for the witness.
+            msg (bytes): CESR message body to send.
+            headers (dict | None): extra HTTP headers.
         """
         self.hab = hab
         self.wit = wit
@@ -967,12 +881,7 @@ class HTTPStreamMessenger(doing.DoDoer):
         super(HTTPStreamMessenger, self).__init__(doers=doers, **kwa)
 
     def recur(self, tyme, deeds=None):
-        """
-        Returns doifiable Doist compatible generator method (doer dog)
-
-        Usage:
-            add result of doify on this method to doers list
-        """
+        """Poll for a response and stop once received."""
         if self.client.responses:
             self.rep = self.client.respond()
             self.remove([self.client])
@@ -1037,8 +946,8 @@ def messengerFrom(hab, pre, urls, auth=None):
 
 
 def streamMessengerFrom(hab, pre, urls, msg, headers=None):
-    """ Create a Witnesser (tcp or http) based on provided endpoints
-
+    """Create a stream messenger (HTTP or TCP) for a single outbound message.
+    
     Parameters:
         hab (Habitat): Environment to use to look up witness URLs
         pre (str): qb64 identifier prefix of recipient to create a messanger for


### PR DESCRIPTION
Lots of components had incorrect, out of date, or missing docs. I know this is just on v1.2.7, though who knows how long we'll have this version in prod? I like correct docs. At some point I'll pull these docs onto main.