### PR TITLE
refactor(db): Migrate dtss database to CesrSuber

### DIFF
--- a/src/keri/app/cli/commands/rollback.py
+++ b/src/keri/app/cli/commands/rollback.py
@@ -69,7 +69,7 @@ def rollback(tymth, tock=0.0, **opts):
             hby.db.wits.rem(keys=(serder.preb, serder.saidb))
             hby.db.delWigs(dgkey)
             hby.db.delSigs(dgkey)  # idempotent
-            hby.db.delDts(dgkey)  # idempotent do not change dts if already
+            hby.db.dtss.rem(keys=dgkey)  # idempotent
             hby.db.delKes(dbing.snKey(serder.preb, serder.sn))
 
             seqner = coring.Number(num=serder.sn - 1)

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -3365,8 +3365,8 @@ class Kever:
         fn = None  # None means not a first seen log event so does not return an fn
         dgkeys = (serder.pre, serder.said)
         dgkey = dgKey(serder.preb, serder.saidb)
-        dtsb = helping.nowIso8601().encode("utf-8")
-        self.db.putDts(dgkey, dtsb)  # idempotent do not change dts if already
+        nowdater = coring.Dater()  # now timestamp
+        self.db.dtss.put(keys=dgkey, val=nowdater)  # idempotent do not change dts if already
         if sigers:
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])  # idempotent
         if wigers:
@@ -3413,18 +3413,18 @@ class Kever:
                             serder.preb, fn, firner.sn, serder.said)
                 logger.debug("Event body=\n%s\n", serder.pretty())
             if dater:  # cloned replay use original's dts from dater
-                dtsb = dater.dtsb
-            self.db.setDts(dgkey, dtsb)  # first seen so set dts to now
+                nowdater = dater
+            self.db.dtss.pin(keys=dgkey, val=nowdater)  # first seen so set dts to now
             self.db.fons.pin(keys=dgkey, val=Seqner(sn=fn))
             logger.debug("AID %s...%s: First seen %s at sn=%s valid event SAID=%s for %s at %s",
                          pre[:4], pre[-4:], serder.ilk, fn, serder.said,
-                         serder.pre, dtsb.decode("utf-8"))
+                         serder.pre, nowdater.dts)
             logger.debug("Event Body=\n%s\n", serder.pretty())
         self.db.addKe(snKey(serder.preb, serder.sn), serder.saidb)
         logger.info("AID %s...%s: Added to KEL %s at sn=%s valid event SAID=%s",
                     pre[:4], pre[-4:], serder.ilk, serder.sn, serder.said)
         logger.debug("Event Body=\n%s\n", serder.pretty())
-        return (fn, dtsb.decode("utf-8"))  # (fn int, dts str) if first else (None, dts str)
+        return (fn, nowdater.dts)  # (fn int, dts str) if first else (None, dts str)
 
 
     def escrowMFEvent(self, serder, sigers, wigers=None,
@@ -3454,7 +3454,7 @@ class Kever:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
         if wigers:
@@ -3496,7 +3496,7 @@ class Kever:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
         if wigers:
@@ -3525,7 +3525,7 @@ class Kever:
         """
         local = True if local else False
         dgkey = dgKey(serder.preb, serder.saidb)
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))  # idempotent
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())  # idempotent
         if sigers:
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         if wigers:
@@ -3568,7 +3568,7 @@ class Kever:
         """
         local = True if local else False
         dgkey = dgKey(serder.preb, serder.saidb)
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))  # idempotent
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())  # idempotent
 
         if sigers:
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
@@ -3624,7 +3624,7 @@ class Kever:
         """
         local = True if local else False
         dgkey = dgKey(serder.preb, serder.saidb)
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))  # idempotent
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())  # idempotent
 
         if sigers:  # idempotent
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
@@ -5238,7 +5238,7 @@ class Kevery:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=(serder.preb, serder.saidb), val=esr)
 
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
         if wigers:
@@ -5278,7 +5278,7 @@ class Kevery:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
         if wigers:
@@ -5303,7 +5303,7 @@ class Kevery:
         """
         cigars = cigars if cigars is not None else []
         dgkey = dgKey(prefixer.qb64b, serder.saidb)
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(prefixer.qb64b, serder.saidb), val=serder)
         self.db.qnfs.add(keys=(prefixer.qb64, serder.said), val=serder.saidb)
@@ -5338,7 +5338,7 @@ class Kevery:
             esr = basing.EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgkey, val=coring.Dater())
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
         self.db.addLde(snKey(serder.preb, serder.sn), serder.saidb)
@@ -5370,7 +5370,7 @@ class Kevery:
         # so can compare digs from receipt and in database for receipted event
         # with different algos.  Can't lookup event by dig for same reason. Must
         # lookup last event by sn not by dig.
-        self.db.putDts(dgKey(serder.preb, said), helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgKey(serder.preb, said), val=coring.Dater())
         for wiger in wigers:  # escrow each couple
             # don't know witness pre yet without witness list so no verfer in wiger
             # if wiger.verfer.transferable:  # skip transferable verfers
@@ -5402,7 +5402,7 @@ class Kevery:
         # so can compare digs from receipt and in database for receipted event
         # with different algos.  Can't lookup event by dig for same reason. Must
         # lookup last event by sn not by dig.
-        self.db.putDts(dgKey(serder.preb, said), helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgKey(serder.preb, said), val=coring.Dater())
         for cigar in cigars:  # escrow each triple
             if cigar.verfer.transferable:  # skip transferable verfers
                 continue  # skip invalid triplets
@@ -5444,7 +5444,7 @@ class Kevery:
         # lookup last event by sn not by dig.
         for tsg in tsgs:
             prefixer, number, saider, sigers = tsg
-            self.db.putDts(dgKey(serder.preb, serder.saidb), helping.nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgKey(serder.preb, serder.saidb), val=coring.Dater())
             # since serder of of receipt not receipted event must use dig in
             # serder.ked["d"] not serder.dig
             for siger in sigers:  # escrow each quintlet
@@ -5490,7 +5490,7 @@ class Kevery:
         # and sig stored at kel pre, sn so can compare digs
         # with different algos.  Can't lookup by dig for the same reason. Must
         # lookup last event by sn not by dig.
-        self.db.putDts(dgKey(serder.preb, serder.saidb), helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgKey(serder.preb, serder.saidb), val=coring.Dater())
         # since serder of of receipt not receipted event must use dig in
         # serder.ked["d"] not serder.dig
 
@@ -5532,7 +5532,7 @@ class Kevery:
         # and sig stored at kel pre, sn so can compare digs
         # with different algos.  Can't lookup by dig for the same reason. Must
         # lookup last event by sn not by dig.
-        self.db.putDts(dgKey(serder.preb, serder.said), helping.nowIso8601().encode("utf-8"))
+        self.db.dtss.put(keys=dgKey(serder.preb, serder.said), val=coring.Dater())
         quintuple = (
             coring.Diger(qb64=serder.said),     # event digest
             sprefixer,                          # Prefixer
@@ -5588,7 +5588,7 @@ class Kevery:
 
         Original Escrow steps:
             dgkey = dgKey(pre, serder.dig)
-            self.db.putDts(dgkey, nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgkey, val=coring.Dater())
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
             self.db.evts.put(keys=(pre, serder.dig), val=serder)
             self.db.ooes.addOn(pre, sn, serder.dig)
@@ -5623,16 +5623,16 @@ class Kevery:
                     raise ValidationError(msg)
                 
                  # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgkey)
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgkey)
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"OOO Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutOOE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"OOO Stale event escrow at dig = {bytes(edig)}"
@@ -5714,7 +5714,7 @@ class Kevery:
 
         Original Escrow steps:
             dgkey = dgKey(pre, serder.digb)
-            .db.putDts(dgkey, nowIso8601().encode("utf-8"))
+            .db.dtss.put(keys=dgkey, val=coring.Dater())
             .db.putSigs(dgkey, [siger.qb64b for siger in sigers])
             .db.evts.put(keys=(pre, serder.digb), val=serder)
             .db.pses.addOn(pre, sn, serder.digb)
@@ -5750,16 +5750,16 @@ class Kevery:
                     raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgkey)
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgkey)
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"PSE Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPSE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"PSE Stale event escrow at dig = {bytes(edig)}"
@@ -5883,7 +5883,7 @@ class Kevery:
 
         Original Escrow steps:
             dgkey = dgKey(pre, serder.digb)
-            .db.putDts(dgkey, nowIso8601().encode("utf-8"))
+            .db.dtss.put(keys=dgkey, val=coring.Dater())
             .db.putWigs(dgkey, [siger.qb64b for siger in sigers])
             .db.evts.put(keys=(pre, serder.digb), val=serder)
             .db.addPwe(snKey(pre, sn), serder.digb)
@@ -5914,16 +5914,16 @@ class Kevery:
                     raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgkey)
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgkey)
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"PWE Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.trace("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"PWE Stale event escrow at dig = {bytes(edig)}"
@@ -6067,16 +6067,16 @@ class Kevery:
                     raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgkey)
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgkey)
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"PDE Missing escrowed event datetime at dig = {bytes(edig).decode()}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutPWE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"PDE Stale event escrow at dig = {bytes(edig)}"
@@ -6214,7 +6214,7 @@ class Kevery:
         Value is couple
 
         Original Escrow steps:
-            self.db.putDts(dgKey(pre, dig), nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgKey(pre, dig), val=coring.Dater())
             for wiger in wigers:  # escrow each couple
                 couple = dig.encode("utf-8") + wiger.qb64b
                 self.db.addUwe(key=snKey(pre, sn), val=triple)
@@ -6239,16 +6239,16 @@ class Kevery:
             try:
                 rdigerBytes = rdiger.encode('utf-8')
                 # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgKey(pre, bytes(rdigerBytes)))
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgKey(pre, bytes(rdigerBytes)))
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"UWE Missing escrowed event datetime at dig = {rdiger.qb64b}"
                     logger.trace("Kevery unescrow error: %s", rdiger.qb64b)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutUWE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"UWE Stale event escrow at dig = {rdiger.qb64b}"
@@ -6318,7 +6318,7 @@ class Kevery:
         Value is triple
 
         Original Escrow steps:
-            self.db.putDts(dgKey(pre, dig), nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgKey(pre, dig), val=coring.Dater())
             for cigar in cigars:  # escrow each triple
                 if cigar.verfer.transferable:  # skip transferable verfers
                     continue  # skip invalid couplets
@@ -6350,16 +6350,16 @@ class Kevery:
                     cigar.verfer = Verfer(qb64b=sprefixer.qb64b)
 
                     # check date if expired then remove escrow.
-                    dtb = self.db.getDts(dgKey(pre, bytes(rsaider.qb64b)))
-                    if dtb is None:  # othewise is a datetime as bytes
+                    dater = self.db.dtss.get(keys=dgKey(pre, bytes(rsaider.qb64b)))
+                    if dater is None:  # no datetime stored
                         # no date time so raise ValidationError which unescrows below
                         msg = f"URE Missing escrowed event datetime at dig = {rsaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
-                    # do date math here and discard if stale nowIso8601() bytes
+                    # do date math here and discard if stale
                     dtnow = helping.nowUTC()
-                    dte = helping.fromIso8601(bytes(dtb))
+                    dte = dater.datetime
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutURE):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"URE Stale event escrow at dig = {rsaider.qb64b}"
@@ -6484,16 +6484,16 @@ class Kevery:
                     raise ValidationError(msg)
 
                 # check date if expired then remove escrow.
-                dtb = self.db.getDts(dgkey)
-                if dtb is None:  # othewise is a datetime as bytes
+                dater = self.db.dtss.get(keys=dgkey)
+                if dater is None:  # no datetime stored
                     # no date time so raise ValidationError which unescrows below
                     msg = f"DEL Missing escrowed event datetime at dig = {bytes(edig)}"
                     logger.info("Kevery unescrow error: %s", msg)
                     raise ValidationError(msg)
 
-                # do date math here and discard if stale nowIso8601() bytes
+                # do date math here and discard if stale
                 dtnow = helping.nowUTC()
-                dte = helping.fromIso8601(bytes(dtb))
+                dte = dater.datetime
                 if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutOOE):
                     # escrow stale so raise ValidationError which unescrows below
                     msg = f"DEL Stale event escrow at dig = {bytes(edig)}"
@@ -6587,16 +6587,16 @@ class Kevery:
                 try:
                     # check date if expired then remove escrow.
                     dgkey = dgKey(pre.encode("utf-8"), edig.encode("utf-8"))
-                    dtb = self.db.getDts(dgkey)
-                    if dtb is None:  # othewise is a datetime as bytes
+                    dater = self.db.dtss.get(keys=dgkey)
+                    if dater is None:  # no datetime stored
                         # no date time so raise ValidationError which unescrows below
                         msg = f"QNF Missing escrowed event datetime at dig = {bytes(edig).decode()}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
-                    # do date math here and discard if stale nowIso8601() bytes
+                    # do date math here and discard if stale
                     dtnow = helping.nowUTC()
-                    dte = helping.fromIso8601(bytes(dtb))
+                    dte = dater.datetime
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutQNF):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"QNF Stale qry event escrow at dig = {bytes(edig).decode()}"
@@ -6791,7 +6791,7 @@ class Kevery:
         Value is quintuple
 
         Original Escrow steps:
-            self.db.putDts(dgKey(serder.preb, dig), nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgKey(serder.preb, dig), val=coring.Dater())
             prelet = (dig.encode("utf-8") + seal.i.encode("utf-8") +
                   Seqner(sn=int(seal.s, 16)).qb64b + seal.d.encode("utf-8"))
             for siger in sigers:  # escrow each quintlet
@@ -6822,16 +6822,16 @@ class Kevery:
                     esaider, sprefixer, snumber, ssaider, siger = equinlet
 
                     # check date if expired then remove escrow.
-                    dtb = self.db.getDts(dgKey(pre, bytes(esaider.qb64b)))
-                    if dtb is None:  # othewise is a datetime as bytes
+                    dater = self.db.dtss.get(keys=dgKey(pre, bytes(esaider.qb64b)))
+                    if dater is None:  # no datetime stored
                         # no date time so raise ValidationError which unescrows below
                         msg = f"VRE Missing escrowed event datetime at dig = {esaider.qb64b}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
-                    # do date math here and discard if stale nowIso8601() bytes
+                    # do date math here and discard if stale
                     dtnow = helping.nowUTC()
-                    dte = helping.fromIso8601(bytes(dtb))
+                    dte = dater.datetime
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutVRE):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"VRE Stale event escrow at dig = {esaider.qb64b}"
@@ -6945,7 +6945,7 @@ class Kevery:
 
         Original Escrow steps:
             dgkey = dgKey(pre, serder.dig)
-            self.db.putDts(dgkey, nowIso8601().encode("utf-8"))
+            self.db.dtss.put(keys=dgkey, val=coring.Dater())
             self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
             self.db.evts.put(keys=(pre, serder.dig), val=serder)
             self.db.addLde(snKey(pre, sn), serder.digb)
@@ -6980,16 +6980,16 @@ class Kevery:
                         raise ValidationError(msg)
 
                     # check date if expired then remove escrow.
-                    dtb = self.db.getDts(dgkey)
-                    if dtb is None:  # othewise is a datetime as bytes
+                    dater = self.db.dtss.get(keys=dgkey)
+                    if dater is None:  # no datetime stored
                         # no date time so raise ValidationError which unescrows below
                         msg = f"DUP Missing escrowed event datetime at dig = {bytes(edig)}"
                         logger.trace("Kevery unescrow error: %s", msg)
                         raise ValidationError(msg)
 
-                    # do date math here and discard if stale nowIso8601() bytes
+                    # do date math here and discard if stale
                     dtnow = helping.nowUTC()
-                    dte = helping.fromIso8601(bytes(dtb))
+                    dte = dater.datetime
                     if (dtnow - dte) > datetime.timedelta(seconds=self.TimeoutLDE):
                         # escrow stale so raise ValidationError which unescrows below
                         msg = f"DUP Stale event escrow at dig = {bytes(edig)}"
@@ -7142,8 +7142,8 @@ def loadEvent(db, preb, dig):
 
     event["receipts"] = receipts
     # add first seen replay couple to attachments
-    if not (dts := db.getDts(key=dgkey)):
+    if not (dater := db.dtss.get(keys=dgkey)):
         raise ValueError("Missing datetime for dig={}.".format(dig))
 
-    event["timestamp"] = coring.Dater(dts=bytes(dts)).dts
+    event["timestamp"] = dater.dts
     return event

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -688,12 +688,13 @@ class Baser(dbing.LMDBer):
             through the misfit escrow and get promoted to local source.
 
 
-        .dtss is named sub DB of datetime stamp strings in ISO 8601 format of
-            the datetime when the event was first escrosed and then later first
-            seen by log. Used for escrows timeouts and extended validation.
+        .dtss is named sub DB instance of CesrSuber for datetime stamps
+            of the datetime when the event was first escrowed and then later
+            first seen by log. Used for escrow timeouts and extended validation.
+            subkey 'dtss.'
             dgKey
             DB is keyed by identifier prefix plus digest of serialized event
-            Value is ISO 8601 datetime stamp bytes
+            Value is Dater instance
 
         .aess is named sub DB instance of CatCesrSuber for authorizing event
             source seal couples that map digest of key event to seal source
@@ -1028,7 +1029,7 @@ class Baser(dbing.LMDBer):
         self.evts = subing.SerderSuber(db=self, subkey='evts.')
         self.fels = subing.OnSuber(db=self, subkey='fels.')
         self.kels = self.env.open_db(key=b'kels.', dupsort=True)
-        self.dtss = self.env.open_db(key=b'dtss.')
+        self.dtss = subing.CesrSuber(db=self, subkey='dtss.', klas=coring.Dater)
         self.aess = subing.CatCesrSuber(db=self, subkey='aess.',
                                         klas=(coring.Number, coring.Saider))
         self.sigs = self.env.open_db(key=b'sigs.', dupsort=True)
@@ -1735,12 +1736,12 @@ class Baser(dbing.LMDBer):
                 atc.extend(coup)
 
         # add first seen replay couple to attachments
-        if not (dts := self.getDts(key=dgkey)):
+        if not (dater := self.dtss.get(keys=dgkey)):
             raise kering.MissingEntryError("Missing datetime for dig={}.".format(dig))
         atc.extend(core.Counter(code=core.Codens.FirstSeenReplayCouples,
                                 count=1, version=kering.Vrsn_1_0).qb64b)
         atc.extend(core.Number(num=fn, code=core.NumDex.Huge).qb64b)  # may not need to be Huge
-        atc.extend(coring.Dater(dts=bytes(dts)).qb64b)
+        atc.extend(dater.qb64b)
 
         # prepend pipelining counter to attachments
         if len(atc) % 4:
@@ -2006,40 +2007,7 @@ class Baser(dbing.LMDBer):
             yield serder  # event as Serder
 
 
-    def putDts(self, key, val):
-        """
-        Use dgKey()
-        Write serialized event datetime stamp val to key
-        Does not overwrite existing val if any
-        Returns True If val successfully written Else False
-        Returns False if key already exists
-        """
-        return self.putVal(self.dtss, key, val)
 
-    def setDts(self, key, val):
-        """
-        Use dgKey()
-        Write serialized event datetime stamp val to key
-        Overwrites existing val if any
-        Returns True If val successfully written Else False
-        """
-        return self.setVal(self.dtss, key, val)
-
-    def getDts(self, key):
-        """
-        Use dgKey()
-        Return datetime stamp at key
-        Returns None if no entry at key
-        """
-        return self.getVal(self.dtss, key)
-
-    def delDts(self, key):
-        """
-        Use dgKey()
-        Deletes value at key.
-        Returns True If key exists in database Else False
-        """
-        return self.delVal(self.dtss, key)
 
     def getSigs(self, key):
         """

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -103,7 +103,7 @@ def test_partial_signed_escrow():
         assert len(sigs) == 2
 
         # get DTS set by escrow date time stamp on event
-        edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        edater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
 
         time.sleep(0.001)
         # verify Kevery process partials escrow now unescrows correctly given
@@ -118,9 +118,9 @@ def test_partial_signed_escrow():
         assert len(escrows) == 0
 
         # get DTS set by first seen event acceptance date time stamp
-        adtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        adater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
         # ensure accept time is later than escrow time, default timedelta is zero
-        assert (helping.fromIso8601(adtsb) - helping.fromIso8601(edtsb)) > datetime.timedelta()
+        assert (adater.datetime - edater.datetime) > datetime.timedelta()
 
         # send duplicate message with all three sigs
         msg = bytearray(srdr.raw)
@@ -137,8 +137,8 @@ def test_partial_signed_escrow():
         assert len(escrows) == 0  # escrow stays gone
 
         # get DTS after partial last sig should not change dts from first accepted
-        pdtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
-        assert pdtsb == adtsb
+        pdater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
+        assert pdater.dts == adater.dts
 
         # get first seen
         fsdig = kvy.db.fels.getOn(keys=pre, on=0)
@@ -222,7 +222,7 @@ def test_partial_signed_escrow():
         assert escrows[0].encode("utf-8") == srdr.saidb  #  escrow entry for event
 
         # get DTS set by escrow date time stamp on event
-        edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        edater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
 
         time.sleep(0.001)
         # Process partials but now escrow not stale
@@ -233,9 +233,9 @@ def test_partial_signed_escrow():
         assert len(escrows) == 0  # escrow gone
 
         # get DTS set by first seen event acceptance date time stamp
-        adtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        adater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
         # ensure accept time is later than escrow time, default timedelta is zero
-        assert (helping.fromIso8601(adtsb) - helping.fromIso8601(edtsb)) > datetime.timedelta()
+        assert (adater.datetime - edater.datetime) > datetime.timedelta()
 
         # send duplicate message but add last sig
         msg = bytearray(srdr.raw)
@@ -250,8 +250,8 @@ def test_partial_signed_escrow():
         assert len(escrows) == 0  # escrow stays gone
 
         # get DTS after partial last sig should not change dts from first accepted
-        pdtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
-        assert pdtsb == adtsb
+        pdater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
+        assert pdater.dts == adater.dts
 
         # get first seen
         fsdig = kvy.db.fels.getOn(keys=pre, on=1)
@@ -333,7 +333,7 @@ def test_partial_signed_escrow():
         assert kvr.serder.said != srdr.said  # key state not updated
 
         # get DTS set by escrow date time stamp on event
-        edtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        edater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
 
         time.sleep(0.001)
         # process escrow
@@ -341,9 +341,9 @@ def test_partial_signed_escrow():
         assert kvr.serder.said == srdr.said  # key state updated
 
         # get DTS set by first seen event acceptance date time stamp
-        adtsb = bytes(kvy.db.getDts(dbing.dgKey(pre, srdr.saidb)))
+        adater = kvy.db.dtss.get(keys=dbing.dgKey(pre, srdr.saidb))
         # ensure accept time is later than escrow time, default timedelta is zero
-        assert (helping.fromIso8601(adtsb) - helping.fromIso8601(edtsb)) > datetime.timedelta()
+        assert (adater.datetime - edater.datetime) > datetime.timedelta()
 
         # get first seen
         fsdig = kvy.db.fels.getOn(keys=pre, on=3)
@@ -930,7 +930,7 @@ def test_ooes_missing_db_entries_escrow_cleanup():
         dgkey = dbing.dgKey(pre, ixndig)
 
         # missing DTS → OOES must remove entry
-        db.delDts(dgkey)
+        db.dtss.rem(keys=dgkey)
         kvy.processEscrowOutOfOrders()
         assert db.ooes.getOn(keys=pre, on=1) == []  # cleaned up
 

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -49,7 +49,7 @@ def test_baser():
 
     assert isinstance(baser.evts, subing.SerderSuber)
     assert isinstance(baser.sigs, lmdb._Database)
-    assert isinstance(baser.dtss, lmdb._Database)
+    assert isinstance(baser.dtss, subing.CesrSuber)
     assert isinstance(baser.rcts, lmdb._Database)
     assert isinstance(baser.ures, lmdb._Database)
     assert isinstance(baser.kels, lmdb._Database)
@@ -80,7 +80,7 @@ def test_baser():
 
     assert isinstance(baser.evts, subing.SerderSuber)
     assert isinstance(baser.sigs, lmdb._Database)
-    assert isinstance(baser.dtss, lmdb._Database)
+    assert isinstance(baser.dtss, subing.CesrSuber)
     assert isinstance(baser.rcts, lmdb._Database)
     assert isinstance(baser.ures, lmdb._Database)
     assert isinstance(baser.kels, lmdb._Database)
@@ -108,7 +108,7 @@ def test_baser():
 
         assert isinstance(baser.evts, subing.SerderSuber)
         assert isinstance(baser.sigs, lmdb._Database)
-        assert isinstance(baser.dtss, lmdb._Database)
+        assert isinstance(baser.dtss, subing.CesrSuber)
         assert isinstance(baser.rcts, lmdb._Database)
         assert isinstance(baser.ures, lmdb._Database)
         assert isinstance(baser.kels, lmdb._Database)
@@ -300,20 +300,24 @@ def test_baser():
         key = dgKey(preb, digb)
         assert key == f'{preb.decode("utf-8")}.{digb.decode("utf-8")}'.encode("utf-8")
 
-        # test .dtss sub db methods
-        val1 = b'2020-08-22T17:50:09.988921+00:00'
-        val2 = b'2020-08-22T17:50:09.988921+00:00'
+        # test .dtss sub db methods - now returns Dater objects
+        dater1 = coring.Dater(dts='2020-08-22T17:50:09.988921+00:00')
+        dater2 = coring.Dater(dts='2020-08-22T17:50:10.000000+00:00')
 
-        assert db.getDts(key) == None
-        assert db.delDts(key) == False
-        assert db.putDts(key, val1) == True
-        assert db.getDts(key) == val1
-        assert db.putDts(key, val2) == False
-        assert db.getDts(key) == val1
-        assert db.setDts(key, val2) == True
-        assert db.getDts(key) == val2
-        assert db.delDts(key) == True
-        assert db.getDts(key) == None
+        assert db.dtss.get(keys=key) is None
+        assert db.dtss.rem(keys=key) == False
+        assert db.dtss.put(keys=key, val=dater1) == True
+        result = db.dtss.get(keys=key)
+        assert isinstance(result, coring.Dater)
+        assert result.dts == dater1.dts
+        assert db.dtss.put(keys=key, val=dater2) == False  # idempotent
+        result = db.dtss.get(keys=key)
+        assert result.dts == dater1.dts  # still original
+        assert db.dtss.pin(keys=key, val=dater2) == True  # overwrites
+        result = db.dtss.get(keys=key)
+        assert result.dts == dater2.dts
+        assert db.dtss.rem(keys=key) == True
+        assert db.dtss.get(keys=key) is None
 
         # Test .aess authorizing event source seal couples
         # test .aess sub db methods


### PR DESCRIPTION
# Refactor: Migrate `dtss` database to CesrSuber

Migrates the `dtss` (Date Time Stamps) database from raw LMDB calls to `CesrSuber` abstraction with typed `Dater` objects.

## Changes

### Schema Update
```python
# Before
self.dtss = self.env.open_db(key=b'dtss.')

# After
self.dtss = subing.CesrSuber(db=self, subkey='dtss.', klas=coring.Dater)
```

### Removed Helper Methods (4 total)
- ❌ `getDts(key)` - Returns Dater directly via `.get()`
- ❌ `putDts(key, val)` - Use `.put()` with Dater object
- ❌ `setDts(key, val)` - Use `.pin()` for overwrites
- ❌ `delDts(key)` - Use `.rem()` for removals

### Updated Consumers (5 files, 45+ call sites)
1. **`src/keri/core/eventing.py`** - 35 calls updated
   - Escrow timestamp logic now uses typed Dater objects
   - Direct property access: `dater.datetime` instead of `fromIso8601(bytes(dtb))`
2. **`src/keri/app/cli/commands/rollback.py`** - 1 call updated
3. **`src/keri/db/basing.py`** - 1 call updated (`cloneEvtMsg`)
4. **`tests/core/test_escrow.py`** - 8 calls updated
5. **`tests/db/test_basing.py`** - Complete rewrite to use Suber API

## Pattern Examples

### Write (Idempotent)
```python
# OLD
self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))

# NEW
self.db.dtss.put(keys=dgkey, val=coring.Dater())
```

### Read
```python
# OLD
dtb = self.db.getDts(dgkey)
if dtb:
    dte = helping.fromIso8601(bytes(dtb))

# NEW
if not (dater := self.db.dtss.get(keys=dgkey)):
    raise ValidationError(...)
dte = dater.datetime  # Direct property access
```

### Overwrite (Non-Idempotent)
```python
# OLD
self.db.setDts(dgkey, dts_bytes)

# NEW
self.db.dtss.pin(keys=dgkey, val=dater)
```

## Testing

✅ **45/45 tests passing (100%)**
```
tests/db/test_basing.py:       12/12 passed
tests/core/test_escrow.py:      6/6 passed
tests/core/test_eventing.py:   27/27 passed
```

## Metrics

- **Files Modified:** 5
- **Lines Changed:** ~380 removed (helper boilerplate), ~200 added (typed calls)
- **Helper Methods Deleted:** 4
- **Consumer Calls Updated:** 45+
- **Bugs Fixed:** 2 (scope issues discovered during testing)

## References

- **Pattern Source:** Production `.udes` database (no helpers, direct Suber usage)
- **Related:** Follows pattern from Ryan Hansen's `.aess` migration (PR #1159)
- **Issue:** #1163
