### PR TITLE
Switched internal receipting mechanism of Registrar to use Receiptor

### DIFF
--- a/src/keri/app/cli/commands/vc/import.py
+++ b/src/keri/app/cli/commands/vc/import.py
@@ -1,0 +1,93 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands module
+
+"""
+import argparse
+
+from hio import help
+from hio.base import doing
+
+from keri.app import habbing
+from keri.app.cli.common import existing
+from keri.core import parsing
+from keri.vdr import eventing as teventing, verifying, credentialing
+
+logger = help.ogler.getLogger()
+
+parser = argparse.ArgumentParser(description='Import an ACDC credential in CESR stream format')
+parser.set_defaults(handler=lambda args: imprt(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of KERI keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)  # passcode => bran
+parser.add_argument("--file", help="File of streamed CESR credential to import", required=True)
+parser.add_argument("--said", "-s", help="SAID of the credential to expect.", required=False, default=None)
+
+
+def imprt(args):
+    """ Command line list credential registries handler
+
+    """
+
+    ed = ImportDoer(name=args.name,
+                    base=args.base,
+                    bran=args.bran,
+                    file=args.file,
+                    said=args.said)
+    return [ed]
+
+
+class ImportDoer(doing.DoDoer):
+
+    def __init__(self, name, base, bran, file, said=None):
+        self.file = file
+        self.said = said
+
+        self.hby = existing.setupHby(name=name, base=base, bran=bran)
+        self.rgy = credentialing.Regery(hby=self.hby, name=name, base=base)
+        self.tvy = teventing.Tevery(db=self.hby.db, reger=self.rgy.reger)
+        self.vry = verifying.Verifier(hby=self.hby, reger=self.rgy.reger)
+
+        doers = [doing.doify(self.importDo), habbing.HaberyDoer(self.hby)]
+
+        super(ImportDoer, self).__init__(doers=doers)
+
+    def importDo(self, tymth, tock=0.0, **kwa):
+        """ Export credential from store and any related material
+
+        Parameters:
+            tymth (function): injected function wrapper closure returned by .tymen() of
+                Tymist instance. Calling tymth() returns associated Tymist .tyme.
+            tock (float): injected initial tock value
+
+        Returns:  doifiable Doist compatible generator method
+
+        """
+        # enter context
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        with open(self.file, 'rb') as f:
+            ims = f.read()
+
+            parsing.Parser(kvy=self.hby.kvy, tvy=self.tvy, vry=self.vry, local=False).parse(ims=ims)
+            self.tvy.processEscrows()
+            self.vry.processEscrows()
+            self.hby.kvy.processEscrows()
+
+            if self.said:
+                while self.vry.reger.creds.get(keys=self.said) is None:
+                    self.tvy.processEscrows()
+                    self.vry.processEscrows()
+                    self.hby.kvy.processEscrows()
+                    yield self.tock
+
+                print("Credential successfully imported.")
+
+        self.exit()
+        return True

--- a/src/keri/app/cli/commands/witness/demo.py
+++ b/src/keri/app/cli/commands/witness/demo.py
@@ -22,6 +22,8 @@ from keri.core import Salter
 parser = argparse.ArgumentParser(description="Run a demo collection of witnesses")
 parser.add_argument("--loglevel", action="store", required=False, default=os.getenv("KERI_LOG_LEVEL", "CRITICAL"),
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
 parser.set_defaults(handler=lambda args: demo(args))
 
 logger = help.ogler.getLogger()
@@ -46,12 +48,12 @@ def demo(args):
     wubcf = configing.Configer(name="wub", headDirPath="scripts", temp=False, reopen=True, clear=False)
     wyzcf = configing.Configer(name="wyz", headDirPath="scripts", temp=False, reopen=True, clear=False)
 
-    wanHby = habbing.Habery(name="wan", salt=Salter(raw=b'wann-the-witness').qb64, temp=False, cf=wancf)
-    wilHby = habbing.Habery(name="wil", salt=Salter(raw=b'will-the-witness').qb64, temp=False, cf=wilcf)
-    wesHby = habbing.Habery(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=False, cf=wescf)
-    witHby = habbing.Habery(name="wit", salt=Salter(raw=b'witn-the-witness').qb64, temp=False, cf=witcf)
-    wubHby = habbing.Habery(name="wub", salt=Salter(raw=b'wubl-the-witness').qb64, temp=False, cf=wubcf)
-    wyzHby = habbing.Habery(name="wyz", salt=Salter(raw=b'wyzs-the-witness').qb64, temp=False, cf=wyzcf)
+    wanHby = habbing.Habery(name="wan", salt=Salter(raw=b'wann-the-witness').qb64, temp=False, cf=wancf, base=args.base)
+    wilHby = habbing.Habery(name="wil", salt=Salter(raw=b'will-the-witness').qb64, temp=False, cf=wilcf, base=args.base)
+    wesHby = habbing.Habery(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=False, cf=wescf, base=args.base)
+    witHby = habbing.Habery(name="wit", salt=Salter(raw=b'witn-the-witness').qb64, temp=False, cf=witcf, base=args.base)
+    wubHby = habbing.Habery(name="wub", salt=Salter(raw=b'wubl-the-witness').qb64, temp=False, cf=wubcf, base=args.base)
+    wyzHby = habbing.Habery(name="wyz", salt=Salter(raw=b'wyzs-the-witness').qb64, temp=False, cf=wyzcf, base=args.base)
 
     doers = [InitDoer(wan=wanHby, wil=wilHby, wes=wesHby, wit=witHby, wub=wubHby, wyz=wyzHby)]
 

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -493,10 +493,10 @@ class Registrar(doing.DoDoer):
         self.hby = hby
         self.rgy = rgy
         self.counselor = counselor
-        self.witDoer = agenting.WitnessReceiptor(hby=self.hby)
+        self.receiptor = agenting.Receiptor(hby=self.hby)
         self.witPub = agenting.WitnessPublisher(hby=self.hby)
 
-        doers = [self.witDoer, self.witPub, doing.doify(self.escrowDo)]
+        doers = [self.receiptor, self.witPub, doing.doify(self.escrowDo)]
 
         super(Registrar, self).__init__(doers=doers)
 
@@ -524,7 +524,7 @@ class Registrar(doing.DoDoer):
                                saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=anc.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=anc.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(registry.regk, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
@@ -565,7 +565,7 @@ class Registrar(doing.DoDoer):
             registry.anchorMsg(pre=vcid, regd=iserder.said, seqner=seqner, saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
@@ -605,7 +605,7 @@ class Registrar(doing.DoDoer):
             registry.anchorMsg(pre=vcid, regd=rserder.said, seqner=seqner, saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
             return vcid, rseq.sn
@@ -704,7 +704,7 @@ class Registrar(doing.DoDoer):
                 if len(wigs) == len(kever.wits):  # We have all of them, this event is finished
                     hab = self.hby.habs[prefixer.qb64]
                     witnessed = False
-                    for cue in self.witDoer.cues:
+                    for cue in self.receiptor.cues:
                         if cue["pre"] == hab.pre and cue["sn"] == seqner.sn:
                             witnessed = True
 


### PR DESCRIPTION
This PR includes the following changes:

* Switched internal receipting mechanism of Registrar to use Receiptor for witness receipts.  This uses the HTTP API for receipts and does not require witnesses to also behave as mailboxes.

* New command for importing an ACDC create, `kli vc import`