### PR TITLE
fix: KEL walk for delegables AES seal lookup

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -6308,6 +6308,7 @@ class Kevery:
 
                 # get delgate seal
                 couple = self.db.getAes(dgkey)
+                seqner = saider = None
                 if couple is not None:  # Only try to parse the event if we have the del seal
                     raw = bytearray(couple)
                     seqner = coring.Seqner(qb64b=raw, strip=True)
@@ -6316,9 +6317,23 @@ class Kevery:
                     # process event
                     self.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=seqner,
                                       delsaider=saider, local=esr.local)
-                else:
+                elif eserder.delpre in self.prefixes:
+                    # Only triggered for delegator when processing the delegate's KEL.
+                    # Seal will not be found in delegator's AES database until after appearing in the
+                    # delegator's the KEL. Then it can be looked up and sent through event processing
+                    # so that logEvent can save the seal in the AES DB.
+                    seal = dict(i=eserder.pre, s=eserder.snh, d=eserder.said)
+                    dserder = self.db.fetchLastSealingEventByEventSeal(pre=eserder.delpre,
+                                                                       seal=seal)
+                    if dserder is not None:
+                        seqner = coring.Seqner(sn=dserder.sn)
+                        saider = coring.Saider(qb64=dserder.said)
+                if seqner is None or saider is None:
                     raise MissingDelegableApprovalError("No delegation seal found for event.")
 
+                # process event
+                self.processEvent(serder=eserder, sigers=sigers, wigers=wigers,
+                                  delseqner=seqner, delsaider=saider, local=esr.local)
             except MissingDelegableApprovalError as ex:
                 # still waiting on missing delegation approval
                 if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
Provisional: this PR is 

This fix allows dip unescrow following approval by seal lookup via KEL walk.

Walks the KEL to find a delegation approval seal so that Kevery.processEvent can be called with the seal data in order to allow validation to proceed to Kever.logEvent, which eventually puts the seal in the AES database.


### Tests

Once we decide the approach to propagation of the AES seal then I will adjust and retarget https://github.com/kentbull/keripy/pull/11 to `v1.3.3` so we can have integration tests that test these backported fixes.