### PR TITLE
fix: replace Saider with Diger for chas/reps challenge escrow sub-DBs (issue #1209, sub-PR 3c)

### DIFF
--- a/src/keri/app/challenging.py
+++ b/src/keri/app/challenging.py
@@ -54,4 +54,4 @@ class ChallengeHandler:
         self.signaler.push(msg, topic="/challenge")
 
         # Log signer against event to track successful challenges with signed response
-        self.db.reps.add(keys=(signer,), val=coring.Saider(qb64=serder.said))
+        self.db.reps.add(keys=(signer,), val=coring.Diger(qb64=serder.said))

--- a/src/keri/app/cli/commands/challenge/verify.py
+++ b/src/keri/app/cli/commands/challenge/verify.py
@@ -114,12 +114,12 @@ class VerifyDoer(doing.DoDoer):
             sys.stdout.write(".")
             sys.stdout.flush()
 
-            saiders = self.hby.db.reps.get(keys=(sig,))
-            for saider in saiders:
-                exn = self.hby.db.exns.get(keys=(saider.qb64,))
+            digers = self.hby.db.reps.get(keys=(sig,))
+            for diger in digers:
+                exn = self.hby.db.exns.get(keys=(diger.qb64,))
                 if words == exn.ked['a']['words']:
                     found = True
-                    self.hby.db.chas.add(keys=(sig,), val=saider)
+                    self.hby.db.chas.add(keys=(sig,), val=diger)
                     break
 
             if found:

--- a/src/keri/app/cli/commands/contacts/get.py
+++ b/src/keri/app/cli/commands/contacts/get.py
@@ -73,8 +73,8 @@ def get(tymth, tock=0.0, **opts):
                 print("Contact not found")
                 return -1
 
-            accepted = [saider.qb64 for saider in hby.db.chas.get(keys=(pre,))]
-            received = [saider.qb64 for saider in hby.db.reps.get(keys=(pre,))]
+            accepted = [diger.qb64 for diger in hby.db.chas.get(keys=(pre,))]
+            received = [diger.qb64 for diger in hby.db.reps.get(keys=(pre,))]
             valid = set(accepted) & set(received)
 
             challenges = []

--- a/src/keri/app/cli/commands/contacts/list.py
+++ b/src/keri/app/cli/commands/contacts/list.py
@@ -43,8 +43,8 @@ def list(tymth, tock=0.0, **opts):
             for c in org.list():
 
                 aid = c['id']
-                accepted = [saider.qb64 for saider in hby.db.chas.get(keys=(aid,))]
-                received = [saider.qb64 for saider in hby.db.reps.get(keys=(aid,))]
+                accepted = [diger.qb64 for diger in hby.db.chas.get(keys=(aid,))]
+                received = [diger.qb64 for diger in hby.db.reps.get(keys=(aid,))]
                 valid = set(accepted) & set(received)
 
                 challenges = []

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1194,11 +1194,11 @@ class Baser(dbing.LMDBer):
 
         # accepted signed 12-word challenge response exn messages keys by prefix of signer
         # TODO: clean
-        self.chas = subing.CesrIoSetSuber(db=self, subkey='chas.', klas=coring.Saider)
+        self.chas = subing.CesrIoSetSuber(db=self, subkey='chas.', klas=coring.Diger)
 
         # successfull signed 12-word challenge response exn messages keys by prefix of signer
         # TODO: clean
-        self.reps = subing.CesrIoSetSuber(db=self, subkey='reps.', klas=coring.Saider)
+        self.reps = subing.CesrIoSetSuber(db=self, subkey='reps.', klas=coring.Diger)
 
         # authorzied well known OOBIs
         # TODO: clean


### PR DESCRIPTION
## Summary

Sub-PR 3c of issue #1209 — replaces `Saider` with `Diger` for the `chas` (challenge-pending) and `reps` (challenge-response) database entries and their consumers.

## Changes

### `src/keri/db/basing.py`
- `chas`: `klas=coring.Saider` → `klas=coring.Diger`
- `reps`: `klas=coring.Saider` → `klas=coring.Diger`

### `src/keri/app/challenging.py`
- `ChallengeHandler.handle`: `coring.Saider(qb64=serder.said)` → `coring.Diger(qb64=serder.said)` for `reps.put`

### CLI files (local variable renames only)
- `app/cli/commands/challenge/verify.py`
- `app/cli/commands/contacts/get.py`
- `app/cli/commands/contacts/list.py`

## Tests

```
pytest tests/app/test_challenging.py -q
# 1 passed
```

---
**Status:** Rebased onto `upstream/main` (2026-02-24) — includes Keanu's PR #1211 merge and PR #1226. No conflicts. All tests passing. Awaiting review.