### PR TITLE
remove duplicate Baser.ooes DB

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -929,7 +929,6 @@ class Baser(dbing.LMDBer):
         self.udes = subing.CatCesrSuber(db=self, subkey='udes.', klas=(coring.Number, coring.Diger))
         self.uwes = subing.B64OnIoDupSuber(db=self, subkey='uwes.')
         self.ooes = subing.OnIoDupSuber(db=self, subkey='ooes.')
-        self.ooes = subing.OnIoDupSuber(db=self, subkey='ooes.')
         self.dels = subing.OnIoDupSuber(db=self, subkey='dels.')
         self.ldes = subing.OnIoDupSuber(db=self, subkey='ldes.')
         self.qnfs = subing.IoSetSuber(db=self, subkey="qnfs.", dupsort=True)


### PR DESCRIPTION
Somehow this duplicate .ooes DB happened in Baser like the duplicate .del DB in https://github.com/WebOfTrust/keripy/pull/1248

Must have been a merge conflict problem with all the recent DB refactoring PRs.