### PR TITLE
docs: align Python install requirement with hio dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We use `--pull=never` to ensure that docker does not implicitly pull a remote im
 ### Dependencies
 #### Binaries
 
-python 3.12.1+
+python 3.14.0+ (Ubuntu 24.04's default Python 3.12.3 is too old for keripy's current `hio` dependency)
 libsodium 1.0.18+
 
 
@@ -75,7 +75,7 @@ $ pip3 install -U cbor2
 ## Development
 
 ### Setup
-* Ensure Python 3.12.1 is present along with venv and dev header files;
+* Ensure Python 3.14.0+ is present along with venv and dev header files;
 * Setup virtual environment: `python3 -m venv keripy`
 * Activate virtual environment: `source keripy/bin/activate`
 * Setup dependencies: `pip install -r requirements.txt`

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         # uncomment if you test on these interpreters:
         # 'Programming Language :: Python :: Implementation :: PyPy',


### PR DESCRIPTION
Align README.md setup instructions and setup.py classifier with keripy's existing Python `>=3.14.0` requirement and current `hio` dependency constraints.

## Context

Ubuntu 24.04 defaults to Python 3.12.3, which is too old for keripy's current dependency chain. The README still referenced older Python setup guidance, which could lead users into a confusing pip resolver failure.

## Changes

- Update README setup instructions to require Python 3.14.0+
- Clarify Ubuntu 24.04's default Python 3.12.3 incompatibility
- Align setup.py Python classifier with existing `python_requires='>=3.14.0'`

## Validation

- `python3 -m py_compile setup.py`
- Metadata/docs assertions for `python_requires`, classifier, and README version text

References #985.
