### PR TITLE
fix: add Organizer.findExact for precise alias matching

### DIFF
--- a/src/keri/app/organizing.py
+++ b/src/keri/app/organizing.py
@@ -176,6 +176,28 @@ class BaseOrganizer:
 
         return [self.get(pre) for pre in pres]
 
+    def findExact(self, field, val):
+        """ Find all contacts where field is an exact case-sensitive match for val
+
+        Unlike find(), which uses a substring regex, this performs a strict
+        equality comparison suitable for alias lookups where similar names
+        (e.g. "sally" vs "sally-direct") must not collide.
+
+        Parameters:
+            field (str): field name to search for
+            val (str): exact value to match (case-sensitive)
+
+        Returns:
+            list: All contacts whose field equals val exactly
+
+        """
+        pres = []
+        for (pre, f), v in self.fielddb.getItemIter():
+            if f == field and v == val:
+                pres.append(pre)
+
+        return [self.get(pre) for pre in pres]
+
     def values(self, field, val=None):
         """ Find unique values for field in all contacts
 

--- a/src/keri/cli/commands/challenge/respond.py
+++ b/src/keri/cli/commands/challenge/respond.py
@@ -7,7 +7,7 @@ import argparse
 
 from hio.base import doing
 
-from ...common import existing 
+from ...common import existing
 from ...common.parsing import Parsery
 from ....app import habbing, forwarding, organizing
 from ....app.habbing import GroupHab
@@ -98,9 +98,11 @@ class RespondDoer(doing.DoDoer):
         if hab is None:
             raise ValueError(f"invalid alias {self.alias}")
 
-        recp = self.org.find("alias", self.recp)
-        if len(recp) != 1:
-            raise ValueError(f"invalid recipient {self.recp}")
+        recp = self.org.findExact("alias", self.recp)
+        if len(recp) == 0:
+            raise ValueError(f"no contact found with alias {self.recp!r}")
+        if len(recp) > 1:
+            raise ValueError(f"multiple contacts match alias {self.recp!r}, use prefix instead")
 
         recp = recp[0]['id']
 

--- a/src/keri/cli/commands/challenge/verify.py
+++ b/src/keri/cli/commands/challenge/verify.py
@@ -97,9 +97,11 @@ class VerifyDoer(doing.DoDoer):
         if self.signer in self.hby.kevers:
             sig = self.signer
         else:
-            sig = self.org.find("alias", self.signer)
-            if len(sig) != 1:
-                raise ValueError(f"invalid signer {self.signer}")
+            sig = self.org.findExact("alias", self.signer)
+            if len(sig) == 0:
+                raise ValueError(f"no contact found with alias {self.signer!r}")
+            if len(sig) > 1:
+                raise ValueError(f"multiple contacts match alias {self.signer!r}, use prefix instead")
             sig = sig[0]['id']
 
         if self.generate:

--- a/src/keri/cli/commands/contacts/delete.py
+++ b/src/keri/cli/commands/contacts/delete.py
@@ -62,7 +62,7 @@ def delete(tymth, tock=0.0, **opts):
                 pre = aid
                 contact = org.get(aid)
             elif alias:
-                contacts = org.find('alias', f"^{alias}$")  # Exact match
+                contacts = org.findExact('alias', alias)
                 if len(contacts) == 0:
                     print(f"Contact with alias '{alias}' not found")
                     return -1

--- a/src/keri/cli/commands/contacts/get.py
+++ b/src/keri/cli/commands/contacts/get.py
@@ -60,7 +60,7 @@ def get(tymth, tock=0.0, **opts):
                 pre = aid
                 contact = org.get(aid)
             elif alias:
-                contacts = org.find('alias', f"^{alias}$")  # Exact match
+                contacts = org.findExact('alias', alias)
                 if len(contacts) > 1:
                     print(f"Multiple contacts match alias '{alias}'")
                     return -1

--- a/src/keri/cli/commands/contacts/query.py
+++ b/src/keri/cli/commands/contacts/query.py
@@ -98,7 +98,7 @@ class ContactQueryDoer(doing.DoDoer):
             pre = self.contact_aid
             contact = org.get(pre)
         elif self.contact_alias:
-            contacts = org.find('alias', f"^{self.contact_alias}$")
+            contacts = org.findExact('alias', self.contact_alias)
             if len(contacts) == 0:
                 print(f"Contact with alias '{self.contact_alias}' not found")
                 self.remove([self.hbyDoer, self.mbd])

--- a/src/keri/cli/commands/contacts/rename.py
+++ b/src/keri/cli/commands/contacts/rename.py
@@ -62,7 +62,7 @@ def rename(tymth, tock=0.0, **opts):
                 pre = aid
                 contact = org.get(aid)
             elif old_alias:
-                contacts = org.find('alias', f"^{old_alias}$")  # Exact match
+                contacts = org.findExact('alias', old_alias)
                 if len(contacts) == 0:
                     print(f"Contact with alias '{old_alias}' not found")
                     return -1

--- a/src/keri/cli/commands/exn/send.py
+++ b/src/keri/cli/commands/exn/send.py
@@ -76,9 +76,11 @@ def resolveRecipient(org: organizing.Organizer, hby, recipient: str) -> str:
     if recipient in hby.kevers:
         return recipient
 
-    matches = org.find("alias", recipient)
-    if len(matches) != 1:
-        raise ValueError(f"invalid recipient {recipient}")
+    matches = org.findExact("alias", recipient)
+    if len(matches) == 0:
+        raise ValueError(f"no contact found with alias {recipient!r}")
+    if len(matches) > 1:
+        raise ValueError(f"multiple contacts match alias {recipient!r}, use prefix instead")
     return matches[0]["id"]
 
 

--- a/src/keri/cli/commands/introduce.py
+++ b/src/keri/cli/commands/introduce.py
@@ -14,7 +14,7 @@ from ...core import serdering
 from ...app import habbing, organizing, forwarding
 
 
-parser = argparse.ArgumentParser(description='Send an rpy /introduce message to recipient with OOBI', 
+parser = argparse.ArgumentParser(description='Send an rpy /introduce message to recipient with OOBI',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: introduce(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the new identifier prefix', required=True)
@@ -87,9 +87,11 @@ class IntroduceDoer(doing.DoDoer):
         if self.recipient in self.hby.kevers:
             recp = self.recipient
         else:
-            recp = self.org.find("alias", self.recipient)
-            if len(recp) != 1:
-                raise ValueError(f"invalid recipient {self.recipient}")
+            recp = self.org.findExact("alias", self.recipient)
+            if len(recp) == 0:
+                raise ValueError(f"no contact found with alias {self.recipient!r}")
+            if len(recp) > 1:
+                raise ValueError(f"multiple contacts match alias {self.recipient!r}, use prefix instead")
             recp = recp[0]['id']
 
         if (ihab := self.hby.habByName(self.introducee)) is not None:
@@ -99,12 +101,10 @@ class IntroduceDoer(doing.DoDoer):
         elif self.introducee in self.hby.kevers:
             introducee = self.introducee
         else:
-            introducee = None
-            results = self.org.find("alias", self.introducee)
-            for result in results:
-                if result["alias"] == self.introducee:
-                    introducee = result['id']
-            if not introducee:
+            results = self.org.findExact("alias", self.introducee)
+            if len(results) == 1:
+                introducee = results[0]['id']
+            else:
                 raise ValueError(f"invalid introducee {self.introducee}")
 
         oobi = None

--- a/src/keri/cli/commands/ipex/grant.py
+++ b/src/keri/cli/commands/ipex/grant.py
@@ -96,9 +96,11 @@ class GrantDoer(doing.DoDoer):
         elif self.recp in self.hby.kevers:
             recp = self.recp
         else:
-            recp = self.org.find("alias", self.recp)
-            if len(recp) != 1:
-                raise ValueError(f"invalid recipient {self.recp}")
+            recp = self.org.findExact("alias", self.recp)
+            if len(recp) == 0:
+                raise ValueError(f"no contact found with alias {self.recp!r}")
+            if len(recp) > 1:
+                raise ValueError(f"multiple contacts match alias {self.recp!r}, use prefix instead")
             recp = recp[0]['id']
 
         if recp is None:

--- a/src/keri/cli/commands/mailbox/add.py
+++ b/src/keri/cli/commands/mailbox/add.py
@@ -18,7 +18,7 @@ from ....app.agenting import httpClient, WitnessPublisher
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Add mailbox role', 
+parser = argparse.ArgumentParser(description='Add mailbox role',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: add(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
@@ -53,9 +53,11 @@ class AddDoer(doing.DoDoer):
         if mailbox in self.hby.kevers:
             mbx = mailbox
         else:
-            mbx = self.org.find("alias", mailbox)
-            if len(mbx) != 1:
-                raise ValueError(f"invalid mailbox {mailbox}")
+            mbx = self.org.findExact("alias", mailbox)
+            if len(mbx) == 0:
+                raise ValueError(f"no contact found with alias {mailbox!r}")
+            if len(mbx) > 1:
+                raise ValueError(f"multiple contacts match alias {mailbox!r}, use prefix instead")
             mbx = mbx[0]['id']
 
         if not mbx:

--- a/src/keri/cli/commands/vc/create.py
+++ b/src/keri/cli/commands/vc/create.py
@@ -17,7 +17,7 @@ from ....vdr import credentialing, verifying
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Issue a verifiable credential', 
+parser = argparse.ArgumentParser(description='Issue a verifiable credential',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: issueCredential(args))
 parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
@@ -167,9 +167,11 @@ class CredentialIssuer(doing.DoDoer):
                 elif recipient in self.hby.kevers:
                     recp = recipient
                 else:
-                    recp = self.org.find("alias", recipient)
-                    if len(recp) != 1:
-                        raise ValueError(f"invalid recipient {recipient}")
+                    recp = self.org.findExact("alias", recipient)
+                    if len(recp) == 0:
+                        raise ValueError(f"no contact found with alias {recipient!r}")
+                    if len(recp) > 1:
+                        raise ValueError(f"multiple contacts match alias {recipient!r}, use prefix instead")
                     recp = recp[0]['id']
 
                 if self.timestamp is not None:

--- a/src/keri/cli/commands/vc/revoke.py
+++ b/src/keri/cli/commands/vc/revoke.py
@@ -18,7 +18,7 @@ from ....peer import exchanging
 from ....vdr import credentialing, verifying
 
 
-parser = argparse.ArgumentParser(description='Revoke a verifiable credential', 
+parser = argparse.ArgumentParser(description='Revoke a verifiable credential',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: revokeCredential(args))
 parser.add_argument('--registry-name', '-r', help='Human readable name for registry, defaults to name of Habitat',
@@ -157,9 +157,11 @@ class RevokeDoer(doing.DoDoer):
                     if send in self.hby.kevers:
                         recp = send
                     else:
-                        recp = self.org.find("alias", send)
-                        if len(recp) != 1:
-                            raise ValueError(f"invalid recipient {send}")
+                        recp = self.org.findExact("alias", send)
+                        if len(recp) == 0:
+                            raise ValueError(f"no contact found with alias {send!r}")
+                        if len(recp) > 1:
+                            raise ValueError(f"multiple contacts match alias {send!r}, use prefix instead")
                         recp = recp[0]['id']
                     for (serder, atc) in msgs:
                         self.postman.send(src=senderHab.pre, dest=recp, topic="credential", serder=serder,

--- a/src/keri/cli/commands/watcher/add.py
+++ b/src/keri/cli/commands/watcher/add.py
@@ -18,7 +18,7 @@ from ....core import serdering
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Add AID or Alias to list of AIDs for a watcher to watch', 
+parser = argparse.ArgumentParser(description='Add AID or Alias to list of AIDs for a watcher to watch',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: add(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
@@ -55,10 +55,9 @@ class AddDoer(doing.DoDoer):
         if watcher in self.hby.kevers:
             wat = watcher
         else:
-            contacts = self.org.find("alias", watcher)
-            for contact in contacts:
-                if contact['alias'] == watcher:
-                    wat = contact['id']
+            contacts = self.org.findExact("alias", watcher)
+            if len(contacts) == 1:
+                wat = contacts[0]['id']
 
         if not wat:
             raise ValueError(f"unknown watcher {watcher}")
@@ -67,10 +66,9 @@ class AddDoer(doing.DoDoer):
         if watched in self.hby.kevers:
             watd = watched
         else:
-            contacts = self.org.find("alias", watched)
-            for contact in contacts:
-                if contact['alias'] == watched:
-                    watd = contact['id']
+            contacts = self.org.findExact("alias", watched)
+            if len(contacts) == 1:
+                watd = contacts[0]['id']
 
         if not watd:
             raise ValueError(f"unknown watched {watched}")

--- a/src/keri/cli/commands/watcher/adjudicate.py
+++ b/src/keri/cli/commands/watcher/adjudicate.py
@@ -21,7 +21,7 @@ from ....help import helping
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Perform key event adjudication on any new key state from watchers.', 
+parser = argparse.ArgumentParser(description='Perform key event adjudication on any new key state from watchers.',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: handle(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
@@ -86,9 +86,11 @@ class AdjudicationDoer(doing.DoDoer):
             if self.watched in self.hby.kevers:
                 watd = self.watched
             else:
-                watd = org.find("alias", self.watched)
-                if len(watd) != 1:
-                    raise ValueError(f"invalid recipient {self.watched}")
+                watd = org.findExact("alias", self.watched)
+                if len(watd) == 0:
+                    raise ValueError(f"no contact found with alias {self.watched!r}")
+                if len(watd) > 1:
+                    raise ValueError(f"multiple contacts match alias {self.watched!r}, use prefix instead")
                 watd = watd[0]['id']
 
             if not watd:
@@ -154,4 +156,3 @@ class AdjudicationDoer(doing.DoDoer):
         except ConfigurationError as e:
             print(f"identifier prefix for {self.name} does not exist, incept must be run first", )
             return -1
-

--- a/src/keri/cli/commands/witness/authenticate.py
+++ b/src/keri/cli/commands/witness/authenticate.py
@@ -25,7 +25,7 @@ from ....core import coring
 
 logger = help.ogler.getLogger()
 
-parser = argparse.ArgumentParser(description='Perform authentication against an witness to get a OTP code', 
+parser = argparse.ArgumentParser(description='Perform authentication against an witness to get a OTP code',
                                  parents=[Parsery.keystore()])
 parser.set_defaults(handler=lambda args: auth(args))
 parser.add_argument('--alias', '-a', help='human readable alias for the identifier to whom the credential was issued',
@@ -63,9 +63,11 @@ class AuthDoer(doing.DoDoer):
         if witness in self.hby.kevers:
             wit = witness
         else:
-            wit = self.org.find("alias", witness)
-            if len(wit) != 1:
-                raise ValueError(f"invalid recipient {witness}")
+            wit = self.org.findExact("alias", witness)
+            if len(wit) == 0:
+                raise ValueError(f"no contact found with alias {witness!r}")
+            if len(wit) > 1:
+                raise ValueError(f"multiple contacts match alias {witness!r}, use prefix instead")
             wit = wit[0]['id']
 
         if not wit:

--- a/tests/app/cli/commands/exn/test_send.py
+++ b/tests/app/cli/commands/exn/test_send.py
@@ -198,7 +198,7 @@ def test_exn_send_invalid_recipient(monkeypatch, capsys, helpers):
     assert len(doers) == 1
 
     try:
-        with pytest.raises(ValueError, match="invalid recipient"):
+        with pytest.raises(ValueError, match="no contact found with alias"):
             directing.runController(doers=doers)
     finally:
         helpers.remove_test_dirs(name)

--- a/tests/app/test_organizing.py
+++ b/tests/app/test_organizing.py
@@ -155,6 +155,60 @@ def test_organizer():
             org.find(field="company", val="GLEIF")
 
 
+def test_find_exact():
+    """Test that findExact returns only exact alias matches.
+
+    Regression test for https://github.com/WebOfTrust/keripy/issues/1001
+    where find() regex caused "sally" to match "sally-direct".
+    """
+    sal = "Eo60ITGA69z4jNBU4RsvbgsjfAHFcTM2HVEXea1SvnXk"
+    sal_direct = "EPzeu5_C80nzPc_BGUHVBkXXfNmlS55Ayl7Rd1I0gWFE"
+    bob = "EuEQX8At31X96iDVpigv-rTdOKvFiWFunbJ1aDfq89IQ"
+
+    sald = dict(first="Sally", last="Smith", alias="sally")
+    sdird = dict(first="Sally", last="Smith-Direct", alias="sally-direct")
+    bobd = dict(first="Bob", last="Burns", alias="bob")
+
+    with habbing.openHby(name="test_exact", temp=True) as hby:
+        org = organizing.Organizer(hby=hby)
+
+        org.replace(pre=sal, data=sald)
+        org.replace(pre=sal_direct, data=sdird)
+        org.replace(pre=bob, data=bobd)
+
+        # find() regex matches both "sally" and "sally-direct"
+        fuzzy = org.find("alias", "sally")
+        assert len(fuzzy) == 2
+
+        # findExact() matches only "sally"
+        exact = org.findExact("alias", "sally")
+        assert len(exact) == 1
+        assert exact[0]["id"] == sal
+        assert exact[0]["alias"] == "sally"
+
+        # findExact() matches only "sally-direct"
+        exact_dir = org.findExact("alias", "sally-direct")
+        assert len(exact_dir) == 1
+        assert exact_dir[0]["id"] == sal_direct
+
+        # findExact() returns empty list for non-existent alias
+        missing = org.findExact("alias", "sal")
+        assert len(missing) == 0
+
+        # findExact() is case-sensitive (unlike find)
+        case_miss = org.findExact("alias", "Sally")
+        assert len(case_miss) == 0
+
+        # find() is case-insensitive
+        case_hit = org.find("alias", "Sally")
+        assert len(case_hit) == 2
+
+        # findExact() works on non-alias fields too
+        exact_bob = org.findExact("first", "Bob")
+        assert len(exact_bob) == 1
+        assert exact_bob[0]["id"] == bob
+
+
 def test_organizer_imgs():
 
     with habbing.openHab(name="test", transferable=True, temp=True) as (hby, hab):
@@ -191,7 +245,7 @@ def test_base_organizer():
     """Test BaseOrganizer with custom database configuration"""
     joe = "EtyPSuUjLyLdXAtGMrsTt0-ELyWeU8fJcymHiGOfuaSA"
     bob = "EuEQX8At31X96iDVpigv-rTdOKvFiWFunbJ1aDfq89IQ"
-    
+
     joed = {"first": "Joe", "last": "Jury", "address": "9934 Glen Creek St.", "city": "Lawrence", "state": "MA", "zip": "01841",
                 "company": "HCF", "alias": "joe"}
     bobd = {"first": "Bob", "last": "Burns", "address": "37 East Shadow Brook St.", "city": "Sebastian", "state": "FL",
@@ -253,13 +307,13 @@ def test_identifier_organizer():
     aid2 = "EuEQX8At31X96iDVpigv-rTdOKvFiWFunbJ1aDfq89IQ"
 
     # Sample identifier metadata
-    id1_data = {"name": "Primary ID", "description": "Main identifier", "role": "controller", 
+    id1_data = {"name": "Primary ID", "description": "Main identifier", "role": "controller",
                    "created": "2025-08-29T00:00:00Z", "status": "active"}
     id2_data = {"name": "Secondary ID", "description": "Backup identifier", "role": "witness",
                    "created": "2025-08-29T01:00:00Z", "status": "active"}
 
     with habbing.openHby(name="test", temp=True) as hby:
-        # Test IdentifierOrganizer 
+        # Test IdentifierOrganizer
         id_org = organizing.IdentifierOrganizer(hby=hby)
 
         # Test basic CRUD operations
@@ -339,7 +393,7 @@ def test_organizer_vs_identifier_organizer_separation():
         assert contacts[0]["first"] == "John"
         assert contacts[0]["company"] == "ACME Corp"
 
-        # Verify identifier organizer only has identifier data  
+        # Verify identifier organizer only has identifier data
         identifiers = id_org.list()
         assert len(identifiers) == 1
         assert identifiers[0]["name"] == "Test ID"
@@ -412,21 +466,21 @@ def test_base_organizer_inheritance():
         assert isinstance(id_org, organizing.BaseOrganizer)
 
         # Test that they have all the expected methods
-        expected_methods = ['update', 'replace', 'set', 'unset', 'rem', 'get', 'list', 'find', 'values', 
+        expected_methods = ['update', 'replace', 'set', 'unset', 'rem', 'get', 'list', 'find', 'values',
                           'setImg', 'getImgData', 'getImg']
-        
+
         for method in expected_methods:
             assert hasattr(contact_org, method)
             assert hasattr(id_org, method)
             assert callable(getattr(contact_org, method))
             assert callable(getattr(id_org, method))
-        
+
         # Test that database attributes are set correctly
         assert contact_org.cigsdb == hby.db.ccigs
         assert contact_org.datadb == hby.db.cons
         assert contact_org.fielddb == hby.db.cfld
         assert contact_org.imgsdb == hby.db.imgs
-        
+
         assert id_org.cigsdb == hby.db.icigs
         assert id_org.datadb == hby.db.sids
         assert id_org.fielddb == hby.db.ifld


### PR DESCRIPTION
## Summary

Add `BaseOrganizer.findExact()` method that performs strict equality comparison instead of the substring regex matching used by `find()`. Update all CLI commands that resolve contacts by alias to use `findExact()`, preventing false positives when aliases share a common substring.

Closes #1001

## Problem

When two contacts have similar aliases (e.g. "sally" and "sally-direct"), the `Organizer.find()` method's regex `.*{val}.*` matches both contacts. Commands like `kli ipex grant --recipient sally` then fail with a misleading "invalid recipient" error because `len(recp) != 1`.

## Solution

1. **New method `BaseOrganizer.findExact(field, val)`** - case-sensitive exact equality match on field values, complementing the existing regex-based `find()` which remains unchanged for fuzzy/search use cases.

2. **Updated 15 CLI command files** to use `findExact()` for alias resolution:
   - `ipex/grant`, `vc/create`, `vc/revoke`, `exn/send`
   - `challenge/respond`, `challenge/verify`
   - `witness/authenticate`, `watcher/add`, `watcher/adjudicate`
   - `mailbox/add`, `introduce`
   - `contacts/delete`, `contacts/get`, `contacts/query`, `contacts/rename` (replaced `^alias$` regex workaround)

3. **Improved error messages** - split the generic "invalid recipient" into:
   - `no contact found with alias 'foo'` (0 matches)
   - `multiple contacts match alias 'foo', use prefix instead` (>1 matches)

## Testing

- New `test_find_exact` in `tests/app/test_organizing.py` covering:
  - "sally" vs "sally-direct" scenario from the issue
  - Empty results for non-existent aliases
  - Case sensitivity verification
  - Non-alias field matching
- All 8 existing organizing tests continue to pass

## Changes

- 1 new method in `src/keri/app/organizing.py`
- 15 CLI command files updated (find -> findExact)
- 1 test file updated (new test_find_exact)