### PR TITLE
fix: add missing core exports + clean test_eventing.py imports

### DIFF
--- a/src/keri/core/__init__.py
+++ b/src/keri/core/__init__.py
@@ -12,7 +12,7 @@ from .coring import (Matter, MtrDex, Number, NumDex, Dater, DecDex, Decimer,
                      Texter, Bexter, Pather, Verfer, Cigar, Diger, DigDex,
                      Prefixer, PreDex, Seqner, Verser, Tholder,
                      Labeler, LabelDex, Decimer, DecDex, Noncer, NonceDex)
-from .indexing import Indexer, Siger, IdrDex, IdxSigDex
+from .indexing import Indexer, Siger, IdrDex, IdxSigDex, IdxCrtSigDex, IdxBthSigDex
 from .signing import (Tiers, Signer, Salter, Cipher, CiXDex,
                       Encrypter, Decrypter, Streamer)
 from .counting import Counter, Codens, GenDex, CtrDex_1_0, CtrDex_2_0, ProGen
@@ -21,6 +21,12 @@ from .serdering import Serdery, Serder, SerderKERI, SerderACDC
 from .structing import (Structor, Sealer, Blinder, Mediar,
                         CodenToClans, ClanToCodens,
                         SealDigest, SealRoot, SealBack, SealLast, SealSource,
-                        SealEvent, SealKind, BlindState, BoundState, TypeMedia)
+                        SealEvent, SealKind, BlindState, BoundState, TypeMedia,
+                        StateEvent, StateEstEvent)
 from .eventing import (incept, interact, rotate, delcept, deltate, receipt,
-                       query, reply, prod, bare, exchept, exchange)
+                       query, reply, prod, bare, exchept, exchange,
+                       Kever, Kevery, LastEstLoc,
+                       simple, ample, messagize, state,
+                       deWitnessCouple, deReceiptCouple, deSourceCouple,
+                       deReceiptTriple, deTransReceiptQuadruple,
+                       deTransReceiptQuintuple)

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -10,30 +10,28 @@ import pysodium
 import pytest
 
 from keri import kering
-from keri.kering import Vrsn_1_0
+from keri.kering import (Vrsn_1_0, ValidationError, Ilks,
+                         TraitDex, Kinds, versify, UnverifiedReceiptError)
 from keri.app import habbing
 from keri.app.keeping import openKS, Manager
 from keri import core
-from keri.core import Signer, Counter, Codens
-from keri.core import coring, eventing, parsing
-from keri.core.coring import (Diger, MtrDex, Matter,
-                              Cigar,
-                              Seqner, Verfer, Prefixer, DigDex)
-from keri.core.indexing import (IdrDex, IdxSigDex, Siger)
-from keri.core.eventing import Kever, Kevery, UnverifiedReceiptError
-from keri.core import (SealDigest, SealRoot, SealBack, SealEvent, SealLast)
-from keri.core.structing import (StateEvent, StateEstEvent)
-from keri.core.eventing import (TraitDex, LastEstLoc, Kinds, versify, simple, ample)
-from keri.core.eventing import (deWitnessCouple, deReceiptCouple, deSourceCouple,
-                                deReceiptTriple,
-                                deTransReceiptQuadruple, deTransReceiptQuintuple)
-from keri.core.eventing import (incept, rotate, interact, receipt, query,
-                                delcept, deltate, state, messagize)
-from keri.core import serdering
+from keri.core import (Signer, Counter, Codens,
+                       Diger, MtrDex, Matter, Cigar,
+                       Seqner, Verfer, Prefixer, DigDex,
+                       IdrDex, IdxSigDex, Siger,
+                       Kever, Kevery,
+                       SealDigest, SealRoot, SealBack, SealEvent, SealLast,
+                       StateEvent, StateEstEvent,
+                       LastEstLoc, simple, ample,
+                       deWitnessCouple, deReceiptCouple, deSourceCouple,
+                       deReceiptTriple,
+                       deTransReceiptQuadruple, deTransReceiptQuintuple,
+                       incept, rotate, interact, receipt, query,
+                       delcept, deltate, state, messagize)
+from keri.core import coring, eventing, parsing, serdering
 
 from keri.db.basing import openDB
 from keri.db.dbing import dgKey, snKey
-from keri.kering import (ValidationError, Ilks)
 
 from keri import help
 


### PR DESCRIPTION
## Summary

Continues the import cleanup effort from PR #1246. Adds missing symbols to `keri.core.__init__.py` and consolidates imports in `test_eventing.py` to follow Sam's convention: tests import from the package (`keri.core`), internal code imports from files (`keri.core.coring`).

## Changes

### `src/keri/core/__init__.py`
- Added `IdxCrtSigDex`, `IdxBthSigDex` from `.indexing`
- Added `StateEvent`, `StateEstEvent` from `.structing`
- Added `Kever`, `Kevery`, `LastEstLoc`, `simple`, `ample`, `messagize`, `state` from `.eventing`
- Added `deWitnessCouple`, `deReceiptCouple`, `deSourceCouple`, `deReceiptTriple`, `deTransReceiptQuadruple`, `deTransReceiptQuintuple` from `.eventing`

### `tests/core/test_eventing.py`
- Consolidated 8 separate `from keri.core.xxx import` lines into a single `from keri.core import (...)` block
- Kept `keri.kering` imports (`TraitDex`, `Kinds`, `versify`, etc.) separate since they belong to `keri.kering`, not `keri.core`
- Kept `keri.db` imports as-is (`from keri.db.basing import openDB`, etc.) since `keri.db.__init__.py` has no public exports

## Testing

All 164 tests in `tests/core/` pass.