### PR TITLE
docs: fix Komer docstring indentation

### DIFF
--- a/src/keri/db/koming.py
+++ b/src/keri/db/koming.py
@@ -363,14 +363,14 @@ class Komer(KomerBase):
                 in order to form key
 
         Returns:
-            val (dataclass):
-            None if no entry at keys
+            val (dataclass | None): value at keys, or None if no entry at keys.
 
         Usage:
-            Use walrus operator to catch and raise missing entry
-            if (val := mydb.get(keys)) is None:
-                raise ExceptionHere
-            use val here
+            Use walrus operator to catch and raise missing entry::
+
+                if (val := mydb.get(keys)) is None:
+                    raise ExceptionHere
+                use val here
         """
         return (self._des(self.db.getVal(db=self.sdb,
                                   key=self._tokey(keys))))
@@ -383,14 +383,14 @@ class Komer(KomerBase):
                 in order to form key
 
         Returns:
-            val (dict):
-            None if no entry at keys
+            val (dict | None): dictified value at keys, or None if no entry at keys.
 
         Usage:
-            Use walrus operator to catch and raise missing entry
-            if (val := mydb.get(keys)) is None:
-                raise ExceptionHere
-            use val here
+            Use walrus operator to catch and raise missing entry::
+
+                if (val := mydb.get(keys)) is None:
+                    raise ExceptionHere
+                use val here
         """
         val = self.get(keys)
         return helping.dictify(val) if val is not None else None


### PR DESCRIPTION
## Summary

Fixes two Sphinx/docutils `unexpected-indentation` warnings in `keri.db.koming.Komer` docstrings.

## Scope

- Docstring-only change
- No runtime logic changes
- No imports, signatures, constants, return expressions, or tests changed
- Only touches `src/keri/db/koming.py`

## Validation

- Ran doc-change guard: `check_doc_changes.py`
- Ran focused Sphinx inventory for `unexpected-indentation`
- Confirmed the targeted `Komer.get` and `Komer.getDict` warnings no longer appear in the refreshed Sphinx log