### PR TITLE
fix: remove dead escrow package parser for multicommand 2.0.1 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
                         'multidict>=6.7.0',
                         'ordered-set>=4.1.0',
                         'hio>=0.7.19',
-                        'multicommand==1.0.0',
+                        'multicommand==2.0.1',
                         'jsonschema>=4.26.0',
                         'falcon>=4.2.0',
                         'hjson>=3.1.0',

--- a/src/keri/cli/commands/escrow/__init__.py
+++ b/src/keri/cli/commands/escrow/__init__.py
@@ -5,11 +5,5 @@ keri.app.cli.commands.escrow Package
 
 """
 
-import argparse
-
 from .clear import clear
 from .list import escrows
-
-
-
-parser = argparse.ArgumentParser(description="A collection of escrow operations")

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -312,3 +312,13 @@ def test_incept_and_rotate_opts(helpers, capsys):
     doers = args.handler(args)
 
     directing.runController(doers=doers)
+
+
+def test_create_parser_can_be_called_multiple_times():
+    parser = multicommand.create_parser(commands)
+    args = parser.parse_args(["escrow", "list", "--name", "test"])
+    assert args.handler is not None
+
+    parser = multicommand.create_parser(commands)
+    args = parser.parse_args(["escrow", "list", "--name", "test"])
+    assert args.handler is not None


### PR DESCRIPTION
## Summary

Fixes #1332 — `multicommand==2.0.1` breaks pytest (and any repeated `create_parser()` call) with `ValueError: conflicting subparser`.

## Root Cause

`multicommand` 2.0.1 changed how it handles package-level `__init__.py` files. In 1.0.0, a `parser` object defined in a package `__init__.py` was silently ignored for directory-node packages. In 2.0.1, `_get_or_add_subparsers()` activates and **mutates** these parser objects in place — registering subcommand parsers (e.g., `clear`, `list`) as subparser choices.

`src/keri/cli/commands/escrow/__init__.py` was the only command package in keripy that defined a module-level `parser = argparse.ArgumentParser(...)`. On the first `create_parser()` call, multicommand 2.0.1 registers `clear` and `list` as subparsers on this object. On the **second** call (e.g., a different test function, or any production code that rebuilds the parser), it tries to register them again → `ValueError: conflicting subparser: clear`.

This is **not** pytest-specific — it reproduces in a plain Python script that calls `create_parser()` twice.

## Fix (3 files)

1. **`src/keri/cli/commands/escrow/__init__.py`** — Remove the dead `import argparse` and `parser = ArgumentParser(...)`. This parser was never used for routing (multicommand 1.0.0 ignored it) and was the sole outlier — all other command packages (`delegate`, `oobi`, `contacts`, `multisig`, `witness`, `watcher`) use imports-only `__init__.py` files.

2. **`setup.py`** — Bump `multicommand==1.0.0` → `multicommand==2.0.1`. Keeps the existing exact-pin convention for this dependency.

3. **`tests/app/cli/test_kli_commands.py`** — Add `test_create_parser_can_be_called_multiple_times()` regression test that calls `create_parser(commands)` twice, parsing escrow subcommands each time, asserting both produce working parsers.

## Validation

- 21/21 CLI tests pass under both `multicommand==1.0.0` (without escrow parser) and `multicommand==2.0.1`
- Reproduced the original failure with a standalone script, confirmed the fix eliminates it
- No code anywhere in keripy imports `escrow.parser` — removal is safe
- No other `__init__.py` in the CLI commands tree defines a package-level parser