### PR TITLE
fix: remove dip and drt from escrows once approved

### DIFF
--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -172,6 +172,7 @@ class ConfirmDoer(doing.DoDoer):
 
                         print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
                         self.remove(self.toRemove)
                         return True
 
@@ -228,7 +229,7 @@ class ConfirmDoer(doing.DoDoer):
 
                             print(f"Delegate {eserder.pre} {typ} event committed.")
 
-                        self.hby.db.delegables.rem(keys=(pre, sn))
+                        self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
                         self.remove(self.toRemove)
                         return True
 


### PR DESCRIPTION
Prior to this fix then only single sig workflows removed items from the delegables escrow. Somehow multisig dip and drt were missed. Both dip and drt should be removed from the delegables escrow once they are approved.