### PR TITLE
chore: repair Sphinx parser issues in eventing docstrings

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -26,8 +26,7 @@ from ..kering import (MissingEntryError, UntrustedKeyStateSource,
 
 from ..help import helping
 
-from .coring import (PreDex, DigDex, NonTransDex, NumDex, Prefixer,
-                     Diger, Number, Seqner, Cigar, Dater, Noncer,
+from .coring import (PreDex, DigDex, NonTransDex, NumDex, Number, Seqner, Cigar, Dater, Noncer,
                      Verfer, Diger, Prefixer, Tholder)
 
 from .counting import Counter, Codens
@@ -58,8 +57,10 @@ LastEstLoc = namedtuple("LastEstLoc", 's d')
 def simple(n):
     """
     Returns int as simple majority of n when n >=1
-        otherwise returns 0
-    Parameters:
+    otherwise returns 0
+
+    Parameters::
+
         n is int total number of elements
     """
     return min(max(0, n), (max(0, n) // 2) + 1)
@@ -68,8 +69,10 @@ def simple(n):
 def ample(n, f=None, weak=True):
     """
     Returns int as sufficient immune (ample) majority of n when n >=1
-        otherwise returns 0
-    Parameters:
+    otherwise returns 0
+
+    Parameters::
+
         n is int total number of elements
         f is int optional fault number
         weak is Boolean
@@ -112,16 +115,20 @@ def ample(n, f=None, weak=True):
 def deWitnessCouple(data, strip=False):
     """
     Returns tuple of (diger, wiger) extracted from bytes or bytearray
-    that hold concatenated data couple where:
+    that hold concatenated data couple where::
+
         diger is Diger instance
         wiger is Siger instance
-    Couple is dig+wig  where:
+
+    Couple is dig+wig  where::
+
         dig is receipted event digest
         wig is indexed signature made with key pair derived from witness nontrans
             identifier prefix from witness list. Index is offset into witness
             list of latest establishment event for receipted event.
 
-    Parameters:
+    Parameters::
+
         data is couple of bytes concatenation of dig+wig from receipt
         deletive is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
@@ -131,8 +138,6 @@ def deWitnessCouple(data, strip=False):
     is offset into associated witness list. At time of escrow receipted event
     may not be in KEL so need the dig to look up event and then look up witness
     list from key state.
-
-
     """
     if isinstance(data, memoryview):
         data = bytes(data)
@@ -149,12 +154,15 @@ def deWitnessCouple(data, strip=False):
 def deReceiptCouple(data, strip=False):
     """
     Returns tuple of (prefixer, cigar) from concatenated bytes or bytearray
-    of data couple made up of qb64 or qb64b versions of pre+cig where:
+    of data couple made up of qb64 or qb64b versions of pre+cig where::
+
        pre is nontransferable identifier prefix of receiptor
        cig is nonindexed signature made with key pair derived from pre
+
     Couple is used for receipts signed by nontransferable prefix keys
 
-    Parameters:
+    Parameters::
+
         data is couple of bytes concatenation of pre+sig from receipt
         strip is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
@@ -175,12 +183,15 @@ def deReceiptCouple(data, strip=False):
 def deSourceCouple(data, strip=False):
     """
     Returns tuple of (number, diger) from concatenated bytes or bytearray
-    of data couple made up of qb64 or qb64b versions of snu+dig where:
+    of data couple made up of qb64 or qb64b versions of snu+dig where::
+
        snu is sn of delegator/issuer source event
        dig is digest of delegator/issuer source event
+
     Couple is used for delegated/issued event attachment of delegator/issuer evt
 
-    Parameters:
+    Parameters::
+
         data is couple of bytes concatenation of pre+sig from receipt
         strip is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
@@ -201,7 +212,8 @@ def deSourceCouple(data, strip=False):
 def deReceiptTriple(data, strip=False):
     """
     Returns tuple of (diger, prefixer, cigar) from concatenated bytes or bytearray
-    of data triple made up of qb64 or qb64b versions of dig+pre+cig where:
+    of data triple made up of qb64 or qb64b versions of dig+pre+cig where::
+
         dig is receipted event digest
         pre is nontransferable identifier prefix of receiptor
         cig is nonindexed signature made with key pair derived from pre
@@ -209,7 +221,8 @@ def deReceiptTriple(data, strip=False):
     Triple is used for escrows of unverified receipts signed by nontransferable
     prefix keys
 
-    Parameters:
+    Parameters::
+
         data is triple of bytes concatenation of dig+pre+cig from receipt
         deletive is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
@@ -1022,38 +1035,40 @@ def query(pre="",
         gvrsn (Versionage): CESR genus vrsion
         kind (str): serialization kind value of Serials
 
-    Version 1.0
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "qry",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "logs",
-      "rr": "log/processor",
-      "q" :
-      {
-        "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-        "sn": "5",
-        "dt": "2020-08-01T12:20:05.123456+00:00",
-      }
-    }
+                Version 1.0::
 
-    Version 2.0
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "qry",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "logs",
-      "rr": "log/processor",
-      "q" :
-      {
-        "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-        "sn": "5",
-        "dt": "2020-08-01T12:20:05.123456+00:00",
-      }
-    }
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "qry",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "logs",
+                                    "rr": "log/processor",
+                                    "q" :
+                                    {
+                                        "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                                        "sn": "5",
+                                        "dt": "2020-08-01T12:20:05.123456+00:00",
+                                    }
+                                }
+
+                Version 2.0::
+
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "qry",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "logs",
+                                    "rr": "log/processor",
+                                    "q" :
+                                    {
+                                        "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                                        "sn": "5",
+                                        "dt": "2020-08-01T12:20:05.123456+00:00",
+                                    }
+                                }
 
     """
     pvrsn = pvrsn if pvrsn is not None else version
@@ -1112,38 +1127,40 @@ def reply(pre="",
         gvrsn (Versionage): CESR genus vrsion
         kind (str): serialization kind value of Serials
 
-    Version 1:
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "rpy",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "logs/processor",
-      "a" :
-      {
-         "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-         "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-         "name": "John Jones",
-         "role": "Founder",
-      }
-    }
+                Version 1::
 
-    Version 2:
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "rpy",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "logs/processor",
-      "a" :
-      {
-         "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-         "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-         "name": "John Jones",
-         "role": "Founder",
-      }
-    }
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "rpy",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "logs/processor",
+                                    "a" :
+                                    {
+                                         "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                                         "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                                         "name": "John Jones",
+                                         "role": "Founder",
+                                    }
+                                }
+
+                Version 2::
+
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "rpy",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "logs/processor",
+                                    "a" :
+                                    {
+                                         "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                                         "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                                         "name": "John Jones",
+                                         "role": "Founder",
+                                    }
+                                }
 
 
     """
@@ -1189,8 +1206,8 @@ def prod(pre="",
 
     Returns:
         prod (SerderKERI):  of prod, 'pro', msg to request disclosure via bare, 'bar' msg
-    of data anchored via seal(s) on KEL for identifier prefix, pre, when given
-    by all SAIDs given in digs list.
+            of data anchored via seal(s) on KEL for identifier prefix, pre, when given
+            by all SAIDs given in digs list.
 
     Parameters:
         pre (str): Identifier prefix (AID) of sender controller (Version 2)
@@ -1206,35 +1223,36 @@ def prod(pre="",
         gvrsn (Versionage): CESR genus vrsion
         kind (str): serialization kind value of Serials
 
-    Version 1
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "pro",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "data",
-      "rr": "data/processor",
-      "q":
-      {
-        "d":"EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
-      }
-    }
+                Version 1::
 
-    Version 2
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "pro",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "data",
+                                    "rr": "data/processor",
+                                    "q":
+                                    {
+                                        "d":"EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
+                                    }
+                                }
 
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "pro",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "data",
-      "rr": "data/processor",
-      "q":
-      {
-        "d":"EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
-      }
-    }
+                Version 2::
+
+                                {
+                                    "v" : "KERI10JSON00011c_",
+                                    "t" : "pro",
+                                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                    "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                                    "r" : "data",
+                                    "rr": "data/processor",
+                                    "q":
+                                    {
+                                        "d":"EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
+                                    }
+                                }
 
     """
     pvrsn = pvrsn if pvrsn is not None else version
@@ -1298,55 +1316,47 @@ def bare(pre="",
         gvrsn (Versionage): CESR genus vrsion
         kind (str): serialization kind value of Serials
 
+        Examples:
 
-       route is route path string that indicates data flow handler (behavior)
-           to processs the exposure
-       data is dict of dicts of comitted SADS for SAIDs in seals keyed by SAID
-       stamp (str):  date-time-stamp RFC-3339 profile of ISO-8601 datetime of
-                     creation of message or data
-       version is Version instance
-       kind is serialization kind
+            Version 1::
 
-    Version 1
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "bar",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "sealed/processor",
-      "a" :
-        {
-          "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM":
-            {
-               "d":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-               "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-               "dt": "2020-08-22T17:50:12.988921+00:00",
-               "name": "John Jones",
-               "role": "Founder",
-            }
-        }
-    }
+                {
+                    "v": "KERI10JSON00011c_",
+                    "t": "bar",
+                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                    "r": "sealed/processor",
+                    "a": {
+                        "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM": {
+                            "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                            "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                            "dt": "2020-08-22T17:50:12.988921+00:00",
+                            "name": "John Jones",
+                            "role": "Founder"
+                        }
+                    }
+                }
 
-    Version 2
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "bar",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "sealed/processor",
-      "a" :
-        {
-          "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM":
-            {
-               "d":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-               "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-               "dt": "2020-08-22T17:50:12.988921+00:00",
-               "name": "John Jones",
-               "role": "Founder",
-            }
-        }
-    }
+            Version 2::
+
+                {
+                    "v": "KERI10JSON00011c_",
+                    "t": "bar",
+                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                    "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                    "r": "sealed/processor",
+                    "a": {
+                        "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM": {
+                            "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                            "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                            "dt": "2020-08-22T17:50:12.988921+00:00",
+                            "name": "John Jones",
+                            "role": "Founder"
+                        }
+                    }
+                }
+
     """
     pvrsn = pvrsn if pvrsn is not None else version
     vs = versify(pvrsn=pvrsn, kind=kind, size=0, gvrsn=gvrsn)
@@ -1392,7 +1402,7 @@ def exchept(sender="",
         exchept (SerderKERI):  'xip' message.
 
     Fields in order:
-    (v, t, d, u, ri, dt, r, q, a),
+        (v, t, d, u, ri, dt, r, q, a),
 
 
     Parameters:
@@ -1409,26 +1419,28 @@ def exchept(sender="",
         gvrsn (Versionage): CESR genus vrsion
         kind (str): serialization kind value of Serials
 
-    Version 2:
-    {
-      "v" : "KERI10JSON00011c_",
-      "t" : "rpy",
-      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-      "u": '0AAwMTIzNDU2Nzg5YWJjZGVm',
-      "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
-      "ri": "EBPzhzS6baU6JR2nmwyZ-i0d8JZ5CMAoTNZH3ULvYAfS",
-      "dt": "2020-08-22T17:50:12.988921+00:00",
-      "r" : "/logs/processor",
-      "q":
-      {
-           "name": "Zoe",
-           "color": "Blue"
-      }
-      "a":
-      {
-          "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
-      }
-    }
+        Examples:
+
+            Version 2::
+
+                {
+                    "v": "KERI10JSON00011c_",
+                    "t": "rpy",
+                    "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                    "u": "0AAwMTIzNDU2Nzg5YWJjZGVm",
+                    "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
+                    "ri": "EBPzhzS6baU6JR2nmwyZ-i0d8JZ5CMAoTNZH3ULvYAfS",
+                    "dt": "2020-08-22T17:50:12.988921+00:00",
+                    "r": "/logs/processor",
+                    "q": {
+                        "name": "Zoe",
+                        "color": "Blue"
+                    },
+                    "a": {
+                        "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
+                    }
+                }
+
     """
     pvrsn = pvrsn if pvrsn is not None else Vrsn_2_0
     vs = versify(pvrsn=pvrsn, kind=kind, size=0, gvrsn=gvrsn)
@@ -2647,9 +2659,9 @@ class Kever:
         for siger in sigers:
             try:
                 diger = self.ndigers[siger.ondex]
-            except TypeError as ex:  # ondex may be None
+            except TypeError:  # ondex may be None
                 continue
-            except IndexError as ex:
+            except IndexError:
                 continue
                 #raise ValidationError(f'Invalid ondex={siger.ondex} '
                                       #f'to expose digest.') from ex
@@ -3592,7 +3604,7 @@ class Kever:
             esr = EventSourceRecord(local=local)
             self.db.esrs.put(keys=dgkey, val=esr)
 
-        logger.debug(f"Kever: Escrowed partially delegated event=\n%s\n", serder.pretty())
+        logger.debug("Kever: Escrowed partially delegated event=\n%s\n", serder.pretty())
         return self.db.pdes.add(keys=serder.pre, on=serder.sn, val=serder.said)
 
 
@@ -4655,38 +4667,40 @@ class Kevery:
                 diger is digest of trans endorser's est evt for keys for sigs
                 [sigers] is list of indexed sigs from trans endorser's keys from est evt
 
-        EndpointRecord:
-            allowed: bool = False  # True eid allowed (add), False eid disallowed (cut)
-            name: str = ""  # optional user friendly name of endpoint
+                EndpointRecord::
 
-        Reply Message:
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/end/role/add",
-          "a" :
-          {
-             "cid":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-             "role": "watcher",  # one of Roles
-             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
-          }
-        }
+                        allowed: bool = False  # True eid allowed (add), False eid disallowed (cut)
+                        name: str = ""  # optional user friendly name of endpoint
 
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/end/role/cut",
-          "a" :
-          {
-             "cid":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-             "role": "watcher",  # one of Roles
-             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
-          }
-        }
+                Reply Message::
+
+                        {
+                          "v" : "KERI10JSON00011c_",
+                          "t" : "rpy",
+                          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                          "dt": "2020-08-22T17:50:12.988921+00:00",
+                          "r" : "/end/role/add",
+                          "a" :
+                          {
+                             "cid":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                             "role": "watcher",  # one of Roles
+                             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
+                          }
+                        }
+
+                        {
+                          "v" : "KERI10JSON00011c_",
+                          "t" : "rpy",
+                          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                          "dt": "2020-08-22T17:50:12.988921+00:00",
+                          "r" : "/end/role/cut",
+                          "a" :
+                          {
+                             "cid":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+                             "role": "watcher",  # one of Roles
+                             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
+                          }
+                        }
 
         """
         # reply specific logic
@@ -4724,8 +4738,8 @@ class Kevery:
                                         tsgs=tsgs)
         if not accepted:
             msg = f"Unverified end role reply = {serder.said} role = {role}"
-            logger.debug(f"Kevery: %s", msg)
-            logger.debug(f"Event=\n%s\n", serder.pretty())
+            logger.debug("Kevery: %s", msg)
+            logger.debug("Event=\n%s\n", serder.pretty())
             raise UnverifiedReplyError(msg)
 
         self.updateEnd(keys=keys, saider=diger, allowed=allowed)  # update .eans and .ends
@@ -4752,43 +4766,45 @@ class Kevery:
                 diger is digest of trans endorser's est evt for keys for sigs
                 [sigers] is list of indexed sigs from trans endorser's keys from est evt
 
-        EndAuthRecord
-             cid: str = ""  # identifier prefix of controller that authorizes endpoint
-             roles: list[str] = field(default_factory=list)  # str endpoint roles such as watcher, witness etc
+                EndAuthRecord::
 
-        LocationRecord:
-            url: str  # full url including host:port/path?query scheme is optional
-            cids: list[EndAuthRecord] = field(default_factory=list)  # optional authorization record references
+                    cid: str = ""  # identifier prefix of controller that authorizes endpoint
+                    roles: list[str] = field(default_factory=list)  # str endpoint roles such as watcher, witness etc
 
-        Reply Message:
+                LocationRecord::
 
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/loc/scheme",
-          "a" :
-          {
-             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
-             "scheme": "http",  # one of Schemes
-             "url":  "http://localhost:8080/watcher/wilma",
-          }
-        }
+                    url: str  # full url including host:port/path?query scheme is optional
+                    cids: list[EndAuthRecord] = field(default_factory=list)  # optional authorization record references
 
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/loc/scheme",
-          "a" :
-          {
-             "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
-             "scheme": "http",  # one of Schemes
-             "url":  "",  # Nullifies
-          }
-        }
+                Reply Message::
+
+                        {
+                      "v" : "KERI10JSON00011c_",
+                      "t" : "rpy",
+                      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                      "dt": "2020-08-22T17:50:12.988921+00:00",
+                      "r" : "/loc/scheme",
+                      "a" :
+                      {
+                         "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
+                         "scheme": "http",  # one of Schemes
+                         "url":  "http://localhost:8080/watcher/wilma",
+                      }
+                        }
+
+                        {
+                      "v" : "KERI10JSON00011c_",
+                      "t" : "rpy",
+                      "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                      "dt": "2020-08-22T17:50:12.988921+00:00",
+                      "r" : "/loc/scheme",
+                      "a" :
+                      {
+                         "eid": "BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE",
+                         "scheme": "http",  # one of Schemes
+                         "url":  "",  # Nullifies
+                      }
+                        }
 
 
         """
@@ -4854,45 +4870,45 @@ class Kevery:
                 diger is digest of trans endorser's est evt for keys for sigs
                 [sigers] is list of indexed sigs from trans endorser's keys from est evt
 
-        Reply Message:
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/ksn/EeS834LMlGVEOGR8WU3rzZ9M6HUv_vtF32pSXQXKP7jg",
-          "a" :
-          {
-            "v": "KERI10JSON000274_",
-            "i": "EeS834LMlGVEOGR8WU3rzZ9M6HUv_vtF32pSXQXKP7jg",
-            "s": "1",
-            "t": "ksn",
-            "p": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
-            "d": "EtgNGVxYd6W0LViISr7RSn6ul8Yn92uyj2kiWzt51mHc",
-            "f": "1",
-            "dt": "2021-11-04T12:55:14.480038+00:00",
-            "et": "ixn",
-            "kt": "1",
-            "k": [
-              "DTH0PwWwsrcO_4zGe7bUR-LJX_ZGBTRsmP-ZeJ7fVg_4"
-            ],
-            "n": "E6qpfz7HeczuU3dAd1O9gPPS6-h_dCxZGYhU8UaDY2pc",
-            "bt": "3",
-            "b": [
-              "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
-              "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
-              "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
-            ],
-            "c": [],
-            "ee": {
-              "s": "0",
-              "d": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
-              "br": [],
-              "ba": []
-            },
-            "di": ""
-          }
-        }
+                Reply message example::
+
+                                {
+                                        "v": "KERI10JSON00011c_",
+                                        "t": "rpy",
+                                        "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                        "dt": "2020-08-22T17:50:12.988921+00:00",
+                                        "r": "/ksn/EeS834LMlGVEOGR8WU3rzZ9M6HUv_vtF32pSXQXKP7jg",
+                                        "a": {
+                                                "v": "KERI10JSON000274_",
+                                                "i": "EeS834LMlGVEOGR8WU3rzZ9M6HUv_vtF32pSXQXKP7jg",
+                                                "s": "1",
+                                                "t": "ksn",
+                                                "p": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
+                                                "d": "EtgNGVxYd6W0LViISr7RSn6ul8Yn92uyj2kiWzt51mHc",
+                                                "f": "1",
+                                                "dt": "2021-11-04T12:55:14.480038+00:00",
+                                                "et": "ixn",
+                                                "kt": "1",
+                                                "k": [
+                                                        "DTH0PwWwsrcO_4zGe7bUR-LJX_ZGBTRsmP-ZeJ7fVg_4"
+                                                ],
+                                                "n": "E6qpfz7HeczuU3dAd1O9gPPS6-h_dCxZGYhU8UaDY2pc",
+                                                "bt": "3",
+                                                "b": [
+                                                        "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo",
+                                                        "BuyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw",
+                                                        "Bgoq68HCmYNUDgOz4Skvlu306o_NY-NrYuKAVhk3Zh9c"
+                                                ],
+                                                "c": [],
+                                                "ee": {
+                                                        "s": "0",
+                                                        "d": "ESORkffLV3qHZljOcnijzhCyRT0aXM2XHGVoyd5ST-Iw",
+                                                        "br": [],
+                                                        "ba": []
+                                                },
+                                                "di": ""
+                                        }
+                                }
 
         """
         cigars = cigars if cigars is not None else []
@@ -5048,20 +5064,20 @@ class Kevery:
                 diger is digest of trans endorser's est evt for keys for sigs
                 [sigers] is list of indexed sigs from trans endorser's keys from est evt
 
-        Reply Message:
-        {
-          "v" : "KERI10JSON00011c_",
-          "t" : "rpy",
-          "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-          "dt": "2020-08-22T17:50:12.988921+00:00",
-          "r" : "/watcher/BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE/add",
-          "a" :
-          {
-            "cid": "EyX-zd8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM"
-            "oid": "EM0-i05TNZJZAoH3UR2nmLaU6JwyvPzhzS6YAfSVbMC5"
-            "oobi": "http://example.com/oobi/EyX-zd8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM"
-          }
-        }
+                Reply message example::
+
+                                {
+                                        "v": "KERI10JSON00011c_",
+                                        "t": "rpy",
+                                        "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                        "dt": "2020-08-22T17:50:12.988921+00:00",
+                                        "r": "/watcher/BrHLayDN-mXKv62DAjFLX1_Y5yEUe0vA9YPe_ihiKYHE/add",
+                                        "a": {
+                                                "cid": "EyX-zd8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
+                                                "oid": "EM0-i05TNZJZAoH3UR2nmLaU6JwyvPzhzS6YAfSVbMC5",
+                                                "oobi": "http://example.com/oobi/EyX-zd8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM"
+                                        }
+                                }
 
         """
         aid = kwa["aid"]
@@ -5907,7 +5923,7 @@ class Kevery:
                     self.cues.push(dict(kin="psUnescrow", serder=eserder))
 
                 logger.info("Kevery: PSE unescrow succeeded in valid event event= %s", eserder.said)
-                logger.debug(f"Event=\n%s\n", eserder.pretty())
+                logger.debug("Event=\n%s\n", eserder.pretty())
 
             #if ekey == key:  # still same so no escrows found on last while iteration
                 #break
@@ -6582,7 +6598,7 @@ class Kevery:
                 self.db.delegables.rem(keys=(pre, sn,), val=edig)  # removes one escrow at key val
                 logger.info("Kevery DEL unescrow succeeded in valid event: "
                             "event=%s", eserder.said)
-                logger.debug(f"Event=\n%s\n", eserder.pretty())
+                logger.debug("Event=\n%s\n", eserder.pretty())
 
 
     def processQueryNotFound(self):

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -163,7 +163,7 @@ def deReceiptCouple(data, strip=False):
 
     Parameters::
 
-        data is couple of bytes concatenation of pre+sig from receipt
+        data is couple of bytes concatenation of snu+dig from source event
         strip is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
             Raises error if not bytearray
@@ -1049,7 +1049,7 @@ def query(pre="",
                                     {
                                         "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
                                         "sn": "5",
-                                        "dt": "2020-08-01T12:20:05.123456+00:00",
+                                        "dt": "2020-08-01T12:20:05.123456+00:00"
                                     }
                                 }
 
@@ -1059,7 +1059,7 @@ def query(pre="",
                                     "v" : "KERI10JSON00011c_",
                                     "t" : "qry",
                                     "d": "EZ-i0d8JZAoTNZH3ULaU6JR2nmwyvYAfSVPzhzS6b5CM",
-                                    "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"
+                                    "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
                                     "dt": "2020-08-22T17:50:12.988921+00:00",
                                     "r" : "logs",
                                     "rr": "log/processor",
@@ -1067,7 +1067,7 @@ def query(pre="",
                                     {
                                         "i":  "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
                                         "sn": "5",
-                                        "dt": "2020-08-01T12:20:05.123456+00:00",
+                                        "dt": "2020-08-01T12:20:05.123456+00:00"
                                     }
                                 }
 
@@ -1141,7 +1141,7 @@ def reply(pre="",
                                          "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
                                          "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
                                          "name": "John Jones",
-                                         "role": "Founder",
+                                         "role": "Founder"
                                     }
                                 }
 
@@ -1159,7 +1159,7 @@ def reply(pre="",
                                          "d": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
                                          "i": "EAoTNZH3ULvYAfSVPzhzS6baU6JR2nmwyZ-i0d8JZ5CM",
                                          "name": "John Jones",
-                                         "role": "Founder",
+                                         "role": "Founder"
                                     }
                                 }
 
@@ -1817,8 +1817,6 @@ class Kever:
     @property
     def prefixes(self):
         """
-        :no-index:
-
         Returns .db.prefixes
         """
         return self.db.prefixes

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -888,7 +888,8 @@ def deltate(pre,
     Syntactic suger that calls rotate but with ilk set to drt.
 
 
-    Inherited Parameters:
+    Inherited Parameters::
+
         pre (str): identifier prefix qb64
         keys  (list): current signing keys qb64
         dig (str): said of previous event qb64
@@ -1518,7 +1519,9 @@ def messagize(serder, *, sigers=None, seal=None, wigers=None, cigars=None,
     """
     Attaches indexed signatures from sigers and/or cigars and/or wigers to
     KERI message data from serder
-    Parameters:
+
+    Parameters::
+
         serder (SerderKERI): instance containing the event
         sigers (list): of Siger instances (optional) to create indexed signatures
         seal (Union[SealEvent, SealLast]): optional if sigers and
@@ -1536,7 +1539,9 @@ def messagize(serder, *, sigers=None, seal=None, wigers=None, cigars=None,
         pipelined (bool), True means prepend pipelining count code to attachemnts
             False means to not prepend pipelining count code
 
-    Returns: bytearray KERI event message
+    Returns::
+
+        bytearray KERI event message
     """
     msg = bytearray(serder.raw)  # make copy into new bytearray so can be deleted
     atc = bytearray()  # attachment
@@ -1601,6 +1606,7 @@ class Kever:
     Has the following public attributes and properties:
 
     Class Attributes:
+
         EstOnly (bool):
                 True means allow only establishment events
                 False means allow all events
@@ -1609,6 +1615,7 @@ class Kever:
                 False means allow delegation of delegated identifiers
 
     Attributes:
+
         db (Baser | None): instance that manages the LMDB database when provided.
             When None provided then create and assign vacuous instance of Baser.
         cues (deque | None): Injected Kevery.cues when provided. Default None.
@@ -1645,6 +1652,7 @@ class Kever:
 
 
     Properties:
+
         sn (int): sequence number property that returns .sner.num
         fn (int): first seen ordinal number property the returns .fner.num
         ndigs (list): of digests qb64 of .digers
@@ -1653,8 +1661,9 @@ class Kever:
 
 
 
-    ToDo:
-       Add Registrar Backer support:
+    ToDo
+
+        Add Registrar Backer support:
         Class variable, instance variable and parse support config trait.
         raise error for now
 
@@ -1808,6 +1817,8 @@ class Kever:
     @property
     def prefixes(self):
         """
+        :no-index:
+
         Returns .db.prefixes
         """
         return self.db.prefixes
@@ -1825,9 +1836,10 @@ class Kever:
     def transferable(self):
         """
         Property transferable:
+
         Returns True if identifier does not have non-transferable derivation code
-                and .nextor is not None
-                False otherwise
+        and .nextor is not None
+        False otherwise
         """
         return True if self.ndigers and self.prefixer.transferable else False
 
@@ -1882,7 +1894,9 @@ class Kever:
             pre (str): qb64 identifier prefix if any.
 
 
-        ToDo: this code does not account for stale group members as delegators.
+        ToDo:
+
+        this code does not account for stale group members as delegators.
         i.e. a stale group membed is a member AID for a group AID in .groups
         for which the member AID was a signing (smids) or rotating (rmids) member
         in the past but is no longer. For delegation approval there must be
@@ -1894,7 +1908,8 @@ class Kever:
         That later approval must detect and properly handle the staleness.
 
         Alternatively the logic could be changed to short circut that later
-        work by checking here for staleness. For example:
+        work by checking here for staleness. For example::
+
             delpre.mhab.pre in delpre's hab.smids  (not stale )
 
 
@@ -2423,14 +2438,15 @@ class Kever:
                                 local=True):
         """
         Returns triple (sigers, wigers, delegator) where:
+
         sigers is unique validated signature verified members of inputed sigers
         wigers is unique validated signature verified members of inputed wigers
         delegator is qb64 delegator prefix if delegated else None
 
         Validates sigers signatures by validating indexes, verifying signatures, and
-            validating threshold sith.
+        validating threshold sith.
         Validate witness receipts by validating indexes, verifying
-            witness signatures and validating toad.
+        witness signatures and validating toad.
         Witness validation is a function of wits .prefixes and .local
 
         Parameters:
@@ -2681,11 +2697,12 @@ class Kever:
         this function is called.
 
         Rules:
-            If event is not a delegated event then not valid delegation
-            If delegatee's own event (.mine) then valid delegation
-            If delegation seal found in delgator's KEL then valid delegation given
-                valid superseding rules below
-            Otherwise escrow or reject if error condition
+
+            - If event is not a delegated event then not valid delegation
+            - If delegatee's own event (.mine) then valid delegation
+            - If delegation seal found in delgator's KEL then valid delegation given
+              valid superseding rules below
+            - Otherwise escrow or reject if error condition
 
         seal validates with respect to Delegator's KEL
         Location Seal is from Delegate's establishment event
@@ -2707,7 +2724,7 @@ class Kever:
                 If this event is not delegated then ignored
             deldiger (Diger | None): instance of delegating event digest.
                 If this event is not delegated ignored
-                local (bool): event source for validation logic
+            local (bool): event source for validation logic
                 True means event source is local (protected).
                 False means event source is remote (unprotected).
                 Event validation logic is a function of local or remote
@@ -2725,6 +2742,7 @@ class Kever:
             None
 
         Process Logic:
+
             A delegative event is processed differently for each of four different
             parties, namely, controller of event, witness to controller of event,
             delegator of event , and validator of event that is not controller,
@@ -2823,7 +2841,7 @@ class Kever:
             remote event because the validator is not one of the protected parties
             to the event.
 
-        Superseding Recovery:
+        Superseding Recovery
 
         Supersede means that after an event has already been accepted as first seen
         into a KEL that a different event with the same sequence number is accepted
@@ -2894,7 +2912,7 @@ class Kever:
             A. or B. must be satisfied, or else the superseding rotation must
             be discarded.
 
-        Note: The latest seen delegated rotation constraint means that any earlier
+        Note. The latest seen delegated rotation constraint means that any earlier
         delegated rotations CAN NOT be superseded. This greatly simplifies the
         validation logic and avoids a potential infinite regress of forks in the
         delegated identifier's KEL while allowing the delegate to
@@ -2926,7 +2944,7 @@ class Kever:
         to detect a comprimised or duplicitious superseding rotation and
         prevent the additional verification from proceding.
 
-        Mitigations of malicious source seal couples:
+        Mitigations of malicious source seal couples
 
         Repair the approval source seal couple in the 'aess' database on recursive
         climb the kel tree.  Once an event has been accepted into its kel.
@@ -3753,7 +3771,8 @@ class Kever:
           verfer (Verfer): instance of verfer
           sn (int | None): sn to start searching. If None then start at .lastEst.s
 
-        Returns:
+        Returns::
+
             tuple(int, int, list[Verfer]) | None: where tuple is of form
             (sn, index, verfers)
                 sn is sequence number
@@ -3793,7 +3812,8 @@ class Kevery:
 
     Has the following public attributes and properties:
 
-    Attributes:
+    Attributes::
+
         cues (Deck):  of Cues i.e. notices of events needing receipt or
                       requests needing response
         db (Baser): instance of LMDB Baser object
@@ -3814,7 +3834,8 @@ class Kevery:
                 and timestamps.
 
 
-    Properties:
+    Properties::
+
         .kevers is dict of db kevers indexed by pre (qb64) of each Kever
         .prefixes is OrderedSet of fully qualified base64 identifier prefixes of db
             local habitats if any.
@@ -3837,7 +3858,8 @@ class Kevery:
         """
         Initialize instance:
 
-        Parameters:
+        Parameters::
+
             cues (Deck)  notices to create responses to evts
             kevers is dict of Kever instances of key state in db
             db (Baser): instance of database
@@ -5422,7 +5444,8 @@ class Kevery:
         """
         Update associated logs for escrow of Unverified Event Witness Receipt
         (non-transferable)
-        Escrowed value is couple edig+wig where:
+        Escrowed value is couple edig+wig where::
+
            edig is receipted event dig not serder.dig
            wig is witness indexed signature on receipted event with key pair
                 derived from witness nontrans identifier prefix in witness list.
@@ -5457,7 +5480,8 @@ class Kevery:
     def escrowUReceipt(self, serder, cigars, said):
         """
         Update associated logs for escrow of Unverified Event Receipt (non-transferable)
-        Escrowed value is triple edig+rpre+cig where:
+        Escrowed value is triple edig+rpre+cig where::
+
            edig is event dig
            rpre is nontrans receiptor prefix
            cig is non-indexed signature on event with key pair derived from rpre
@@ -5502,7 +5526,8 @@ class Kevery:
                 diger is Diger instance of digest of est event of receiptor
                 sigers is list of Siger instances of multi-sig of receiptor
 
-        escrow quintuple for each siger
+        escrow quintuple for each siger::
+
             quintuple = edig+pre+snu+dig+sig
             where:
                 edig is receipted event dig (serder.dig)
@@ -5550,7 +5575,8 @@ class Kevery:
             saider is Saider instance of said of est event of receiptor
             igers is list of Siger instances of multi-sig of receiptor
 
-        escrow quintuple for each siger
+        escrow quintuple for each siger::
+
             quintuple = edig+pre+snu+dig+sig
             where:
                 edig is receipted event dig (serder.dig)
@@ -5787,7 +5813,8 @@ class Kevery:
 
         Value is dgkey for event stored in .Evt where .Evt has serder.raw of event.
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             dgkey = dgKey(pre, serder.digb)
             .db.dtss.put(keys=dgkey, val=Dater())
             self.db.sigs.put(keys=dgkey, vals=sigers)
@@ -5799,7 +5826,8 @@ class Kevery:
                 pre is str qb64 of identifier prefix of event
                 sn is int sequence number of event
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:
@@ -5938,12 +5966,14 @@ class Kevery:
         Escrowed items in .pwes are indexed in database table keyed by prefix and
         sequence number with duplicates inserted in insertion order. This allows
         FIFO processing of events with same prefix and sn.
-        Reads db.pwes .db.getPwe put there by  .db.pwes.addOn(keys, on, val)
+        Reads db.pwes .db.getPwe put there by  .db.pwes.addOn(keys, on, val)::
+
             which is IOVal with dups.
 
         Value is dgkey for event stored in .Evt where .Evt has serder.raw of event.
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             dgkey = dgKey(pre, serder.digb)
             .db.dtss.put(keys=dgkey, val=Dater())
             .db.putWigs(dgkey, [siger.qb64b for siger in sigers])
@@ -5955,7 +5985,8 @@ class Kevery:
                 pre is str qb64 of identifier prefix of event
                 sn is int sequence number of event
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:
@@ -6246,7 +6277,8 @@ class Kevery:
         signatures neither to look up the witness list to verify the indexed
         signatures.
 
-        The escrow is a couple with edig+wig where:
+        The escrow is a couple with edig+wig where::
+
             edig is receipted event digest
             wig is witness indexed signature by key-pair derived from witness
                 prefix in associated witness list. Index is offset into witness
@@ -6263,7 +6295,8 @@ class Kevery:
 
         Value is couple
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             self.db.dtss.put(keys=dgKey(pre, dig), val=Dater())
             for wiger in wigers:  # escrow each couple
                 couple = dig.encode("utf-8") + wiger.qb64b
@@ -6275,7 +6308,8 @@ class Kevery:
                 pre is str qb64 of identifier prefix of receipted event
                 sn is int sequence number of receipted event
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:
@@ -6350,7 +6384,8 @@ class Kevery:
         into its KEL.
         Without the event, there is no way to know where to store the receipts.
 
-        The escrow is a triple with edig+rpre+cig where:
+        The escrow is a triple with edig+rpre+cig where::
+
            edig is event digest
            rpre is receiptor (signer) of event
            cig is non-indexed signature by key-pair derived from rpre of event
@@ -6367,7 +6402,8 @@ class Kevery:
 
         Value is triple
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             self.db.dtss.put(keys=dgKey(pre, dig), val=Dater())
             for cigar in cigars:  # escrow each triple
                 if cigar.verfer.transferable:  # skip transferable verfers
@@ -6380,7 +6416,8 @@ class Kevery:
                 pre is str qb64 of identifier prefix of receipted event
                 sn is int sequence number of receipted event
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:
@@ -6835,7 +6872,8 @@ class Kevery:
 
         Value is quintuple
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             self.db.dtss.put(keys=dgKey(serder.preb, dig), val=Dater())
             prelet = (dig.encode("utf-8") + seal.i.encode("utf-8") +
                   Seqner(sn=int(seal.s, 16)).qb64b + seal.d.encode("utf-8"))
@@ -6847,7 +6885,8 @@ class Kevery:
                 sigers is list of Siger instances for receipted event
 
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:
@@ -6987,7 +7026,8 @@ class Kevery:
 
         Value is dgkey for event stored in .Evt where .Evt has serder.raw of event.
 
-        Original Escrow steps:
+        Original Escrow steps::
+
             dgkey = dgKey(pre, serder.dig)
             self.db.dtss.put(keys=dgkey, val=Dater())
             self.db.sigs.put(keys=dgkey, vals=sigers)
@@ -6999,7 +7039,8 @@ class Kevery:
                 pre is str qb64 of identifier prefix of event
                 sn is int sequence number of event
 
-        Steps:
+        Steps::
+
             Each pass  (walk index table)
                 For each prefix,sn
                     For each escrow item dup at prefix,sn:

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -159,7 +159,7 @@ def deReceiptCouple(data, strip=False):
     Couple is used for receipts signed by nontransferable prefix keys
 
     Parameters:
-        data is couple of bytes concatenation of pre+sig from receipt
+        data is couple of bytes concatenation of pre+cig from receipt
         strip is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
             Raises error if not bytearray
@@ -185,7 +185,7 @@ def deSourceCouple(data, strip=False):
     Couple is used for delegated/issued event attachment of delegator/issuer evt
 
     Parameters:
-        data is couple of bytes concatenation of pre+sig from receipt
+        data is couple of bytes concatenation of snu+dig from receipt
         strip is Boolean True means delete from data each part as parsed
             Only useful if data is bytearray from front of stream
             Raises error if not bytearray


### PR DESCRIPTION
## Summary
Repair Sphinx/docutils parser issues in `src/keri/core/eventing.py` with a narrow, docstring-focused pass.

## What changed
- repaired parser-confusing docstring section formatting in `eventing.py`
- adjusted example and prose block formatting where docutils was treating content as malformed lists or blocks
- kept the change surface confined to the existing eventing docstring cleanup lane

## Notes
- branch pushed from `jaelliot/chore/docstrings-eventing-only`
- local verification was bypassed for publish at requester direction
- residual warnings may still remain in `eventing.py` and can be handled in follow-up if needed