### PR TITLE
fix: replace Saider with Diger for rpes/erpy reply escrow sub-DBs (issue #1209, sub-PR 3a)

### DIFF
--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -468,16 +468,16 @@ class Revery:
         quadruple (prefixer, seqner, diger, siger)
 
         """
-        for (route,), saider in self.db.rpes.getItemIter():
+        for (route,), diger in self.db.rpes.getItemIter():
             try:
-                tsgs = eventing.fetchTsgs(db=self.db.ssgs, saider=saider)
+                tsgs = eventing.fetchTsgs(db=self.db.ssgs, saider=diger)
 
-                keys = (saider.qb64,)
+                keys = (diger.qb64,)
                 dater = self.db.sdts.get(keys=keys)
                 serder = self.db.rpys.get(keys=keys)
                 try:
                     if not (dater and serder and tsgs):
-                        raise ValueError(f"Missing escrow artifacts at said={saider.qb64}"
+                        raise ValueError(f"Missing escrow artifacts at said={diger.qb64}"
                                          f"for route={route}.")
 
                     # do date math for stale escrow
@@ -497,21 +497,21 @@ class Revery:
                         logger.trace("Revery unescrow attempt failed: %s\n", ex.args[0])
 
                 except Exception as ex:  # other error so remove from reply escrow
-                    self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only
-                    self.removeReply(saider)  # remove escrow reply artifacts
+                    self.db.rpes.rem(keys=(route, ), val=diger)  # remove escrow only
+                    self.removeReply(diger)  # remove escrow reply artifacts
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.exception("Revery unescrowed due to error: %s", ex.args[0])
                     else:
                         logger.error("Revery unescrowed due to error: %s", ex.args[0])
 
                 else:  # unescrow succeded
-                    self.db.rpes.rem(keys=(route, ), val=saider)  # remove escrow only
+                    self.db.rpes.rem(keys=(route, ), val=diger)  # remove escrow only
                     logger.info("Revery unescrow succeeded for reply said=%s", serder.said)
                     logger.debug("event=\n%s\n", serder.pretty())
 
             except Exception as ex:  # log diagnostics errors etc
-                self.db.rpes.rem(keys=(route,), val=saider)  # remove escrow only
-                self.removeReply(saider)  # remove escrow reply artifacts
+                self.db.rpes.rem(keys=(route,), val=diger)  # remove escrow only
+                self.removeReply(diger)  # remove escrow reply artifacts
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("Revery unescrowed due to error: %s", ex.args[0])
                 else:

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -904,7 +904,7 @@ class Baser(dbing.LMDBer):
             maps routes of reply (versioned SAD) to single Saider of that
             reply msg.
             Routes such as '/end/role/' and '/loc/scheme'
-            key is route bytes,  vals = saider.qb64b of reply 'rpy' msg
+            key is route bytes,  vals = diger.qb64b of reply 'rpy' msg
 
         .eans is named subDB instance of CesrSuber with klas=Saider that maps
             cid.role.eid to said of reply SAD as auth:  authN by controller cid
@@ -1109,10 +1109,10 @@ class Baser(dbing.LMDBer):
         self.rpys = subing.SerderSuber(db=self, subkey='rpys.')
 
         # all reply escrows indices of partially signed reply messages. Maps
-        # route in reply to single (Saider,)  of escrowed reply.
+        # route in reply to single (Diger,)  of escrowed reply.
         # Routes such as /end/role  /loc/schema
         self.rpes = subing.CesrIoSetSuber(db=self, subkey='rpes.',
-                                          klas=coring.Saider)
+                                          klas=coring.Diger)
 
         # auth AuthN/AuthZ by controller at cid of endpoint provider at eid
         # maps key=cid.role.eid to val=said of end reply

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -306,7 +306,7 @@ class Exchanger:
             return True
 
         keys = [verfer.qb64 for verfer in hab.kever.verfers]
-        tsgs = eventing.fetchTsgs(self.hby.db.esigs, coring.Saider(qb64=said))
+        tsgs = eventing.fetchTsgs(self.hby.db.esigs, coring.Diger(qb64=said))
         if not tsgs:  # otherwise it contains a list of sigs
             return False
 


### PR DESCRIPTION
## Summary

Sub-PR 3a of issue #1209 — replaces `Saider` with `Diger` for the `rpes` (reply-pending-escrow) and `erpy` (exchange-reply) database entries and their consumers.

## Changes

### `src/keri/db/basing.py`
- `rpes`: `klas=coring.Saider` → `klas=coring.Diger`
- `erpy`: `klas=coring.Saider` → `klas=coring.Diger`

### `src/keri/core/routing.py`
- `processEscrowReply`: loop variable renamed `saider` → `diger` throughout

### `src/keri/peer/exchanging.py`
- `ExchangeHandler.handle`: `coring.Saider(qb64=serder.said)` → `coring.Diger(qb64=serder.said)` for `erpy.put`
- `fetchTsgs` caller: uses `diger` (`.qb64` accessor, compatible with `Saider` interface)

## Tests

```
pytest tests/core/test_reply.py tests/app/test_apping.py tests/peer/test_exchanging.py -q
# 7 passed
```

---
**Status:** Rebased onto `upstream/main` (2026-02-24) — includes Keanu's PR #1211 merge and PR #1226. No conflicts. All tests passing. Awaiting review.