### PR TITLE
fix: add backward compatibility for kraming

### DIFF
--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -515,6 +515,11 @@ class Kramer:
         Implements timeliness cache checking, auth type detection,
         and cache management for replay attack prevention.
 
+        For exn messages, exchange ID routing is version-gated: v2 exn
+        messages use the x field to determine transactioned vs non-transactioned
+        routing. v1 exn messages have no x field and are always treated as
+        non-transactioned (routed to the msgc cache).
+
         Parameters:
             msg (SerderKERI): message instance
             **kwa: keyword arguments from parser exts dict containing
@@ -527,7 +532,8 @@ class Kramer:
         Raises:
             MissingAuthAttachmentError: no auth attachments on message
             MissingSenderKeyStateError: sender KEL unavailable
-            KramError: General errors used for linter compliance. Something is very wrong if these pop up
+            KramError: general errors used for linter compliance; indicates
+                something is very wrong if raised
         """
 
         senderId = msg.pre

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -29,6 +29,7 @@ def test_auth_type_codex():
     assert 'asmk' in codes
     assert len(codes) == 3
 
+
 def test_configuration():
     """Test Kramer configuration handles valid denials, cache types, and raises appropriate errors"""
 
@@ -160,6 +161,7 @@ def test_configuration():
 
 _testSigner = core.Salter(raw=b'0123456789abcdef').signer(transferable=True)
 TEST_PRE = _testSigner.verfer.qb64
+
 
 def test_intake():
     """Test intake routes messages through denial, passthrough, and kramit logic"""
@@ -307,6 +309,7 @@ KRAM_INTEGRATION_CONFIG = {
             "http://127.0.0.1:5644/.well-known/keri/oobi/EBNaNu-M9P5cgrnfl2Fvymy4E_jvxxyjb70PRtiANlJy?name=Root"
         ]
 }
+
 
 def test_assk(mockHelpingNowUTC):
     """Test processMsg with single-key sender (assk auth type).
@@ -1426,12 +1429,13 @@ def test_transactioned(mockHelpingNowUTC):
 
     """Done Test"""
 
+
 def test_v1_exn_non_transactioned(mockHelpingNowUTC):
     """Test that v1 exn messages are always routed as non-transactional.
 
     The v1 KERI exn message has no x field, so must be treated as
     non-transactioned from the standpoint of KRAM even when it has a
-    non-empty prior p field value (per spec).
+    non-empty prior p field value.
 
     Covers:
     - v1 exn with non-empty p field, no x field -> msgc (non-txn) cache


### PR DESCRIPTION
For issue #1302

The KRAM spec #1299 states: *"This redesign of KRAM assumes v2 KERI. This means that transactioned exn messages must have a non-empty value in their exchange ID x field. The v1 KERI exn message does not have an x field, so must be treated as non-transactioned from the standpoint of KRAM even when it has a non-empty prior p field value."*

`kramit` was checking `msg.ked.get('x', None)` unconditionally for all `exn` messages regardless of protocol version. This meant a v1 `exn` carrying an `x` field (e.g. a malformed or cross-version message arriving on the wire) would be incorrectly routed into the transactional cache path (`tmsc`) instead of the non-transactional path (`msgc`).

**Changes**

`src/keri/core/kraming.py`

In the `match msgType` block inside `kramit`, the `exn` case now gates the `x` field lookup on `msg.pvrsn.major >= 2`. For v1 messages, `exId` stays `None` (its initialized value) regardless of whether `p` or `x` are present in the ked, routing the message to the non-transactional cache. The v2 path is unchanged.

```python
# before
case kering.Ilks.exn:
    exId = msg.ked.get('x', None)

# after
case kering.Ilks.exn:
    if msg.pvrsn.major >= 2:
        exId = msg.ked.get('x', None)
    # v1 exn has no x field; always treat as non-transactional
    # per spec, regardless of p field presence
```

`tests/core/test_kraming.py`

Added `test_v1_exn_non_transactioned` 