### PR TITLE
fix: backport multisig delegation fixes from main

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -6307,6 +6307,7 @@ class Kevery:
 
                 # get delgate seal
                 couple = self.db.getAes(dgkey)
+                seqner = saider = None
                 if couple is not None:  # Only try to parse the event if we have the del seal
                     raw = bytearray(couple)
                     seqner = coring.Seqner(qb64b=raw, strip=True)
@@ -6315,9 +6316,23 @@ class Kevery:
                     # process event
                     self.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=seqner,
                                       delsaider=saider, local=esr.local)
-                else:
+                elif eserder.delpre in self.prefixes:
+                    # Only triggered for delegator when processing the delegate's KEL.
+                    # Seal will not be found in delegator's AES database until after appearing in the
+                    # delegator's the KEL. Then it can be looked up and sent through event processing
+                    # so that logEvent can save the seal in the AES DB.
+                    seal = dict(i=eserder.pre, s=eserder.snh, d=eserder.said)
+                    dserder = self.db.fetchLastSealingEventByEventSeal(pre=eserder.delpre,
+                                                                       seal=seal)
+                    if dserder is not None:
+                        seqner = coring.Seqner(sn=dserder.sn)
+                        saider = coring.Saider(qb64=dserder.said)
+                if seqner is None or saider is None:
                     raise MissingDelegableApprovalError("No delegation seal found for event.")
 
+                # process event
+                self.processEvent(serder=eserder, sigers=sigers, wigers=wigers,
+                                  delseqner=seqner, delsaider=saider, local=esr.local)
             except MissingDelegableApprovalError as ex:
                 # still waiting on missing delegation approval
                 if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
This backports the multisig delegation fixes from main to 1.2.7 and adds one new fix described by the below diagram to, from within the manually-triggered delegables escrow processing, walk the KEL to find a delegation approval seal so that Kevery.processEvent can be called with the seal data in order to allow validation to proceed to Kever.logEvent, which eventually puts the seal in the AES database.

### Diagram

```
┌─────────────────────────────────────────────────────────────────┐
│ 1. DIP arrives at delegator (no seal attached)                  │
│    → escrowed to delegables                                     │
│    → AES is NOT set (logEvent never called)                     │
├─────────────────────────────────────────────────────────────────┤
│ 2. Delegator approves (creates anchor IXN)                      │
│    → Seal {i: delegate_pre, s: 0, d: dip_said} in delegator KEL │
│    → AES for DIP is STILL empty                                 │
├─────────────────────────────────────────────────────────────────┤
│ 3. processEscrowDelegables runs                                 │
│    → getAes(dgkey) returns None (empty!)                        │
│                                                                 │
│    WITHOUT KEL lookup (old code):                               │
│      → seqner=None, saider=None                                 │
│      → processEvent called with no seal                         │
│      → valSigsWigsDel re-escrows to delegables                  │
│      → INFINITE LOOP - test hangs                               │
│                                                                 │
│    WITH KEL lookup (new code):                                  │
│      → fetchLastSealingEventByEventSeal finds seal in KEL       │
│      → seqner, saider populated from KEL                        │
│      → processEvent succeeds                                    │
│      → logEvent called → AES finally set                        │
│      → Event removed from escrow ✓                              │
└─────────────────────────────────────────────────────────────────┘
```

### Tests

Once this PR is merged then I will retarget https://github.com/kentbull/keripy/pull/11 to `v1.3.2` so we can have integration tests that test these backported fixes.