### PR TITLE
fix(agenting): route HTTPMessenger response bodies through hab.psr

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -895,7 +895,21 @@ class HTTPMessenger(doing.DoDoer):
             yield self.tock
 
     def responseDo(self, tymth=None, tock=0.0, **kwa):
-        """Doer loop that processes HTTP responses from the client and adds them into `sent` cues."""
+        """Doer loop that processes HTTP responses from the client.
+
+        Appends each response to ``self.sent`` (so callers inspecting raw
+        responses still work) and, when the response carries a CESR body,
+        routes it through ``self.hab.psr`` so witness receipts land in
+        ``hab.db.wigs``.
+
+        Without this routing, callers that drive an HTTPMessenger via
+        ``WitnessReceiptor`` (witnesses reached over HTTP) never see the
+        receipts the witness actually returned, and their busy-wait loop
+        on ``len(wigers) == len(wits)`` never exits. Mirrors the canonical
+        pattern in ``Receiptor.receiptDo`` and closes the structural gap
+        with ``TCPMessenger`` which already parses inbound CESR via its
+        own ``Kevery``.
+        """
         self.wind(tymth)
         self.tock = tock
         _ = (yield self.tock)
@@ -904,6 +918,11 @@ class HTTPMessenger(doing.DoDoer):
             while self.client.responses:
                 rep = self.client.respond()
                 self.sent.append(rep)
+                if rep.status == 200 and rep.body:
+                    try:
+                        self.hab.psr.parseOne(ims=bytearray(rep.body))
+                    except Exception as ex:
+                        logger.warning("HTTPMessenger response parse failed: %s", ex)
                 yield
             yield
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -237,6 +237,86 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder):
         doist.exit()
 
 
+def test_http_messenger_routes_response_through_parser():
+    """HTTPMessenger.responseDo routes CESR response bodies through the
+    hab's parser so witness receipts land in db.wigs.
+
+    Regression guard for issue #1422: HTTPMessenger previously only
+    appended raw responses to ``self.sent`` and never fed them through
+    Kevery. Callers driving an HTTPMessenger via WitnessReceiptor would
+    receive the receipt body in ``self.sent`` but ``baser.wigs`` stayed
+    empty — busy-wait loops on ``len(wigers) == len(wits)`` would never
+    exit. This mirrors what TCPMessenger and Receiptor already do.
+    """
+    from types import SimpleNamespace
+    from hio.help import decking
+    from keri.app.agenting import HTTPMessenger
+
+    # Witness and controller live in separate Haberies so the receipt
+    # crosses a real "process" boundary — the same shape as production
+    # where the witness is a remote service.
+    with openHby(name="wit-hby", salt=Salter(raw=b'wit-hby-issue1422-').qb64) as wit_hby, \
+            openHby(name="ctrl-hby", salt=Salter(raw=b'ctrl-hby-issue1422').qb64) as ctrl_hby:
+        wit = wit_hby.makeHab(name="wit", transferable=False, isith="1",
+                              icount=1, ncount=0, nsith="0")
+
+        # Controller's hby learns the witness's KEL via OOBI in real life;
+        # here we just parse the witness's inception into ctrl_hby.
+        ctrl_hby.psr.parse(ims=bytearray(wit.msgOwnInception()))
+        ctrl = ctrl_hby.makeHab(name="ctrl", transferable=True, isith="1",
+                                icount=1, ncount=1, nsith="1",
+                                toad=1, wits=[wit.pre])
+
+        # Witness side must have seen ctrl's inception to build a wig.
+        wit_hby.psr.parse(ims=bytearray(ctrl.msgOwnInception()))
+        rct_bytes = wit.witness(serder=wit_hby.kevers[ctrl.pre].serder)
+
+        # Sanity: receipt was built and ctrl_hby has no wig yet for it.
+        dgkey = (ctrl.pre.encode(), ctrl.kever.serder.saidb)
+        assert len(ctrl_hby.db.wigs.get(keys=dgkey)) == 0, (
+            "ctrl_hby unexpectedly has a wig before the messenger runs"
+        )
+
+        # Build an HTTPMessenger but replace its live client with a
+        # test-double exposing only the responseDo surface we exercise:
+        # .responses (a Deck) and .respond() (pop one).
+        msgr = HTTPMessenger(hab=ctrl, wit=wit.pre, url="http://localhost:9/")
+
+        fake_rep = SimpleNamespace(status=200, body=bytes(rct_bytes))
+        responses = decking.Deck([fake_rep])
+
+        class _StubClient:
+            def __init__(self, deck):
+                self.responses = deck
+            def respond(self):
+                return self.responses.popleft()
+
+        msgr.client = _StubClient(responses)
+
+        # Drive responseDo as a generator. First next() primes past the
+        # initial `_ = (yield self.tock)`. Second next() enters the inner
+        # `while self.client.responses` loop, pops fake_rep, appends to
+        # self.sent, runs hab.psr.parseOne(rep.body), then yields.
+        gen = msgr.responseDo(tymth=lambda: 0.0, tock=0.0)
+        next(gen)
+        next(gen)
+
+        wigs = ctrl_hby.db.wigs.get(keys=dgkey)
+        assert len(wigs) == 1, (
+            f"expected 1 wig in ctrl_hby.db.wigs after HTTPMessenger "
+            f"parsed the response body; got {len(wigs)}. "
+            f"len(msgr.sent)={len(msgr.sent)}, "
+            f"len(msgr.client.responses)={len(msgr.client.responses)}"
+        )
+
+        # Raw response is still preserved on self.sent for callers that
+        # inspect bodies directly (no behavioral regression).
+        assert len(msgr.sent) == 1
+
+
+
+
+
 def test_messenger_prefers_https():
     """Verify messengerFrom and streamMessengerFrom prefer HTTPS over HTTP.
 


### PR DESCRIPTION
## Summary

Wires `HTTPMessenger.responseDo` to feed received HTTP response bodies through the hab's parser (`self.hab.psr.parseOne`) alongside the existing `self.sent` append. Mirrors the canonical pattern in `Receiptor.receiptDo` and closes the structural gap with `TCPMessenger`, which already parses inbound CESR via its own `Kevery`.

Without this, witness receipts returned in HTTP response bodies are accepted on the wire but never land in `baser.wigs`. Any caller using `WitnessReceiptor` against an HTTP witness then loops indefinitely on `len(wigers) == len(wits)`.

Closes #1422.

## Why

Side-by-side on `main`, `src/keri/app/agenting.py`:

- `TCPMessenger` (line 692): builds a `Kevery` + `parsing.Parser(ims=client.rxbs, framed=True, kvy=...)`, runs `parsator(local=True)` in `msgDo`.
- `Receiptor.receiptDo` (line 116): `hab.psr.parseOne(bytearray(rep.body))` directly on each 200 response. Known-working in production.
- `HTTPMessenger.__init__` (line 856): `self.parser = None`. `responseDo`: only `self.sent.append(rep)`. Nothing routes to `Kevery`.

The fix uses the `Receiptor` pattern (inline `hab.psr.parseOne`) rather than the issue's proposed `parsing.Parser(ims=client.rxbs, ...)` because hio's `client.rxbs` is the raw socket buffer — HTTP-parsed response bodies live in `client.responses[].body`, not `client.rxbs`. Using `hab.psr` also avoids constructing a second `Kevery` that could escrow-desync against the hab's own.

## Changes

`src/keri/app/agenting.py` — `HTTPMessenger.responseDo` now:

```python
while True:
    while self.client.responses:
        rep = self.client.respond()
        self.sent.append(rep)
        if rep.status == 200 and rep.body:
            try:
                self.hab.psr.parseOne(ims=bytearray(rep.body))
            except Exception as ex:
                logger.warning("HTTPMessenger response parse failed: %s", ex)
        yield
    yield
```

- `self.sent.append(rep)` preserved so existing callers inspecting raw responses still get them.
- Parse failure is logged via the module's existing `logger` (`ogler.getLogger()`) and the doer keeps running; matches the resilience posture elsewhere in the file.
- `self.parser = None` is intentionally not removed — callers that wanted to hang a custom parser off it can still do so; nothing in the diff touches that.

`tests/app/test_agenting.py` — adds `test_http_messenger_routes_response_through_parser`:

- Two separate `Habery` instances (witness and controller) so the receipt crosses a real "process" boundary, mirroring production.
- Controller's hby learns the witness's KEL, then incepts with `wits=[wit.pre]`. Witness sees the controller's inception, then produces a real `wit.witness(ctrl.kever.serder)` receipt.
- HTTPMessenger built with a stub `client` exposing only `.responses` and `.respond()` — drives `responseDo` as a generator (two `next()` calls: prime, then process one response).
- Asserts `ctrl_hby.db.wigs[(ctrl.pre, ctrl.kever.serder.saidb)]` has 1 entry and `len(msgr.sent) == 1` (no regression of the raw-response path).

## Verification

- **Regression guard validated.** Test confirmed to fail on `origin/main` HEAD (the bug repros) and pass with this patch.
- `pytest tests/app/test_agenting.py -v` — **6/6 pass** including the pre-existing `test_withness_receiptor` end-to-end TCP test (no TCP regression).
- `pytest tests/app/` — **126/126 pass** in ~134s.

## Not in this PR

- `WitnessReceiptor` deprecation — the issue raises it as an alternative if maintainers are moving consumers to `Receiptor` long-term. Happy to add a follow-up PR with a `DeprecationWarning` and a pointer if you'd like.
- The Locksmith side has already migrated to `Receiptor` (out-of-tree). This PR is filed primarily so the next consumer that walks into the same trap doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)