### PR TITLE
Fix multisig join habitat name persistence

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -21,7 +21,7 @@ from .. import (Vrsn_1_0, ClosedError, AuthError,
 from ..core import (coring, eventing, parsing, routing,
                     Counter, Salter, Codens)
 from ..recording import HabitatRecord, OobiRecord
- 
+
 
 logger = ogler.getLogger()
 
@@ -519,7 +519,7 @@ class Habery:
 
         hab.pre = pre
         habord = HabitatRecord(hid=hab.pre,
-                                      name=self.name,
+                                      name=hab.name,
                                       domain=ns,
                                       mid=mhab.pre,
                                       smids=smids,

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -821,6 +821,36 @@ def test_namespaced_habs():
     hby.cf.close(clear=True)
 
 
+def test_join_group_hab_persists_group_name_on_reload():
+    hby_name = "multisig-join"
+    group_name = "test_group_4"
+    group_pre = core.Salter(raw=b'fedcba9876543210').signer(transferable=False).verfer.qb64
+
+    with habbing.openHby(name=hby_name, base="test", temp=False, clear=True,
+                         salt=core.Salter(raw=b'0123456789abcdef').qb64) as hby:
+        mhab = hby.makeHab(name="member1")
+        other = hby.makeHab(name="member2")
+
+        group = hby.joinGroupHab(pre=group_pre,
+                                 group=group_name,
+                                 mhab=mhab,
+                                 smids=[mhab.pre, other.pre])
+
+        assert group.name == group_name
+        assert hby.db.habs.get(keys=group_pre).name == group_name
+
+    with habbing.openHby(name=hby_name, base="test", temp=False,
+                         salt=core.Salter(raw=b'0123456789abcdef').qb64) as hby:
+        found = hby.habByName(name=group_name)
+        assert found is not None
+        assert found.pre == group_pre
+        assert found.name == group_name
+        assert hby.db.habs.get(keys=group_pre).name == group_name
+
+    hby.close(clear=True)
+    hby.cf.close(clear=True)
+
+
 def test_make_other_event():
     with habbing.openHby(salt=core.Salter(raw=b'0123456789abcdef').qb64) as hby:
         hab = hby.makeHab(name="test")


### PR DESCRIPTION
## Summary
Fixes #1264 by persisting the joined group habitat's alias instead of the Habery name when `joinGroupHab()` stores the `HabitatRecord`.

## Root Cause
`joinGroupHab()` creates the `GroupHab` with the requested group alias, but the persisted `HabitatRecord` was storing `self.name` instead of `hab.name`. After reload, the group habitat could be reconstructed with the wrong name.

## Testing
- `pytest -q tests/app/test_habbing.py`

## Notes
Added a regression test that verifies the stored habitat record and the reloaded group habitat both retain the expected multisig group name.