### PR TITLE
docs: fix Sphinx docstring formatting

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -34,7 +34,7 @@ def openHby(*, name="test", base="", temp=True, salt=None, **kwa):
     """Context manager that creates and yields a ``Habery`` instance, closing
     and optionally clearing it on exit.
 
-    Parameters::
+    Parameters:
         name (str): Name used for the shared databases and config file path.
         base (str): Optional path component inserted before ``name`` for
             further hierarchical differentiation of databases. Empty string

--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -711,7 +711,7 @@ class Matter:
         code (str): hard part of derivation code to indicate cypher suite
         hard (str): hard part of derivation code. alias for code
         soft (str | bytes): soft part of full code exclusive of xs xtra prepad.
-                    Empty when ss = 0.
+        Empty when ss = 0.
         both (str): hard + soft parts of full text code
         size (int | None): Number of quadlets/triplets of chars/bytes including
                             lead bytes of variable sized material (fs = None).
@@ -2560,7 +2560,7 @@ class Verser(Tagger):
         code (str): hard part of derivation code to indicate cypher suite
         hard (str): hard part of derivation code. alias for code
         soft (str): soft part of derivation code fs any.
-                    Empty when ss = 0.
+            Empty when ss = 0.
         both (str): hard + soft parts of full text code
         size (int | None): Number of quadlets/triplets of chars/bytes including
                             lead bytes of variable sized material (fs = None).
@@ -3526,7 +3526,7 @@ class Cigar(Matter):
     Properties:  (Inherited)
         .code is str derivation code to indicate cypher suite
         .size is size (int): number of quadlets when variable sized material besides
-                        full derivation code else None
+                    full derivation code else None
         .raw is bytes crypto material only without code
         .qb64 is str in Base64 fully qualified with derivation code + crypto mat
         .qb64b is bytes in Base64 fully qualified with derivation code + crypto mat

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -170,8 +170,6 @@ class Baser(LMDBer):
     Attributes:
         see superclass LMDBer for inherited attributes
 
-        kevers (dbdict): read-through cache of Kever instances indexed by
-            identifier prefix qb64
         prefixes (OrderedSet): local prefixes corresponding to habitats for
             this db
         groups (OrderedSet): group hab identifier prefixes for this db
@@ -1441,13 +1439,15 @@ class Baser(LMDBer):
     def current(self):
         """ Current property determines if we are at the current database migration state.
 
-         If the database version matches the library version return True
-         If the current database version is behind the current library version, check for migrations
-            - If there are migrations to run, return False
-            - If there are no migrations to run, reset database version to library version and return True
-         If the current database version is ahead of the current library version, raise exception
+        If the database version matches the library version return True
+        If the current database version is behind the current library version, check for migrations
 
-         """
+           - If there are migrations to run, return False
+           - If there are no migrations to run, reset database version to library version and return True
+
+        If the current database version is ahead of the current library version, raise exception
+
+        """
         if self.version == __version__:
             return True
 
@@ -1769,8 +1769,8 @@ class Baser(LMDBer):
         witnessed. Searchs from sn forward (default = 0).Searches all events in
         KEL of pre including disputed and/or superseded events.
         Returns the Serder of the first event with the anchored SealEvent seal,
-            None if not found
 
+            None if not found
 
         Parameters:
             pre (bytes|str): identifier of the KEL to search
@@ -1808,8 +1808,8 @@ class Baser(LMDBer):
 
         Returns:
             srdr (Serder): instance of the first event with the matching
-                           anchoring SealEvent seal,
-                        None if not found
+                anchoring SealEvent seal,
+                None if not found
 
         Parameters:
             pre (bytes|str): identifier of the KEL to search
@@ -1842,6 +1842,7 @@ class Baser(LMDBer):
         an anchored Seal with same Seal type as provided seal but in dict form.
         Searchs from sn forward (default = 0).
         Returns the Serder of the first found event with the anchored Seal seal,
+
             None if not found
 
         Parameters:

--- a/src/keri/demo/demoing.py
+++ b/src/keri/demo/demoing.py
@@ -77,9 +77,11 @@ class BobDirector(directing.Director):
     Inherited Properties:
         .tyme is float relative cycle time of associated Tymist .tyme obtained
             via injected .tymth function wrapper closure.
+
         .tymth is function wrapper closure returned by Tymist .tymeth() method.
             When .tymth is called it returns associated Tymist .tyme.
             .tymth provides injected dependency on Tymist tyme base.
+
         .tock is desired time in seconds between runs or until next run,
                  non negative, zero means run asap
 
@@ -94,6 +96,7 @@ class BobDirector(directing.Director):
     Hidden:
        ._tymth is injected function wrapper closure returned by .tymen() of
             associated Tymist instance that returns Tymist .tyme. when called.
+
        ._tock is hidden attribute for .tock property
     """
 
@@ -179,9 +182,11 @@ class SamDirector(directing.Director):
     Inherited Properties:
         .tyme is float relative cycle time of associated Tymist .tyme obtained
             via injected .tymth function wrapper closure.
+
         .tymth is function wrapper closure returned by Tymist .tymeth() method.
             When .tymth is called it returns associated Tymist .tyme.
             .tymth provides injected dependency on Tymist tyme base.
+
         .tock is desired time in seconds between runs or until next run,
                  non negative, zero means run asap
 
@@ -196,6 +201,7 @@ class SamDirector(directing.Director):
     Hidden:
        ._tymth is injected function wrapper closure returned by .tymen() of
             associated Tymist instance that returns Tymist .tyme. when called.
+
        ._tock is hidden attribute for .tock property
     """
 
@@ -304,9 +310,11 @@ class CamDirector(directing.Director):
     Inherited Properties:
         .tyme is float relative cycle time of associated Tymist .tyme obtained
             via injected .tymth function wrapper closure.
+
         .tymth is function wrapper closure returned by Tymist .tymeth() method.
             When .tymth is called it returns associated Tymist .tyme.
             .tymth provides injected dependency on Tymist tyme base.
+
         .tock is desired time in seconds between runs or until next run,
                  non negative, zero means run asap
 
@@ -321,6 +329,7 @@ class CamDirector(directing.Director):
     Hidden:
        ._tymth is injected function wrapper closure returned by .tymen() of
             associated Tymist instance that returns Tymist .tyme. when called.
+
        ._tock is hidden attribute for .tock property
     """
 
@@ -382,9 +391,11 @@ class EveDirector(directing.Director):
     Inherited Properties:
         .tyme is float relative cycle time of associated Tymist .tyme obtained
             via injected .tymth function wrapper closure.
+
         .tymth is function wrapper closure returned by Tymist .tymeth() method.
             When .tymth is called it returns associated Tymist .tyme.
             .tymth provides injected dependency on Tymist tyme base.
+
         .tock is desired time in seconds between runs or until next run,
                  non negative, zero means run asap
 
@@ -399,6 +410,7 @@ class EveDirector(directing.Director):
     Hidden:
        ._tymth is injected function wrapper closure returned by .tymen() of
             associated Tymist instance that returns Tymist .tyme. when called.
+
        ._tock is hidden attribute for .tock property
     """
 

--- a/src/keri/help/helping.py
+++ b/src/keri/help/helping.py
@@ -39,11 +39,10 @@ def sceil(r):
     Returns:
        sceil (int): value that is symmetric ceiling of r away from zero
 
-    Because int() provides a symmetric floor towards zero, just inc int(r) by:
-     1 when r - int(r) >  0  (r positive)
-    -1 when r - int(r) <  0  (r negative)
-     0 when r - int(r) == 0  (r integral already)
-    abs(r) > abs(int(r) or 0 when abs(r)
+    Because int() provides a symmetric floor towards zero, just increment
+    int(r) by 1 when r - int(r) > 0, -1 when r - int(r) < 0, or 0 when
+    r - int(r) == 0.  abs(r) > abs(int(r) or 0 when abs(r)
+
     """
     return (int(r) + isign(r - int(r)))
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -622,7 +622,7 @@ def cloneMessage(hby, said):
 def serializeMessage(hby, said, framed=False):
     """Fetch message and attachments from hby.db by said and then serialize them
 
-    Parameters::
+    Parameters:
         hby (Habery): environment with db
         said (str): of message
         framed (bool): True means may assume each message plus its attachments
@@ -632,7 +632,7 @@ def serializeMessage(hby, said, framed=False):
                             is isolated as frame when parsing so do need
                             attachment group when messagizing
 
-    Returns::
+    Returns:
         msg (bytearray):  message by said with attachments
 
     """


### PR DESCRIPTION
## Summary

Docstring-only Sphinx formatting corrections across six Keripy modules.

- Normalize parser-facing section and field-list formatting.
- Correct localized indentation and continuation layout.
- Add blank-line separation for repeated definition-list entries in demo director docstrings.

## Validation

- `git diff --check origin/main...HEAD`
- `check_doc_changes` reported `DOC_ONLY=1`.
- PR diff contains exactly six Python files.
- No runtime behavior, imports, signatures, tests, or executable Python code changed.
- Sphinx Doctor direct build confirmed the targeted demo director diagnostics were resolved.

## Scope

`src/keri/core/indexing.py` already matches `origin/main` and is intentionally excluded. The Dockerfile and unrelated historical branch changes are excluded.