### PR TITLE
Xdist test parallel

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -11,6 +11,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12.6+
+        uses: actions/setup-python@v5
+        with:
+          python-version: '>=3.12.6'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if (Test-Path requirements.txt) { pip install -r requirements.txt }
+        shell: pwsh
+      - name: Lint changes
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
+        shell: pwsh
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
@@ -54,15 +76,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-xdist
+          pip install pytest pytest-xdist
           if (Test-Path requirements.txt) { pip install -r requirements.txt }
-        shell: pwsh
-      - name: Lint changes
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --ignore=E7,F841,E301,E302,E303 --max-complexity=10 --max-line-length=127 --statistics
         shell: pwsh
       - name: Run core KERI tests
         run: |

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -48,10 +48,10 @@ jobs:
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
           - os: windows-latest
             job_name: "test (windows-latest, core)"
-            pytest_command: "pytest tests/core -n auto"
+            pytest_command: "pytest tests/core"
           - os: windows-latest
             job_name: "test (windows-latest, non-core)"
-            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm -n auto"
+            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm"
     name: ${{ matrix.job_name }}
 
     steps:

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -19,14 +19,17 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            pytest_args: "-n auto"
+            pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
             pytest_mode: "auto workers"
           - os: ubuntu-latest
-            pytest_args: "-n auto"
+            pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
             pytest_mode: "auto workers"
           - os: windows-latest
-            pytest_args: "-n auto"
-            pytest_mode: "auto workers"
+            pytest_command: "pytest tests/core"
+            pytest_mode: "serial core"
+          - os: windows-latest
+            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm"
+            pytest_mode: "serial non-core"
     name: test (${{ matrix.os }}, ${{ matrix.pytest_mode }})
 
     steps:
@@ -63,7 +66,7 @@ jobs:
         shell: pwsh
       - name: Run core KERI tests
         run: |
-          pytest tests/ --ignore tests/demo/ --ignore test/scripts ${{ matrix.pytest_args }}
+          ${{ matrix.pytest_command }}
         shell: pwsh
       - name: Run KERI demo tests
         run: |

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -13,16 +13,21 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: macos-latest
-            pytest_workers: 2
+            pytest_args: "-n auto"
+            pytest_mode: "auto workers"
           - os: ubuntu-latest
-            pytest_workers: 4
+            pytest_args: "-n auto"
+            pytest_mode: "auto workers"
           - os: windows-latest
-            pytest_workers: 4
+            pytest_args: "-n auto"
+            pytest_mode: "auto workers"
+    name: test (${{ matrix.os }}, ${{ matrix.pytest_mode }})
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +63,7 @@ jobs:
         shell: pwsh
       - name: Run core KERI tests
         run: |
-          pytest tests/ --ignore tests/demo/ --ignore test/scripts -n ${{ matrix.pytest_workers }}
+          pytest tests/ --ignore tests/demo/ --ignore test/scripts ${{ matrix.pytest_args }}
         shell: pwsh
       - name: Run KERI demo tests
         run: |

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -35,7 +35,6 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -16,7 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        include:
+          - os: macos-latest
+            pytest_workers: 2
+          - os: ubuntu-latest
+            pytest_workers: 4
+          - os: windows-latest
+            pytest_workers: 4
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 pytest pytest-xdist
           if (Test-Path requirements.txt) { pip install -r requirements.txt }
         shell: pwsh
       - name: Lint changes
@@ -52,7 +58,7 @@ jobs:
         shell: pwsh
       - name: Run core KERI tests
         run: |
-          pytest tests/ --ignore tests/demo/ --ignore test/scripts
+          pytest tests/ --ignore tests/demo/ --ignore test/scripts -n ${{ matrix.pytest_workers }}
         shell: pwsh
       - name: Run KERI demo tests
         run: |

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -46,11 +46,101 @@ jobs:
             job_name: "test (ubuntu-latest)"
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
           - os: windows-latest
-            job_name: "test (windows-latest, core)"
-            pytest_command: "pytest tests/core"
+            job_name: "test (windows-latest, shard 1)"
+            pytest_command: >-
+              pytest
+              tests/core/test_kraming.py
+              tests/core/test_delegating.py
+              tests/vdr/test_eventing.py
+              tests/vdr/test_verifying.py
+              tests/core/test_eventing_messagize.py
+              tests/app/test_directing.py
+              tests/app/cli/test_kli_commands.py
+              tests/app/test_querying.py
+              tests/peer/test_exchanging.py
+              tests/app/test_signing.py
+              tests/core/test_partial_rotation.py
+              tests/app/test_watching.py
+              tests/core/test_coring.py
+              tests/spec/acdc/test_acdc_examples.py
+              tests/core/test_indexing.py
+              tests/cli/commands/vc/test_vc_schema_validation.py
+              tests/spec/keri/test_keri_examples.py
+              tests/wasm/test_webdbing_wasm.py
           - os: windows-latest
-            job_name: "test (windows-latest, non-core)"
-            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm"
+            job_name: "test (windows-latest, shard 2)"
+            pytest_command: >-
+              pytest
+              tests/app/test_grouping.py
+              tests/core/test_eventing_v1.py
+              tests/db/test_basing.py
+              tests/core/test_witness.py
+              tests/core/test_replay.py
+              tests/vdr/test_issuing.py
+              tests/app/test_indirecting.py
+              tests/app/cli/commands/exn/test_send.py
+              tests/app/test_keeping.py
+              tests/core/test_serdering.py
+              tests/core/test_signing.py
+              tests/core/test_parsing_pathed.py
+              tests/core/test_weighted_threshold.py
+              tests/db/test_dbing.py
+              tests/app/test_challenging.py
+              tests/core/test_counting.py
+              tests/core/test_crypto.py
+              tests/core/test_bare.py
+              tests/app/test_apping.py
+              tests/help/test_ogling.py
+              tests/spac/test_payloading.py
+          - os: windows-latest
+            job_name: "test (windows-latest, shard 3)"
+            pytest_command: >-
+              pytest
+              tests/app/test_habbing_v2.py
+              tests/app/test_habbing_v1.py
+              tests/app/test_forwarding.py
+              tests/vdr/test_txn_state.py
+              tests/app/cli/commands/contacts/test_contacts.py
+              tests/app/test_oobiing.py
+              tests/app/test_delegating.py
+              tests/app/test_organizing.py
+              tests/vc/test_protocoling.py
+              tests/app/test_signaling.py
+              tests/vc/test_proving.py
+              tests/comply/test_direct_mode.py
+              tests/vdr/test_viring.py
+              tests/core/test_structing.py
+              tests/app/test_storing.py
+              tests/db/test_koming.py
+              tests/db/test_webdbing.py
+              tests/core/test_annotating.py
+              tests/help/test_helping.py
+              tests/test_kering.py
+          - os: windows-latest
+            job_name: "test (windows-latest, shard 4)"
+            pytest_command: >-
+              pytest
+              tests/core/test_eventing_v2.py
+              tests/core/test_parsing.py
+              tests/app/test_agenting.py
+              tests/core/test_reply.py
+              tests/core/test_escrow.py
+              tests/core/test_keystate.py
+              tests/vdr/test_credentialing.py
+              tests/core/test_kevery.py
+              tests/end/test_ending.py
+              tests/db/test_escrowing.py
+              tests/db/test_subing.py
+              tests/app/test_httping.py
+              tests/app/test_signify.py
+              tests/vc/test_walleting.py
+              tests/app/test_notifying.py
+              tests/core/test_scheming.py
+              tests/acdc/test_messaging.py
+              tests/core/test_mapping.py
+              tests/app/test_configing.py
+              tests/app/cli/common/test_parsing.py
+              tests/spec/cesr/test_cesr_examples.py
     name: ${{ matrix.job_name }}
 
     steps:

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -48,10 +48,10 @@ jobs:
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
           - os: windows-latest
             job_name: "test (windows-latest, core)"
-            pytest_command: "pytest tests/core"
+            pytest_command: "pytest tests/core -n auto"
           - os: windows-latest
             job_name: "test (windows-latest, non-core)"
-            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm"
+            pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm -n auto"
     name: ${{ matrix.job_name }}
 
     steps:

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -41,18 +41,18 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+            job_name: "test (macos-latest)"
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
-            pytest_mode: "auto workers"
           - os: ubuntu-latest
+            job_name: "test (ubuntu-latest)"
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
-            pytest_mode: "auto workers"
           - os: windows-latest
+            job_name: "test (windows-latest, core)"
             pytest_command: "pytest tests/core"
-            pytest_mode: "serial core"
           - os: windows-latest
+            job_name: "test (windows-latest, non-core)"
             pytest_command: "pytest tests/acdc tests/app tests/cli tests/comply tests/db tests/end tests/help tests/peer tests/spac tests/spec tests/test_kering.py tests/vc tests/vdr tests/wasm"
-            pytest_mode: "serial non-core"
-    name: test (${{ matrix.os }}, ${{ matrix.pytest_mode }})
+    name: ${{ matrix.job_name }}
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ $ pip3 install -U cbor2
 * Setup dependencies: `pip install -r requirements.txt`
 
 ### Testing
-* Install pytest: `pip install pytest`
+* Install pytest and xdist: `pip install pytest pytest-xdist`
 
 * Run the test suites:
 
 ```shell
-pytest tests/ --ignore tests/demo/
+pytest tests/ --ignore tests/demo/ -n auto
 pytest tests/demo/
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
                     'coverage>=7.13.1',
                     'pytest>=9.0.2',
                     'pytest-shell>=0.3.2',
+                    'pytest-xdist>=3.8.0',
                   ],
     setup_requires=[
     ],

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -18,20 +18,28 @@ KWA = dict(version=TEST_VERSION, kind=Kinds.json)
 CUE_KWA = dict(**KWA, gvrsn=TEST_VERSION)
 
 
-def test_witness_receiptor(seeder):
+def test_witness_receiptor(seeder, witnessPorter):
     with openHby(name="wan1", salt=Salter(raw=b'wann-the-witness').qb64, version=TEST_VERSION) as wanHby, \
             openHby(name="wil1", salt=Salter(raw=b'will-the-witness').qb64, version=TEST_VERSION) as wilHby, \
             openHby(name="wes1", salt=Salter(raw=b'wess-the-witness').qb64, version=TEST_VERSION) as wesHby, \
             openHby(name="pal1", salt=Salter(raw=b'0123456789abcdef').qb64, version=TEST_VERSION) as palHby:
 
-        wanDoers = setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642, **KWA)
-        wilDoers = setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643, **KWA)
-        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+        witnessPorts, witnessUrls = witnessPorter("wan", "wil", "wes")
+        wanDoers = setupWitness(alias="wan", hby=wanHby,
+                                tcpPort=witnessPorts["wan"]["tcp"],
+                                httpPort=witnessPorts["wan"]["http"], **KWA)
+        wilDoers = setupWitness(alias="wil", hby=wilHby,
+                                tcpPort=witnessPorts["wil"]["tcp"],
+                                httpPort=witnessPorts["wil"]["http"], **KWA)
+        wesDoers = setupWitness(alias="wes", hby=wesHby,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
 
         wanHab = wanHby.habByName(name="wan")
         wilHab = wilHby.habByName(name="wil")
         wesHab = wesHby.habByName(name="wes")
-        seeder.seedWitEnds(palHby.db, witHabs=[wanHab, wilHab, wesHab], protocols=[Schemes.tcp], **KWA)
+        seeder.seedWitEnds(palHby.db, witHabs=[wanHab, wilHab, wesHab],
+                           protocols=[Schemes.tcp], witnessUrls=witnessUrls, **KWA)
 
         rctDoer = ReceiptDoer(hby=palHby, wanHab=wanHab, wilHab=wilHab, wesHab=wesHab)
 
@@ -113,30 +121,37 @@ class ReceiptDoer(doing.DoDoer):
         return True
 
 
-def test_witness_sender(seeder):
+def test_witness_sender(seeder, witnessPorter):
     with openHby(name="wan2", salt=Salter(raw=b'wann-the-witness').qb64, version=TEST_VERSION) as wanHby, \
             openHby(name="wil2", salt=Salter(raw=b'will-the-witness').qb64, version=TEST_VERSION) as wilHby, \
             openHby(name="wes2", salt=Salter(raw=b'wess-the-witness').qb64, version=TEST_VERSION) as wesHby, \
             openHby(name="pal2", salt=Salter(raw=b'0123456789abcdef').qb64, version=TEST_VERSION) as palHby:
 
         # looks like bad magic value in seeder is causing this to fail
-        pdoer = PublishDoer(wanHby, wilHby, wesHby, palHby, seeder)
+        witnessPorts, witnessUrls = witnessPorter("wan", "wil", "wes")
+        pdoer = PublishDoer(wanHby, wilHby, wesHby, palHby, seeder, witnessPorts, witnessUrls)
         runController(doers=[pdoer], expire=15.0)
         assert pdoer.done is True
 
 
 class PublishDoer(doing.DoDoer):
 
-    def __init__(self, wanHby, wilHby, wesHby, palHby, seeder):
-        wanDoers = setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642, **KWA)
-        wilDoers = setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643, **KWA)
-        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+    def __init__(self, wanHby, wilHby, wesHby, palHby, seeder, witnessPorts, witnessUrls):
+        wanDoers = setupWitness(alias="wan", hby=wanHby,
+                                tcpPort=witnessPorts["wan"]["tcp"],
+                                httpPort=witnessPorts["wan"]["http"], **KWA)
+        wilDoers = setupWitness(alias="wil", hby=wilHby,
+                                tcpPort=witnessPorts["wil"]["tcp"],
+                                httpPort=witnessPorts["wil"]["http"], **KWA)
+        wesDoers = setupWitness(alias="wes", hby=wesHby,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
 
         self.wanHab = wanHby.habByName(name="wan")
         self.wilHab = wilHby.habByName(name="wil")
         self.wesHab = wesHby.habByName(name="wes")
         seeder.seedWitEnds(palHby.db, witHabs=[self.wanHab, self.wilHab, self.wesHab],
-                           protocols=[Schemes.tcp], **KWA)
+                           protocols=[Schemes.tcp], witnessUrls=witnessUrls, **KWA)
 
         self.palHab = palHby.makeHab(name="pal", wits=[self.wanHab.pre, self.wilHab.pre, self.wesHab.pre],
                                      transferable=True, **KWA)
@@ -168,21 +183,30 @@ class PublishDoer(doing.DoDoer):
         return True
 
 
-def test_witness_inquisitor(mockHelpingNowUTC, seeder):
+def test_witness_inquisitor(mockHelpingNowUTC, seeder, witnessPorter):
     with openHby(name="wan3", salt=Salter(raw=b'wann-the-witness').qb64, version=TEST_VERSION) as wanHby, \
             openHby(name="wil3", salt=Salter(raw=b'will-the-witness').qb64, version=TEST_VERSION) as wilHby, \
             openHby(name="wes3", salt=Salter(raw=b'wess-the-witness').qb64, version=TEST_VERSION) as wesHby, \
             openHby(name="pal3", salt=Salter(raw=b'0123456789abcdef').qb64, version=TEST_VERSION) as palHby, \
             openHby(name="qin3", salt=Salter(raw=b'abcdef0123456789').qb64, version=TEST_VERSION) as qinHby:
-        wanDoers = setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642, **KWA)
-        wilDoers = setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643, **KWA)
-        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+        witnessPorts, witnessUrls = witnessPorter("wan", "wil", "wes")
+        wanDoers = setupWitness(alias="wan", hby=wanHby,
+                                tcpPort=witnessPorts["wan"]["tcp"],
+                                httpPort=witnessPorts["wan"]["http"], **KWA)
+        wilDoers = setupWitness(alias="wil", hby=wilHby,
+                                tcpPort=witnessPorts["wil"]["tcp"],
+                                httpPort=witnessPorts["wil"]["http"], **KWA)
+        wesDoers = setupWitness(alias="wes", hby=wesHby,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
 
         wanHab = wanHby.habByName(name="wan")
         wilHab = wilHby.habByName(name="wil")
         wesHab = wesHby.habByName(name="wes")
-        seeder.seedWitEnds(palHby.db, witHabs=[wanHab, wilHab, wesHab], protocols=[Schemes.tcp], **KWA)
-        seeder.seedWitEnds(qinHby.db, witHabs=[wanHab, wilHab, wesHab], protocols=[Schemes.tcp], **KWA)
+        seeder.seedWitEnds(palHby.db, witHabs=[wanHab, wilHab, wesHab],
+                           protocols=[Schemes.tcp], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(qinHby.db, witHabs=[wanHab, wilHab, wesHab],
+                           protocols=[Schemes.tcp], witnessUrls=witnessUrls, **KWA)
 
         palHab = palHby.makeHab(name="pal", wits=[wanHab.pre, wilHab.pre, wesHab.pre], transferable=True, **KWA)
         qinHab = qinHby.makeHab(name="qin", wits=[wanHab.pre, wilHab.pre, wesHab.pre], transferable=True, **KWA)

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -28,19 +28,24 @@ def test_anchorer_explicit_version_propagates_to_postman():
 
 
 
-def test_anchorer(seeder):
+def test_anchorer(seeder, witnessPorter):
     with openHby(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, version=Vrsn_1_0) as wesHby, \
             openHby(name="pal", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_1_0) as palHby, \
             openHby(name="del", salt=Salter(raw=b'0123456789ghijkl').qb64, version=Vrsn_1_0) as delHby:
 
-        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+        witnessPorts, witnessUrls = witnessPorter("wes")
+        wesDoers = setupWitness(alias="wes", hby=wesHby,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
         witDoer = Receiptor(hby=palHby)
 
         bts = Anchorer(hby=delHby, version=Vrsn_1_0, kind=Kinds.json)
 
         wesHab = wesHby.habByName(name="wes")
-        seeder.seedWitEnds(palHby.db, witHabs=[wesHab], protocols=[Schemes.http], **KWA)
-        seeder.seedWitEnds(delHby.db, witHabs=[wesHab], protocols=[Schemes.http], **KWA)
+        seeder.seedWitEnds(palHby.db, witHabs=[wesHab],
+                           protocols=[Schemes.http], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(delHby.db, witHabs=[wesHab],
+                           protocols=[Schemes.http], witnessUrls=witnessUrls, **KWA)
 
         opts = dict(
             wesHab=wesHab,

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -48,7 +48,7 @@ def test_directing_defaults_use_hab_version_and_kind():
         assert reactor.parser.version == Vrsn_1_0
 
 
-def test_directing_basic():
+def test_directing_basic(unused_tcp_port_factory):
     """
     Test directing
     """
@@ -89,7 +89,8 @@ def test_directing_basic():
         tock = 0.03125
         doist = doing.Doist(limit=limit, tock=tock)
 
-        bobPort, evePort = _free_ports(2)
+        bobPort = unused_tcp_port_factory()
+        evePort = unused_tcp_port_factory()
 
         # setup bob
         bobHab = bobHby.makeHab(name="Bob", secrecies=bobSecrecies, **KWA)
@@ -188,14 +189,15 @@ def test_directing_basic():
     """End Test"""
 
 
-def test_runcontroller_demo():
+def test_runcontroller_demo(unused_tcp_port_factory):
     """
     Test demo runController function
     """
     ogler.resetLevel(level=logging.DEBUG)
 
     name = "bob"  # must be one of 'bob', 'sam', 'eve'
-    local, remote = _free_ports(2)
+    remote = unused_tcp_port_factory()
+    local = unused_tcp_port_factory()
     expire = 1.0
 
     raw = b"raw salt to test"

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -6,7 +6,6 @@ tests.db.dbing module
 
 import logging
 import os
-import socket
 
 from hio.base import doing
 from hio.help import ogler
@@ -17,21 +16,6 @@ from keri.core import Salter, Diger, MtrDex, incept
 from keri.app import Director, Directant, Reactor, openHby, runController
 from keri.demo import setupDemoController
 from tests.common import KWA
-
-
-def _free_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-def _free_ports(count):
-    ports = []
-    while len(ports) < count:
-        port = _free_port()
-        if port not in ports:
-            ports.append(port)
-    return ports
 
 
 def test_directing_defaults_use_hab_version_and_kind():

--- a/tests/app/test_forwarding.py
+++ b/tests/app/test_forwarding.py
@@ -90,22 +90,23 @@ def test_forwarding_legacy_wrapper_body_uses_v1_and_outer_framing_uses_environme
     assert counter_caps == [Vrsn_1_0, Version]
 
 
-def test_postman(seeder):
+def test_postman(seeder, witnessPorter):
     with openHab(name="test", transferable=True, temp=True, **KWA) as (hby, hab), \
             openHby(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=True, version=Vrsn_1_0) as wesHby, \
             openHby(name="repTest", temp=True, version=Vrsn_1_0) as recpHby:
 
+        witnessPorts, witnessUrls = witnessPorter("wes")
         mbx = Mailboxer(name="wes", temp=True)
         wesDoers = setupWitness(alias="wes",
                                 hby=wesHby,
                                 mbx=mbx,
-                                tcpPort=5634,
-                                httpPort=5644,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"],
                                 **KWA)
         wesHab = wesHby.habByName("wes")
-        seeder.seedWitEnds(hby.db, witHabs=[wesHab], **KWA)
-        seeder.seedWitEnds(wesHby.db, witHabs=[wesHab], **KWA)
-        seeder.seedWitEnds(recpHby.db, witHabs=[wesHab], **KWA)
+        seeder.seedWitEnds(hby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(wesHby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(recpHby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
 
         recpHab = recpHby.makeHab(name="repTest",
                                   transferable=True,
@@ -300,14 +301,15 @@ def test_forward_handler():
         assert count_after == count_before
 
 
-def test_essr_stream(seeder):
+def test_essr_stream(seeder, unused_tcp_port):
     with openHab(name="test", transferable=True, temp=True, **KWA) as (hby, hab), \
             openHab(name="recp", transferable=True, temp=True, **KWA) as (recpHby, recpHab):
 
+        httpPort = unused_tcp_port
         app = falcon.App()
         httpEnd = HttpEnd(rxbs=recpHab.psr.ims)
         app.add_route("/", httpEnd)
-        server = http.Server(port=5555, app=app)
+        server = http.Server(port=httpPort, app=app)
         httpServerDoer = http.ServerDoer(server=server)
 
         kvy = Kevery(db=hab.db)
@@ -327,7 +329,7 @@ def test_essr_stream(seeder):
                                         role=Roles.controller,
                                         stamp=help.nowIso8601(), **KWA))
 
-        msgs.extend(recpHab.makeLocScheme(url='http://127.0.0.1:5555',
+        msgs.extend(recpHab.makeLocScheme(url=f'http://127.0.0.1:{httpPort}',
                                           scheme=Schemes.http,
                                           stamp=help.nowIso8601(), **KWA))
         hab.psr.parse(ims=msgs)
@@ -407,17 +409,20 @@ def test_essr_stream(seeder):
         assert serder.ked["a"] == dict(msg="test", i=39)
 
 
-def test_essr_mbx(seeder):
+def test_essr_mbx(seeder, witnessPorter):
     with openHab(name="test", transferable=True, temp=True, **KWA) as (hby, hab), \
             openHby(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=True, version=Vrsn_1_0) as wesHby, \
             openHby(name="repTest", temp=True, version=Vrsn_1_0) as recpHby:
 
+        witnessPorts, witnessUrls = witnessPorter("wes")
         mbx = Mailboxer(name="wes", temp=True)
-        wesDoers = setupWitness(alias="wes", hby=wesHby, mbx=mbx, tcpPort=5634, httpPort=5644, **KWA)
+        wesDoers = setupWitness(alias="wes", hby=wesHby, mbx=mbx,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
         wesHab = wesHby.habByName("wes")
-        seeder.seedWitEnds(hby.db, witHabs=[wesHab], **KWA)
-        seeder.seedWitEnds(wesHby.db, witHabs=[wesHab], **KWA)
-        seeder.seedWitEnds(recpHby.db, witHabs=[wesHab], **KWA)
+        seeder.seedWitEnds(hby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(wesHby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
+        seeder.seedWitEnds(recpHby.db, witHabs=[wesHab], witnessUrls=witnessUrls, **KWA)
 
         recpHab = recpHby.makeHab(name="repTest", transferable=True, wits=[wesHab.pre], **KWA)
 

--- a/tests/app/test_habbing_v1.py
+++ b/tests/app/test_habbing_v1.py
@@ -6,8 +6,7 @@ tests.app.apping module
 import pytest
 
 import os
-import platform
-import shutil
+import uuid
 
 from hio.base import doing
 
@@ -138,11 +137,10 @@ def test_make_load_hab_with_habery_v1():
     assert os.path.exists(hby.ks.path)
 
     # test load from database
-    base = "hold"
     with openHby(base=base, temp=False, version=TEST_VERSION) as hby:  # default is temp=True
-        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
-        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
-        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", base, "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", base, "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", base, "test"))
 
         assert hby.inited
         assert len(hby.habs) == 2
@@ -177,24 +175,7 @@ def test_hab_rotate_with_witness_v1():
     """
     Reload from disk and rotate hab with witness
     """
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/test/phil-test.json'):
-            os.remove('/usr/local/var/keri/cf/test/phil-test.json')
-        if os.path.exists('/usr/local/var/keri/db/test/phil-test'):
-            shutil.rmtree('/usr/local/var/keri/db/test/phil-test')
-        if os.path.exists('/usr/local/var/keri/ks/test/phil-test'):
-            shutil.rmtree('/usr/local/var/keri/ks/test/phil-test')
-
-    name = "phil-test"
+    name = f"phil-test-v1-{uuid.uuid4().hex}"
 
     with openHby(name=name, base="test", temp=False, version=TEST_VERSION) as hby:
         hab = hby.makeHab(name=name, icount=1, wits=["BANkPDTGELcUDH-TBCEjo4dpCvUnO_DnOSNEaNlL--4M"], **KWA)
@@ -225,33 +206,18 @@ def test_hab_rotate_with_witness_v1():
 def test_habery_reinitialization_v1():
     """Test Reinitializing Habery and its Habs
     """
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/test/bob-test.json'):
-            os.remove('/usr/local/var/keri/cf/test/bob-test.json')
-        if os.path.exists('/usr/local/var/keri/db/test/bob-test'):
-            shutil.rmtree('/usr/local/var/keri/db/test/bob-test')
-        if os.path.exists('/usr/local/var/keri/ks/test/bob-test'):
-            shutil.rmtree('/usr/local/var/keri/ks/test/bob-test')
+    name = f"bob-test-v1-{uuid.uuid4().hex}"
+    base = f"test-v1-{uuid.uuid4().hex}"
+    salt = Salter(raw=b'0123456789abcdef').qb64
 
-    name = "bob-test"
-
-    with openHby(name=name, base="test", temp=False, clear=True, version=TEST_VERSION) as hby:
+    with openHby(name=name, base=base, temp=False, clear=True, salt=salt, version=TEST_VERSION) as hby:
         hab = hby.makeHab(name=name, icount=1, **KWA)
         oidig = hab.iserder.said
         opre = hab.pre
         opub = hab.kever.verfers[0].qb64
         odig = hab.kever.serder.said
 
-    with openHby(name=name, base="test", temp=False, version=TEST_VERSION) as hby:
+    with openHby(name=name, base=base, temp=False, salt=salt, version=TEST_VERSION) as hby:
 
         assert opre in hby.db.kevers  # read through cache
         assert opre in hby.db.prefixes

--- a/tests/app/test_habbing_v1.py
+++ b/tests/app/test_habbing_v1.py
@@ -73,32 +73,15 @@ def test_make_load_hab_with_habery_v1():
     assert not os.path.exists(hby.ks.path)
 
     # create not temp and then reload from not temp
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/hold/test.json'):
-            os.remove('/usr/local/var/keri/cf/hold/test.json')
-        if os.path.exists('/usr/local/var/keri/db/hold/test'):
-            shutil.rmtree('/usr/local/var/keri/db/hold/test')
-        if os.path.exists('/usr/local/var/keri/ks/hold/test'):
-            shutil.rmtree('/usr/local/var/keri/ks/hold/test')
-
-    base = "hold"
+    base = f"hold-v1-{uuid.uuid4().hex}"
     suePre = 'EAxe215BJ4Iy9r0mfoMEGVmHW8A4Avk3RYBC1A1_DZam'  # with temp=False
     bobPre = 'ENya5E5pvc6MVCe75huDK0QQhE4_64J55vCn4aKdXhR9'  # with temp=False
 
     with openHby(base=base, temp=False, salt=Salter(raw=b'0123456789abcdef').qb64, version=TEST_VERSION) as hby:  # default is temp=True
 
-        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
-        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
-        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", base, "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", base, "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", base, "test"))
 
         sueHab = hby.makeHab(name='Sue', **KWA)
         assert isinstance(sueHab, Hab)

--- a/tests/app/test_habbing_v2.py
+++ b/tests/app/test_habbing_v2.py
@@ -6,8 +6,7 @@ tests.app.apping module
 import pytest
 
 import os
-import platform
-import shutil
+import uuid
 
 from hio.base import doing
 
@@ -387,32 +386,15 @@ def test_make_load_hab_with_habery_v2():
     assert not os.path.exists(hby.ks.path)
 
     # create not temp and then reload from not temp
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "hold", "test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "hold", "test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "hold", "test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/hold/test.json'):
-            os.remove('/usr/local/var/keri/cf/hold/test.json')
-        if os.path.exists('/usr/local/var/keri/db/hold/test'):
-            shutil.rmtree('/usr/local/var/keri/db/hold/test')
-        if os.path.exists('/usr/local/var/keri/ks/hold/test'):
-            shutil.rmtree('/usr/local/var/keri/ks/hold/test')
-
-    base = "hold"
+    base = f"hold-v2-{uuid.uuid4().hex}"
     suePre = 'EEthprUZGcz6_jX5h04BR_ACNiuN9WifQv1VV9ep6KYS'  # with temp=False
     bobPre = 'EMaiUz76PInYC_V68dag8Ku3_FRLvGrQi7glZPntPEej'  # with temp=False
 
     with openHby(base=base, temp=False, salt=Salter(raw=b'0123456789abcdef').qb64) as hby:  # default is temp=True
 
-        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
-        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
-        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", base, "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", base, "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", base, "test"))
 
         sueHab = hby.makeHab(name='Sue', **KWA)
         assert isinstance(sueHab, Hab)
@@ -451,11 +433,10 @@ def test_make_load_hab_with_habery_v2():
     assert os.path.exists(hby.ks.path)
 
     # test load from database
-    base = "hold"
     with openHby(base=base, temp=False) as hby:  # default is temp=True
-        assert hby.cf.path.endswith(os.path.join("keri", "cf", "hold", "test.json"))
-        assert hby.db.path.endswith(os.path.join("keri", "db", "hold", "test"))
-        assert hby.ks.path.endswith(os.path.join("keri", "ks", "hold", "test"))
+        assert hby.cf.path.endswith(os.path.join("keri", "cf", base, "test.json"))
+        assert hby.db.path.endswith(os.path.join("keri", "db", base, "test"))
+        assert hby.ks.path.endswith(os.path.join("keri", "ks", base, "test"))
 
         assert hby.inited
         assert len(hby.habs) == 2
@@ -490,24 +471,7 @@ def test_hab_rotate_with_witness_v2():
     """
     Reload from disk and rotate hab with witness
     """
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "phil-test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "phil-test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "phil-test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/test/phil-test.json'):
-            os.remove('/usr/local/var/keri/cf/test/phil-test.json')
-        if os.path.exists('/usr/local/var/keri/db/test/phil-test'):
-            shutil.rmtree('/usr/local/var/keri/db/test/phil-test')
-        if os.path.exists('/usr/local/var/keri/ks/test/phil-test'):
-            shutil.rmtree('/usr/local/var/keri/ks/test/phil-test')
-
-    name = "phil-test"
+    name = f"phil-test-v2-{uuid.uuid4().hex}"
 
     with openHby(name=name, base="test", temp=False) as hby:
         hab = hby.makeHab(name=name, icount=1, wits=["BANkPDTGELcUDH-TBCEjo4dpCvUnO_DnOSNEaNlL--4M"], **KWA)
@@ -538,33 +502,18 @@ def test_hab_rotate_with_witness_v2():
 def test_habery_reinitialization_v2():
     """Test Reinitializing Habery and its Habs
     """
-    if platform.system() == "Windows":
-        drives = [d for d in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' if os.path.exists(f'{d}:\\')]
-        for drive in drives:
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json")):
-                os.remove(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "cf", "test", "bob-test.json"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "db", "test", "bob-test"))
-            if os.path.exists(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test")):
-                shutil.rmtree(os.path.join(os.path.sep, (drive + ":\\"), "usr", "local", "var", "keri", "ks", "test", "bob-test"))
-    else:
-        if os.path.exists('/usr/local/var/keri/cf/test/bob-test.json'):
-            os.remove('/usr/local/var/keri/cf/test/bob-test.json')
-        if os.path.exists('/usr/local/var/keri/db/test/bob-test'):
-            shutil.rmtree('/usr/local/var/keri/db/test/bob-test')
-        if os.path.exists('/usr/local/var/keri/ks/test/bob-test'):
-            shutil.rmtree('/usr/local/var/keri/ks/test/bob-test')
+    name = f"bob-test-v2-{uuid.uuid4().hex}"
+    base = f"test-v2-{uuid.uuid4().hex}"
+    salt = Salter(raw=b'0123456789abcdef').qb64
 
-    name = "bob-test"
-
-    with openHby(name=name, base="test", temp=False, clear=True) as hby:
+    with openHby(name=name, base=base, temp=False, clear=True, salt=salt) as hby:
         hab = hby.makeHab(name=name, icount=1, **KWA)
         oidig = hab.iserder.said
         opre = hab.pre
         opub = hab.kever.verfers[0].qb64
         odig = hab.kever.serder.said
 
-    with openHby(name=name, base="test", temp=False) as hby:
+    with openHby(name=name, base=base, temp=False, salt=salt) as hby:
 
         assert opre in hby.db.kevers  # read through cache
         assert opre in hby.db.prefixes

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -167,16 +167,20 @@ def test_qrymailbox_iter():
             next(mbi)
 
 
-def test_wit_query_ends(seeder):
+def test_wit_query_ends(seeder, witnessPorter):
     with openHby(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, version=Vrsn_1_0) as wesHby, \
             openHby(name="pal", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_1_0) as palHby:
-        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+        witnessPorts, witnessUrls = witnessPorter("wes")
+        wesDoers = setupWitness(alias="wes", hby=wesHby,
+                                tcpPort=witnessPorts["wes"]["tcp"],
+                                httpPort=witnessPorts["wes"]["http"], **KWA)
         # Pull the reger out of the Doers so the reger is reused and does not trigger an LMDB error on reuse
         wesReger = next(doer.baser for doer in wesDoers if isinstance(doer, basing.BaserDoer))
         witDoer = Receiptor(hby=palHby)
 
         wesHab = wesHby.habByName(name="wes")
-        seeder.seedWitEnds(palHby.db, witHabs=[wesHab], protocols=[Schemes.http], **KWA)
+        seeder.seedWitEnds(palHby.db, witHabs=[wesHab],
+                           protocols=[Schemes.http], witnessUrls=witnessUrls, **KWA)
 
         app = falcon.App()
         query_endpoint = QueryEnd(wesHab, reger=wesReger)

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -134,15 +134,17 @@ def test_oobi_share_v2(mockHelpingNowUTC):
           b'bPsKX1uF_zANa_6QBnjDl6L6k_VcMBPzNGDIGBU6N8xLbkYZNsH')
 
 
-def test_oobiery():
+def test_oobiery(unused_tcp_port_factory):
     with openHby(name="oobi", version=Vrsn_1_0) as hby:
+        locPort = unused_tcp_port_factory()
+        oobiPort = unused_tcp_port_factory()
         hab = hby.makeHab(name="oobi", **KWA)
         msgs = bytearray()
         msgs.extend(hab.makeEndRole(eid=hab.pre,
                                     role=Roles.controller,
                                     stamp=helping.nowIso8601(), **KWA))
 
-        msgs.extend(hab.makeLocScheme(url='http://127.0.0.1:5555',
+        msgs.extend(hab.makeLocScheme(url=f'http://127.0.0.1:{locPort}',
                                       scheme=Schemes.http,
                                       stamp=helping.nowIso8601(), **KWA))
         hab.psr.parse(ims=msgs)
@@ -150,20 +152,20 @@ def test_oobiery():
         oobiery = Oobiery(hby=hby)
 
         # Insert some that will fail
-        url = 'http://127.0.0.1:5644/oobi/EADqo6tHmYTuQ3Lope4mZF_4hBoGJl93cBHRekr_iD_A/witness' \
-              '/BAyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw?name=jim'
+        url = f'http://127.0.0.1:{oobiPort}/oobi/EADqo6tHmYTuQ3Lope4mZF_4hBoGJl93cBHRekr_iD_A/witness' \
+              f'/BAyRFMideczFZoapylLIyCjSdhtqVb31wZkRKvPfNqkw?name=jim'
         obr = OobiRecord(date=helping.nowIso8601())
         hby.db.oobis.pin(keys=(url,), val=obr)
-        url = 'http://127.0.0.1:5644/oobi/EBRzmSCFmG2a5U2OqZF-yUobeSYkW-a3FsN82eZXMxY0'
+        url = f'http://127.0.0.1:{oobiPort}/oobi/EBRzmSCFmG2a5U2OqZF-yUobeSYkW-a3FsN82eZXMxY0'
         obr = OobiRecord(date=helping.nowIso8601())
         hby.db.oobis.pin(keys=(url,), val=obr)
-        url = 'http://127.0.0.1:5644/oobi?name=Blind'
+        url = f'http://127.0.0.1:{oobiPort}/oobi?name=Blind'
         obr = OobiRecord(date=helping.nowIso8601())
         hby.db.oobis.pin(keys=(url,), val=obr)
 
         # Configure the MOOBI rpy URL and the controller URL
-        curl = f'http://127.0.0.1:5644/oobi/{hab.pre}/controller'
-        murl = f'http://127.0.0.1:5644/.well-known/keri/oobi/{hab.pre}?name=Root'
+        curl = f'http://127.0.0.1:{oobiPort}/oobi/{hab.pre}/controller'
+        murl = f'http://127.0.0.1:{oobiPort}/.well-known/keri/oobi/{hab.pre}?name=Root'
         obr = OobiRecord(date=helping.nowIso8601())
         hby.db.oobis.pin(keys=(murl,), val=obr)
 
@@ -172,7 +174,7 @@ def test_oobiery():
         moobi = MOOBIEnd(hab=hab, url=curl)
         app.add_route(f"/.well-known/keri/oobi/{hab.pre}", moobi)
 
-        server = http.Server(port=5644, app=app)
+        server = http.Server(port=oobiPort, app=app)
         httpServerDoer = http.ServerDoer(server=server)
 
         limit = 2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ https://docs.pytest.org/en/latest/pythonpath.html
 """
 import os
 import shutil
+import socket
 import multicommand
 import datetime
 
@@ -123,9 +124,57 @@ def seeder():
     return DbSeed
 
 
+def _unused_tcp_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def unused_tcp_port_factory():
+    """Return a callable that allocates currently free localhost TCP ports."""
+
+    produced = set()
+
+    def make():
+        for _ in range(100):
+            port = _unused_tcp_port()
+            if port not in produced:
+                produced.add(port)
+                return port
+
+        raise RuntimeError("unable to allocate an unused TCP port")
+
+    return make
+
+
+@pytest.fixture()
+def unused_tcp_port(unused_tcp_port_factory):
+    return unused_tcp_port_factory()
+
+
+@pytest.fixture()
+def witnessPorter(unused_tcp_port_factory):
+    """Allocate witness TCP/HTTP ports and matching endpoint URLs for one test."""
+
+    def make(*aliases):
+        ports = {}
+        urls = {}
+        for alias in aliases:
+            tcpPort = unused_tcp_port_factory()
+            httpPort = unused_tcp_port_factory()
+            ports[alias] = {"tcp": tcpPort, "http": httpPort}
+            urls[f"{alias}:tcp"] = f"tcp://127.0.0.1:{tcpPort}/"
+            urls[f"{alias}:http"] = f"http://127.0.0.1:{httpPort}/"
+
+        return ports, urls
+
+    return make
+
+
 class DbSeed:
     @staticmethod
-    def seedWitEnds(db, witHabs, protocols=None, version=Vrsn_1_0, kind=Kinds.json):
+    def seedWitEnds(db, witHabs, protocols=None, version=Vrsn_1_0, kind=Kinds.json, witnessUrls=None):
         """ Add endpoint and location records for well known test witnesses
 
         Args:
@@ -145,10 +194,12 @@ class DbSeed:
         if protocols is None:
             protocols = [Schemes.tcp, Schemes.http]
 
+        witnessUrls = witnessUrls if witnessUrls is not None else WitnessUrls
+
         for scheme in protocols:
             msgs = bytearray()
             for hab in witHabs:
-                url = WitnessUrls[f"{hab.name}:{scheme}"]
+                url = witnessUrls[f"{hab.name}:{scheme}"]
                 msgs.extend(hab.makeEndRole(eid=hab.pre,
                                             role=Roles.controller,
                                             stamp=help.nowIso8601(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,17 +131,30 @@ def _unused_tcp_port():
 
 
 @pytest.fixture(scope="session")
-def unused_tcp_port_factory():
+def unused_tcp_port_factory(tmp_path_factory):
     """Return a callable that allocates currently free localhost TCP ports."""
 
     produced = set()
+    base = tmp_path_factory.getbasetemp()
+    root = base.parent if os.environ.get("PYTEST_XDIST_WORKER") else base
+    reservationDir = root / "keripy-port-reservations"
+    reservationDir.mkdir(parents=True, exist_ok=True)
 
     def make():
         for _ in range(100):
             port = _unused_tcp_port()
-            if port not in produced:
-                produced.add(port)
-                return port
+            if port in produced:
+                continue
+
+            try:
+                fd = os.open(reservationDir / f"{port}.lock",
+                             os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                continue
+
+            os.close(fd)
+            produced.add(port)
+            return port
 
         raise RuntimeError("unable to allocate an unused TCP port")
 

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -5,7 +5,6 @@ tests.db.dbing module
 """
 import logging
 import os
-import socket
 
 import time
 from hio.base import doing
@@ -18,21 +17,6 @@ from keri.app import Reactor, Directant, openHby
 from keri.demo import (BobDirector, EveDirector,
                        SamDirector, CamDirector, setupDemoController)
 from tests.common import KWA
-
-
-def _free_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-def _free_ports(count):
-    ports = []
-    while len(ports) < count:
-        port = _free_port()
-        if port not in ports:
-            ports.append(port)
-    return ports
 
 
 def test_direct_mode_bob_eve_demo(unused_tcp_port_factory):
@@ -593,4 +577,3 @@ if __name__ == "__main__":
     test_run_bob_eve_demo()
     test_run_sam_eve_demo()
     test_indirect_mode_sam_cam_wit_demo()
-

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -593,3 +593,4 @@ if __name__ == "__main__":
     test_run_bob_eve_demo()
     test_run_sam_eve_demo()
     test_indirect_mode_sam_cam_wit_demo()
+

--- a/tests/demo/test_demo.py
+++ b/tests/demo/test_demo.py
@@ -35,7 +35,7 @@ def _free_ports(count):
     return ports
 
 
-def test_direct_mode_bob_eve_demo():
+def test_direct_mode_bob_eve_demo(unused_tcp_port_factory):
     """
     Test direct mode bob and eve
     """
@@ -74,7 +74,8 @@ def test_direct_mode_bob_eve_demo():
         tock = 0.03125
         doist = doing.Doist(limit=limit, tock=tock)
 
-        bobPort, evePort = _free_ports(2)
+        bobPort = unused_tcp_port_factory()
+        evePort = unused_tcp_port_factory()
 
         # setup bob
         bobHab = bobHby.makeHab(name="Bob", secrecies=bobSecrecies, **KWA)
@@ -165,7 +166,7 @@ def test_direct_mode_bob_eve_demo():
 
 
 
-def test_direct_mode_sam_eve_demo():
+def test_direct_mode_sam_eve_demo(unused_tcp_port_factory):
     """
     Test direct mode sam and eve
     """
@@ -205,7 +206,8 @@ def test_direct_mode_sam_eve_demo():
         tock = 0.03125
         doist = doing.Doist(limit=limit, tock=tock)
 
-        samPort, evePort = _free_ports(2)
+        samPort = unused_tcp_port_factory()
+        evePort = unused_tcp_port_factory()
 
         # setup Sam
         samHab = samHby.makeHab(name="Sam", secrecies=samSecrecies, **KWA)
@@ -308,7 +310,7 @@ def test_direct_mode_sam_eve_demo():
 
 
 
-def test_run_bob_eve_demo():
+def test_run_bob_eve_demo(unused_tcp_port_factory):
     """
     Test demo setupController and run with DoDoers and Doist
     """
@@ -320,8 +322,12 @@ def test_run_bob_eve_demo():
 
     raw = b"raw salt to test"
 
+    bobPort = unused_tcp_port_factory()
+    evePort = unused_tcp_port_factory()
+
     name = "bob"
-    local, remote = _free_ports(2)
+    remote = evePort
+    local = bobPort
 
     #  create bob secrecies
     secrecies = [[signer.qb64] for signer in
@@ -337,7 +343,8 @@ def test_run_bob_eve_demo():
                                **KWA)
 
     name = "eve"
-    remote, local = local, remote
+    remote = bobPort
+    local = evePort
 
     #  create eve secrecies
     secrecies = [[signer.qb64] for signer in
@@ -362,7 +369,7 @@ def test_run_bob_eve_demo():
     """End Test"""
 
 
-def test_run_sam_eve_demo():
+def test_run_sam_eve_demo(unused_tcp_port_factory):
     """
     Test demo setupController and run with DoDoers and Doist
     """
@@ -374,8 +381,12 @@ def test_run_sam_eve_demo():
 
     raw = b"raw salt to test"
 
+    samPort = unused_tcp_port_factory()
+    evePort = unused_tcp_port_factory()
+
     name = "sam"
-    local, remote = _free_ports(2)
+    remote = evePort
+    local = samPort
 
     #  create sam secrecies
     secrecies = [[signer.qb64] for signer in
@@ -392,7 +403,8 @@ def test_run_sam_eve_demo():
 
 
     name = "eve"
-    remote, local = local, remote
+    remote = samPort
+    local = evePort
 
      #  create eve secrecies
     secrecies = [[signer.qb64] for signer in
@@ -419,7 +431,7 @@ def test_run_sam_eve_demo():
     """End Test"""
 
 
-def test_indirect_mode_sam_cam_wit_demo():
+def test_indirect_mode_sam_cam_wit_demo(unused_tcp_port_factory):
     """ Test indirect mode, sam and cam with witness """
 
     ogler.resetLevel(level=logging.DEBUG)
@@ -438,7 +450,8 @@ def test_indirect_mode_sam_cam_wit_demo():
           openHby(name="sam", base="test", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_1_0) as samHby,
           openHby(name="wit", base="test", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_1_0) as witHby):
 
-        samPort, witPort = _free_ports(2)
+        samPort = unused_tcp_port_factory()
+        witPort = unused_tcp_port_factory()
 
         # setup the witness
         witHab = witHby.makeHab(name="Wit",

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -14,6 +14,10 @@ from hio.help import ogling
 from keri import help
 
 
+def loggerHandlerCount(ogler):
+    return sum((ogler.consoled, ogler.syslogged, ogler.filed and ogler.opened))
+
+
 def test_openogler():
     """
     Test context manager openOgler
@@ -242,7 +246,7 @@ def test_ogler():
     assert not os.path.exists(path)
     assert ogler.opened == False
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -258,18 +262,12 @@ def test_init_ogler():
     assert help.ogler.dirPath == None
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
 
     # nothing should log to file because .path not created and level critical
     # # nothing should log to console because level critical
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -277,10 +275,7 @@ def test_init_ogler():
     help.ogler.level = logging.DEBUG
     # nothing should log because .path not created despite loggin level debug
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -293,10 +288,7 @@ def test_init_ogler():
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -340,7 +332,7 @@ def test_init_ogler():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -355,10 +347,7 @@ def test_reset_levels():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
 
     # logger console: nothing should log  because level CRITICAL
     # logger file: nothing should log because .path not created
@@ -384,10 +373,7 @@ def test_reset_levels():
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because .path created
@@ -404,17 +390,15 @@ def test_reset_levels():
 
     # force reinit on different path
     ogler = help.ogler = ogling.initOgler(name="test", level=logging.DEBUG,
-                            temp=True, prefix='keri', reopen=True, clear=True)
+                            temp=True, prefix='keri', reopen=True, clear=True,
+                            syslogged=False)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
     assert ogler.path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
-    # Still have 3 handlers
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    # Still has handlers from the previous logger until recreated.
+    assert len(logger.handlers) == loggerHandlerCount(ogler)
 
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -432,10 +416,7 @@ def test_reset_levels():
 
     # recreate loggers to pick up new path
     logger = ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    assert len(logger.handlers) == loggerHandlerCount(ogler)
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because new path on file handler
@@ -453,7 +434,7 @@ def test_reset_levels():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -462,4 +443,3 @@ if __name__ == "__main__":
     test_ogler()
     test_init_ogler()
     test_reset_levels()
-

--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -14,10 +14,6 @@ from hio.help import ogling
 from keri import help
 
 
-def loggerHandlerCount(ogler):
-    return sum((ogler.consoled, ogler.syslogged, ogler.filed and ogler.opened))
-
-
 def test_openogler():
     """
     Test context manager openOgler
@@ -246,7 +242,7 @@ def test_ogler():
     assert not os.path.exists(path)
     assert ogler.opened == False
 
-    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -262,12 +258,18 @@ def test_init_ogler():
     assert help.ogler.dirPath == None
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
 
     # nothing should log to file because .path not created and level critical
     # # nothing should log to console because level critical
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -275,7 +277,10 @@ def test_init_ogler():
     help.ogler.level = logging.DEBUG
     # nothing should log because .path not created despite loggin level debug
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -288,7 +293,10 @@ def test_init_ogler():
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -332,7 +340,7 @@ def test_init_ogler():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -347,7 +355,10 @@ def test_reset_levels():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 1
+    else:
+        assert len(logger.handlers) == 2
 
     # logger console: nothing should log  because level CRITICAL
     # logger file: nothing should log because .path not created
@@ -373,7 +384,10 @@ def test_reset_levels():
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(help.ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because .path created
@@ -390,15 +404,17 @@ def test_reset_levels():
 
     # force reinit on different path
     ogler = help.ogler = ogling.initOgler(name="test", level=logging.DEBUG,
-                            temp=True, prefix='keri', reopen=True, clear=True,
-                            syslogged=False)
+                            temp=True, prefix='keri', reopen=True, clear=True)
     assert ogler.opened
     assert ogler.level == logging.DEBUG
     assert ogler.path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
-    # Still has handlers from the previous logger until recreated.
-    assert len(logger.handlers) == loggerHandlerCount(ogler)
+    # Still have 3 handlers
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -416,7 +432,10 @@ def test_reset_levels():
 
     # recreate loggers to pick up new path
     logger = ogler.getLogger()
-    assert len(logger.handlers) == loggerHandlerCount(ogler)
+    if platform.system() == "Windows":
+        assert len(logger.handlers) == 2
+    else:
+        assert len(logger.handlers) == 3
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because new path on file handler
@@ -434,7 +453,7 @@ def test_reset_levels():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -443,3 +462,4 @@ if __name__ == "__main__":
     test_ogler()
     test_init_ogler()
     test_reset_levels()
+


### PR DESCRIPTION
In this PR:

- Add pytest xdist to CI and run Ubuntu and macOS with pytest -n auto
- Keep Windows as two serial jobs, core and non core, because Windows xdist was slower and larger Python projects shard Windows when needed [DVC tests](https://github.com/iterative/dvc/blob/main/.github/workflows/tests.yaml#L57-L131), [conda lock tests](https://github.com/conda/conda-lock/blob/main/.github/workflows/test.yml#L33-L81)
- Move the flake8 checks into one Ubuntu lint job so lint runs once in parallel with tests instead of running on every test job
- Use GitHub matrix include to for each OS test command and add the two Windows jobs without adding separate workflow jobs
- Replace fixed localhost ports with dynamically allocated ports, then pass generated witness URLs into seedWitEnds so parallel workers do not reuse hardcoded endpoints
- Add shared xdist port reservations under the pytest base temp parent, using atomic lock file creation so worker processes don't reserve the same fixture issued port [xdist shared fixtures](https://pytest-xdist.readthedocs.io/en/stable/how-to.html#making-session-scoped-fixtures-execute-only-once), [xdist worker model](https://pytest-xdist.readthedocs.io/en/stable/how-it-works.html)
- Replace the path deletions in test_habbing_v1 and test_habbing_v2 with unique Habery names and bases, so the tests don't delete shared global state during parallel runs
  
  
Observed speedup:

- I ran these a bunch on my fork for timing estimates as I was developing
  - Windows: 16m15 avg before -> 5 min after  
  - Ubuntu: 2m11 avg before -> 1m23 after
  - macOS: 4m20 avg before -> 2m39 after