### PR TITLE
fix: prefer HTTPS over HTTP when both endpoints are available

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -175,11 +175,11 @@ class Receiptor(doing.DoDoer):
             return
 
         wit = random.choice(hab.kever.wits)
-        urls = hab.fetchUrls(eid=wit, scheme=Schemes.http) or hab.fetchUrls(eid=wit, scheme=Schemes.https)
+        urls = hab.fetchUrls(eid=wit, scheme=Schemes.https) or hab.fetchUrls(eid=wit, scheme=Schemes.http)
         if not urls:
             raise MissingEntryError(f"unable to query witness {wit}, no http endpoint")
 
-        base = urls[Schemes.http] if Schemes.http in urls else urls[Schemes.https]
+        base = urls[Schemes.https] if Schemes.https in urls else urls[Schemes.http]
         url = urljoin(base, f"/receipts?pre={pre}&sn={sn}")
 
         client = self.clienter.request("GET", url)
@@ -1011,7 +1011,7 @@ def messengerFrom(hab, pre, urls, auth=None):
         Optional(TcpWitnesser, HTTPMessenger): witnesser for ensuring full reciepts
     """
     if Schemes.http in urls or Schemes.https in urls:
-        url = urls[Schemes.http] if Schemes.http in urls else urls[Schemes.https]
+        url = urls[Schemes.https] if Schemes.https in urls else urls[Schemes.http]
         witer = HTTPMessenger(hab=hab, wit=pre, url=url, auth=auth)
     elif Schemes.tcp in urls:
         url = urls[Schemes.tcp]
@@ -1036,7 +1036,7 @@ def streamMessengerFrom(hab, pre, urls, msg, headers=None):
         Optional(TcpWitnesser, HTTPMessenger): witnesser for ensuring full reciepts
     """
     if Schemes.http in urls or Schemes.https in urls:
-        url = urls[Schemes.http] if Schemes.http in urls else urls[Schemes.https]
+        url = urls[Schemes.https] if Schemes.https in urls else urls[Schemes.http]
         witer = HTTPStreamMessenger(hab=hab, wit=pre, url=url, msg=msg, headers=headers)
     elif Schemes.tcp in urls:
         url = urls[Schemes.tcp]
@@ -1059,11 +1059,11 @@ def httpClient(hab, wit):
         ClientDoer: Doer for client
 
     """
-    urls = hab.fetchUrls(eid=wit, scheme=Schemes.http) or hab.fetchUrls(eid=wit, scheme=Schemes.https)
+    urls = hab.fetchUrls(eid=wit, scheme=Schemes.https) or hab.fetchUrls(eid=wit, scheme=Schemes.http)
     if not urls:
         raise MissingEntryError(f"unable to query witness {wit}, no http endpoint")
 
-    url = urls[Schemes.http] if Schemes.http in urls else urls[Schemes.https]
+    url = urls[Schemes.https] if Schemes.https in urls else urls[Schemes.http]
     up = urlparse(url)
     client = http.clienting.Client(scheme=up.scheme, hostname=up.hostname, port=up.port, path=up.path)
     clientDoer = http.clienting.ClientDoer(client=client)

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -127,13 +127,13 @@ class OobiResource:
             res["oobis"] = oobis
         elif role in (Roles.controller,):  # Fetch any controller URL OOBIs
             oobis = []
-            urls = hab.fetchUrls(eid=hab.pre, scheme=Schemes.http) or hab.fetchUrls(eid=hab.pre,
-                                                                                           scheme=Schemes.https)
+            urls = hab.fetchUrls(eid=hab.pre, scheme=Schemes.https) or hab.fetchUrls(eid=hab.pre,
+                                                                                           scheme=Schemes.http)
             if not urls:
                 rep.status = falcon.HTTP_404
                 rep.text = f"unable to query controller {hab.pre}, no http endpoint"
                 return
-            url = urls[Schemes.http] if Schemes.http in urls else urls[Schemes.https]
+            url = urls[Schemes.https] if Schemes.https in urls else urls[Schemes.http]
             oobis.append(f"{url.rstrip("/")}/oobi/{hab.pre}/controller")
             res["oobis"] = oobis
         else:

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -228,3 +228,49 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder):
         assert qinHab.pre in palHab.kevers
 
         doist.exit()
+
+
+def test_messenger_prefers_https():
+    """Verify messengerFrom and streamMessengerFrom prefer HTTPS over HTTP.
+
+    Regression test for https://github.com/WebOfTrust/keripy/issues/1008
+    """
+    from unittest.mock import MagicMock, patch
+    from keri.app.agenting import messengerFrom, streamMessengerFrom
+
+    hab = MagicMock()
+    pre = "EtyPSuUjLyLdXAtGMrsTt0-ELyWeU8fJcymHiGOfuaSA"
+
+    # Both HTTP and HTTPS available
+    urls = {
+        kering.Schemes.http: "http://example.com:5632",
+        kering.Schemes.https: "https://example.com:5643",
+    }
+
+    with patch("keri.app.agenting.HTTPMessenger") as MockHTTP:
+        messengerFrom(hab, pre, urls)
+        MockHTTP.assert_called_once()
+        call_url = MockHTTP.call_args[1]["url"]
+        assert call_url == "https://example.com:5643", f"Expected HTTPS URL, got {call_url}"
+
+    with patch("keri.app.agenting.HTTPStreamMessenger") as MockStream:
+        streamMessengerFrom(hab, pre, urls, msg=b"test")
+        MockStream.assert_called_once()
+        call_url = MockStream.call_args[1]["url"]
+        assert call_url == "https://example.com:5643", f"Expected HTTPS URL, got {call_url}"
+
+    # Only HTTP available - should still work
+    http_only = {kering.Schemes.http: "http://example.com:5632"}
+
+    with patch("keri.app.agenting.HTTPMessenger") as MockHTTP:
+        messengerFrom(hab, pre, http_only)
+        call_url = MockHTTP.call_args[1]["url"]
+        assert call_url == "http://example.com:5632"
+
+    # Only HTTPS available - should still work
+    https_only = {kering.Schemes.https: "https://example.com:5643"}
+
+    with patch("keri.app.agenting.HTTPStreamMessenger") as MockStream:
+        streamMessengerFrom(hab, pre, https_only, msg=b"test")
+        call_url = MockStream.call_args[1]["url"]
+        assert call_url == "https://example.com:5643"


### PR DESCRIPTION
## Summary

Flip URL scheme preference from HTTP-first to HTTPS-first across all messenger factory functions and endpoint resolvers.

Closes #1008

## Problem

When both HTTP and HTTPS endpoints are advertised for a witness/controller, the code always preferred HTTP, silently ignoring HTTPS. This is a security concern as HTTPS provides transport-layer encryption.

As Phil noted in #1008: "We should just change the default here to use HTTPS instead of HTTP."

## Solution

Changed 7 instances across 2 files to prefer HTTPS over HTTP:

### `src/keri/app/agenting.py` (6 instances)
- `Receiptor.receiptDo` - fetchUrls order + URL selection
- `messengerFrom()` - URL selection
- `streamMessengerFrom()` - URL selection (the original bug report)
- `httpClient()` - fetchUrls order + URL selection

### `src/keri/app/oobiing.py` (1 instance)
- `OobiResource.on_get` controller OOBI - fetchUrls order + URL selection
  (Note: the witness OOBI branch on line 125 already correctly preferred HTTPS)

## Behavior

- **Both HTTP + HTTPS available**: HTTPS is now selected (was HTTP)
- **Only HTTP available**: HTTP is still used (no regression)
- **Only HTTPS available**: HTTPS is still used (no change)
- **Only TCP available**: TCP is still used (no change)

## Testing

New `test_messenger_prefers_https` in `tests/app/test_agenting.py` verifying:
- HTTPS selected when both schemes present
- HTTP fallback when only HTTP available
- HTTPS works when only HTTPS available