### PR TITLE
chore: ignore Sphinx Doctor diagnostics mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+.sphinx-diagnostics/
 
 # PyBuilder
 target/


### PR DESCRIPTION
## Summary

- Ignore Sphinx Doctor’s local diagnostics mirror directory.

## Notes

Sphinx Doctor writes `.sphinx-diagnostics/` under the analyzed source repository so VSCode can load and refresh diagnostics. This directory is generated local tooling output and should not be committed.

## Validation

- Commit changes only `.gitignore`.
- Local pre-push hook currently fails in `tests/app/test_apping.py::test_consoler` with `TypeError: a bytes-like object is required, not 'str'`, unrelated to this `.gitignore`-only change.
