### PR TITLE
Fix Double Opening of Reger for lmdb >= 2.0.0

### DIFF
--- a/src/keri/app/cli/commands/escrow/clear.py
+++ b/src/keri/app/cli/commands/escrow/clear.py
@@ -53,4 +53,7 @@ def clear(tymth, tock=0.0, **opts):
     with existing.existingHby(name=name, base=base, bran=bran) as hby:
         hby.db.clearEscrows()
         reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
-        reger.clearEscrows()
+        try:
+            reger.clearEscrows()
+        finally:
+            reger.close()

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -50,187 +50,186 @@ def escrows(tymth, tock=0.0, **opts):
     try:
         with existing.existingHby(name=name, base=base, bran=bran) as hby:
             reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
-            try:
-                escrows = dict()
 
-                # KEL / Baser escrows - counts only
+            escrows = dict()
 
-                if (not escrow) or escrow == "unverified-receipts":
-                    escrows["unverified-receipts"] = sum(1 for key, _ in hby.db.getUreItemIter())
+            # KEL / Baser escrows - counts only
 
-                if (not escrow) or escrow == "verified-receipts":
-                    escrows["verified-receipts"] = sum(1 for key, _ in hby.db.getVreItemIter())
+            if (not escrow) or escrow == "unverified-receipts":
+                escrows["unverified-receipts"] = sum(1 for key, _ in hby.db.getUreItemIter())
 
-                if (not escrow) or escrow == "out-of-order-events":
-                    oots = list()
-                    key = ekey = b''  # both start same. when not same means escrows found
-                    while True:
-                        for ekey, edig in hby.db.getOoeItemIter(key=key):
-                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+            if (not escrow) or escrow == "verified-receipts":
+                escrows["verified-receipts"] = sum(1 for key, _ in hby.db.getVreItemIter())
 
-                            try:
-                                oots.append(eventing.loadEvent(hby.db, pre, edig))
-                            except ValueError as e:
-                                raise e
+            if (not escrow) or escrow == "out-of-order-events":
+                oots = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:
+                    for ekey, edig in hby.db.getOoeItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-                        if ekey == key:  # still same so no escrows found on last while iteration
-                            break
-                        key = ekey  # setup next while iteration, with key after ekey
+                        try:
+                            oots.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
 
-                    escrows["out-of-order-events"] = oots
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
 
-                if (not escrow) or escrow == "partially-witnessed-events":
-                    pwes = list()
-                    key = ekey = b''  # both start same. when not same means escrows found
-                    while True:  # break when done
-                        for ekey, edig in hby.db.getPweItemIter(key=key):
-                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                escrows["out-of-order-events"] = oots
 
-                            try:
-                                pwes.append(eventing.loadEvent(hby.db, pre, edig))
-                            except ValueError as e:
-                                raise e
+            if (not escrow) or escrow == "partially-witnessed-events":
+                pwes = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getPweItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-                        if ekey == key:  # still same so no escrows found on last while iteration
-                            break
-                        key = ekey  # setup next while iteration, with key after ekey
+                        try:
+                            pwes.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
 
-                    escrows["partially-witnessed-events"] = pwes
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
 
-                if (not escrow) or escrow == "partially-signed-events":
-                    pses = list()
-                    key = ekey = b''  # both start same. when not same means escrows found
-                    while True:  # break when done
-                        for ekey, edig in hby.db.getPseItemIter(key=key):
-                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                escrows["partially-witnessed-events"] = pwes
 
-                            try:
-                                pses.append(eventing.loadEvent(hby.db, pre, edig))
-                            except ValueError as e:
-                                raise e
+            if (not escrow) or escrow == "partially-signed-events":
+                pses = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getPseItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-                        if ekey == key:  # still same so no escrows found on last while iteration
-                            break
-                        key = ekey  # setup next while iteration, with key after ekey
+                        try:
+                            pses.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
 
-                    escrows["partially-signed-events"] = pses
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
 
-                if (not escrow) or escrow == "likely-duplicitous-events":
-                    ldes = list()
-                    key = ekey = b''  # both start same. when not same means escrows found
-                    while True:  # break when done
-                        for ekey, edig in hby.db.getLdeItemIter(key=key):
-                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                escrows["partially-signed-events"] = pses
 
-                            try:
-                                ldes.append(eventing.loadEvent(hby.db, pre, edig))
-                            except ValueError as e:
-                                raise e
+            if (not escrow) or escrow == "likely-duplicitous-events":
+                ldes = list()
+                key = ekey = b''  # both start same. when not same means escrows found
+                while True:  # break when done
+                    for ekey, edig in hby.db.getLdeItemIter(key=key):
+                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-                        if ekey == key:  # still same so no escrows found on last while iteration
-                            break
-                        key = ekey  # setup next while iteration, with key after ekey
+                        try:
+                            ldes.append(eventing.loadEvent(hby.db, pre, edig))
+                        except ValueError as e:
+                            raise e
 
-                    escrows["likely-duplicitous-events"] = ldes
+                    if ekey == key:  # still same so no escrows found on last while iteration
+                        break
+                    key = ekey  # setup next while iteration, with key after ekey
 
-                if (not escrow) or escrow == "unverified-event-indexed-couples":
-                    escrows["unverified-event-indexed-couples"] = sum(1 for key, _ in hby.db.uwes.getItemIter())
+                escrows["likely-duplicitous-events"] = ldes
 
-                if (not escrow) or escrow == "query-not-found":
-                    escrows["query-not-found"] = sum(1 for key, _ in hby.db.qnfs.getItemIter())
+            if (not escrow) or escrow == "unverified-event-indexed-couples":
+                escrows["unverified-event-indexed-couples"] = sum(1 for key, _ in hby.db.uwes.getItemIter())
 
-                if (not escrow) or escrow == "partially-delegated-events":
-                    escrows["partially-delegated-events"] = sum(1 for key, _ in hby.db.pdes.getItemIter())
+            if (not escrow) or escrow == "query-not-found":
+                escrows["query-not-found"] = sum(1 for key, _ in hby.db.qnfs.getItemIter())
 
-                if (not escrow) or escrow == "reply":
-                    escrows["reply"] = sum(1 for key, _ in hby.db.rpes.getItemIter())
+            if (not escrow) or escrow == "partially-delegated-events":
+                escrows["partially-delegated-events"] = sum(1 for key, _ in hby.db.pdes.getItemIter())
 
-                if (not escrow) or escrow == "failed-oobi":
-                    escrows["failed-oobi"] = sum(1 for key, _ in hby.db.eoobi.getItemIter())
+            if (not escrow) or escrow == "reply":
+                escrows["reply"] = sum(1 for key, _ in hby.db.rpes.getItemIter())
 
-                if (not escrow) or escrow == "group-partial-witness":
-                    escrows["group-partial-witness"] = sum(1 for key, _ in hby.db.gpwe.getItemIter())
+            if (not escrow) or escrow == "failed-oobi":
+                escrows["failed-oobi"] = sum(1 for key, _ in hby.db.eoobi.getItemIter())
 
-                if (not escrow) or escrow == "group-delegate":
-                    escrows["group-delegate"] = sum(1 for key, _ in hby.db.gdee.getItemIter())
+            if (not escrow) or escrow == "group-partial-witness":
+                escrows["group-partial-witness"] = sum(1 for key, _ in hby.db.gpwe.getItemIter())
 
-                if (not escrow) or escrow == "delegated-partial-witness":
-                    escrows["delegated-partial-witness"] = sum(1 for key, _ in hby.db.dpwe.getItemIter())
+            if (not escrow) or escrow == "group-delegate":
+                escrows["group-delegate"] = sum(1 for key, _ in hby.db.gdee.getItemIter())
 
-                if (not escrow) or escrow == "group-partial-signed":
-                    escrows["group-partial-signed"] = sum(1 for key, _ in hby.db.gpse.getItemIter())
+            if (not escrow) or escrow == "delegated-partial-witness":
+                escrows["delegated-partial-witness"] = sum(1 for key, _ in hby.db.dpwe.getItemIter())
 
-                if (not escrow) or escrow == "exchange-partial-signed":
-                    escrows["exchange-partial-signed"] = sum(1 for key, _ in hby.db.epse.getItemIter())
+            if (not escrow) or escrow == "group-partial-signed":
+                escrows["group-partial-signed"] = sum(1 for key, _ in hby.db.gpse.getItemIter())
 
-                if (not escrow) or escrow == "delegated-unanchored":
-                    escrows["delegated-unanchored"] = sum(1 for key, _ in hby.db.dune.getItemIter())
+            if (not escrow) or escrow == "exchange-partial-signed":
+                escrows["exchange-partial-signed"] = sum(1 for key, _ in hby.db.epse.getItemIter())
 
-                # TEL / Reger escrows
+            if (not escrow) or escrow == "delegated-unanchored":
+                escrows["delegated-unanchored"] = sum(1 for key, _ in hby.db.dune.getItemIter())
 
-                if (not escrow) or escrow == "tel-out-of-order":
-                    escrows["tel-out-of-order"] = sum(1 for key, _ in reger.getOotItemIter())
+            # TEL / Reger escrows
 
-                if (not escrow) or escrow == "tel-partially-witnessed":
-                    escrows["tel-partially-witnessed"] = sum(1 for key, _ in reger.getTweItemIter())
+            if (not escrow) or escrow == "tel-out-of-order":
+                escrows["tel-out-of-order"] = sum(1 for key, _ in reger.getOotItemIter())
 
-                if (not escrow) or escrow == "tel-anchorless":
-                    escrows["tel-anchorless"] = sum(1 for key, _ in reger.getTaeItemIter())
+            if (not escrow) or escrow == "tel-partially-witnessed":
+                escrows["tel-partially-witnessed"] = sum(1 for key, _ in reger.getTweItemIter())
 
-                if (not escrow) or escrow == "missing-registry-escrow":
-                    creds = list()
-                    for (said,), dater in reger.mre.getItemIter():
-                        creder, *_ = reger.cloneCred(said)
-                        creds.append(creder.sad)
+            if (not escrow) or escrow == "tel-anchorless":
+                escrows["tel-anchorless"] = sum(1 for key, _ in reger.getTaeItemIter())
 
-                    escrows["missing-registry-escrow"] = creds
+            if (not escrow) or escrow == "missing-registry-escrow":
+                creds = list()
+                for (said,), dater in reger.mre.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
 
-                if (not escrow) or escrow == "broken-chain-escrow":
-                    creds = list()
-                    for (said,), dater in reger.mce.getItemIter():
-                        creder, *_ = reger.cloneCred(said)
-                        creds.append(creder.sad)
+                escrows["missing-registry-escrow"] = creds
 
-                    escrows["broken-chain-escrow"] = creds
+            if (not escrow) or escrow == "broken-chain-escrow":
+                creds = list()
+                for (said,), dater in reger.mce.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
 
-                if (not escrow) or escrow == "missing-schema-escrow":
-                    creds = list()
-                    for (said,), dater in reger.mse.getItemIter():
-                        creder, *_ = reger.cloneCred(said)
-                        creds.append(creder.sad)
+                escrows["broken-chain-escrow"] = creds
 
-                    escrows["missing-schema-escrow"] = creds
+            if (not escrow) or escrow == "missing-schema-escrow":
+                creds = list()
+                for (said,), dater in reger.mse.getItemIter():
+                    creder, *_ = reger.cloneCred(said)
+                    creds.append(creder.sad)
 
-                if (not escrow) or escrow == "tel-missing-signature":
-                    escrows["tel-missing-signature"] = sum(1 for key, _ in reger.cmse.getItemIter())
+                escrows["missing-schema-escrow"] = creds
 
-                if (not escrow) or escrow == "tel-partial-witness-escrow":
-                    escrows["tel-partial-witness-escrow"] = sum(1 for key, _ in reger.tpwe.getItemIter())
+            if (not escrow) or escrow == "tel-missing-signature":
+                escrows["tel-missing-signature"] = sum(1 for key, _ in reger.cmse.getItemIter())
 
-                if (not escrow) or escrow == "tel-multisig":
-                    escrows["tel-multisig"] = sum(1 for key, _ in reger.tmse.getItemIter())
+            if (not escrow) or escrow == "tel-partial-witness-escrow":
+                escrows["tel-partial-witness-escrow"] = sum(1 for key, _ in reger.tpwe.getItemIter())
 
-                if (not escrow) or escrow == "tel-event-dissemination":
-                    escrows["tel-event-dissemination"] = sum(1 for key, _ in reger.tede.getItemIter())
+            if (not escrow) or escrow == "tel-multisig":
+                escrows["tel-multisig"] = sum(1 for key, _ in reger.tmse.getItemIter())
 
-                if (not escrow) or escrow == "registry-missing-anchor":
-                    escrows["registry-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-mae", "")))
+            if (not escrow) or escrow == "tel-event-dissemination":
+                escrows["tel-event-dissemination"] = sum(1 for key, _ in reger.tede.getItemIter())
 
-                if (not escrow) or escrow == "registry-out-of-order":
-                    escrows["registry-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-ooo", "")))
+            if (not escrow) or escrow == "registry-missing-anchor":
+                escrows["registry-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-mae", "")))
 
-                if (not escrow) or escrow == "credential-missing-registry":
-                    escrows["credential-missing-registry"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mre", "")))
+            if (not escrow) or escrow == "registry-out-of-order":
+                escrows["registry-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-ooo", "")))
 
-                if (not escrow) or escrow == "credential-missing-anchor":
-                    escrows["credential-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mae", "")))
+            if (not escrow) or escrow == "credential-missing-registry":
+                escrows["credential-missing-registry"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mre", "")))
 
-                if (not escrow) or escrow == "credential-out-of-order":
-                    escrows["credential-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-ooo", "")))
+            if (not escrow) or escrow == "credential-missing-anchor":
+                escrows["credential-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mae", "")))
 
-                    print(json.dumps(escrows, indent=2))
-            finally:
-                reger.close()
+            if (not escrow) or escrow == "credential-out-of-order":
+                escrows["credential-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-ooo", "")))
+
+            print(json.dumps(escrows, indent=2))
+            reger.close()
 
     except ConfigurationError as e:
         print(f"identifier prefix for {name} does not exist, incept must be run first", )

--- a/src/keri/app/cli/commands/escrow/list.py
+++ b/src/keri/app/cli/commands/escrow/list.py
@@ -50,185 +50,187 @@ def escrows(tymth, tock=0.0, **opts):
     try:
         with existing.existingHby(name=name, base=base, bran=bran) as hby:
             reger = viring.Reger(name=hby.name, db=hby.db, temp=False)
+            try:
+                escrows = dict()
 
-            escrows = dict()
+                # KEL / Baser escrows - counts only
 
-            # KEL / Baser escrows - counts only
+                if (not escrow) or escrow == "unverified-receipts":
+                    escrows["unverified-receipts"] = sum(1 for key, _ in hby.db.getUreItemIter())
 
-            if (not escrow) or escrow == "unverified-receipts":
-                escrows["unverified-receipts"] = sum(1 for key, _ in hby.db.getUreItemIter())
+                if (not escrow) or escrow == "verified-receipts":
+                    escrows["verified-receipts"] = sum(1 for key, _ in hby.db.getVreItemIter())
 
-            if (not escrow) or escrow == "verified-receipts":
-                escrows["verified-receipts"] = sum(1 for key, _ in hby.db.getVreItemIter())
+                if (not escrow) or escrow == "out-of-order-events":
+                    oots = list()
+                    key = ekey = b''  # both start same. when not same means escrows found
+                    while True:
+                        for ekey, edig in hby.db.getOoeItemIter(key=key):
+                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-            if (not escrow) or escrow == "out-of-order-events":
-                oots = list()
-                key = ekey = b''  # both start same. when not same means escrows found
-                while True:
-                    for ekey, edig in hby.db.getOoeItemIter(key=key):
-                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                            try:
+                                oots.append(eventing.loadEvent(hby.db, pre, edig))
+                            except ValueError as e:
+                                raise e
 
-                        try:
-                            oots.append(eventing.loadEvent(hby.db, pre, edig))
-                        except ValueError as e:
-                            raise e
+                        if ekey == key:  # still same so no escrows found on last while iteration
+                            break
+                        key = ekey  # setup next while iteration, with key after ekey
 
-                    if ekey == key:  # still same so no escrows found on last while iteration
-                        break
-                    key = ekey  # setup next while iteration, with key after ekey
+                    escrows["out-of-order-events"] = oots
 
-                escrows["out-of-order-events"] = oots
+                if (not escrow) or escrow == "partially-witnessed-events":
+                    pwes = list()
+                    key = ekey = b''  # both start same. when not same means escrows found
+                    while True:  # break when done
+                        for ekey, edig in hby.db.getPweItemIter(key=key):
+                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-            if (not escrow) or escrow == "partially-witnessed-events":
-                pwes = list()
-                key = ekey = b''  # both start same. when not same means escrows found
-                while True:  # break when done
-                    for ekey, edig in hby.db.getPweItemIter(key=key):
-                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                            try:
+                                pwes.append(eventing.loadEvent(hby.db, pre, edig))
+                            except ValueError as e:
+                                raise e
 
-                        try:
-                            pwes.append(eventing.loadEvent(hby.db, pre, edig))
-                        except ValueError as e:
-                            raise e
+                        if ekey == key:  # still same so no escrows found on last while iteration
+                            break
+                        key = ekey  # setup next while iteration, with key after ekey
 
-                    if ekey == key:  # still same so no escrows found on last while iteration
-                        break
-                    key = ekey  # setup next while iteration, with key after ekey
+                    escrows["partially-witnessed-events"] = pwes
 
-                escrows["partially-witnessed-events"] = pwes
+                if (not escrow) or escrow == "partially-signed-events":
+                    pses = list()
+                    key = ekey = b''  # both start same. when not same means escrows found
+                    while True:  # break when done
+                        for ekey, edig in hby.db.getPseItemIter(key=key):
+                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-            if (not escrow) or escrow == "partially-signed-events":
-                pses = list()
-                key = ekey = b''  # both start same. when not same means escrows found
-                while True:  # break when done
-                    for ekey, edig in hby.db.getPseItemIter(key=key):
-                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                            try:
+                                pses.append(eventing.loadEvent(hby.db, pre, edig))
+                            except ValueError as e:
+                                raise e
 
-                        try:
-                            pses.append(eventing.loadEvent(hby.db, pre, edig))
-                        except ValueError as e:
-                            raise e
+                        if ekey == key:  # still same so no escrows found on last while iteration
+                            break
+                        key = ekey  # setup next while iteration, with key after ekey
 
-                    if ekey == key:  # still same so no escrows found on last while iteration
-                        break
-                    key = ekey  # setup next while iteration, with key after ekey
+                    escrows["partially-signed-events"] = pses
 
-                escrows["partially-signed-events"] = pses
+                if (not escrow) or escrow == "likely-duplicitous-events":
+                    ldes = list()
+                    key = ekey = b''  # both start same. when not same means escrows found
+                    while True:  # break when done
+                        for ekey, edig in hby.db.getLdeItemIter(key=key):
+                            pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
 
-            if (not escrow) or escrow == "likely-duplicitous-events":
-                ldes = list()
-                key = ekey = b''  # both start same. when not same means escrows found
-                while True:  # break when done
-                    for ekey, edig in hby.db.getLdeItemIter(key=key):
-                        pre, sn = dbing.splitSnKey(ekey)  # get pre and sn from escrow item
+                            try:
+                                ldes.append(eventing.loadEvent(hby.db, pre, edig))
+                            except ValueError as e:
+                                raise e
 
-                        try:
-                            ldes.append(eventing.loadEvent(hby.db, pre, edig))
-                        except ValueError as e:
-                            raise e
+                        if ekey == key:  # still same so no escrows found on last while iteration
+                            break
+                        key = ekey  # setup next while iteration, with key after ekey
 
-                    if ekey == key:  # still same so no escrows found on last while iteration
-                        break
-                    key = ekey  # setup next while iteration, with key after ekey
+                    escrows["likely-duplicitous-events"] = ldes
 
-                escrows["likely-duplicitous-events"] = ldes
+                if (not escrow) or escrow == "unverified-event-indexed-couples":
+                    escrows["unverified-event-indexed-couples"] = sum(1 for key, _ in hby.db.uwes.getItemIter())
 
-            if (not escrow) or escrow == "unverified-event-indexed-couples":
-                escrows["unverified-event-indexed-couples"] = sum(1 for key, _ in hby.db.uwes.getItemIter())
+                if (not escrow) or escrow == "query-not-found":
+                    escrows["query-not-found"] = sum(1 for key, _ in hby.db.qnfs.getItemIter())
 
-            if (not escrow) or escrow == "query-not-found":
-                escrows["query-not-found"] = sum(1 for key, _ in hby.db.qnfs.getItemIter())
+                if (not escrow) or escrow == "partially-delegated-events":
+                    escrows["partially-delegated-events"] = sum(1 for key, _ in hby.db.pdes.getItemIter())
 
-            if (not escrow) or escrow == "partially-delegated-events":
-                escrows["partially-delegated-events"] = sum(1 for key, _ in hby.db.pdes.getItemIter())
+                if (not escrow) or escrow == "reply":
+                    escrows["reply"] = sum(1 for key, _ in hby.db.rpes.getItemIter())
 
-            if (not escrow) or escrow == "reply":
-                escrows["reply"] = sum(1 for key, _ in hby.db.rpes.getItemIter())
+                if (not escrow) or escrow == "failed-oobi":
+                    escrows["failed-oobi"] = sum(1 for key, _ in hby.db.eoobi.getItemIter())
 
-            if (not escrow) or escrow == "failed-oobi":
-                escrows["failed-oobi"] = sum(1 for key, _ in hby.db.eoobi.getItemIter())
+                if (not escrow) or escrow == "group-partial-witness":
+                    escrows["group-partial-witness"] = sum(1 for key, _ in hby.db.gpwe.getItemIter())
 
-            if (not escrow) or escrow == "group-partial-witness":
-                escrows["group-partial-witness"] = sum(1 for key, _ in hby.db.gpwe.getItemIter())
+                if (not escrow) or escrow == "group-delegate":
+                    escrows["group-delegate"] = sum(1 for key, _ in hby.db.gdee.getItemIter())
 
-            if (not escrow) or escrow == "group-delegate":
-                escrows["group-delegate"] = sum(1 for key, _ in hby.db.gdee.getItemIter())
+                if (not escrow) or escrow == "delegated-partial-witness":
+                    escrows["delegated-partial-witness"] = sum(1 for key, _ in hby.db.dpwe.getItemIter())
 
-            if (not escrow) or escrow == "delegated-partial-witness":
-                escrows["delegated-partial-witness"] = sum(1 for key, _ in hby.db.dpwe.getItemIter())
+                if (not escrow) or escrow == "group-partial-signed":
+                    escrows["group-partial-signed"] = sum(1 for key, _ in hby.db.gpse.getItemIter())
 
-            if (not escrow) or escrow == "group-partial-signed":
-                escrows["group-partial-signed"] = sum(1 for key, _ in hby.db.gpse.getItemIter())
+                if (not escrow) or escrow == "exchange-partial-signed":
+                    escrows["exchange-partial-signed"] = sum(1 for key, _ in hby.db.epse.getItemIter())
 
-            if (not escrow) or escrow == "exchange-partial-signed":
-                escrows["exchange-partial-signed"] = sum(1 for key, _ in hby.db.epse.getItemIter())
+                if (not escrow) or escrow == "delegated-unanchored":
+                    escrows["delegated-unanchored"] = sum(1 for key, _ in hby.db.dune.getItemIter())
 
-            if (not escrow) or escrow == "delegated-unanchored":
-                escrows["delegated-unanchored"] = sum(1 for key, _ in hby.db.dune.getItemIter())
+                # TEL / Reger escrows
 
-            # TEL / Reger escrows
+                if (not escrow) or escrow == "tel-out-of-order":
+                    escrows["tel-out-of-order"] = sum(1 for key, _ in reger.getOotItemIter())
 
-            if (not escrow) or escrow == "tel-out-of-order":
-                escrows["tel-out-of-order"] = sum(1 for key, _ in reger.getOotItemIter())
+                if (not escrow) or escrow == "tel-partially-witnessed":
+                    escrows["tel-partially-witnessed"] = sum(1 for key, _ in reger.getTweItemIter())
 
-            if (not escrow) or escrow == "tel-partially-witnessed":
-                escrows["tel-partially-witnessed"] = sum(1 for key, _ in reger.getTweItemIter())
+                if (not escrow) or escrow == "tel-anchorless":
+                    escrows["tel-anchorless"] = sum(1 for key, _ in reger.getTaeItemIter())
 
-            if (not escrow) or escrow == "tel-anchorless":
-                escrows["tel-anchorless"] = sum(1 for key, _ in reger.getTaeItemIter())
+                if (not escrow) or escrow == "missing-registry-escrow":
+                    creds = list()
+                    for (said,), dater in reger.mre.getItemIter():
+                        creder, *_ = reger.cloneCred(said)
+                        creds.append(creder.sad)
 
-            if (not escrow) or escrow == "missing-registry-escrow":
-                creds = list()
-                for (said,), dater in reger.mre.getItemIter():
-                    creder, *_ = reger.cloneCred(said)
-                    creds.append(creder.sad)
+                    escrows["missing-registry-escrow"] = creds
 
-                escrows["missing-registry-escrow"] = creds
+                if (not escrow) or escrow == "broken-chain-escrow":
+                    creds = list()
+                    for (said,), dater in reger.mce.getItemIter():
+                        creder, *_ = reger.cloneCred(said)
+                        creds.append(creder.sad)
 
-            if (not escrow) or escrow == "broken-chain-escrow":
-                creds = list()
-                for (said,), dater in reger.mce.getItemIter():
-                    creder, *_ = reger.cloneCred(said)
-                    creds.append(creder.sad)
+                    escrows["broken-chain-escrow"] = creds
 
-                escrows["broken-chain-escrow"] = creds
+                if (not escrow) or escrow == "missing-schema-escrow":
+                    creds = list()
+                    for (said,), dater in reger.mse.getItemIter():
+                        creder, *_ = reger.cloneCred(said)
+                        creds.append(creder.sad)
 
-            if (not escrow) or escrow == "missing-schema-escrow":
-                creds = list()
-                for (said,), dater in reger.mse.getItemIter():
-                    creder, *_ = reger.cloneCred(said)
-                    creds.append(creder.sad)
+                    escrows["missing-schema-escrow"] = creds
 
-                escrows["missing-schema-escrow"] = creds
+                if (not escrow) or escrow == "tel-missing-signature":
+                    escrows["tel-missing-signature"] = sum(1 for key, _ in reger.cmse.getItemIter())
 
-            if (not escrow) or escrow == "tel-missing-signature":
-                escrows["tel-missing-signature"] = sum(1 for key, _ in reger.cmse.getItemIter())
+                if (not escrow) or escrow == "tel-partial-witness-escrow":
+                    escrows["tel-partial-witness-escrow"] = sum(1 for key, _ in reger.tpwe.getItemIter())
 
-            if (not escrow) or escrow == "tel-partial-witness-escrow":
-                escrows["tel-partial-witness-escrow"] = sum(1 for key, _ in reger.tpwe.getItemIter())
+                if (not escrow) or escrow == "tel-multisig":
+                    escrows["tel-multisig"] = sum(1 for key, _ in reger.tmse.getItemIter())
 
-            if (not escrow) or escrow == "tel-multisig":
-                escrows["tel-multisig"] = sum(1 for key, _ in reger.tmse.getItemIter())
+                if (not escrow) or escrow == "tel-event-dissemination":
+                    escrows["tel-event-dissemination"] = sum(1 for key, _ in reger.tede.getItemIter())
 
-            if (not escrow) or escrow == "tel-event-dissemination":
-                escrows["tel-event-dissemination"] = sum(1 for key, _ in reger.tede.getItemIter())
+                if (not escrow) or escrow == "registry-missing-anchor":
+                    escrows["registry-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-mae", "")))
 
-            if (not escrow) or escrow == "registry-missing-anchor":
-                escrows["registry-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-mae", "")))
+                if (not escrow) or escrow == "registry-out-of-order":
+                    escrows["registry-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-ooo", "")))
 
-            if (not escrow) or escrow == "registry-out-of-order":
-                escrows["registry-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("registry-ooo", "")))
+                if (not escrow) or escrow == "credential-missing-registry":
+                    escrows["credential-missing-registry"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mre", "")))
 
-            if (not escrow) or escrow == "credential-missing-registry":
-                escrows["credential-missing-registry"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mre", "")))
+                if (not escrow) or escrow == "credential-missing-anchor":
+                    escrows["credential-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mae", "")))
 
-            if (not escrow) or escrow == "credential-missing-anchor":
-                escrows["credential-missing-anchor"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-mae", "")))
+                if (not escrow) or escrow == "credential-out-of-order":
+                    escrows["credential-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-ooo", "")))
 
-            if (not escrow) or escrow == "credential-out-of-order":
-                escrows["credential-out-of-order"] = sum(1 for key, _ in reger.txnsb.escrowdb.getItemIter(keys=("credential-ooo", "")))
-
-            print(json.dumps(escrows, indent=2))
+                    print(json.dumps(escrows, indent=2))
+            finally:
+                reger.close()
 
     except ConfigurationError as e:
         print(f"identifier prefix for {name} does not exist, incept must be run first", )

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -91,6 +91,7 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
                         reopen=True)
 
     aeid = ks.gbls.get('aeid')
+    ks.close()
 
     cf = None
     if configFile is not None:

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -91,7 +91,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     app.add_route("/", httpEnd)
     receiptEnd = ReceiptEnd(hab=hab, inbound=cues, aids=aids)
     app.add_route("/receipts", receiptEnd)
-    queryEnd = QueryEnd(hab=hab)
+    queryEnd = QueryEnd(hab=hab, reger=reger)
     app.add_route("/query", queryEnd)
     metricsEnd = EscrowEnd(hby=hby, reger=reger)
     app.add_route("/metrics", metricsEnd)
@@ -102,7 +102,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     httpServerDoer = http.ServerDoer(server=server)
 
     # setup doers
-    regDoer = basing.BaserDoer(baser=verfer.reger)
+    regDoer = basing.BaserDoer(baser=reger)
 
     if tcpPort is not None:
         server = serving.Server(host="", port=tcpPort)
@@ -1195,9 +1195,9 @@ class QueryEnd:
 
      """
 
-    def __init__(self, hab):
+    def __init__(self, hab, reger):
         self.hab = hab
-        self.reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
+        self.reger = reger
 
     def on_get(self, req, rep):
         """ Handles GET requests to query KEL or TEL events of a pre from a witness.
@@ -1287,5 +1287,5 @@ class QueryEnd:
 
         else:
             rep.set_header('Content-Type', "application/json")
-            rep.text = "unkown query type."
+            rep.text = "unknown query type."
             rep.status = falcon.HTTP_400

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -12,7 +12,7 @@ from keri.core import coring, serdering
 from keri.core.coring import Seqner
 from keri.help import nowIso8601
 from keri.app import habbing, indirecting, agenting, directing
-from keri.db import dbing
+from keri.db import basing, dbing
 from keri.vdr import eventing, viring
 
 
@@ -131,6 +131,12 @@ class PublishDoer(doing.DoDoer):
         wilDoers = indirecting.setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643)
         wesDoers = indirecting.setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644)
 
+        self.regers = dict(
+            wan=next(doer.baser for doer in wanDoers if isinstance(doer, basing.BaserDoer)),
+            wil=next(doer.baser for doer in wilDoers if isinstance(doer, basing.BaserDoer)),
+            wes=next(doer.baser for doer in wesDoers if isinstance(doer, basing.BaserDoer)),
+        )
+
         wanHab = wanHby.habByName(name="wan")
         wilHab = wilHby.habByName(name="wil")
         wesHab = wesHby.habByName(name="wes")
@@ -170,7 +176,7 @@ class PublishDoer(doing.DoDoer):
         assert cue["msg"] == msg
 
         for name in ["wes", "wil", "wan"]:
-            reger = viring.Reger(name=name)
+            reger = self.regers[name]
             while True:
                 raw = reger.getTvt(dbing.dgKey(serder.preb, serder.saidb))
                 if raw:

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -164,13 +164,18 @@ def test_wit_query_ends(seeder):
     with habbing.openHby(name="wes", salt=core.Salter(raw=b'wess-the-witness').qb64) as wesHby, \
             habbing.openHby(name="pal", salt=core.Salter(raw=b'0123456789abcdef').qb64) as palHby:
         wesDoers = indirecting.setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644)
+
+        # Pull the reger out of the Doers so the reger is reused and does not trigger an LMDB error on reuse
+        wesReger = next(doer.baser for doer in wesDoers
+                        if isinstance(getattr(doer, "baser", None), viring.Reger))
+
         witDoer = agenting.Receiptor(hby=palHby)
 
         wesHab = wesHby.habByName(name="wes")
         seeder.seedWitEnds(palHby.db, witHabs=[wesHab], protocols=[kering.Schemes.http])
 
         app = falcon.App()
-        query_endpoint = indirecting.QueryEnd(wesHab)
+        query_endpoint = indirecting.QueryEnd(wesHab, reger=wesReger)
         app.add_route("/query", query_endpoint)
 
         wesClient = testing.TestClient(app)
@@ -263,7 +268,7 @@ class QueryTestDoer(doing.Doer):
         res = wesClient.simulate_get("/query", params={"typ": "invalid"})
         assert res.status_code == 400
         assert res.headers['Content-Type'] == "application/json"
-        assert "unkown query type" in res.text
+        assert "unknown query type" in res.text
 
         return True
 


### PR DESCRIPTION
## This PR Includes:
- Fix double opening of reger in kli witness start
- Changed tests to reuse reger instances
- Fixed typo