### PR TITLE
fix: update .readthedocs.yaml for reliable RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 # .readthedocs.yaml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# See https://docs.readthedocs.com/platform/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
@@ -9,21 +9,18 @@ version: 2
 build:
   os: ubuntu-24.04
   apt_packages:
-    - libsodium23
+    - libsodium-dev
   tools:
     python: "3.13"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
    builder: dirhtml
 
-# Optionally declare the Python requirements required to build your docs
+# Install keripy itself (for import keri in conf.py) then Sphinx dependencies
 python:
    install:
-   - requirements: requirements.txt
+   - method: pip
+     path: .
    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary

Fix ReadTheDocs builds by correcting the `.readthedocs.yaml` configuration. RTD builds have been auto-disabled after 25 consecutive failures.

## Problem

RTD builds are failing (25 consecutive failures, auto-disabled). Root causes identified:

1. **`libsodium23` apt package** — while this package does exist on Ubuntu 24.04, `libsodium-dev` is more robust as it includes both the shared library and the unversioned `.so` symlink that `ctypes.util.find_library('sodium')` may need
2. **`requirements.txt` with `--editable .`** — the root `requirements.txt` uses `--editable .` for local development, which is fragile in RTD's sandboxed build environment. RTD's native package install (`method: pip, path: .`) is the recommended approach

## Changes

- **Replace `libsodium23` with `libsodium-dev`** in `apt_packages` (includes headers + `.so` symlink, future-proofs against ABI version changes)
- **Replace `requirements: requirements.txt`** (which runs `pip install -e .`) with native RTD `method: pip, path: .` package install
- **Remove commented-out tool version examples** (reduce noise)
- **Update RTD docs reference URL** to current domain (`docs.readthedocs.com`)

## Verification

- Sphinx docs build succeeds locally (`sphinx-build -b dirhtml docs docs/_build/dirhtml`)
- Config validated against [RTD V2 schema](https://docs.readthedocs.com/platform/en/stable/config-file/v2.html)

## Note

After merging, RTD builds will need to be **manually re-enabled** on the RTD dashboard since they were auto-disabled after 25 consecutive failures.