### PR TITLE
fix: provide issuer prefix for telquery on admit

### DIFF
--- a/src/keri/app/cli/commands/ipex/admit.py
+++ b/src/keri/app/cli/commands/ipex/admit.py
@@ -108,7 +108,7 @@ class AdmitDoer(doing.DoDoer):
         # Lets get the latest KEL and Registry if needed
         self.witq.query(src=self.hab.pre, pre=issr)
         if "ri" in acdc:
-            self.witq.telquery(src=self.hab.pre, wits=self.hab.kevers[issr].wits, ri=acdc["ri"], i=acdc["d"])
+            self.witq.telquery(src=self.hab.pre, pre=issr, wits=self.hab.kevers[issr].wits, ri=acdc["ri"], i=acdc["d"])
 
         for label in ("anc", "iss", "acdc"):
             ked = embeds[label]


### PR DESCRIPTION
Resolves #1160 by passing the issuer prefix to the telquery. This way, the WitnessInquisitor will resolve the end roles for the issuer if there are no witnesses.

This is similar to how KERIA does it here: https://github.com/WebOfTrust/keria/blob/262b7ce019d1c38fdebfee3df39eb0e080cb2240/src/keria/app/agenting.py#L1353-L1358

```
         # Lets get the latest KEL and Registry if needed
            self.witq.query(hab=self.agentHab, pre=issr)
            if "ri" in acdc:
                self.witq.telquery(
                    hab=self.agentHab, pre=issr, ri=acdc["ri"], i=acdc["d"]
                )
```