### PR TITLE
fix: rollback key state on failed rotation (#819)

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -2361,19 +2361,42 @@ class Hab(BaseHab):
         if ncount is None:
             ncount = len(kever.ndigers)  # use len of prior next digers as default
 
+        # Save pre-rotation key state so we can rollback if event validation
+        # fails. Both mgr.replay() and mgr.rotate() advance and persist key
+        # state before the rotation event is validated by BaseHab.rotate().
+        # Without rollback, a failed rotation leaves the key store out of
+        # sync with the KEL (issue #819).
+        ps_before = self.mgr.ks.sits.get(self.pre)
+
         try:
-            verfers, digers = self.mgr.replay(pre=self.pre)
+            verfers, digers = self.mgr.replay(pre=self.pre, erase=False)
         except IndexError:  # old next is new current
             verfers, digers = self.mgr.rotate(pre=self.pre,
                                               ncount=ncount,
-                                              temp=self.temp)
-        return super(Hab, self).rotate(verfers=verfers, digers=digers,
-                                       isith=isith,
-                                       nsith=nsith,
-                                       toad=toad,
-                                       cuts=cuts,
-                                       adds=adds,
-                                       data=data)
+                                              temp=self.temp,
+                                              erase=False)
+
+        try:
+            msg = super(Hab, self).rotate(verfers=verfers, digers=digers,
+                                          isith=isith,
+                                          nsith=nsith,
+                                          toad=toad,
+                                          cuts=cuts,
+                                          adds=adds,
+                                          data=data)
+        except Exception:
+            # Rotation event validation failed. Rollback key state to
+            # pre-rotation snapshot so KEL and key store stay in sync.
+            self.mgr.ks.sits.pin(self.pre, val=ps_before)
+            raise
+
+        # Event validated successfully. Now safe to erase old stale
+        # private keys that were preserved during the key advancement.
+        if ps_before.old.pubs:
+            for pub in ps_before.old.pubs:
+                self.mgr.ks.pris.rem(pub)
+
+        return msg
 
 
 class SignifyHab(BaseHab):

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -1050,3 +1050,45 @@ if __name__ == "__main__":
     pass
     test_habery()
     # pytest.main(['-vv', 'test_habbing.py::test_habery_reconfigure'])
+
+
+def test_failed_rotation_rollback():
+    """Test that a failed rotation does not mutate key store state.
+
+    Reproduces issue #819: kli rotate with invalid parameters persists key
+    state to DB (via Manager.rotate) before event validation, leaving the
+    key store out of sync with the KEL when validation fails.
+    """
+    salt = core.Salter(raw=b'0123456789abcdef').qb64
+
+    with habbing.openHby(name="rollback-test", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="rollback-test", isith="1", icount=1,
+                          ncount=1, nsith="1")
+
+        assert hab.kever.sn == 0
+        pre = hab.pre
+
+        # Snapshot key state before attempting rotation
+        ps_before = hab.mgr.ks.sits.get(pre)
+        old_pubs_new = list(ps_before.new.pubs)
+        old_pubs_nxt = list(ps_before.nxt.pubs)
+        old_ridx = ps_before.new.ridx
+
+        # Attempt rotation with isith too high for the number of keys.
+        # This should fail during event creation (eventing.rotate raises
+        # ValueError when tholder.size > len(keys)).
+        with pytest.raises(ValueError):
+            hab.rotate(isith="2")
+
+        # Key store state must be unchanged after the failed rotation
+        ps_after = hab.mgr.ks.sits.get(pre)
+        assert list(ps_after.new.pubs) == old_pubs_new
+        assert list(ps_after.nxt.pubs) == old_pubs_nxt
+        assert ps_after.new.ridx == old_ridx
+
+        # KEL sequence number must also be unchanged
+        assert hab.kever.sn == 0
+
+        # A subsequent valid rotation must still succeed
+        hab.rotate()
+        assert hab.kever.sn == 1


### PR DESCRIPTION
## Summary

Fixes #819 — `kli rotate` with invalid parameters persists key state to the database before event validation, leaving the key store out of sync with the KEL.

## Root Cause

`Hab.rotate()` calls `Manager.rotate()` (or `Manager.replay()`), both of which advance the `PreSit` key state (old → new → nxt) and persist it to the key store DB **before** `BaseHab.rotate()` creates and validates the rotation event via `eventing.rotate()` and `Kevery.processEvent()`.

If event validation fails (e.g., invalid `isith`, threshold satisfaction failure), the key store has already been mutated — the keys have advanced one rotation — but the KEL has not. Subsequent operations see a key store that's one rotation ahead of the KEL.

## Fix

In `Hab.rotate()`:

1. **Snapshot** `PreSit` before calling `mgr.rotate()` or `mgr.replay()`
2. Call both with **`erase=False`** to preserve old private keys until validation succeeds  
3. **Wrap** `super().rotate()` in try/except — on failure, **rollback** `PreSit` to the pre-rotation snapshot
4. On success, **erase** old stale private keys (deferred from step 2)

This ensures the key store and KEL stay in sync regardless of whether the rotation event validates.

## Changes

### `src/keri/app/habbing.py`
- `Hab.rotate()`: snapshot-rollback pattern around key advancement + event validation
- `mgr.rotate(erase=False)` and `mgr.replay(erase=False)` — defer old key erasure until event is validated

### `tests/app/test_habbing.py`  
- `test_failed_rotation_rollback()` — regression test that:
  - Creates hab with 1 signing key
  - Attempts rotation with `isith="2"` (too high → `ValueError`)
  - Asserts `PreSit` (new/nxt pubs, ridx) unchanged after failure
  - Asserts KEL sn unchanged
  - Asserts subsequent valid rotation succeeds

## Testing

- `tests/app/test_habbing.py` — **13/13** passed (including new regression test)
- `tests/app/test_keeping.py` — **9/9** passed (erase=False change is compatible)