### PR TITLE
feat(vdr): migrate reger tels to OnSuber

### DIFF
--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -110,26 +110,14 @@ def escrows(tymth, tock=0.0, **opts):
 
             if (not escrow) or escrow == "likely-duplicitous-events":
                 ldes = list()
-                key = b""  # start key for iteration
-                while True:  # break when done
-                    found = False
-                    for pre, sn, edig in hby.db.ldes.getOnItemIterAll(keys=key):
-                        # pre and sn are already unpacked by Suber
-                        edig = edig.encode(
-                            "utf-8"
-                        )  # Suber returns str, loadEvent expects bytes
-                        found = True
+                for (pre,), sn, edig in hby.db.ldes.getOnItemIterAll(keys=b""):
+                    if hasattr(edig, "encode"):
+                        edig = edig.encode("utf-8")  # Suber returns str, loadEvent expects bytes
 
-                        try:
-                            ldes.append(eventing.loadEvent(hby.db, pre, edig))
-                        except ValueError as e:
-                            raise e
-
-                        # Update key for next iteration (after current pre.sn)
-                        key = dbing.snKey(pre, sn)
-
-                    if not found:  # no more escrows found
-                        break
+                    try:
+                        ldes.append(eventing.loadEvent(hby.db, pre, edig))
+                    except ValueError as e:
+                        raise e
 
                 escrows["likely-duplicitous-events"] = ldes
 

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -6966,11 +6966,12 @@ class Kevery:
         """
         key = ekey = b''  # both start same. when not same means escrows found
         while True:  # break when done
-            for pre, sn, edig in self.db.ldes.getOnItemIterAll(keys=key):
+            for (pre,), sn, edig in self.db.ldes.getOnItemIterAll(keys=key):
                 try:
                     # pre and sn are already unpacked
                     ekey = snKey(pre, sn)
-                    edig = edig.encode("utf-8")  # convert to bytes for legacy compatibility
+                    if hasattr(edig, "encode"):
+                        edig = edig.encode("utf-8")  # convert to bytes for legacy compatibility
                     dgkey = dgKey(pre, edig)
                     if not (esr := self.db.esrs.get(keys=dgkey)):  # get event source, otherwise error
                         # no local source so raise ValidationError which unescrows below

--- a/src/keri/db/migrations/add_key_and_reg_state_schemas.py
+++ b/src/keri/db/migrations/add_key_and_reg_state_schemas.py
@@ -99,7 +99,7 @@ def migrate(db):
 
         for (said,), _ in rgy.saved.getItemIter():
             snkey = dbing.snKey(said, 0)
-            dig = rgy.getTel(key=snkey)
+            dig = rgy.tels.get(keys=snkey)
 
             prefixer = coring.Prefixer(qb64=said)
             seqner = coring.Seqner(sn=0)

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -378,7 +378,7 @@ class Registry(BaseRegistry):
             SerderKERI: The SerderKERI of the credential revocation event
         """
         vci = said
-        vcser = self.reger.getTel(snKey(pre=vci, sn=0))
+        vcser = self.reger.tels.get(keys=snKey(pre=vci, sn=0))
         if vcser is None:
             raise kering.ValidationError("Invalid revoke of {} that has not been issued "
                                          "pre={}.".format(vci, self.regk))
@@ -477,7 +477,7 @@ class SignifyRegistry(BaseRegistry):
             SerderKERI: The SerderKERI of the credential revocation event
         """
         vci = said
-        vcser = self.reger.getTel(snKey(pre=vci, sn=0))
+        vcser = self.reger.tels.get(keys=snKey(pre=vci, sn=0))
         if vcser is None:
             raise kering.ValidationError("Invalid revoke of {} that has not been issued "
                                          "pre={}.".format(vci, self.regk))
@@ -785,7 +785,7 @@ class Registrar(doing.DoDoer):
         """
         for (regk, snq), (prefixer, seqner, saider) in self.rgy.reger.tede.getItemIter():  # group multisig escrow
             rseq = coring.Seqner(qb64=snq)
-            dig = self.rgy.reger.getTel(key=snKey(pre=regk, sn=rseq.sn))
+            dig = self.rgy.reger.tels.get(keys=snKey(pre=regk, sn=rseq.sn))
             if dig is None:
                 continue
 

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1113,7 +1113,7 @@ class Tever:
         # have to compare with VC issuance serder
         vci = vcpre
 
-        dig = self.reger.getTel(snKey(pre=vci, sn=sn - 1))
+        dig = self.reger.tels.get(keys=snKey(pre=vci, sn=sn - 1))
         ievt = self.reger.tvts.get(keys=(vci, dig))
         if ievt is None:
             raise ValidationError("revoke without issue... probably have to escrow")
@@ -1170,14 +1170,14 @@ class Tever:
             status (Serder): transaction event state notification message
         """
         digs = []
-        for _, _, dig in self.reger.getTelItemPreIter(pre=vci.encode("utf-8")):
+        for _, _, dig in self.reger.tels.getOnItemIterAll(keys=vci.encode("utf-8")):
             digs.append(dig)
 
         if len(digs) == 0:
             return None
 
         vcsn = len(digs) - 1
-        vcdig = bytes(digs[-1])
+        vcdig = digs[-1].encode("utf-8")
 
         dgkey = dbing.dgKey(vci, vcdig)  # get message
         raw = self.reger.tvts.get(keys=dgkey)
@@ -1218,7 +1218,7 @@ class Tever:
             int: current TEL sequence number of credential or None if not found
 
         """
-        cnt = self.reger.cntTels(vci)
+        cnt = self.reger.tels.cntOnAll(keys=vci)
 
         return None if cnt == 0 else cnt - 1
 
@@ -1250,7 +1250,7 @@ class Tever:
             self.reger.putBaks(key, [bak.encode("utf-8") for bak in baks])
         self.reger.tets.pin(keys=(pre.decode("utf-8"), dig.decode("utf-8")), val=coring.Dater())
         self.reger.tvts.put(keys=key, val=serder.raw)
-        self.reger.putTel(snKey(pre, sn), dig)
+        self.reger.tels.put(keys=snKey(pre, sn), val=dig)
         logger.info("Tever: Added to TEL valid %s event %s said=%s reg=%.8s iss=%.8s",
                     serder.ilk, pre.decode(), serder.said, self.regk, self.pre)
         logger.debug("TEL Event Body=\n%s\n", serder.pretty())
@@ -1787,7 +1787,7 @@ class Tevery:
         if not accepted:
             raise kering.UnverifiedReplyError(f"Unverified registry txn state reply.")
 
-        ldig = self.reger.getTel(key=snKey(pre=regk, sn=sn))  # retrieve dig of last event at sn.
+        ldig = self.reger.tels.get(keys=snKey(pre=regk, sn=sn))  # retrieve dig of last event at sn.
 
         # Only accept key state if for last seen version of event at sn
         if ldig is None:  # escrow because event does not yet exist in database
@@ -1798,7 +1798,7 @@ class Tevery:
             raise kering.OutOfOrderTxnStateError("Out of order txn state={}.".format(rsr))
 
         tsaider = coring.Saider(qb64=rsr.d)
-        ldig = bytes(ldig)
+        ldig = ldig.encode("utf-8")
         # retrieve last event itself of signer given sdig
         sraw = self.reger.tvts.get(keys=(regk, ldig))
         # assumes db ensures that sraw must not be none because sdig was in KE
@@ -1927,7 +1927,7 @@ class Tevery:
         if not accepted:
             raise kering.UnverifiedReplyError(f"Unverified credential state reply.")
 
-        ldig = self.reger.getTel(key=snKey(pre=vci, sn=sn))  # retrieve dig of last event at sn.
+        ldig = self.reger.tels.get(keys=snKey(pre=vci, sn=sn))  # retrieve dig of last event at sn.
 
         # Only accept key state if for last seen version of event at sn
         if ldig is None:  # escrow because event does not yet exist in database
@@ -1938,7 +1938,7 @@ class Tevery:
             raise kering.OutOfOrderTxnStateError("Out of order txn state={}.".format(vsr))
 
         tsaider = coring.Saider(qb64=vsr.d)
-        ldig = bytes(ldig)
+        ldig = ldig.encode("utf-8")
         # retrieve last event itself of signer given sdig
         sraw = self.reger.tvts.get(keys=(vci, ldig))
         # assumes db ensures that sraw must not be none because sdig was in KE

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -301,7 +301,7 @@ class Reger(dbing.LMDBer):
         # to avoid namespace collisions with Base64 identifier prefixes.
 
         self.tvts = subing.Suber(db=self, subkey='tvts.')
-        self.tels = self.env.open_db(key=b'tels.')
+        self.tels = subing.OnSuber(db=self, subkey='tels.')
         self.ancs = self.env.open_db(key=b'ancs.')
         self.tibs = subing.CesrDupSuber(db=self, subkey='tibs.', klas=indexing.Siger)
         self.baks = self.env.open_db(key=b'baks.', dupsort=True)
@@ -530,13 +530,13 @@ class Reger(dbing.LMDBer):
         if hasattr(pre, 'encode'):
             pre = pre.encode("utf-8")
 
-        for _, fn, dig in self.getTelItemPreIter(pre, fn=fn):
+        for _, fn, dig in self.tels.getOnItemIterAll(keys=pre, on=fn):
             msg = self.cloneTvt(pre, dig)
             yield msg
 
     def cloneTvtAt(self, pre, sn=0):
         snkey = dbing.snKey(pre, sn)
-        dig = self.getTel(key=snkey)
+        dig = self.tels.get(keys=snkey)
         return self.cloneTvt(pre, dig)
 
     def cloneTvt(self, pre, dig):
@@ -607,72 +607,6 @@ class Reger(dbing.LMDBer):
             sources.extend(self.sources(db, screder))
 
         return sources
-
-    def putTel(self, key, val):
-        """
-        Use snKey()
-        Write serialized VC bytes val to key
-        Does not overwrite existing val if any
-        Returns True If val successfully written Else False
-        Return False if key already exists
-        """
-        return self.putVal(self.tels, key, val)
-
-    def setTel(self, key, val):
-        """
-        Use snKey()
-        Write serialized VC bytes val to key
-        Overwrites existing val if any
-        Returns True If val successfully written Else False
-        """
-        return self.setVal(self.tels, key, val)
-
-    def getTel(self, key):
-        """
-        Use snKey()
-        Return event at key
-        Returns None if no entry at key
-        """
-        return self.getVal(self.tels, key)
-
-    def delTel(self, key):
-        """
-        Use snKey()
-        Deletes value at key.
-        Returns True If key exists in database Else False
-        """
-        return self.delVal(self.tels, key)
-
-    def getTelItemPreIter(self, pre, fn=0):
-        """
-        Returns iterator of all (fn, dig) duples in first seen order for all events
-        with same prefix, pre, in database. Items are sorted by fnKey(pre, fn)
-        where fn is first seen order number int.
-        Returns a First Seen Event Log TEL.
-        Returned items are duples of (fn, dig): Where fn is first seen order
-        number int and dig is event digest for lookup in .evts sub db.
-
-        Raises StopIteration Error when empty.
-
-        Parameters:
-            pre is bytes of itdentifier prefix
-            fn is int fn to resume replay. Earliset is fn=0
-        """
-        return self.getOnItemIterAll(db=self.tels, key=pre, on=fn)
-
-    def cntTels(self, pre, fn=0):
-        """
-        Returns count of all (fn, dig)  for all events
-        with same prefix, pre, in database.
-
-        Parameters:
-            pre is bytes of itdentifier prefix
-            fn is int fn to resume replay. Earliset is fn=0
-        """
-        if hasattr(pre, "encode"):
-            pre = pre.encode("utf-8")  # convert str to bytes
-
-        return self.cntOnAll(db=self.tels, key=pre, on=fn)
 
     def putTwe(self, key, val):
         """

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -405,7 +405,7 @@ def test_tever_escrow(mockCoringRandomNonce):
 
         anc = reg.getAnc(dgkey)
         assert bytes(anc) == b'0AAAAAAAAAAAAAAAAAAAAAABEErlKvdXWTpOg9s5AasfABIk17o_EaM2uAuGe-c_LEbc'
-        assert reg.getTel(snKey(pre=regk, sn=0)) is None
+        assert reg.tels.get(keys=snKey(pre=regk, sn=0)) is None
         dig = reg.getTwe(snKey(pre=regk, sn=0))
         assert bytes(dig) ==b'EBkUjPBzZuFeSTP-Quuz0Exr6jdUNd8VDa5hoNvnS1Jo'
 
@@ -447,7 +447,7 @@ def test_tever_no_backers(mockHelpingNowUTC, mockCoringRandomNonce):
 
 
         assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAABEGe5uFh3t0JglSPQtJJoxCV1RlFoTBept1BPRk3o6hgh'
-        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'EKWuqbpBPglFWnzZuD3f_DTCLwYd4ub1bWUZXdRB2g6C'
+        assert reg.tels.get(keys=snKey(pre=regk, sn=0)).encode("utf-8") == b'EKWuqbpBPglFWnzZuD3f_DTCLwYd4ub1bWUZXdRB2g6C'
         assert reg.tibs.get(keys=(regk, vcp.said)) == []
         assert reg.getTwe(snKey(pre=regk, sn=0)) is None
 
@@ -548,9 +548,9 @@ def test_tever_backers(mockHelpingNowUTC, mockCoringRandomNonce):
             b'8VCMGHB475dgKWCxO3qX4HlvW_4_lsrVZ9Q","s":"0","c":[],"bt":"1","b":["BPmRWtx8n'
             b'wSzRdJ0zTvP5uBb0t3BSjjstDk0gTayFfjV"],"n":"0AAUiJMii_rPXXCiLTEEaDT7"}')
         assert bytes(reg.getAnc(dgkey)) == b'0AAAAAAAAAAAAAAAAAAAAAABEDD2vrz4Eg3iLOOlZw5-d3ioZ1q703IC0M0LJP_3v-PT'
-        assert bytes(reg.getTel(snKey(pre=regk, sn=0))) == b'ECfzJv1hIYAF68tEDDSelka5aPNKg_pmdcZOTs0aubF-'
+        assert reg.tels.get(keys=snKey(pre=regk, sn=0)).encode("utf-8") == b'ECfzJv1hIYAF68tEDDSelka5aPNKg_pmdcZOTs0aubF-'
         assert [tib.qb64b for tib in reg.tibs.get(keys=(regk, vcp.said))] == [b'AAAUr5RHYiDH8RU0ig-2Dp5h7rVKx89StH5M3CL60-cWEbgG-XmtW31pZlFicYgSPduJZUnD838_'
-                                                                    b'QLbASSQLAZcC']
+                                           b'QLbASSQLAZcC']
         assert reg.getTwe(snKey(pre=regk, sn=0)) is None
 
         debSecret = 'AKUotEE0eAheKdDJh9QvNmSEmO_bjIav8V_GmctGpuCQ'

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -107,15 +107,15 @@ def test_issuer():
         assert issuer.tvts.get(keys=key) is None
 
         telKey = snKey(regk, sn)
-        assert issuer.getTel(telKey) is None
-        assert issuer.delTel(telKey) is False
-        assert issuer.putTel(telKey, val=vdig.qb64b)
-        assert issuer.getTel(telKey) == vdig.qb64b
-        assert issuer.putTel(telKey, val=vdig.qb64b) is False
-        assert issuer.setTel(telKey, val=vdig.qb64b) is True
-        assert issuer.getTel(telKey) == vdig.qb64b
-        assert issuer.delTel(telKey) is True
-        assert issuer.getTel(telKey) is None
+        assert issuer.tels.get(keys=telKey) is None
+        assert issuer.tels.rem(keys=telKey) is False
+        assert issuer.tels.put(keys=telKey, val=vdig.qb64b)
+        assert issuer.tels.get(keys=telKey) == vdig.qb64
+        assert issuer.tels.put(keys=telKey, val=vdig.qb64b) is False
+        assert issuer.tels.pin(keys=telKey, val=vdig.qb64b) is True
+        assert issuer.tels.get(keys=telKey) == vdig.qb64
+        assert issuer.tels.rem(keys=telKey) is True
+        assert issuer.tels.get(keys=telKey) is None
 
         # Tibs store Siger instances; use valid Siger bytes and distinct indices
         valid_tib_bytes = (b'AAAUr5RHYiDH8RU0ig-2Dp5h7rVKx89StH5M3CL60-cWEbgG-XmtW31pZlFicYgSPduJZUnD838_'
@@ -212,15 +212,15 @@ def test_issuer():
         assert issuer.tvts.get(keys=key) is None
 
         telKey = snKey(vcdig, sn)
-        assert issuer.getTel(telKey) is None
-        assert issuer.delTel(telKey) is False
-        assert issuer.putTel(telKey, val=idig.qb64b)
-        assert issuer.getTel(telKey) == idig.qb64b
-        assert issuer.putTel(telKey, val=idig.qb64b) is False
-        assert issuer.setTel(telKey, val=idig.qb64b) is True
-        assert issuer.getTel(telKey) == idig.qb64b
-        assert issuer.delTel(telKey) is True
-        assert issuer.getTel(telKey) is None
+        assert issuer.tels.get(keys=telKey) is None
+        assert issuer.tels.rem(keys=telKey) is False
+        assert issuer.tels.put(keys=telKey, val=idig.qb64b)
+        assert issuer.tels.get(keys=telKey) == idig.qb64
+        assert issuer.tels.put(keys=telKey, val=idig.qb64b) is False
+        assert issuer.tels.pin(keys=telKey, val=idig.qb64b) is True
+        assert issuer.tels.get(keys=telKey) == idig.qb64
+        assert issuer.tels.rem(keys=telKey) is True
+        assert issuer.tels.get(keys=telKey) is None
 
         rev = dict(v=vs, i=vcdig.decode("utf-8"),
                    s="{:x}".format(sn + 1),
@@ -230,13 +230,13 @@ def test_issuer():
         assert revb == b'{"v":"KERI10JSON000014_","i":"EAvR3p8V95W8J7Ui4-mEzZ79S-A1esAnJo1Kmzq80Jkc","s":"1","t":"rev"}'
         rdig = Diger(raw=revb)
 
-        assert issuer.putTel(snKey(vcdig, sn), val=idig.qb64b) is True
-        assert issuer.putTel(snKey(vcdig, sn + 1), val=rdig.qb64b) is True
-        assert issuer.putTel(snKey(vcdig, sn + 2), val=idig.qb64b) is True
-        assert issuer.putTel(snKey(vcdig, sn + 3), val=rdig.qb64b) is True
+        assert issuer.tels.put(keys=snKey(vcdig, sn), val=idig.qb64b) is True
+        assert issuer.tels.put(keys=snKey(vcdig, sn + 1), val=rdig.qb64b) is True
+        assert issuer.tels.put(keys=snKey(vcdig, sn + 2), val=idig.qb64b) is True
+        assert issuer.tels.put(keys=snKey(vcdig, sn + 3), val=rdig.qb64b) is True
 
-        result = [(sn, dig) for _, sn, dig in issuer.getTelItemPreIter(vcdig)]
-        assert result == [(0, idig.qb64b), (1, rdig.qb64b), (2, idig.qb64b), (3, rdig.qb64b)]
+        result = [(sn, dig) for _, sn, dig in issuer.tels.getOnItemIterAll(keys=vcdig)]
+        assert result == [(0, idig.qb64), (1, rdig.qb64), (2, idig.qb64), (3, rdig.qb64)]
 
         bak1 = b'BA1Q98kT0HRn9R62lY-LufjjKdbCeL1mqu9arTgOmbqI'
         bak2 = b'DAEpNJeSJjxo6oAxkNE8eCOJg2HRPstqkeHWBAvN9XNU'
@@ -306,21 +306,21 @@ def test_clone():
         dgkey = dgKey(regk, vdig.qb64b)
         snkey = snKey(regk, sn)
         assert issuer.tvts.put(keys=dgkey, val=vcpb) is True
-        assert issuer.putTel(snkey, val=vdig.qb64b)
+        assert issuer.tels.put(keys=snkey, val=vdig.qb64b)
         assert issuer.putAnc(dgkey, val=anc01) is True
         assert issuer.tibs.pin(keys=(regk, vdig.qb64b), vals=[indexing.Siger(qb64b=tib01)]) is True
 
         dgkey = dgKey(regk, r1dig.qb64b)
         snkey = snKey(regk, sn + 1)
         assert issuer.tvts.put(keys=dgkey, val=rot1b) is True
-        assert issuer.putTel(snkey, val=r1dig.qb64b)
+        assert issuer.tels.put(keys=snkey, val=r1dig.qb64b)
         assert issuer.putAnc(dgkey, val=anc02) is True
         assert issuer.tibs.pin(keys=(regk, r1dig.qb64b), vals=[indexing.Siger(qb64b=tib02)]) is True
 
         dgkey = dgKey(regk, r2dig.qb64b)
         snkey = snKey(regk, sn + 2)
         assert issuer.tvts.put(keys=dgkey, val=rot2b) is True
-        assert issuer.putTel(snkey, val=r2dig.qb64b)
+        assert issuer.tels.put(keys=snkey, val=r2dig.qb64b)
         assert issuer.putAnc(dgkey, val=anc03) is True
         assert issuer.tibs.pin(keys=(regk, r2dig.qb64b), vals=[indexing.Siger(qb64b=tib03)]) is True
 


### PR DESCRIPTION
# PR Draft — `tels` migration

Date: 2026-02-12

**Title**
`feat(vdr): migrate Reger tels to OnSuber (remove tels helpers)`

**Branch**
`feature/reger-migrate-tels`

**PR Link**
https://github.com/jaelliot/keripy/pull/new/feature/reger-migrate-tels

**Summary**
This PR migrates Reger `tels` from direct LMDB access to `subing.OnSuber` and removes legacy `tels` helper methods (`putTel`, `setTel`, `getTel`, `delTel`, `getTelItemPreIter`, `cntTels`). Runtime/test callsites now use direct OnSuber APIs.

**Scope**
- `src/keri/vdr/viring.py`
  - `self.tels` declaration migrated to `subing.OnSuber`
  - Removed `tels` helper methods
  - Internal iteration/count paths migrated to direct OnSuber iteration/count APIs
- `src/keri/vdr/eventing.py`
  - Replaced `getTel/putTel/getTelItemPreIter/cntTels` helper usage with direct `reger.tels` calls
  - Normalized `str` digest handling from OnSuber for existing byte-oriented paths
- `src/keri/vdr/credentialing.py`
  - Replaced `getTel` helper usage with direct `reger.tels.get`
- `src/keri/db/migrations/add_key_and_reg_state_schemas.py`
  - Replaced `rgy.getTel(...)` with direct `rgy.tels.get(...)`
- `tests/vdr/test_viring.py`, `tests/vdr/test_eventing.py`
  - Replaced helper-based assertions with direct `tels` API calls

**Validation**
- `pytest tests/vdr/test_viring.py -q` → pass
- `pytest tests/vdr/test_eventing.py -q` → pass

**Notes**
- No compatibility wrappers retained for `tels` helper API.
- This PR is scoped to `tels` migration only.
