### PR TITLE
chore: relax python_requires for RTD 3.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=3.14.2',
+    python_requires='>=3.14.0',
     install_requires=[
                         'lmdb>=1.7.5',
                         'pysodium>=0.7.18',
@@ -112,4 +112,3 @@ setup(
         ]
     },
 )
-


### PR DESCRIPTION
## Summary
- relax `python_requires` to `>=3.14.0` to match RTD’s current 3.14.0 runtime

## Why
RTD builds are failing with:
`Package 'keri' requires a different Python: 3.14.0 not in '>=3.14.2'`

RTD currently installs Python 3.14.0, so the strict `>=3.14.2` constraint blocks documentation builds.

## Validation
- single-file change in `setup.py`
- no runtime or test changes
- intended follow-up: trigger RTD rebuild and confirm install + Sphinx steps pass