### PR TITLE
feat(db): migrate .meids database from Saider to Diger

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1317,7 +1317,7 @@ class Baser(dbing.LMDBer):
 
         # multisig sig embed payload SAID mapped to containing exn messages across group multisig participants
         # TODO: clean
-        self.meids = subing.CesrIoSetSuber(db=self, subkey="meids.", klas=coring.Saider)
+        self.meids = subing.CesrIoSetSuber(db=self, subkey="meids.", klas=coring.Diger)
 
         # multisig sig embed payload SAID mapped to group multisig participants AIDs
         # TODO: clean


### PR DESCRIPTION
# PR Draft: `meids` Saider → Diger

## Title
feat(db): migrate .meids database from Saider to Diger

## Body
## Summary
- Changes `.meids` schema declaration in `Baser.reopen()` from `coring.Saider` to `coring.Diger`.
- Preserves IoSet semantics (`CesrIoSetSuber`) and only updates the CESR value class.

## Why
- `.meids` values are digest-oriented and should use `Diger` rather than SAID-specific `Saider`.
- Improves semantic correctness and aligns with ongoing migration decisions.

## Change
- File updated:
  - `src/keri/db/basing.py`
- Exact change:
  - `self.meids = subing.CesrIoSetSuber(db=self, subkey="meids.", klas=coring.Saider)`
  - → `self.meids = subing.CesrIoSetSuber(db=self, subkey="meids.", klas=coring.Diger)`

## Validation
- Ran focused test:
  - `pytest tests/app/test_grouping.py -q`
- Result:
  - `9 passed`

## Scope
- This PR intentionally contains only the `.meids` conversion.
- Other targets are split into separate PRs (`.knas`, `.wwas`) for review clarity.
