### PR TITLE
fix: KEL walk for delegables AES seal lookup

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -6399,16 +6399,28 @@ class Kevery:
 
                 # get delgate seal
                 couple = self.db.getAes(dgkey)
+                seqner = saider = None
                 if couple is not None:  # Only try to parse the event if we have the del seal
                     raw = bytearray(couple)
                     seqner = coring.Seqner(qb64b=raw, strip=True)
                     saider = coring.Saider(qb64b=raw)
-
-                    # process event
-                    self.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=seqner,
-                                      delsaider=saider, local=esr.local)
-                else:
+                elif eserder.delpre in self.prefixes:
+                    # Only triggered for delegator when processing the delegate's KEL.
+                    # Seal will not be found in delegator's AES database until after appearing in the
+                    # delegator's the KEL. Then it can be looked up and sent through event processing
+                    # so that logEvent can save the seal in the AES DB.
+                    seal = dict(i=eserder.pre, s=eserder.snh, d=eserder.said)
+                    dserder = self.db.fetchLastSealingEventByEventSeal(pre=eserder.delpre,
+                                                                       seal=seal)
+                    if dserder is not None:
+                        seqner = coring.Seqner(sn=dserder.sn)
+                        saider = coring.Saider(qb64=dserder.said)
+                if seqner is None or saider is None:
                     raise MissingDelegableApprovalError("No delegation seal found for event.")
+
+                # process event
+                self.processEvent(serder=eserder, sigers=sigers, wigers=wigers,
+                                  delseqner=seqner, delsaider=saider, local=esr.local)
 
             except MissingDelegableApprovalError as ex:
                 # still waiting on missing delegation approval


### PR DESCRIPTION
This allows adding the delegate KEL to the delegator Basing.kevers by ensuring the AES seal for a DIP or DRT event is looked up prior to validating the DIP or DRT. Enabling this validation means the delegator acts a bit like the witness of a delegate by storing its KEL and the AES seal.