### PR TITLE
feat(db): migrate .wwas database from Saider to Diger

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1200,7 +1200,7 @@ class Baser(dbing.LMDBer):
         # Watcher watched SAID database for successfully saved watched AIDs for a watcher
         # maps key=(cid, aid, oid) to val=said of rpy message
         # TODO: clean
-        self.wwas = subing.CesrSuber(db=self, subkey='wwas.', klas=coring.Saider)
+        self.wwas = subing.CesrSuber(db=self, subkey='wwas.', klas=coring.Diger)
 
         # config loaded oobis to be processed asynchronously, keyed by oobi URL
         # TODO: clean


### PR DESCRIPTION
# PR Draft: `wwas` Saider → Diger

## Title
feat(db): migrate .wwas database from Saider to Diger

## Body
## Summary
- Changes `.wwas` schema declaration in `Baser.reopen()` from `coring.Saider` to `coring.Diger`.
- Keeps storage/access pattern the same; updates only the CESR class semantics for digest values.

## Why
- `.wwas` stores digest-like values where `Diger` is the intended type.
- Aligns database typing with current migration direction and event-digest semantics.

## Change
- File updated:
  - `src/keri/db/basing.py`
- Exact change:
  - `self.wwas = subing.CesrSuber(db=self, subkey='wwas.', klas=coring.Saider)`
  - → `self.wwas = subing.CesrSuber(db=self, subkey='wwas.', klas=coring.Diger)`

## Validation
- Ran focused test:
  - `pytest tests/app/test_watching.py -q`
- Result:
  - `2 passed`

## Scope
- This PR intentionally contains only the `.wwas` conversion.
- Other targets are split into separate PRs (`.knas`, `.meids`) to keep review isolated.
