### PR TITLE
Bugfix: multisig join timeout in scripts

### DIFF
--- a/scripts/demo/basic/multisig-join.sh
+++ b/scripts/demo/basic/multisig-join.sh
@@ -5,7 +5,7 @@
 # $ kli witness demo
 
 # Bound how long multisig join waits so that failures in the initiating side do not leave runs hanging.
-# JOIN_TIMEOUT and TIMEOUT_BIN may be overridden
+# JOIN_TIMEOUT may be overridden
 # by the caller (for example, in CI configuration).
 JOIN_TIMEOUT=${JOIN_TIMEOUT:-60}
 


### PR DESCRIPTION
The multisig-join.sh script attempts to simulate a two-party multisig by running both the initiating CLI commands (incept/rotate/interact) and the responding join in parallel, then waiting for all background PIDs.

The problem is multisig join is implemented as a blocking, wait-forever loop that only exits when it receives appropriate multisig notices. In the test script it is run in the background. If the corresponding multisig event (e.g., a group rotation) fails validation and never produces a notice for whatever reason, the join process blocks indefinitely. The higher-level invoking script (test_scripts.sh) never reaches its post-call isSuccess check, so the process hangs until cancelled. 

NOTE: This doesn't solve the underlying blocking wait problem in the join command; it just makes it not tie up the test run process indefinitely. 