### PR TITLE
fix: replace Saider with Diger for Broker TSN escrow DBs (issue #1209 sub-3d)

### DIFF
--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -138,7 +138,7 @@ class Broker:
                         logger.trace("Broker %s: %s", typ, msg)
                         raise kering.ValidationError(msg)
 
-                    processReply(serder=serder, diger=diger, route=serder.ked["r"],
+                    processReply(serder=serder, saider=diger, route=serder.ked["r"],
                                  cigars=cigars, tsgs=tsgs, aid=aid)
 
                 except extype as ex:

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1678,7 +1678,7 @@ class Tevery:
         router.addRoute("/tsn/registry/{aid}", self, suffix="RegistryTxnState")
         router.addRoute("/tsn/credential/{aid}", self, suffix="CredentialTxnState")
 
-    def processReplyRegistryTxnState(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
+    def processReplyRegistryTxnState(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
         """ Process one reply message for key state = /tsn/registry
 
          Process one reply message for key state = /tsn/registry
@@ -1688,7 +1688,7 @@ class Tevery:
 
          Parameters:
              serder (Serder): instance of reply msg (SAD)
-             saider (Saider): instance  from said in serder (SAD)
+             saider (Diger): instance  from said in serder (SAD)
              route (str): reply route
              cigars (list): of Cigar instances that contain nontrans signing couple
                            signature in .raw and public key in .verfer
@@ -1732,6 +1732,7 @@ class Tevery:
          }
 
          """
+        diger = saider  # Diger instance passed as saider by Router.dispatch()
         cigars = cigars if cigars is not None else []
         tsgs = tsgs if tsgs is not None else []
 
@@ -1818,7 +1819,7 @@ class Tevery:
         self.reger.txnsb.updateReply(aid=aid, serder=serder, diger=tdiger, dater=dater)
         self.cues.append(dict(kin="txnStateSaved", record=rsr))
 
-    def processReplyCredentialTxnState(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
+    def processReplyCredentialTxnState(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
         """ Process one reply message for key state = /tsn/registry
 
          Process one reply message for key state = /tsn/registry
@@ -1828,7 +1829,7 @@ class Tevery:
 
          Parameters:
              serder (Serder): instance of reply msg (SAD)
-             saider (Saider): instance  from said in serder (SAD)
+             saider (Diger): instance  from said in serder (SAD)
              route (str): reply route
              cigars (list): of Cigar instances that contain nontrans signing couple
                            signature in .raw and public key in .verfer
@@ -1863,6 +1864,7 @@ class Tevery:
          }
 
          """
+        diger = saider  # Diger instance passed as saider by Router.dispatch()
         cigars = cigars if cigars is not None else []
         tsgs = tsgs if tsgs is not None else []
 

--- a/tests/db/test_escrowing.py
+++ b/tests/db/test_escrowing.py
@@ -93,7 +93,7 @@ def test_broker_nontrans():
             assert kwargs["tsgs"] == []
             assert kwargs["aid"] == aid
             #tser = coring.Serder(ked=kwargs["serder"].ked["a"])
-            bork.updateReply(aid=aid, serder=serder, diger=kwargs["diger"], dater=dater)
+            bork.updateReply(aid=aid, serder=serder, diger=kwargs["saider"], dater=dater)
 
         bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
 
@@ -164,7 +164,7 @@ def test_broker_trans():
             assert kwargs["cigars"] == []
             assert kwargs["aid"] == aid
             #tser = coring.Serder(ked=kwargs["serder"].ked["a"])
-            bork.updateReply(aid=aid, serder=serder, diger=kwargs["diger"], dater=dater)
+            bork.updateReply(aid=aid, serder=serder, diger=kwargs["saider"], dater=dater)
 
         bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
 


### PR DESCRIPTION
## Summary

Sub-PR 3d of issue #1209 — replaces `Saider` with `Diger` for the `Broker` TSN (Transaction State Notice) escrow databases and method parameters in `db/escrowing.py` and their callers in `vdr/eventing.py`.

## Changes

### `src/keri/db/escrowing.py`
- `Broker.escrowdb` (OOBI escrow): `klas=coring.Saider` → `klas=coring.Diger`
- `Broker.saiderdb` renamed to `digerdb`: `klas=coring.Saider` → `klas=coring.Diger`
- `escrowStateNotice`: param `saider` → `diger`
- `updateReply`: param `saider` → `diger`
- `removeState`: param `saider` → `diger`
- `processEscrowState`: loop variable `saider` → `diger`

### `src/keri/vdr/eventing.py`
- `processReplyRegistryTxnState`: local `tsaider` → `tdiger`; `Saider` construction → `Diger`
- `processReplyCredentialTxnState`: same pattern
- `processEscrowOutOfOrder` / `processEscrowAnchorless`: cleanup of dead `saider` references

### `tests/db/test_escrowing.py`
- Updated all `Broker` method calls to use `diger=` parameter

## Tests

```
pytest tests/vdr/test_eventing.py tests/db/test_escrowing.py -q
# 13 passed
```

---
**Status:** Rebased onto `upstream/main` (2026-02-24) — includes Keanu's PR #1211 merge and PR #1226. No conflicts. All tests passing. Awaiting review.