### PR TITLE
feat: add remaining escrows to kli escrow list command

### DIFF
--- a/src/keri/cli/commands/escrow/list.py
+++ b/src/keri/cli/commands/escrow/list.py
@@ -117,6 +117,37 @@ def escrows(tymth, tock=0.0, **opts):
 
                 escrows["likely-duplicitous-events"] = ldes
 
+            if (not escrow) or escrow == "partially-delegated-events":
+                pdes = list()
+                for pre, sn, edig in hby.db.pdes.getOnItemIterAll():
+                    try:
+                        pdes.append(eventing.loadEvent(hby.db, pre, edig))
+                    except ValueError:
+                        continue
+                escrows["partially-delegated-events"] = pdes
+
+            if (not escrow) or escrow == "query-not-found":
+                items = list()
+                for (pre, said), saidb in hby.db.qnfs.getItemIter():
+                    try:
+                        items.append(eventing.loadEvent(hby.db,
+                                                        pre.encode("utf-8"),
+                                                        saidb))
+                    except ValueError:
+                        continue
+                escrows["query-not-found"] = items
+
+            if (not escrow) or escrow == "misfits":
+                items = list()
+                for (pre, snh), saidb in hby.db.misfits.getItemIter():
+                    try:
+                        items.append(eventing.loadEvent(hby.db,
+                                                        pre.encode("utf-8"),
+                                                        saidb))
+                    except ValueError:
+                        continue
+                escrows["misfits"] = items
+
             if (not escrow) or escrow == "missing-registry-escrow":
                 creds = list()
                 for (said,), dater in reger.mre.getItemIter():
@@ -141,11 +172,95 @@ def escrows(tymth, tock=0.0, **opts):
 
                 escrows["missing-schema-escrow"] = creds
 
-            print(json.dumps(escrows, indent=2))
-
-            if not (escrow) or escrow == "tel-partial-witness-escrow":
+            if (not escrow) or escrow == "tel-partial-witness-escrow":
+                tpwes = list()
                 for (regk, snq), (prefixer, number, diger) in reger.tpwe.getItemIter():
-                    pass
+                    tpwes.append(dict(
+                        registry=regk,
+                        prefix=prefixer.qb64,
+                        sn=number.sn,
+                        digest=diger.qb64,
+                    ))
+                escrows["tel-partial-witness-escrow"] = tpwes
+
+            if (not escrow) or escrow == "group-partially-signed-events":
+                items = list()
+                for (pre,), (number, diger) in hby.db.gpse.getItemIter():
+                    items.append(dict(prefix=pre, sn=number.sn,
+                                      digest=diger.qb64))
+                escrows["group-partially-signed-events"] = items
+
+            if (not escrow) or escrow == "group-delegated-events":
+                items = list()
+                for (pre,), (number, diger) in hby.db.gdee.getItemIter():
+                    items.append(dict(prefix=pre, sn=number.sn,
+                                      digest=diger.qb64))
+                escrows["group-delegated-events"] = items
+
+            if (not escrow) or escrow == "group-partially-witnessed-events":
+                items = list()
+                for (pre,), (number, diger) in hby.db.gpwe.getItemIter():
+                    items.append(dict(prefix=pre, sn=number.sn,
+                                      digest=diger.qb64))
+                escrows["group-partially-witnessed-events"] = items
+
+            if (not escrow) or escrow == "escrowed-partially-signed-exchange":
+                items = list()
+                for keys, serder in hby.db.epse.getItemIter():
+                    items.append(serder.sad)
+                escrows["escrowed-partially-signed-exchange"] = items
+
+            if (not escrow) or escrow == "escrowed-exchange-datetime":
+                items = list()
+                for (dig,), dater in hby.db.epsd.getItemIter():
+                    items.append(dict(said=dig, datetime=dater.dts))
+                escrows["escrowed-exchange-datetime"] = items
+
+            if (not escrow) or escrow == "delegated-partially-witnessed-events":
+                items = list()
+                for keys, serder in hby.db.dpwe.getItemIter():
+                    items.append(serder.sad)
+                escrows["delegated-partially-witnessed-events"] = items
+
+            if (not escrow) or escrow == "delegated-unverified-events":
+                items = list()
+                for keys, serder in hby.db.dune.getItemIter():
+                    items.append(serder.sad)
+                escrows["delegated-unverified-events"] = items
+
+            if (not escrow) or escrow == "delegated-partially-unduplicated-backer":
+                items = list()
+                for keys, serder in hby.db.dpub.getItemIter():
+                    items.append(serder.sad)
+                escrows["delegated-partially-unduplicated-backer"] = items
+
+            if (not escrow) or escrow == "reply-escrow":
+                items = list()
+                for (route,), diger in hby.db.rpes.getItemIter():
+                    items.append(dict(route=route, said=diger.qb64))
+                escrows["reply-escrow"] = items
+
+            if (not escrow) or escrow == "delegable-events":
+                escrows["delegable-events"] = {"count": hby.db.delegables.cnt()}
+
+            if (not escrow) or escrow == "unverified-delegated-events":
+                escrows["unverified-delegated-events"] = {"count": hby.db.udes.cnt()}
+
+            if (not escrow) or escrow == "escrowed-oobi":
+                escrows["escrowed-oobi"] = {"count": hby.db.eoobi.cnt()}
+
+            if (not escrow) or escrow == "unverified-receipt-escrow":
+                escrows["unverified-receipt-escrow"] = {"count": hby.db.ures.cnt()}
+
+            if (not escrow) or escrow == "unverified-witness-escrow":
+                escrows["unverified-witness-escrow"] = {"count": hby.db.uwes.cnt()}
+
+            if (not escrow) or escrow == "unverified-transferable-receipt-escrow":
+                escrows["unverified-transferable-receipt-escrow"] = {
+                    "count": hby.db.vres.cnt()
+                }
+
+            print(json.dumps(escrows, indent=2))
 
     except ConfigurationError:
         print(

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import multicommand
@@ -242,15 +243,33 @@ def test_standalone_kli_commands(helpers, capsys):
     doers = args.handler(args)
     directing.runController(doers=doers)
     capesc = capsys.readouterr()
-    assert capesc.out == ('{\n'
-                          '  "out-of-order-events": [],\n'
-                          '  "partially-witnessed-events": [],\n'
-                          '  "partially-signed-events": [],\n'
-                          '  "likely-duplicitous-events": [],\n'
-                          '  "missing-registry-escrow": [],\n'
-                          '  "broken-chain-escrow": [],\n'
-                          '  "missing-schema-escrow": []\n'
-                          '}\n')
+    result = json.loads(capesc.out)
+    assert result["out-of-order-events"] == []
+    assert result["partially-witnessed-events"] == []
+    assert result["partially-signed-events"] == []
+    assert result["likely-duplicitous-events"] == []
+    assert result["partially-delegated-events"] == []
+    assert result["query-not-found"] == []
+    assert result["misfits"] == []
+    assert result["missing-registry-escrow"] == []
+    assert result["broken-chain-escrow"] == []
+    assert result["missing-schema-escrow"] == []
+    assert result["tel-partial-witness-escrow"] == []
+    assert result["group-partially-signed-events"] == []
+    assert result["group-delegated-events"] == []
+    assert result["group-partially-witnessed-events"] == []
+    assert result["escrowed-partially-signed-exchange"] == []
+    assert result["escrowed-exchange-datetime"] == []
+    assert result["delegated-partially-witnessed-events"] == []
+    assert result["delegated-unverified-events"] == []
+    assert result["delegated-partially-unduplicated-backer"] == []
+    assert result["reply-escrow"] == []
+    assert result["delegable-events"] == {"count": 0}
+    assert result["unverified-delegated-events"] == {"count": 0}
+    assert result["escrowed-oobi"] == {"count": 0}
+    assert result["unverified-receipt-escrow"] == {"count": 0}
+    assert result["unverified-witness-escrow"] == {"count": 0}
+    assert result["unverified-transferable-receipt-escrow"] == {"count": 0}
 
 
 def test_incept_and_rotate_opts(helpers, capsys):
@@ -293,7 +312,3 @@ def test_incept_and_rotate_opts(helpers, capsys):
     doers = args.handler(args)
 
     directing.runController(doers=doers)
-
-
-
-


### PR DESCRIPTION
Closes #1101

## Summary

Adds 19 additional escrow types to the `kli escrow list` command, giving operators comprehensive visibility into all escrowed state for debugging purposes.

References GLEIF-IT/keripy#18 as requested in the issue.

## Changes

### New escrow types with full event/message details (12):

| Escrow Name | DB Attribute | Type | Display Format |
|---|---|---|---|
| `partially-delegated-events` | `pdes` | `OnIoDupSuber` | Full event via `loadEvent()` |
| `query-not-found` | `qnfs` | `IoSetSuber` | Full event via `loadEvent()` |
| `misfits` | `misfits` | `IoSetSuber` | Full event via `loadEvent()` |
| `group-partially-signed-events` | `gpse` | `CatCesrIoSetSuber` | prefix/sn/digest |
| `group-delegated-events` | `gdee` | `CatCesrIoSetSuber` | prefix/sn/digest |
| `group-partially-witnessed-events` | `gpwe` | `CatCesrIoSetSuber` | prefix/sn/digest |
| `escrowed-partially-signed-exchange` | `epse` | `SerderSuber` | Full SAD dict |
| `escrowed-exchange-datetime` | `epsd` | `CesrSuber` | SAID + datetime |
| `delegated-partially-witnessed-events` | `dpwe` | `SerderSuber` | Full SAD dict |
| `delegated-unverified-events` | `dune` | `SerderSuber` | Full SAD dict |
| `delegated-partially-unduplicated-backer` | `dpub` | `SerderSuber` | Full SAD dict |
| `reply-escrow` | `rpes` | `CesrIoSetSuber` | route + SAID |

### Count-only escrows (6):

These escrow types have complex receipt/delegation tuple formats. They report item counts for now, with detailed output available in a follow-up if needed:

- `delegable-events`
- `unverified-delegated-events`
- `escrowed-oobi`
- `unverified-receipt-escrow`
- `unverified-witness-escrow`
- `unverified-transferable-receipt-escrow`

### Bug fix: `tel-partial-witness-escrow`

The existing `tel-partial-witness-escrow` block was placed **after** the `print(json.dumps(...))` call and had a `pass` body — its data was never included in the output. Fixed by:
1. Moving the block before the print statement
2. Adding proper formatting (registry, prefix, sn, digest)

### Test update

Updated `test_standalone_kli_commands` to use `json.loads()` for structured assertions instead of exact string matching. This makes the test:
- Resilient to key ordering changes
- Easy to extend as new escrow types are added
- Clear about what each escrow type should contain when empty

## Testing

- All 2 CLI tests pass ✅
- All 11 core escrow tests pass ✅
- All 3 DB escrow tests pass ✅

Each new escrow type can be individually queried with `kli escrow list -e <escrow-name>`.