### PR TITLE
chore: use package-level imports in test files

### DIFF
--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -6,10 +6,10 @@ keri.app.querying module
 from hio.base import doing
 
 from keri.kering import Vrsn_1_0
-from keri.app import habbing
-from keri.app.querying import QueryDoer, KeyStateNoticer, LogQuerier, SeqNoQuerier, AnchorQuerier
+from keri.app import (habbing, QueryDoer, KeyStateNoticer, LogQuerier,
+                      SeqNoQuerier, AnchorQuerier)
 from keri.core import parsing, eventing, serdering
-from keri.db.dbing import dgKey
+from keri.db import dgKey
 
 
 def test_querying():

--- a/tests/app/test_signify.py
+++ b/tests/app/test_signify.py
@@ -10,8 +10,7 @@ from keri import kering
 from keri import core
 from keri.core import coring, eventing
 
-from keri.app import habbing
-from keri.app.keeping import SaltyCreator
+from keri.app import habbing, SaltyCreator
 
 
 def test_remote_salty_hab():

--- a/tests/app/test_storing.py
+++ b/tests/app/test_storing.py
@@ -7,11 +7,10 @@ import os
 
 import lmdb
 
-from keri.app import keeping
+from keri.app import keeping, Mailboxer
 from keri.core import coring, serdering
 from keri.db import dbing, basing, subing
 from keri.peer import exchanging
-from keri.app.storing import Mailboxer
 
 
 def test_mailboxing():

--- a/tests/app/test_watching.py
+++ b/tests/app/test_watching.py
@@ -8,8 +8,7 @@ from dataclasses import asdict
 import pytest
 
 from keri import core
-from keri.app import watching, habbing
-from keri.app.watching import DiffState
+from keri.app import watching, habbing, DiffState
 from keri.core import coring
 from keri.recording import KeyStateRecord, ObservedRecord
 

--- a/tests/comply/test_direct_mode.py
+++ b/tests/comply/test_direct_mode.py
@@ -5,14 +5,12 @@ import os
 from keri.kering import Vrsn_1_0, Vrsn_2_0
 from keri import core
 from keri.core import  eventing, parsing
-from keri.core import MtrDex
+from keri.core import (MtrDex, incept, rotate, interact, messagize,
+                       SealEvent, receipt)
 
-from keri.core.eventing import (incept, rotate, interact, messagize, SealEvent, receipt)
+from keri.app import Manager, openKS
 
-from keri.app.keeping import Manager, openKS
-
-from keri.db.dbing import dgKey, snKey
-from keri.db.basing import  openDB
+from keri.db import dgKey, snKey, openDB
 
 
 def test_direct_mode_with_manager():
@@ -153,7 +151,7 @@ def test_direct_mode_with_manager():
         assert val_prefixer.qb64 == valKever.prefixer.qb64
         assert est_num.num == valKever.sn
         assert est_diger.qb64 == valKever.serder.said
-        assert sig.qb64b == sigers[0].qb64b 
+        assert sig.qb64b == sigers[0].qb64b
 
 
         # create receipt to escrow use invalid digest and sequence number so not in controller's db
@@ -177,7 +175,7 @@ def test_direct_mode_with_manager():
         assert val_prefixer.qb64 == valKever.prefixer.qb64
         assert est_num.num == valKever.sn
         assert est_diger.qb64 == valKever.serder.said
-        assert sig.qb64b == sigers[0].qb64b 
+        assert sig.qb64b == sigers[0].qb64b
 
         # Send receipt from controller to validator
         # create receipt of validator's inception
@@ -211,11 +209,11 @@ def test_direct_mode_with_manager():
         result = valKevery.db.vrcs.get(keys=dgKey(pre=valKever.prefixer.qb64,
                                                 dig=valKever.serder.said))
         rct_prefixer, rct_num, rct_est_diger, rct_siger = result[0]
-        
+
         assert rct_prefixer.qb64 == coeKever.prefixer.qb64
         assert rct_num.num == coeKever.sn
         assert rct_est_diger.qb64 == coeKever.serder.said
-        assert rct_siger.qb64b == sigers[0].qb64b 
+        assert rct_siger.qb64b == sigers[0].qb64b
 
         # Controller Event 1 Rotation Transferable
         csn += 1
@@ -280,11 +278,11 @@ def test_direct_mode_with_manager():
         result = coeKevery.db.vrcs.get(keys=dgKey(pre=coeKever.prefixer.qb64,
                                                 dig=coeKever.serder.said))
         rct_prefixer, rct_num, rct_est_diger, rct_siger = result[0]
-        
+
         assert rct_prefixer.qb64 == valKever.prefixer.qb64
         assert rct_num.num == valKever.sn
         assert rct_est_diger.qb64 == valKever.serder.said
-        assert rct_siger.qb64b == sigers[0].qb64b 
+        assert rct_siger.qb64b == sigers[0].qb64b
 
         # Next Event 2 Controller Interaction
         csn += 1  # do not increment esn
@@ -346,11 +344,11 @@ def test_direct_mode_with_manager():
         result = coeKevery.db.vrcs.get(keys=dgKey(pre=coeKever.prefixer.qb64,
                                                 dig=coeKever.serder.said))
         rct_prefixer, rct_num, rct_est_diger, rct_siger = result[0]
-        
+
         assert rct_prefixer.qb64 == valKever.prefixer.qb64
         assert rct_num.num == valKever.sn
         assert rct_est_diger.qb64 == valKever.serder.said
-        assert rct_siger.qb64b == sigers[0].qb64b 
+        assert rct_siger.qb64b == sigers[0].qb64b
 
 
         #  verify final controller event state

--- a/tests/core/test_delegating.py
+++ b/tests/core/test_delegating.py
@@ -10,8 +10,7 @@ from keri.core import (Number, Seqner, Diger, Kevery, SealEvent, parsing,
                        NumDex, MtrDex, incept, delcept, interact, deltate)
 
 from keri.app import keeping, habbing
-from keri.db import basing
-from keri.db.dbing import snKey
+from keri.db import basing, snKey
 
 logger = help.ogler.getLogger()
 

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -12,8 +12,7 @@ import pytest
 from keri.kering import (ValidationError, UnverifiedReceiptError,
                          Ilks, TraitDex, Vrsn_1_0, Ilks, Kinds,
                          versify)
-from keri.app import habbing
-from keri.app.keeping import openKS, Manager
+from keri.app import habbing, openKS, Manager
 from keri.core import (Signer, Counter, Codens, eventing, parsing,
                        serdering, Salter, Diger, Matter, Cigar, Seqner,
                        Verfer, Prefixer, Number, Saider, Seqner,
@@ -26,8 +25,7 @@ from keri.core import (Signer, Counter, Codens, eventing, parsing,
                        incept, rotate, interact, receipt, query, delcept,
                        deltate, state, messagize)
 
-from keri.db.basing import openDB
-from keri.db.dbing import dgKey, snKey
+from keri.db import openDB, dgKey, snKey
 from keri.help import helping, ogler
 
 logger = ogler.getLogger()

--- a/tests/core/test_kevery.py
+++ b/tests/core/test_kevery.py
@@ -8,7 +8,7 @@ from keri.core import (Salter, parsing, eventing, coring, serdering,
                        Counter, Kever, Kevery, Codens,
                        incept, rotate, interact)
 from keri.app import habbing
-from keri.db.basing import openDB
+from keri.db import openDB
 
 
 logger = help.ogler.getLogger()

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -8,8 +8,7 @@ processMsg on Kevery.
 import pytest
 
 from keri import core, kering, Vrsn_1_0, Vrsn_2_0
-from keri.core import eventing, parsing, coring, Verser
-from keri.core.kraming import Kramer, AuthTypes
+from keri.core import eventing, parsing, coring, Verser, Kramer, AuthTypes
 from keri.app import habbing, configing
 from keri.db import basing
 from keri.peer import exchanging

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -16,7 +16,7 @@ from keri.core import (Counter, GenDex, Codens, Seqner, Dater, Texter, Pather,
                        Blinder, Mediar, TypeMedia, Sealer, SealKind, Verser,
                        Salter, Parser, Kever, Kevery, incept, rotate, interact)
 
-from keri.db.basing import openDB
+from keri.db import openDB
 
 
 logger = help.ogler.getLogger()

--- a/tests/core/test_partial_rotation.py
+++ b/tests/core/test_partial_rotation.py
@@ -9,7 +9,7 @@ from keri import MissingSignatureError
 
 from keri.core import Salter, coring, eventing
 
-from keri.db.basing import openDB
+from keri.db import openDB
 
 
 def test_partial_rotation():

--- a/tests/db/test_dbing.py
+++ b/tests/db/test_dbing.py
@@ -9,10 +9,9 @@ import pytest
 import os
 import lmdb
 
-from keri.db import dbing
-from keri.db.dbing import (LMDBer, dgKey, onKey, openLMDB,
-                           snKey, dtKey, splitKey,
-                           splitOnKey, splitKeyDT, splitSnKey)
+from keri.db import (dbing, LMDBer, dgKey, onKey, openLMDB,
+                     snKey, dtKey, splitKey,
+                     splitOnKey, splitKeyDT, splitSnKey)
 
 from keri.help import helping
 

--- a/tests/db/test_escrowing.py
+++ b/tests/db/test_escrowing.py
@@ -5,8 +5,7 @@ tests.db.escrowing module
 """
 from keri import kering
 
-from keri.core import Salter, coring, eventing, serdering
-from keri.core.eventing import SealEvent
+from keri.core import Salter, coring, eventing, serdering, SealEvent
 
 from keri.app import habbing
 from keri.db import escrowing, dbing, subing

--- a/tests/db/test_koming.py
+++ b/tests/db/test_koming.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, asdict
 
 import pytest
 
-from keri.core.coring import Kinds
+from keri import Kinds
 from keri.db import dbing, koming
 from keri.help import helping
 

--- a/tests/help/test_helping.py
+++ b/tests/help/test_helping.py
@@ -135,7 +135,7 @@ def test_klasify():
     """
     Test klasify utility function
     """
-    from keri.core.coring import Dater, Seqner, Diger
+    from keri.core import Dater, Seqner, Diger
 
     dater = Dater(dts="2021-01-01T00:00:00.000000+00:00")
     assert dater.qb64 == '1AAG2021-01-01T00c00c00d000000p00c00'

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -14,7 +14,7 @@ from keri.core import (Salter, Counter, coring, serdering,
 from keri.app import habbing
 
 from keri.peer import exchanging
-from keri.vdr.eventing import incept
+from keri.vdr import incept
 
 
 def test_nesting():

--- a/tests/spec/acdc/test_acdc_examples.py
+++ b/tests/spec/acdc/test_acdc_examples.py
@@ -8,8 +8,7 @@ from base64 import urlsafe_b64decode as decodeB64
 
 from keri import Vrsn_2_0, Kinds, Protocols, Ilks
 from keri.core import (MtrDex, Salter, Labeler, Noncer, Mapper, Compactor, Aggor,
-                       Blinder, BlindState, BoundState, GenDex)
-from keri.core.eventing import incept
+                       Blinder, BlindState, BoundState, GenDex, incept)
 from keri.acdc import regcept, blindate, update, acdcmap
 
 
@@ -3588,5 +3587,3 @@ if __name__ == "__main__":
     test_acdc_aggregate_section_CESR()
     test_acdc_rule_section_JSON()
     test_acdc_examples_JSON()
-
-

--- a/tests/vc/test_proving.py
+++ b/tests/vc/test_proving.py
@@ -8,9 +8,8 @@ import pytest
 from keri import InvalidValueError, Versionage, Vrsn_1_0, Kinds
 from keri.core import (Prefixer, Seqner, Diger, Siger,
                        Salter, Counter, coring, scheming,
-                       parsing, serdering, counting, Codens)
-
-from keri.core.scheming import CacheResolver
+                       parsing, serdering, counting, Codens,
+                       CacheResolver)
 
 from keri.app import habbing
 from keri.vc import credential

--- a/tests/vc/test_walleting.py
+++ b/tests/vc/test_walleting.py
@@ -8,7 +8,7 @@ from keri.core import (Salter, Counter, coring,
 from keri.kering import Vrsn_1_0
 from keri.app import habbing
 
-from keri.vc.proving import credential
+from keri.vc import credential
 from keri.vdr import verifying, credentialing
 
 

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -8,8 +8,7 @@ import pytest
 from keri.app import keeping
 from keri.core import (Signer, coring, serdering, SealEvent,
                        Prefixer, Seqner, Diger, MtrDex)
-from keri.db import basing
-from keri.db.dbing import snKey, dgKey
+from keri.db import basing, snKey, dgKey
 from keri import (Ilks, TraitDex, MissingAnchorError, ValidationError,
                   MissingWitnessSignatureError, LikelyDuplicitousError)
 from keri.vdr import (openReger, incept, rotate,
@@ -784,4 +783,3 @@ if __name__ == "__main__":
     #test_tever_escrow()
     #test_tevery_process_escrow()
     pass
-

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -13,9 +13,8 @@ import lmdb
 from keri import versify, Kinds
 
 from keri.core import indexing, Diger, Number, Prefixer, Saider, Seqner
-from keri.db import subing
-from keri.db.dbing import openLMDB, dgKey, snKey
-from keri.vdr.viring import Reger
+from keri.db import subing, openLMDB, dgKey, snKey
+from keri.vdr import Reger
 
 
 def test_issuer():


### PR DESCRIPTION
## Summary

Replace submodule-level imports with package-level imports across 21 test files.

All `__init__.py` exports are already in place (thanks to prior work in PR #1278 and others). This change aligns test imports with the public API surface, making tests resilient to internal module refactoring.

## Changes (21 files)

**Pattern replaced:**
```python
# Before (submodule-level)
from keri.core.coring import Dater, Seqner, Diger
from keri.db.basing import openDB
from keri.db.dbing import dgKey, snKey
from keri.app.keeping import openKS, Manager
from keri.vdr.viring import Reger

# After (package-level)
from keri.core import Dater, Seqner, Diger
from keri.db import openDB, dgKey, snKey
from keri.app import openKS, Manager
from keri.vdr import Reger
```

**Files modified:**
- `tests/core/`: test_eventing, test_parsing, test_kevery, test_delegating, test_kraming, test_partial_rotation
- `tests/app/`: test_storing, test_signify, test_watching, test_querying
- `tests/db/`: test_dbing, test_koming, test_escrowing
- `tests/vdr/`: test_viring, test_eventing
- `tests/vc/`: test_proving, test_walleting
- `tests/peer/`: test_exchanging
- `tests/spec/acdc/`: test_acdc_examples
- `tests/help/`: test_helping
- `tests/comply/`: test_direct_mode

## Testing

All 118 tests across the modified files pass locally (Python 3.14.2).