### PR TITLE
fix: use pre= instead of wits= in kli admit telquery (fixes #1160)

### DIFF
--- a/src/keri/cli/commands/ipex/admit.py
+++ b/src/keri/cli/commands/ipex/admit.py
@@ -104,7 +104,7 @@ class AdmitDoer(doing.DoDoer):
         # Lets get the latest KEL and Registry if needed
         self.witq.query(src=self.hab.pre, pre=issr)
         if "ri" in acdc:
-            self.witq.telquery(src=self.hab.pre, wits=self.hab.kevers[issr].wits, ri=acdc["ri"], i=acdc["d"])
+            self.witq.telquery(src=self.hab.pre, pre=issr, ri=acdc["ri"], i=acdc["d"])
 
         for label in ("anc", "iss", "acdc"):
             ked = embeds[label]

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -274,3 +274,37 @@ def test_messenger_prefers_https():
         streamMessengerFrom(hab, pre, https_only, msg=b"test")
         call_url = MockStream.call_args[1]["url"]
         assert call_url == "https://example.com:5643"
+
+
+def test_telquery_uses_pre_not_wits():
+    """Test that WitnessInquisitor.telquery queues a message with `pre` parameter
+    for endpoint resolution instead of `wits`, matching KERIA behavior.
+
+    Regression test for issue #1160: kli admit fails when issuer has no witness
+    because telquery was called with wits=[] (empty list) instead of pre=issr.
+    When wits is an empty list, random.choice([]) raises IndexError.
+    When pre is provided, WitnessInquisitor.msgDo resolves endpoints via
+    hab.endsFor(pre=pre) which works for issuers with or without witnesses.
+    """
+    with habbing.openHby(name="test", temp=True) as hby:
+        hab = hby.makeHab(name="test")
+        witq = agenting.WitnessInquisitor(hby=hby)
+
+        issr_pre = hab.pre  # use hab's own prefix as a stand-in issuer
+        ri = "EAbcdefghijklmnopqrstuvwxyz012345678901234567"
+        acdc_said = "EBcdefghijklmnopqrstuvwxyz0123456789012345678"
+
+        # Call telquery with pre= (the fix) instead of wits=
+        witq.telquery(src=hab.pre, pre=issr_pre, ri=ri, i=acdc_said)
+
+        assert len(witq.msgs) == 1
+        msg = witq.msgs[0]
+
+        # Verify pre is set for endpoint resolution
+        assert msg["pre"] == issr_pre
+        # Verify wits is None (endpoint resolution path, not random witness path)
+        assert msg["wits"] is None
+        # Verify other fields
+        assert msg["src"] == hab.pre
+        assert msg["target"] == acdc_said
+        assert msg["q"]["ri"] == ri


### PR DESCRIPTION
## Summary

Fixes #1160 — `kli admit` crashes with `NoneType is not iterable` when the issuer of a credential has no witnesses.

## Root Cause

In `src/keri/cli/commands/ipex/admit.py`, the `telquery` call passed `wits=self.hab.kevers[issr].wits`. When the issuer has no witnesses, this is an empty list `[]`. Downstream in `WitnessInquisitor.msgDo`, `random.choice([])` raises `IndexError`, and passing through `koming.py` with `pre=None` raises `NoneType is not iterable`.

## Fix

Replace `wits=self.hab.kevers[issr].wits` with `pre=issr` in the `telquery` call.

This matches KERIA's behavior (`keria/app/agenting.py:1353-1358`) which passes `pre=issr`, allowing `WitnessInquisitor.msgDo` to resolve endpoints via `hab.endsFor(pre=pre)` — working for issuers with or without witnesses.

## Changes

- **`src/keri/cli/commands/ipex/admit.py`**: 1-line fix — `telquery(src=..., pre=issr, ri=..., i=...)` instead of `telquery(src=..., wits=..., ri=..., i=...)`
- **`tests/app/test_agenting.py`**: Added `test_telquery_uses_pre_not_wits` regression test verifying telquery queues a message with `pre` set and `wits=None` for endpoint resolution

## Testing

- All 4 tests in `test_agenting.py` pass (including new regression test)
- 1 source file changed, 1 test file changed
