### PR TITLE
fix: replace Saider with Diger for group multisig escrow sub-DBs (issue #1209, sub-PR 3b)

### DIFF
--- a/ref/ChangeLog.md
+++ b/ref/ChangeLog.md
@@ -8,6 +8,8 @@ Changes to call signatures that will break dependent libraries
 Changed `complete(self, prefixer, seqner, saider=None)` to `complete(self, prefixer, number, diger=None)`.
 Renamed `seqner` and `saider` parameter to `number` and `diger` to match the actual type (`Number`, `Diger`) being
 passed. All callers functions in `test_grouping.py` are updated.
+Fixed stale docstring in `complete()`: `saider (Saider)` → `diger (Diger)`.
+Renamed `saiders`/`saider` → `digers`/`diger` local variables in `Counselor.get()` (meids sub-DB returns Diger instances).
 
 ## 2.0.0-dev5
 ### Backwards breaking interface changes
@@ -96,7 +98,3 @@ from keri.core import Streamer still works.
 moved Tierage and Tiers defintions from keri.core.coring to keri.core.signing
 where they more naturally belong (not used in coring)
 from keri.core import Tiers still works
-
-
-
-

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -72,7 +72,7 @@ class Counselor(doing.DoDoer):
         Parameters:
             prefixer (Prefixer): qb64 identifier prefix of event to check
             number (Number): sequence number of event to check
-            saider (Saider): optional digest of event to verify
+            diger (Diger): optional digest of event to verify
 
         Returns:
 
@@ -692,11 +692,11 @@ class Multiplexor:
                 self.notifier.add(attrs=data)
 
     def get(self, esaid):
-        saiders = self.hby.db.meids.get(keys=(esaid,))
+        digers = self.hby.db.meids.get(keys=(esaid,))
 
         exns = []
-        for saider in saiders:
-            exn, paths = exchanging.cloneMessage(hby=self.hby, said=saider.qb64)
+        for diger in digers:
+            exn, paths = exchanging.cloneMessage(hby=self.hby, said=diger.qb64)
             exns.append(dict(
                 exn=exn.ked,
                 paths={k: path.decode("utf-8") for k, path in paths.items()},

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -719,9 +719,9 @@ def test_multisig_incept_handler(mockHelpingNowUTC):
         assert len(notifier.signaler.signals) == 0
 
         esaid = exn.ked['e']['d']
-        saiders = hby.db.meids.get(keys=(esaid, ))
-        assert len(saiders) == 1
-        assert saiders[0].qb64 == exn.said
+        digers = hby.db.meids.get(keys=(esaid, ))
+        assert len(digers) == 1
+        assert digers[0].qb64 == exn.said
         prefixers = hby.db.maids.get(keys=(esaid,))
         assert len(prefixers) == 1
         assert prefixers[0].qb64 == exn.pre
@@ -746,9 +746,9 @@ def test_multisig_rotate_handler(mockHelpingNowUTC):
         assert len(notifier.signaler.signals) == 1
 
         esaid = exn.ked['e']['d']
-        saiders = hby1.db.meids.get(keys=(esaid, ))
-        assert len(saiders) == 1
-        assert saiders[0].qb64 == exn.said
+        digers = hby1.db.meids.get(keys=(esaid, ))
+        assert len(digers) == 1
+        assert digers[0].qb64 == exn.said
         prefixers = hby1.db.maids.get(keys=(esaid,))
         assert len(prefixers) == 1
         assert prefixers[0].qb64 == ghab2.mhab.pre
@@ -763,9 +763,9 @@ def test_multisig_rotate_handler(mockHelpingNowUTC):
         # There should still only be one notification because we don't notify for our own event
         assert len(notifier.signaler.signals) == 1
 
-        saiders = hby1.db.meids.get(keys=(esaid, ))
-        assert len(saiders) == 2
-        assert saiders[1].qb64 == exn.said
+        digers = hby1.db.meids.get(keys=(esaid, ))
+        assert len(digers) == 2
+        assert digers[1].qb64 == exn.said
         prefixers = hby1.db.maids.get(keys=(esaid,))
         assert len(prefixers) == 2
         assert prefixers[1].qb64 == ghab1.mhab.pre
@@ -788,9 +788,9 @@ def test_multisig_interact_handler(mockHelpingNowUTC):
 
         esaid = exn.ked['e']['d']
         assert len(notifier.signaler.signals) == 1
-        saiders = hby1.db.meids.get(keys=(esaid, ))
-        assert len(saiders) == 1
-        assert saiders[0].qb64 == exn.said
+        digers = hby1.db.meids.get(keys=(esaid, ))
+        assert len(digers) == 1
+        assert digers[0].qb64 == exn.said
         prefixers = hby1.db.maids.get(keys=(esaid,))
         assert len(prefixers) == 1
         assert prefixers[0].qb64 == ghab2.mhab.pre


### PR DESCRIPTION
## Summary

Sub-PR 3b of issue #1209 — renames remaining `saider`→`diger` references in `grouping.py` and `test_grouping.py`.

> **Note:** The `basing.py` sub-DB type changes (`gpse`, `gdee`, `gpwe`, `cgms`) and CLI call-site renames were already merged to `main` via prior PRs. This PR completes the cleanup.

## Changes

### `src/keri/app/grouping.py`
- Fixed stale docstring in `complete()`: `saider (Saider)` → `diger (Diger)`
- Renamed `saiders`/`saider` → `digers`/`diger` local variables in `Counselor.get()` method (meids sub-DB returns `Diger` instances)

### `tests/app/test_grouping.py`
- Renamed `saiders` → `digers` in 4 test blocks where `meids.get()` results are asserted

### `ref/ChangeLog.md`
- Added entries for the above renames

## Tests

```
pytest tests/app/test_grouping.py -q
# 9 passed
```

## Diff

3 files changed, +18/−16. Zero whitespace-only changes (`git diff -w` identical).

---
**Status:** Rebased onto `upstream/main` (2026-03-04, post-PR #1287). All tests passing.