### PR TITLE
fix: allow tests to use temp=True properly for Configer

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -102,7 +102,7 @@ def openHab(name="test", base="", salt=None, temp=True, cf=None, **kwa):
 
     with openHby(name=name, base=base, salt=salt, temp=temp, cf=cf) as hby:
         if (hab := hby.habByName(name)) is None:
-            hab = hby.makeHab(name=name, icount=1, isith='1', ncount=1, nsith='1', **kwa)
+            hab = hby.makeHab(name=name, icount=1, isith='1', ncount=1, nsith='1', cf=cf, **kwa)
 
         yield hby, hab
 


### PR DESCRIPTION
Configer instances in tests were being created in local dirs instead of temp dirs because cf was not being passed to hby.makeHab.

This fixes that.