### PR TITLE
feat: delegator AES seal saved to delegator DB on approved delegation

### DIFF
--- a/scripts/demo/basic/delegate.sh
+++ b/scripts/demo/basic/delegate.sh
@@ -1,88 +1,112 @@
 #!/bin/bash
-set -e
 
-source "$(dirname "$0")/script-utils.sh"
+# ==================== Setup ====================
+kli init --name delegate --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9aBc
+kli init --name delegator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWdoaWpsaw
+kli incept --name delegator --alias delegator --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
+kli oobi resolve --name delegate --oobi-alias delegator --oobi http://127.0.0.1:5642/oobi/EHpD0-CDWOdu5RJ8jHBSUkOqBZ3cXeDVHWNb_Ul89VI7/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha
 
-delegator=$(random_name delegator)
-delegate=$(random_name delegate)
-validator=$(random_name validator)
-
-kli init --name "$delegator" --nopasscode
-kli init --name "$delegate" --nopasscode
-kli init --name "$validator" --nopasscode
-
-kli oobi resolve --name "$delegator" --oobi http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller
-kli oobi resolve --name "$delegate" --oobi http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller
-kli oobi resolve --name "$validator" --oobi http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller
-
-kli incept --name "$delegator" --alias delegator \
-    --wit BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
-
-kli incept --name "$delegate" --alias proxy \
-    --wit BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
-
-kli incept --name "$validator" --alias validator \
-    --wit BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX \
-    --toad 1 \
-    --icount 1 \
-    --ncount 1 \
-    --isith 1 \
-    --nsith 1 \
-    --transferable
-
-kli ends add --name "$delegate" --alias proxy --eid "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha" --role mailbox
-
-delegator_oobi=$(kli oobi generate --name "$delegator" --alias delegator --role witness | tail -n 1)
-delegator_aid=$(kli aid --name "$delegator" --alias delegator)
-proxy_oobi=$(kli oobi generate --name "$delegate" --alias proxy --role witness | tail -n 1)
-
-kli oobi resolve --name "$delegate" --oobi-alias delegator --oobi "${delegator_oobi}"
-kli oobi resolve --name "$delegator" --oobi-alias proxy --oobi "${proxy_oobi}"
-
-delegate_json=$(mktemp)
-cat << EOF > "$delegate_json"
-{
-    "transferable": true,
-    "toad": 1,
-    "wits": ["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"],
-    "icount": 1,
-    "ncount": 1,
-    "isith": "1",
-    "nsith": "1",
-    "delpre": "$delegator_aid"
-}
-EOF
-
-# Create delegated identifier
-kli incept --name "$delegate" --alias delegate --proxy proxy --file "$delegate_json" &
+# ==================== Delegated Inception ====================
+kli incept --name delegate --alias proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegator.json
+kli incept --name delegate --alias delegate --proxy proxy --file ${KERI_DEMO_SCRIPT_DIR}/data/delegatee.json &
 pid=$!
-kli delegate confirm --name "$delegator" --alias delegator --interact -Y
-wait $pid
+PID_LIST+=" $pid"
 
-kli status --name "$delegate" --alias delegate
-delegate_oobi=$(kli oobi generate --name "$delegate" --alias delegate --role witness | tail -n 1)
-delegate_aid=$(kli aid --name "$delegate" --alias delegate)
-
-# Rotate delegated identifier
-kli rotate --name "$delegate" --alias delegate --proxy proxy &
+kli delegate confirm --name delegator --alias delegator -Y &
 pid=$!
-kli delegate confirm --name "$delegator" --alias delegator --interact -Y
+PID_LIST+=" $pid"
 
-kli status --name "$delegate" --alias delegate
+wait $PID_LIST
 
-# 3rd party validated delegated identifier
-kli oobi resolve --name "$validator" --oobi-alias delegate --oobi "$delegate_oobi"
-kli oobi resolve --name "$validator" --oobi-alias delegator --oobi "$delegator_oobi"
-kli kevers --name "$validator" --prefix "$delegate_aid" --poll
+echo ""
+echo "==================== Post-Inception Verification ===================="
+echo ""
+
+echo "Delegate status after inception (sn=0):"
+kli status --name delegate --alias delegate
+echo ""
+
+echo "Delegator status after inception anchor (sn=1):"
+kli status --name delegator --alias delegator
+echo ""
+
+# Delegator resolves delegate OOBI to verify inception
+DELEGATE_AID=$(kli aid --name delegate --alias delegate)
+DELEGATOR_AID=$(kli aid --name delegator --alias delegator)
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+echo "Delegator resolving delegate OOBI..."
+kli oobi resolve --name delegator --oobi-alias delegate --oobi "${OOBI}"
+
+echo ""
+echo "--- Verification: delegator views delegate keystate after inception (sn=0) ---"
+kli kevers --name delegator --prefix "${DELEGATE_AID}"
+
+echo ""
+echo "--- Verification: delegator anchor event (sn=1) ---"
+kli kevers --name delegator --prefix "${DELEGATOR_AID}"
+
+# ==================== Delegated Rotation ====================
+echo ""
+echo "==================== Delegated Rotation ===================="
+echo ""
+
+echo "Now rotating delegate..."
+PID_LIST=""
+kli rotate --name delegate --alias delegate --proxy proxy &
+pid=$!
+PID_LIST="$pid"
+
+echo "Checking for delegate rotate..."
+kli delegate confirm --name delegator --alias delegator -Y &
+pid=$!
+PID_LIST+=" $pid"
+
+wait $PID_LIST
+
+echo ""
+echo "==================== Post-Rotation Verification ===================="
+echo ""
+
+echo "Delegate status after rotation (sn=1):"
+kli status --name delegate --alias delegate
+echo ""
+
+echo "Delegator status after rotation anchor (sn=2):"
+kli status --name delegator --alias delegator
+echo ""
+
+# Re-resolve delegate OOBI to pick up rotation event
+echo "Re-resolving delegate OOBI after rotation..."
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+kli oobi resolve --name delegator --oobi-alias delegate --oobi "${OOBI}"
+
+echo ""
+echo "--- Verification: delegator views delegate keystate after rotation (sn=1) ---"
+kli kevers --name delegator --prefix "${DELEGATE_AID}"
+
+echo ""
+echo "--- Verification: delegator anchor event after rotation (sn=2) ---"
+kli kevers --name delegator --prefix "${DELEGATOR_AID}"
+
+# ==================== Third-Party Validator ====================
+echo ""
+echo "==================== Third-Party Validator ===================="
+echo ""
+
+kli init --name validator --nopasscode --config-dir ${KERI_SCRIPT_DIR} --config-file demo-witness-oobis --salt 0ACDEyMzQ1Njc4OWxtbm9vAl
+
+echo "Validator resolving delegator OOBI..."
+OOBI=$(kli oobi generate --name delegator --alias delegator --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegator --oobi "${OOBI}"
+
+echo "Validator resolving delegate OOBI..."
+OOBI=$(kli oobi generate --name delegate --alias delegate --role witness | head -n 1)
+kli oobi resolve --name validator --oobi-alias delegate --oobi "${OOBI}"
+
+echo ""
+echo "--- Verification: validator views delegate keystate (should show sn=1 after rotation) ---"
+kli kevers --name validator --prefix "${DELEGATE_AID}"
+
+echo ""
+echo "==================== Script complete ===================="
+

--- a/src/keri/cli/commands/delegate/confirm.py
+++ b/src/keri/cli/commands/delegate/confirm.py
@@ -93,6 +93,21 @@ class ConfirmDoer(doing.DoDoer):
         self.auto = auto
         super(ConfirmDoer, self).__init__(doers=doers)
 
+    def _addAuthorizerSeal(self, pre, edig, anchorSn, anchorSaid):
+        """Save the authorizer (delegator) event seal of the anchoring IXN event for an approved delegation."""
+        sner = core.Number(num=anchorSn, code=core.NumDex.Huge)
+        diger = coring.Diger(qb64=anchorSaid)
+        self.hby.db.aess.pin(keys=(pre, edig), val=(sner, diger))
+
+    def _processEvent(self, pre, edig, eserder, anchorSn, anchorSaid):
+        """Process the DIP or DRT event so it appears in the delegator's hby.kevers."""
+        sigers = self.hby.db.sigs.get(keys=(pre, edig))
+        wigers = self.hby.db.wigs.get(keys=(pre, bytes(edig)))
+        sner = core.Number(num=anchorSn, code=core.NumDex.Huge)
+        saider = coring.Saider(qb64=anchorSaid)
+        self.hby.kvy.processEvent(serder=eserder, sigers=sigers, wigers=wigers, delseqner=sner,
+                                      delsaider=saider, local=True)
+
     def confirmDo(self, tymth, tock=0.0, **kwa):
         """
         Parameters:
@@ -171,7 +186,11 @@ class ConfirmDoer(doing.DoDoer):
 
                         print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        # TODO: once both delegables and misfit escrows are automated then refactor
+                        #   the following direct removal to instead rely on normal escrow processing.
                         self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
+                        self._addAuthorizerSeal(pre, edig, anchorSn=serder.sn, anchorSaid=serder.said)
+                        self._processEvent(pre=pre, edig=edig, eserder=eserder, anchorSn=serder.sn, anchorSaid=serder.said)
                         self.remove(self.toRemove)
                         return True
 
@@ -228,7 +247,11 @@ class ConfirmDoer(doing.DoDoer):
 
                             print(f"Delegate {eserder.pre} {typ} event committed.")
 
+                        # TODO: once both delegables and misfit escrows are automated then refactor
+                        #   the following direct removal to instead rely on normal escrow processing.
                         self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
+                        self._addAuthorizerSeal(pre, edig, anchorSn=hab.kever.sn, anchorSaid=hab.kever.serder.said)
+                        self._processEvent(pre=pre, edig=edig, eserder=eserder, anchorSn=eserder.sn, anchorSaid=eserder.said)
                         self.remove(self.toRemove)
                         return True
 


### PR DESCRIPTION
As per the maintainer discussion last week this PR:
- saves AES seal for a dip/drt to the delegator's AES database near the end of `kli delegate confirm`
- modifies existing Bash script integration tests  to ensure `dip` and `drt` events populate `.kevers` for the delegator in both multi sig and single sig workflows.

So, instead of a KEL walk within the escrow logic we decided to just save the AES seal, for the delegator, to the delegator's .aes DB key.

An unresolved issue is how to propagate the AES seal to the witnesses of the delegate as a part of the overall `dip/drt` operation.