### PR TITLE
feat(db): migrate .cdel database from Saider to Diger

### DIFF
--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -82,23 +82,23 @@ class Anchorer(doing.DoDoer):
         self.witDoer.msgs.append(dict(pre=pre, sn=srdr.sn, auths=self.auths))
         self.hby.db.dpwe.pin(keys=(srdr.pre, srdr.said), val=srdr)
 
-    def complete(self, prefixer, seqner, saider=None):
+    def complete(self, prefixer, seqner, diger=None):
         """ Check for completed delegation for the specific delegation event
 
         Parameters:
             prefixer (Prefixer): qb64 identifier prefix of event to check
             seqner (Seqner): sequence number of event to check
-            saider (Saider): optional digest of event to verify
+            diger (Diger): optional digest of event to verify
 
         Returns:
             bool: True if delegation protocol is complete, False otherwise
         """
-        csaider = self.hby.db.cdel.get(keys=(prefixer.qb64, seqner.qb64))
-        if not csaider:
+        cdiger = self.hby.db.cdel.get(keys=(prefixer.qb64, seqner.qb64))
+        if not cdiger:
             return False
         else:
-            if saider and (csaider.qb64 != saider.qb64):
-                raise kering.ValidationError(f"invalid delegation protocol escrowed event {csaider.qb64}-{saider.qb64}")
+            if diger and (cdiger.qb64 != diger.qb64):
+                raise kering.ValidationError(f"invalid delegation protocol escrowed event {cdiger.qb64}-{diger.qb64}")
 
         return True
 
@@ -232,7 +232,7 @@ class Anchorer(doing.DoDoer):
             del self.publishers[pre]
 
             self.hby.db.dpub.rem(keys=(pre, said))
-            self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Saider(qb64=serder.said))
+            self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Diger(qb64=serder.said))
 
     def publishDelegator(self, pre):
         """Publish the delegation event to my witnesses."""

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1313,7 +1313,7 @@ class Baser(dbing.LMDBer):
         # completed group delegated AIDs
         # TODO: clean
         self.cdel = subing.CesrSuber(db=self, subkey='cdel.',
-                                     klas=coring.Saider)
+                                     klas=coring.Diger)
 
         # multisig sig embed payload SAID mapped to containing exn messages across group multisig participants
         # TODO: clean


### PR DESCRIPTION
## Changes

Migrated `.cdel` (credential deletion tracking) database from `Saider` to `Diger`.

### Modified Files
- `src/keri/db/basing.py` (line 1316): Schema declaration
- `src/keri/app/delegating.py`: Consumer updates
  - `complete()` method: parameter and variable renamed
  - Storage call updated to use `Diger`

### Rationale

**Per Sam's Feb 9 explanation:** Event digests should use `Diger`, not `Saider`. 

- `Saider` is for self-addressing documents (ACDCs) with single SAID fields
- Events have multiple SAID fields, making `Saider` semantically incorrect
- Using `Diger` prevents latent errors from incorrect abstraction

### Tests

- ✅ `tests/app/test_delegating.py`: 3/3 passed
- ✅ `tests/db/test_basing.py`: 12/12 passed

### Related

- Issue #1163 (database migration tracking)
- Part of Saider→Diger conversion series (`.cdel`, `.meids`, `.knas`, `.wwas`)