### PR TITLE
fix: use mailbox eid for HTTPS endpoint lookup in oobi generate (#1105)

### DIFF
--- a/src/keri/app/cli/commands/oobi/generate.py
+++ b/src/keri/app/cli/commands/oobi/generate.py
@@ -14,7 +14,7 @@ from ...common.parsing import Parsery
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Generate and print role OOBIs for the AID of the provide alias.', 
+parser = argparse.ArgumentParser(description='Generate and print role OOBIs for the AID of the provide alias.',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: handler(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', default=None)
@@ -60,7 +60,7 @@ def generate(tymth, tock=0.0, **opts):
                        or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
                 if not urls:
                     raise kering.ConfigurationError(f"unable to query witness {wit}, no http endpoint")
-            
+
                 url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
                 print(f"{url.rstrip("/")}/oobi/{hab.pre}/witness")
         elif role in (kering.Roles.controller,):
@@ -76,7 +76,7 @@ def generate(tymth, tock=0.0, **opts):
                 if not (end.allowed and end.enabled is not False):
                     continue
 
-                urls = hab.fetchUrls(eid=eid, scheme=kering.Schemes.http) or hab.fetchUrls(eid=hab.pre,
+                urls = hab.fetchUrls(eid=eid, scheme=kering.Schemes.http) or hab.fetchUrls(eid=eid,
                                                                                            scheme=kering.Schemes.https)
                 if not urls:
                     print(f"{alias} identifier {hab.pre} does not have any mailbox endpoints")


### PR DESCRIPTION
# Fix: HTTPS mailbox OOBI uses `hab.pre` instead of `eid`

Closes #1105

## Problem

In `kli oobi generate`, the mailbox branch falls back to HTTPS when no HTTP endpoint is found. The HTTP lookup correctly uses `eid=eid` (the mailbox endpoint provider), but the HTTPS fallback uses `eid=hab.pre` (the local controller's prefix).

This causes HTTPS mailbox OOBIs to fail when the mailbox is hosted by a different entity than the controller — which is the common case.

## Fix

```diff
-                urls = hab.fetchUrls(eid=eid, scheme=kering.Schemes.http) or hab.fetchUrls(eid=hab.pre,
+                urls = hab.fetchUrls(eid=eid, scheme=kering.Schemes.http) or hab.fetchUrls(eid=eid,
                                                                                            scheme=kering.Schemes.https)
```

This matches the pattern used in both the witness and controller branches, which use the same `eid` for both HTTP and HTTPS lookups.

## Context

- The witness branch (lines 61-67) correctly uses `eid=wit` for both schemes
- The controller branch (lines 69-74) correctly uses `eid=hab.pre` for both (controller IS the hab)
- The mailbox branch was the only one with a mismatch

Credit to @kentbull for the clear bug report.