### PR TITLE
test: fix the flakiness of kli tests by reloading parser context

### DIFF
--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -13,7 +13,7 @@ from keri.app import directing
 
 from keri.app.cli import commands
 from keri.app.cli.common import existing
-
+from tests import conftest
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -259,6 +259,9 @@ def test_incept_and_rotate_opts(helpers, capsys):
     """
     Tests using the command line arguments for incept and the file argument for rotate
     """
+    # Reload commands module to ensure fresh parser objects - see fn docs for explanation
+    conftest.reload_commands_module()
+
     helpers.remove_test_dirs("test-opts")
     assert os.path.isdir("/usr/local/var/keri/ks/test-opts") is False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ https://docs.pytest.org/en/latest/pythonpath.html
 import os
 import shutil
 import multicommand
+import sys
+import importlib
+import pkgutil
 
 import pytest
 from hio.base import doing
@@ -388,3 +391,22 @@ class CommandDoer(doing.DoDoer):
             yield self.tock
 
         return True
+
+def reload_commands_module():
+    """
+    Reload the commands module and all its submodules to ensure fresh parser objects.
+
+    This is necessary because multicommand modifies parsers in-place by calling
+    add_subparsers(), and Python 3.12+ doesn't allow calling add_subparsers()
+    multiple times on the same parser object.
+    """
+    # Reload all submodules first
+    for importer, modname, ispkg in pkgutil.walk_packages(
+        path=commands.__path__,
+        prefix=commands.__name__ + ".",
+        onerror=lambda x: None
+    ):
+        if modname in sys.modules:
+            importlib.reload(sys.modules[modname])
+    # Then reload the main module
+    importlib.reload(commands)


### PR DESCRIPTION
KLI tests have been flaky on recent CI test runs and I found out how to fix this by resetting the argument parsing context.

Reload commands module to ensure fresh parser objects