### PR TITLE
fix: set RTD Python tool to 3.14 for docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - libsodium-dev
   tools:
-    python: "3.13"
+    python: "3.14"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary
- update `.readthedocs.yaml` `build.tools.python` from `3.13` to `3.14`
- align RTD runtime with package constraint `python_requires='>=3.14.2'`

## Why
RTD build was failing during package install with:
`Package 'keri' requires a different Python: 3.13.3 not in '>=3.14.2'`

This keeps package constraints unchanged and fixes docs build runtime mismatch at the RTD config layer.

## Validation
- single-file change only
- no application/runtime logic changes
- intended follow-up: trigger RTD rebuild and verify install + sphinx steps pass