### PR TITLE
docs: refine indexing docstrings

### DIFF
--- a/src/keri/core/indexing.py
+++ b/src/keri/core/indexing.py
@@ -233,10 +233,11 @@ class Indexer:
     def __init__(self, raw=None, code=IdrDex.Ed25519_Sig, index=0, ondex=None,
                  qb64b=None, qb64=None, qb2=None, strip=False, **kwa):
         """
-        Validate as fully qualified
+        Validate as fully qualified.
+
         Parameters:
             raw (bytes): unqualified crypto material usable for crypto operations
-            code is str of stable (hard) part of derivation code
+            code (str): stable (hard) part of derivation code
             index (int): main index offset into list or length of material
             ondex (int | None): other index offset into list or length of material
             qb64b (bytes): fully qualified Base64 crypto material
@@ -245,12 +246,13 @@ class Indexer:
             strip (bool): True means strip counter contents from input stream
                 bytearray after parsing qb64b or qb2. False means do not strip
 
-        Needs either (raw and code and index) or qb64b or qb64 or qb2
-        Otherwise raises EmptyMaterialError
-        When raw and code provided then validate that code is correct
-        for length of raw  and assign .raw
-        Else when qb64b or qb64 or qb2 provided extract and assign
-        .raw, .code, .index, .ondex.
+        Notes:
+            Needs either (raw and code and index) or qb64b or qb64 or qb2.
+            Otherwise raises EmptyMaterialError.
+            When raw and code provided then validate that code is correct for
+            length of raw and assign .raw.
+            Else when qb64b or qb64 or qb2 provided extract and assign .raw,
+            .code, .index, .ondex.
 
         """
         if raw is not None:  # raw provided


### PR DESCRIPTION
## Summary

Refines `src/keri/core/indexing.py` docstrings and formatting for clearer Sphinx/reStructuredText-friendly documentation.

No intended behavior changes.

## Scope

Changed:

- `src/keri/core/indexing.py`

Not changed:

- tests
- runtime behavior
- other Keripy modules

## Validation

Ran:

- `git diff --check upstream/main...HEAD` — passed
- `python -m compileall src/keri/core/indexing.py` — passed
- `ruff check src/keri/core/indexing.py` — passed
- `python -m pytest tests/core/test_indexing.py -x --tb=short` — passed
- Pre-push hook — passed using doc-only fast path

## Notes

The pre-push hook identified this as a doc-only change:

- Python files changed: 1
- Changed file: `src/keri/core/indexing.py`
- Tests skipped by doc-only fast path

Broader Sphinx/docutils validation currently emits project-wide warnings/errors in unrelated modules. This PR intentionally keeps scope limited to `indexing.py`.