### PR TITLE
fix: clear escrows during migration to prevent old key format crashes

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -920,9 +920,9 @@ class Baser(dbing.LMDBer):
         self.ures = subing.CatCesrIoSetSuber(db=self, subkey='ures.',
                                              klas=(coring.Diger, coring.Prefixer, coring.Cigar))
         self.vrcs = subing.CatCesrIoSetSuber(db=self, subkey='vrcs.',
-                        klas=(coring.Prefixer, coring.Number, coring.Diger, indexing.Siger))
+                             klas=(coring.Prefixer, coring.Number, coring.Diger, indexing.Siger))
         self.vres = subing.CatCesrIoSetSuber(db=self, subkey='vres.',
-                        klas=(coring.Diger, coring.Prefixer, coring.Number, coring.Diger, indexing.Siger))
+                             klas=(coring.Diger, coring.Prefixer, coring.Number, coring.Diger, indexing.Siger))
         self.pses = subing.OnIoDupSuber(db=self, subkey='pses.')
         self.pwes = subing.OnIoDupSuber(db=self, subkey='pwes.')
         self.pdes = subing.OnIoDupSuber(db=self, subkey='pdes.')
@@ -1347,6 +1347,8 @@ class Baser(dbing.LMDBer):
         """
         from ..core import coring
 
+        escrows_cleared = False
+
         for (version, migrations) in MIGRATIONS:
             # Only run migration if current source code version is at or below the migration version
             ver = semver.VersionInfo.parse(keri.__version__)
@@ -1358,6 +1360,13 @@ class Baser(dbing.LMDBer):
             # Skip migrations already run - where version less than (-1) or equal to (0) database version
             if self.version is not None and semver.compare(version, self.version) != 1:
                 continue
+
+            # Clear all escrows before first migration to prevent old key
+            # format crashes (e.g. qnfs keys without insertion-order suffix).
+            # Uses .trim() which bypasses key parsing. See #863.
+            if not escrows_cleared:
+                self._trimAllEscrows()
+                escrows_cleared = True
 
             print(f"Migrating database v{self.version} --> v{version}")
             for migration in migrations:
@@ -1379,6 +1388,30 @@ class Baser(dbing.LMDBer):
             self.version = version
 
         self.version = keri.__version__
+
+    def _trimAllEscrows(self):
+        """Trim all escrow databases via low-level .trim().
+
+        Safe for old key formats that would crash higher-level iterators
+        (e.g., qnfs keys without insertion-order suffix from pre-1.2.0).
+        Called at the beginning of migration per spec call guidance.
+        See: https://github.com/WebOfTrust/keripy/issues/863
+        """
+        escrows = [
+            self.ures, self.vres, self.pses, self.pwes, self.ooes,
+            self.qnfs, self.uwes, self.misfits, self.delegables,
+            self.pdes, self.udes, self.rpes, self.ldes, self.epsd,
+            self.eoobi, self.dpub, self.gpwe, self.gdee, self.dpwe,
+            self.gpse, self.epse, self.dune,
+        ]
+        total = 0
+        for escrow in escrows:
+            count = escrow.cnt()
+            if count > 0:
+                escrow.trim()
+                total += count
+        if total > 0:
+            print(f"Cleared {total} escrow entries before migration")
 
     def clearEscrows(self):
         """

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -2617,6 +2617,93 @@ def test_clear_escrows():
         assert db.epsd.cntAll() == 0
         assert db.dpub.cntAll() == 0
 
+
+def test_trim_all_escrows_during_migration():
+    """Regression test for issue #863: old qnfs key format crashes migration.
+
+    When upgrading from keripy <1.2.0, qnfs entries lack the insertion-order
+    suffix (e.g. 'PRE.SAID' instead of 'PRE.SAID.00000000'). The high-level
+    iterators in clearEscrows() call unsuffix() which does int(SAID, 16) and
+    crashes with ValueError.
+
+    _trimAllEscrows() uses low-level .trim() which bypasses key parsing,
+    safely clearing all escrow databases regardless of key format.
+    """
+    with openDB() as db:
+        # Populate escrow databases with test data
+        pre = b'k'
+        saidb = b'saidb'
+        vals = [b"z", b"m", b"x"]
+
+        db.qnfs.add(keys=(pre, saidb), val=b"z")
+        assert db.qnfs.cnt(keys=(pre, saidb)) == 1
+
+        db.pses.putOn(keys=pre, vals=vals)
+        assert db.pses.cntOn(keys=pre) == 3
+
+        ooes_key = (snKey(pre, 0),)
+        db.ooes.putOn(keys=ooes_key, vals=vals)
+        assert db.ooes.cntAll() > 0
+
+        db.misfits.add(keys=(pre, b'snh'), val=saidb)
+        assert db.misfits.cnt(keys=(pre, b'snh')) == 1
+
+        # _trimAllEscrows clears everything via .trim()
+        db._trimAllEscrows()
+
+        assert db.qnfs.cntAll() == 0
+        assert db.pses.cntAll() == 0
+        assert db.ooes.cntAll() == 0
+        assert db.misfits.cntAll() == 0
+        assert db.ures.cntAll() == 0
+        assert db.vres.cntAll() == 0
+        assert db.pwes.cntAll() == 0
+        assert db.uwes.cntAll() == 0
+        assert db.delegables.cntAll() == 0
+        assert db.pdes.cntAll() == 0
+        assert db.udes.cntAll() == 0
+        assert db.rpes.cntAll() == 0
+        assert db.ldes.cntAll() == 0
+        assert db.epsd.cntAll() == 0
+        assert db.eoobi.cnt() == 0
+        assert db.dpub.cntAll() == 0
+        assert db.gpwe.cntAll() == 0
+        assert db.gdee.cntAll() == 0
+        assert db.dpwe.cntAll() == 0
+        assert db.gpse.cntAll() == 0
+        assert db.epse.cntAll() == 0
+        assert db.dune.cntAll() == 0
+
+
+def test_trim_all_escrows_old_key_format():
+    """Regression test for issue #863: simulate old qnfs key format.
+
+    Injects a raw LMDB entry with the old key format (no insertion-order
+    suffix) directly into the qnfs sub-database, then verifies that
+    _trimAllEscrows() clears it without crashing.
+    """
+    with openDB() as db:
+        # Simulate an old-format qnfs key by writing directly to LMDB.
+        # Old format: 'PRE.SAID' (no '.00000000' suffix)
+        # New format: 'PRE.SAID.00000000'
+        old_key = b'EBMbr7Z-pd4KJwzxuptSmCYqxrBnE2xKVO-MnjYkeUrt.EBMbr7Z-pd4KJwzxuptSmCYqxrBnE2xKVO-MnjYkeUrt'
+        old_val = b'EALkveIFUPvt38xhtgYYJRCCpAGO7WjjHVR37Pawv67E'
+        with db.env.begin(db=db.qnfs.sdb, write=True) as txn:
+            txn.put(old_key, old_val)
+
+        # Verify the entry exists
+        with db.env.begin(db=db.qnfs.sdb) as txn:
+            assert txn.get(old_key) == old_val
+
+        # _trimAllEscrows must not crash on old key format
+        db._trimAllEscrows()
+
+        # Verify it was cleared
+        with db.env.begin(db=db.qnfs.sdb) as txn:
+            assert txn.get(old_key) is None
+        assert db.qnfs.cntAll() == 0
+
+
 def test_db_keyspace_end_to_end_migration():
     """
     End-to-end test for DB keyspace migration from Seqner.qb64 to Number with Huge code.
@@ -2696,3 +2783,5 @@ if __name__ == "__main__":
     test_statedict()
     test_baserdoer()
     test_db_keyspace_end_to_end_migration()
+    test_trim_all_escrows_during_migration()
+    test_trim_all_escrows_old_key_format()


### PR DESCRIPTION
## Summary

Fixes #863 — **Migration bug on `qnfs` database key lookup**.

When upgrading from keripy <1.2.0, `qnfs` entries lack the insertion-order suffix (e.g. `PRE.SAID` instead of `PRE.SAID.00000000`). The high-level iterators call `unsuffix()` which does `int(SAID, 16)` and crashes with `ValueError`:

```
ERR: invalid literal for int() with base 16: b'EA59RST48MLqNoh_jNxHysEXFL4PeQlj2mII0TVEdz64'
```

## Root Cause

The `rekey_habs` migration (v1.2.0) changed the key format for many sub-databases but did not clear escrows. Old-format escrow entries persist in LMDB and crash when runtime iterators encounter them post-migration.

The existing `clearEscrows()` method cannot be used because its manual iteration loops (`getItemIter()`, `getOnItemIterAll()`) invoke the same `unsuffix()` that crashes on old keys.

## Fix

- Add `_trimAllEscrows()` method that uses low-level `.trim()` on all 22 escrow databases. `.trim()` calls `delTop()` which uses raw LMDB cursor operations — no key parsing, no `unsuffix()`, no crash.
- Modify `migrate()` to call `_trimAllEscrows()` once before the first migration that needs to run.
- Escrow data is transient and safe to discard during a version upgrade.

This follows the approach discussed by @pfeairheller and @kentbull in the issue comments.

## Testing

Two regression tests added to `tests/db/test_basing.py`:

1. **`test_trim_all_escrows_during_migration`** — Populates multiple escrow DBs via normal APIs, calls `_trimAllEscrows()`, asserts all 22 escrow databases have `cntAll() == 0`.
2. **`test_trim_all_escrows_old_key_format`** — Injects a raw LMDB entry with the OLD key format (no insertion-order suffix) directly into `qnfs.sdb`, verifies `_trimAllEscrows()` clears it without crashing.

All 16 tests in `test_basing.py` pass locally.

## Files Changed

- `src/keri/db/basing.py` — Added `_trimAllEscrows()`, modified `migrate()` with escrow clearing guard
- `tests/db/test_basing.py` — Two new test functions

Closes #863