### PR TITLE
passing bytes to cbor loads

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -158,7 +158,7 @@ def loads(raw, size=None, kind=Kinds.json):
 
     elif kind == Kinds.cbor:
         try:
-            ked = cbor.loads(raw[:size])
+            ked = cbor.loads(bytes(raw[:size]))
         except Exception as ex:
             raise DeserializeError("Error deserializing CBOR: {}"
                                        "".format(raw[:size]))

--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -1285,7 +1285,7 @@ class Serder:
 
         elif kind == Kinds.cbor:
             try:
-                sad = cbor.loads(raw[:size])
+                sad = cbor.loads(bytes(raw[:size]))
             except Exception as ex:
                 raise DeserializeError(f"Error deserializing CBOR: "
                     f"{raw[:size].decode()}") from ex


### PR DESCRIPTION
- cbor2 updated to version 6.0.1 (rust rewrite) and loads() now does not accept a bytearray
- 6.0.2 will support bytearrays again ([line 195](https://github.com/agronholm/cbor2/blob/master/rust/lib.rs)) but currently this is breaking tests/core/test_eventing.py::test_direct_mode_cbor_mgp
- so for now we can just pass bytes() to cbor.loads()