### PR TITLE
fix(docker): align image with Python 3.14 requirement

### DIFF
--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=python:3.13.2-alpine3.20
+ARG BASE=python:3.14.6-alpine3.24
 
 FROM ${BASE} AS builder
 
@@ -23,7 +23,7 @@ RUN python -m venv venv
 
 ENV PATH=/keripy/venv/bin:${PATH}
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip setuptools
 RUN mkdir /keripy/src
 
 COPY requirements.txt setup.py ./


### PR DESCRIPTION
Align keripy Dockerfile with the existing Python `>=3.14.0` requirement and ensure `setuptools` is available for `lmdb`/CFFI initialization.

## Context

`WebOfTrust/keripy#1175` reports that `docker run weboftrust/keri:1.2.7 version` fails with an `lmdb.cpython` import error followed by a setuptools/CFFI error on Python >=3.12.

The Dockerfile was still pinned to a Python 3.13 Alpine image even though keripy currently requires Python >=3.14.0. Python 3.14 virtual environments also do not provide setuptools by default, so the Docker build needs to bootstrap it explicitly before installing dependencies.

## Changes

- Update `images/keripy.dockerfile` to use a Python 3.14 Alpine base image
- Install `setuptools` during Docker build alongside the pip upgrade
- Leave KERI source/protocol logic unchanged

## Validation

- `docker build -f images/keripy.dockerfile -t keripy-issue-1175-fixed .`
- `docker run --rm keripy-issue-1175-fixed version`
- `docker run --rm --entrypoint python keripy-issue-1175-fixed -c "import setuptools; import lmdb; print('setuptools ok'); print('lmdb ok')"`
- Pre-push test suite: 570 passed, 3 skipped

References #1175.
