### PR TITLE
feat(db): migrate .knas database from Saider to Diger

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1195,7 +1195,7 @@ class Baser(dbing.LMDBer):
         # key state SAID database for successfully saved key state notices
         # maps key=(prefix, aid) to val=said of key state
         # TODO: clean
-        self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Saider)
+        self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Diger)
 
         # Watcher watched SAID database for successfully saved watched AIDs for a watcher
         # maps key=(cid, aid, oid) to val=said of rpy message


### PR DESCRIPTION
# PR Draft: `knas` Saider → Diger

## Title
feat(db): migrate .knas database from Saider to Diger

## Body
## Summary
- Changes `.knas` schema declaration in `Baser.reopen()` from `coring.Saider` to `coring.Diger`.
- Keeps behavior and key layout unchanged; this is a semantic class correction for event digest storage.

## Why
- Per current database migration guidance, event/message digests should use `Diger` rather than `Saider`.
- This reduces latent misuse of SAID-specific semantics in places where plain digest semantics are intended.

## Change
- File updated:
  - `src/keri/db/basing.py`
- Exact change:
  - `self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Saider)`
  - → `self.knas = subing.CesrSuber(db=self, subkey='knas.', klas=coring.Diger)`

## Validation
- Ran focused test:
  - `pytest tests/core/test_keystate.py -q`
- Result:
  - `1 passed`

## Scope
- This PR intentionally contains only the `.knas` conversion.
- Other Saider→Diger targets are split into separate PRs (`.wwas`, `.meids`) for simpler review.
