### PR TITLE
fix: rename processReply* dispatch parameter saider→diger

### DIFF
--- a/ref/ChangeLog.md
+++ b/ref/ChangeLog.md
@@ -4,6 +4,29 @@
 ### Backwards breaking interface changes
 Changes to call signatures that will break dependent libraries
 
+#### keri.core.routing.py
+Changed `Router.dispatch(self, serder, saider, ...)` to `dispatch(self, serder, diger, ...)`.
+Changed `Router.processRouteNotFound(self, *, serder, saider, ...)` to `processRouteNotFound(self, *, serder, diger, ...)`.
+Changed `Revery.processReply` local variable from `saider` to `diger`.
+
+#### keri.core.eventing.py
+Changed `Kevery.processReplyEndRole(self, *, serder, saider, ...)` to `processReplyEndRole(self, *, serder, diger, ...)`.
+Changed `Kevery.processReplyLocScheme(self, *, serder, saider, ...)` to `processReplyLocScheme(self, *, serder, diger, ...)`.
+Changed `Kevery.processReplyKeyStateNotice(self, *, serder, saider, ...)` to `processReplyKeyStateNotice(self, *, serder, diger, ...)`.
+Renamed local `diger` to `ksr_diger` in `processReplyKeyStateNotice` to avoid shadowing the parameter.
+Changed `Kevery.processReplyAddWatched(self, *, serder, saider, ...)` to `processReplyAddWatched(self, *, serder, diger, ...)`.
+
+#### keri.app.oobiing.py
+Changed `Oobiery.processReply(self, *, serder, saider, ...)` to `processReply(self, *, serder, diger, ...)`.
+
+#### keri.vdr.eventing.py
+Changed `Tvy.processReplyRegistryTxnState(self, *, serder, saider, ...)` to `processReplyRegistryTxnState(self, *, serder, diger, ...)`.
+Changed `Tvy.processReplyCredentialTxnState(self, *, serder, saider, ...)` to `processReplyCredentialTxnState(self, *, serder, diger, ...)`.
+Removed redundant `diger = saider` alias lines in both functions.
+
+#### keri.db.escrowing.py
+Changed `Broker.processEscrowState` dispatch call from `processReply(saider=diger, ...)` to `processReply(diger=diger, ...)`.
+
 #### keri.app.grouping.py
 Changed `complete(self, prefixer, seqner, saider=None)` to `complete(self, prefixer, number, diger=None)`.
 Renamed `seqner` and `saider` parameter to `number` and `diger` to match the actual type (`Number`, `Diger`) being
@@ -96,7 +119,3 @@ from keri.core import Streamer still works.
 moved Tierage and Tiers defintions from keri.core.coring to keri.core.signing
 where they more naturally belong (not used in coring)
 from keri.core import Tiers still works
-
-
-
-

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -314,16 +314,16 @@ class Oobiery:
         """
         router.addRoute("/introduce", self)
 
-    def processReply(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
+    def processReply(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
         """
         Process one reply message for route = /introduce
         with either attached nontrans receipt couples in cigars or attached trans
         indexed sig groups in tsgs.
-        Assumes already validated saider, dater, and route from serder.ked
+        Assumes already validated diger, dater, and route from serder.ked
 
         Parameters:
             serder (SerderKERI): instance of reply msg (SAD)
-            saider (Diger): instance from said in serder (SAD)
+            diger (Diger): instance from said in serder (SAD)
             route (str): reply route
             cigars (list): of Cigar instances that contain nontrans signing couple
                           signature in .raw and public key in .verfer
@@ -377,7 +377,7 @@ class Oobiery:
             raise ConfigurationError("this oobiery is not configured to handle rpy introductions")
 
         # Process BADA RUN but with no previous reply message, always process introductions
-        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+        accepted = self.rvy.acceptReply(serder=serder, saider=diger, route=route,
                                         aid=aid, osaider=None, cigars=cigars,
                                         tsgs=tsgs)
         if not accepted:

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4614,16 +4614,16 @@ class Kevery:
         router.addRoute("/watcher/{aid}/{action}", self, suffix="AddWatched")
 
 
-    def processReplyEndRole(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
+    def processReplyEndRole(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
         """
         Process one reply message for route = /end/role/add or /end/role/cut
         with either attached nontrans receipt couples in cigars or attached trans
         indexed sig groups in tsgs.
-        Assumes already validated saider, dater, and route from serder.ked
+        Assumes already validated diger, dater, and route from serder.ked
 
         Parameters:
             serder (SerderKERI): instance of reply msg (SAD)
-            saider (Diger): instance from said in serder (SAD)
+            diger (Diger): instance from said in serder (SAD)
             route (str): reply route
             cigars (list): of Cigar instances that contain nontrans signing couple
                           signature in .raw and public key in .verfer
@@ -4695,10 +4695,10 @@ class Kevery:
         aid = cid  # authorizing attribution id
         keys = (aid, role, eid)
         osaider = self.db.eans.get(keys=keys)  # get old said if any
-        if osaider is not None and osaider.qb64b == saider.qb64b: # check idempotent
+        if osaider is not None and osaider.qb64b == diger.qb64b: # check idempotent
             osaider = None
         # BADA Logic
-        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+        accepted = self.rvy.acceptReply(serder=serder, saider=diger, route=route,
                                         aid=aid, osaider=osaider, cigars=cigars,
                                         tsgs=tsgs)
         if not accepted:
@@ -4707,20 +4707,20 @@ class Kevery:
             logger.debug(f"Event=\n%s\n", serder.pretty())
             raise UnverifiedReplyError(msg)
 
-        self.updateEnd(keys=keys, saider=saider, allowed=allowed)  # update .eans and .ends
+        self.updateEnd(keys=keys, saider=diger, allowed=allowed)  # update .eans and .ends
 
 
-    def processReplyLocScheme(self, *, serder, saider, route,
+    def processReplyLocScheme(self, *, serder, diger, route,
                               cigars=None, tsgs=None):
         """
         Process one reply message for route = /loc/scheme with either
         attached nontrans receipt couples in cigars or attached trans indexed
         sig groups in tsgs.
-        Assumes already validated saider, dater, and route from serder.ked
+        Assumes already validated diger, dater, and route from serder.ked
 
         Parameters:
             serder (SerderKERI): instance of reply msg (SAD)
-            saider (Diger): instance from said in serder (SAD)
+            diger (Diger): instance from said in serder (SAD)
             route (str): reply route
             cigars (list): of Cigar instances that contain nontrans signing couple
                           signature in .raw and public key in .verfer
@@ -4799,7 +4799,7 @@ class Kevery:
         keys = (aid, scheme)
         osaider = self.db.lans.get(keys=keys)  # get old said if any
         # BADA Logic
-        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+        accepted = self.rvy.acceptReply(serder=serder, saider=diger, route=route,
                                       aid=aid, osaider=osaider, cigars=cigars,
                                       tsgs=tsgs)
         if not accepted:
@@ -4808,21 +4808,21 @@ class Kevery:
             logger.debug("Event Body=\n%s\n", serder.pretty())
             raise UnverifiedReplyError(msg)
 
-        self.updateLoc(keys=keys, saider=saider, url=url)  # update .lans and .locs
+        self.updateLoc(keys=keys, saider=diger, url=url)  # update .lans and .locs
 
 
-    def processReplyKeyStateNotice(self, *, serder, saider, route,
+    def processReplyKeyStateNotice(self, *, serder, diger, route,
                                    cigars=None, tsgs=None, **kwa):
         """ Process one reply message for key state = /ksn
 
         Process one reply message for key state = /ksn
         with either attached nontrans receipt couples in cigars or attached trans
         indexed sig groups in tsgs.
-        Assumes already validated saider, dater, and route from serder.ked
+        Assumes already validated diger, dater, and route from serder.ked
 
         Parameters:
             serder (SerderKERI): instance of reply msg (SAD)
-            saider (Diger): instance from said in serder (SAD)
+            diger (Diger): instance from said in serder (SAD)
             route (str): reply route
             cigars (list): of Cigar instances that contain nontrans signing couple
                           signature in .raw and public key in .verfer
@@ -4917,14 +4917,14 @@ class Kevery:
         dater = Dater(dts=ksr.dt)
 
         # BADA Logic
-        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+        accepted = self.rvy.acceptReply(serder=serder, saider=diger, route=route,
                                         aid=aid, osaider=osaider, cigars=cigars,
                                         tsgs=tsgs)
         if not accepted:
             raise UnverifiedReplyError(f"Unverified key state notice reply. {serder.ked}")
 
         ldig = self.db.kels.getOnLast(keys=pre, on=sn)  # retrieve dig of last event at sn.
-        diger = Diger(qb64=ksr.d)
+        ksr_diger = Diger(qb64=ksr.d)
 
         # Only accept key state if for last seen version of event at sn
         if ldig is not None:  # escrow because event does not yet exist in database
@@ -4932,10 +4932,10 @@ class Kevery:
             # retrieve last event itself of signer given sdig
             sserder = self.db.evts.get(keys=(pre, ldig))
             # assumes db ensures that sserder must not be none because sdig was in KE
-            if not sserder.compare(said=diger.qb64b):  # mismatch events problem with replay
+            if not sserder.compare(said=ksr_diger.qb64b):  # mismatch events problem with replay
                 raise ValidationError(f"Mismatch keystate at sn = {int(ksr.s,16)} with db.")
 
-        self.updateKeyState(aid=aid, ksr=ksr, saider=diger, dater=dater)
+        self.updateKeyState(aid=aid, ksr=ksr, saider=ksr_diger, dater=dater)
         self.cues.push(dict(kin="keyStateSaved", ksn=asdict(ksr)))
 
 
@@ -5005,18 +5005,18 @@ class Kevery:
             self.db.kdts.rem(keys=keys)
 
 
-    def processReplyAddWatched(self, *, serder, saider, route,
+    def processReplyAddWatched(self, *, serder, diger, route,
                                cigars=None, tsgs=None, **kwa):
         """ Process one reply message for adding an AID for a watcher to watch
 
         Process one reply message for adding an AID for a watcher to watch = /watcher/{aid}/add
         with either attached nontrans receipt couples in cigars or attached trans
         indexed sig groups in tsgs.
-        Assumes already validated saider, dater, and route from serder.ked
+        Assumes already validated diger, dater, and route from serder.ked
 
         Parameters:
             serder (SerderKERI): instance of reply msg (SAD)
-            saider (Diger): instance from said in serder (SAD)
+            diger (Diger): instance from said in serder (SAD)
             route (str): reply route
             cigars (list): of Cigar instances that contain nontrans signing couple
                           signature in .raw and public key in .verfer
@@ -5072,7 +5072,7 @@ class Kevery:
         osaider = self.db.wwas.get(keys=keys)  # get old said if any
 
         # BADA Logic
-        accepted = self.rvy.acceptReply(serder=serder, saider=saider, route=route,
+        accepted = self.rvy.acceptReply(serder=serder, saider=diger, route=route,
                                         aid=cid, osaider=osaider, cigars=cigars,
                                         tsgs=tsgs)
         if not accepted:
@@ -5080,7 +5080,7 @@ class Kevery:
 
         if oobi:
             self.db.oobis.pin(keys=(oobi,), val=OobiRecord(date=nowIso8601()))
-        self.updateWatched(keys=keys, saider=saider, enabled=enabled)
+        self.updateWatched(keys=keys, saider=diger, enabled=enabled)
 
     def updateWatched(self, keys, saider, enabled=None):
         """

--- a/src/keri/core/routing.py
+++ b/src/keri/core/routing.py
@@ -55,12 +55,12 @@ class Router:
             Route(regex=regex, fields=fields, resource=resource, suffix=suffix)
         )
 
-    def dispatch(self, serder, saider, cigars, tsgs):
+    def dispatch(self, serder, diger, cigars, tsgs):
         """
 
         Parameters:
             serder:
-            saider:
+            diger:
             cigars:
             tsgs:
 
@@ -84,7 +84,7 @@ class Router:
                 raise ValidationError(f"parameter {name} not found in route {r}")
 
         fn = getattr(route.resource, fname, self.processRouteNotFound)
-        fn(serder=serder, saider=saider, route=r, cigars=cigars, tsgs=tsgs, **kwargs)
+        fn(serder=serder, diger=diger, route=r, cigars=cigars, tsgs=tsgs, **kwargs)
 
     def _find(self, route):
         """Linear seach thru added routes, returning the first one that matchs
@@ -107,13 +107,13 @@ class Router:
         return None, None
 
     def processRouteNotFound(
-        self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs
+        self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs
     ):
         """Default handler for processing reply message with an unregistered route
 
         Parameters:
             serder (Serder): reply event message
-            saider (Diger): instance from said of reply serder
+            diger (Diger): instance from said of reply serder
             route (str): route ('r') of the event message
             cigars (Optional(list)): list of non-transferable signature tuples
             tsgs (Optional(list)): list of transferable signature tuples
@@ -191,8 +191,8 @@ class Revery:
         if not serder.verify():
             raise ValidationError(f"Invalid said for reply msg={serder.ked}.")
 
-        saider = Diger(qb64=serder.said)
-        self.rtr.dispatch(serder=serder, saider=saider, cigars=cigars, tsgs=tsgs)
+        diger = Diger(qb64=serder.said)
+        self.rtr.dispatch(serder=serder, diger=diger, cigars=cigars, tsgs=tsgs)
 
     def acceptReply(
         self, serder, saider, route, aid, osaider=None, cigars=None, tsgs=None

--- a/src/keri/db/escrowing.py
+++ b/src/keri/db/escrowing.py
@@ -140,7 +140,7 @@ class Broker:
                         logger.trace("Broker %s: %s", typ, msg)
                         raise kering.ValidationError(msg)
 
-                    processReply(serder=serder, saider=diger, route=serder.ked["r"],
+                    processReply(serder=serder, diger=diger, route=serder.ked["r"],
                                  cigars=cigars, tsgs=tsgs, aid=aid)
 
                 except extype as ex:

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -1674,7 +1674,7 @@ class Tevery:
         router.addRoute("/tsn/registry/{aid}", self, suffix="RegistryTxnState")
         router.addRoute("/tsn/credential/{aid}", self, suffix="CredentialTxnState")
 
-    def processReplyRegistryTxnState(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
+    def processReplyRegistryTxnState(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
         """ Process one reply message for key state = /tsn/registry
 
          Process one reply message for key state = /tsn/registry
@@ -1728,7 +1728,6 @@ class Tevery:
          }
 
          """
-        diger = saider  # Diger instance passed as saider by Router.dispatch()
         cigars = cigars if cigars is not None else []
         tsgs = tsgs if tsgs is not None else []
 
@@ -1815,7 +1814,7 @@ class Tevery:
         self.reger.txnsb.updateReply(aid=aid, serder=serder, diger=tdiger, dater=dater)
         self.cues.append(dict(kin="txnStateSaved", record=rsr))
 
-    def processReplyCredentialTxnState(self, *, serder, saider, route, cigars=None, tsgs=None, **kwargs):
+    def processReplyCredentialTxnState(self, *, serder, diger, route, cigars=None, tsgs=None, **kwargs):
         """ Process one reply message for key state = /tsn/registry
 
          Process one reply message for key state = /tsn/registry
@@ -1860,7 +1859,6 @@ class Tevery:
          }
 
          """
-        diger = saider  # Diger instance passed as saider by Router.dispatch()
         cigars = cigars if cigars is not None else []
         tsgs = tsgs if tsgs is not None else []
 

--- a/tests/db/test_escrowing.py
+++ b/tests/db/test_escrowing.py
@@ -93,7 +93,7 @@ def test_broker_nontrans():
             assert kwargs["tsgs"] == []
             assert kwargs["aid"] == aid
             #tser = coring.Serder(ked=kwargs["serder"].ked["a"])
-            bork.updateReply(aid=aid, serder=serder, diger=kwargs["saider"], dater=dater)
+            bork.updateReply(aid=aid, serder=serder, diger=kwargs["diger"], dater=dater)
 
         bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
 
@@ -164,7 +164,7 @@ def test_broker_trans():
             assert kwargs["cigars"] == []
             assert kwargs["aid"] == aid
             #tser = coring.Serder(ked=kwargs["serder"].ked["a"])
-            bork.updateReply(aid=aid, serder=serder, diger=kwargs["saider"], dater=dater)
+            bork.updateReply(aid=aid, serder=serder, diger=kwargs["diger"], dater=dater)
 
         bork.processEscrowState(typ=typ, processReply=process, extype=kering.OutOfOrderError)
 


### PR DESCRIPTION
## Summary

All `processReply*` handler functions in the reply dispatch chain receive a `Diger` instance (not a `Saider`). The parameter was historically misnamed `saider`. This PR aligns the parameter names with the actual types throughout the chain.

## Files changed

| File | Change |
|------|--------|
| `src/keri/core/routing.py` | `Router.dispatch(saider→diger)`, `processRouteNotFound(saider→diger)`, `Revery.processReply` local var + dispatch call |
| `src/keri/core/eventing.py` | `processReplyEndRole`, `processReplyLocScheme`, `processReplyKeyStateNotice`, `processReplyAddWatched` — all `saider→diger`; `processReplyKeyStateNotice` local `diger` renamed to `ksr_diger` to avoid shadowing |
| `src/keri/app/oobiing.py` | `Oobiery.processReply(saider→diger)` |
| `src/keri/vdr/eventing.py` | `processReplyRegistryTxnState`, `processReplyCredentialTxnState` — `saider→diger`; removed now-redundant `diger = saider` alias lines |
| `src/keri/db/escrowing.py` | `Broker.processEscrowState` dispatch call: `processReply(saider=diger, ...)` → `processReply(diger=diger, ...)` |
| `tests/db/test_escrowing.py` | Updated mock `process()` callbacks to use `kwargs["diger"]` instead of `kwargs["saider"]` |
| `ref/ChangeLog.md` | Added `2.0.0-dev5` entries for all renamed signatures |

## Tests

```
pytest tests/ --ignore tests/demo/ -x -q
# 439 passed, 0 failed
```

## Diff

7 files changed, +62/−45. Zero whitespace-only changes (`git diff -w` identical).

## Notes

- `acceptReply(saider=...)` call sites are intentionally left unchanged — that rename is scoped to a separate PR
- `fetchTsgs` and other unrelated `saider` uses in `eventing.py` are untouched
- Part of the PR-1209 sub-PR series cleaning up `Saider→Diger` naming throughout