### PR TITLE
test: gate WASM WebDBer tests with explicit opt-in env

### DIFF
--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -36,7 +36,7 @@ jobs:
           cp src/keri/db/webdbing.py ./webdbing.py
       - name: Run WebDBer WASM tests in Pyodide
         env:
-          RUN_IN_CI: "true" # Set a custom environment variable to detect CI
+          RUN_WASM_TESTS: "true"
         run: |
           pytest tests/wasm/test_webdbing_wasm.py \
             --confcutdir=tests/wasm \

--- a/tests/wasm/test_webdbing_wasm.py
+++ b/tests/wasm/test_webdbing_wasm.py
@@ -6,27 +6,13 @@ WASM smoke tests for WebDBer — runs inside Pyodide via pytest-pyodide.
 The workflow copies webdbing.py into this directory before running.
 """
 import os
-import sys
 
 import pytest
 
 
-def _wasm_runtime_requested() -> bool:
-    if os.environ.get("RUN_IN_CI") == "true":
-        return True
-    args = sys.argv[1:]
-    return any(
-        arg in {"--runtime", "--rt", "--run-in-pyodide"}
-        or arg.startswith("--runtime=")
-        or arg.startswith("--rt=")
-        or arg.startswith("--run-in-pyodide=")
-        for arg in args
-    )
-
-
-if not _wasm_runtime_requested():
+if os.environ.get("RUN_WASM_TESTS") != "true":
     pytest.skip(
-        "WASM tests require CI or explicit pytest-pyodide runtime selection",
+        "WASM tests require RUN_WASM_TESTS=true with a pytest-pyodide runtime",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
## Summary

Replace the ad hoc runtime detection in `tests/wasm/test_webdbing_wasm.py` with one explicit opt-in environment variable.

The WASM test module now only runs when `RUN_WASM_TESTS=true` is set, and otherwise skips at module load. The Pyodide workflow sets that variable explicitly.

## Problem

When `pytest-pyodide` is installed locally, the old `importorskip("pytest_pyodide")` check was too broad: native local pytest runs could still collect the WASM module even though there was no intentional Pyodide run requested.

The first fix direction used inferred runtime detection in the test module, but that left the contract spread across CLI flag parsing and a repo-local CI variable. That worked, but it was harder to review and more ad hoc than necessary.

## Fix

Use a single explicit contract:

```python
if os.environ.get("RUN_WASM_TESTS") != "true":
    pytest.skip(
        "WASM tests require RUN_WASM_TESTS=true with a pytest-pyodide runtime",
        allow_module_level=True,
    )
```

And in the workflow:

```yaml
env:
  RUN_WASM_TESTS: "true"
```

This keeps native local runs safe, avoids test-local CLI parsing, and makes the CI path explicit.

## Verification

- macOS native run: `pytest tests/wasm/test_webdbing_wasm.py -q` -> `1 skipped`
- macOS with explicit env but no local `pytest-pyodide` install: `RUN_WASM_TESTS=true pytest tests/wasm/test_webdbing_wasm.py -q` -> `1 skipped`
- Existing non-WASM WebDBer tests were not changed
- Known `scripts` job instability remains out of scope for this PR

## Context

This keeps the fix focused on preventing accidental native collection of the WASM module without mixing in the separate, already-known scripts failures.