### PR TITLE
feat: delegator AES seal saved to delegator DB on approved delegation

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+
+# ==================== Setup ====================
 kli init --name delegate --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9aBc
 kli init --name delegator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWdoaWpsaw
 kli incept --name delegator --alias delegator --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
 kli oobi resolve --name delegate --oobi-alias delegator --oobi http://127.0.0.1:5642/oobi/EHpD0-CDWOdu5RJ8jHBSUkOqBZ3cXeDVHWNb_Ul89VI7/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
+# ==================== Delegated Inception ====================
 kli incept --name delegate --alias proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
 kli incept --name delegate --alias delegate --proxy proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegatee.json &
 pid=$!
@@ -15,9 +18,40 @@ PID_LIST+=" $pid"
 
 wait $PID_LIST
 
+echo ""
+echo "==================== Post-Inception Verification ===================="
+echo ""
+
+echo "Delegate status after inception (sn=0):"
 kli status --name delegate --alias delegate
+echo ""
+
+echo "Delegator status after inception anchor (sn=1):"
+kli status --name delegator --alias delegator
+echo ""
+
+# Delegator resolves delegate OOBI to verify inception
+DELEGATE_AID=$(kli aid --name delegate --alias delegate)
+DELEGATOR_AID=$(kli aid --name delegator --alias delegator)
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+echo "Delegator resolving delegate OOBI..."
+kli oobi resolve --name delegator --oobi-alias delegate --oobi "${OOBI}"
+
+echo ""
+echo "--- Verification: delegator views delegate keystate after inception (sn=0) ---"
+kli kevers --name delegator --prefix "${DELEGATE_AID}"
+
+echo ""
+echo "--- Verification: delegator anchor event (sn=1) ---"
+kli kevers --name delegator --prefix "${DELEGATOR_AID}"
+
+# ==================== Delegated Rotation ====================
+echo ""
+echo "==================== Delegated Rotation ===================="
+echo ""
 
 echo "Now rotating delegate..."
+PID_LIST=""
 kli rotate --name delegate --alias delegate --proxy proxy &
 pid=$!
 PID_LIST="$pid"
@@ -29,17 +63,50 @@ PID_LIST+=" $pid"
 
 wait $PID_LIST
 
+echo ""
+echo "==================== Post-Rotation Verification ===================="
+echo ""
+
+echo "Delegate status after rotation (sn=1):"
 kli status --name delegate --alias delegate
+echo ""
+
+echo "Delegator status after rotation anchor (sn=2):"
+kli status --name delegator --alias delegator
+echo ""
+
+# Re-resolve delegate OOBI to pick up rotation event
+echo "Re-resolving delegate OOBI after rotation..."
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+kli oobi resolve --name delegator --oobi-alias delegate --oobi "${OOBI}"
+
+echo ""
+echo "--- Verification: delegator views delegate keystate after rotation (sn=1) ---"
+kli kevers --name delegator --prefix "${DELEGATE_AID}"
+
+echo ""
+echo "--- Verification: delegator anchor event after rotation (sn=2) ---"
+kli kevers --name delegator --prefix "${DELEGATOR_AID}"
+
+# ==================== Third-Party Validator ====================
+echo ""
+echo "==================== Third-Party Validator ===================="
+echo ""
 
 kli init --name validator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9vAl
 
+echo "Validator resolving delegator OOBI..."
 OOBI=$(kli oobi generate --name delegator --alias delegator --role witness | head -n 1)
 kli oobi resolve --name validator --oobi-alias delegator --oobi "${OOBI}"
+
+echo "Validator resolving delegate OOBI..."
 OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
 kli oobi resolve --name validator --oobi-alias delegate --oobi "${OOBI}"
 
-AID=$(kli aid --name delegate --alias delegate)
-kli kevers --name validator --prefix "${AID}"
+echo ""
+echo "--- Verification: validator views delegate keystate (should show sn=1 after rotation) ---"
+kli kevers --name validator --prefix "${DELEGATE_AID}"
 
-
+echo ""
+echo "==================== Script complete ===================="
 

--- a/src/keri/app/cli/commands/delegate/confirm.py
+++ b/src/keri/app/cli/commands/delegate/confirm.py
@@ -14,8 +14,9 @@ from keri.app import habbing, indirecting, agenting, grouping, forwarding, deleg
 from keri.app.cli.common import existing
 from keri.app.habbing import GroupHab
 from keri import core
-from keri.core import coring, serdering
+from keri.core import coring, serdering, Siger
 from keri.db import dbing
+from keri.db.dbing import dgKey
 from keri.help import helping
 from keri.peer import exchanging
 
@@ -93,6 +94,26 @@ class ConfirmDoer(doing.DoDoer):
         self.interact = interact
         self.auto = auto
         super(ConfirmDoer, self).__init__(doers=doers)
+
+    def _addAuthorizerSeal(self, pre, edig, anchorSn, anchorSaid):
+        """Save the authorizer (delegator) event seal of the anchoring IXN event for an approved delegation."""
+        dgkey = dbing.dgKey(pre, edig)
+        seqner = coring.Seqner(sn=anchorSn)
+        saider = coring.Saider(qb64=anchorSaid)
+        couple = seqner.qb64b + saider.qb64b
+        self.hby.db.setAes(dgkey, couple)
+
+    def _processEvent(self, pre, edig, eserder, anchorSn, anchorSaid):
+        """Process the DIP or DRT event so it appears in the delegator's hby.kevers."""
+        dgkey = dbing.dgKey(pre.encode("utf-8"), edig.encode("utf-8"))
+        sigs = self.hby.db.getSigs(dgkey)  # list of sigs
+        sigers = [Siger(qb64b=bytes(sig)) for sig in sigs]
+        wigs = self.hby.db.getWigs(dgkey)  # list of wigs
+        wigers = [Siger(qb64b=bytes(wig)) for wig in wigs]
+        sner = core.Number(num=anchorSn, code=core.NumDex.Huge)
+        saider = coring.Saider(qb64=anchorSaid)
+        self.hby.kvy.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=sner,
+                                      delsaider=saider, local=True)
 
     def confirmDo(self, tymth, tock=0.0, **kwa):
         """
@@ -175,7 +196,11 @@ class ConfirmDoer(doing.DoDoer):
 
                         print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        # TODO: once both delegables and misfit escrows are automated then refactor
+                        #   the following direct removal to instead rely on normal escrow processing.
                         self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
+                        self._addAuthorizerSeal(pre, edig, anchorSn=serder.sn, anchorSaid=serder.said)
+                        self._processEvent(pre=pre, edig=edig, eserder=eserder, anchorSn=serder.sn, anchorSaid=serder.said)
                         self.remove(self.toRemove)
                         return True
 
@@ -232,7 +257,11 @@ class ConfirmDoer(doing.DoDoer):
 
                             print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        # TODO: once both delegables and misfit escrows are automated then refactor
+                        #   the following direct removal to instead rely on normal escrow processing.
                         self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
+                        self._addAuthorizerSeal(pre, edig, anchorSn=hab.kever.sn, anchorSaid=hab.kever.serder.said)
+                        self._processEvent(pre=pre, edig=edig, eserder=eserder, anchorSn=eserder.sn, anchorSaid=eserder.said)
                         self.remove(self.toRemove)
                         return True
 


### PR DESCRIPTION
As per the maintainer discussion last week this PR:
- saves AES seal for a dip/drt to the delegator's AES database near the end of `kli delegate confirm`
- modifies existing Bash script integration tests  to ensure `dip` and `drt` events populate `.kevers` for the delegator in both multi sig and single sig workflows.

So, instead of a KEL walk within the escrow logic we decided to just save the AES seal, for the delegator, to the delegator's .aes DB key.

An unresolved issue is how to propagate the AES seal to the witnesses of the delegate as a part of the overall `dip/drt` operation.