### PR TITLE
parser raises error if no progress made

### DIFF
--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -808,6 +808,7 @@ class Parser:
                         continue  # captures immediate further nested groups
 
                 # process substream at current nesting level
+                presize = len(ims)
                 try:
 
 
@@ -831,6 +832,8 @@ class Parser:
                     # Non extraction errors happen after a message has been
                     # successfully extracted from stream
                     # so we don't flush rest of stream just resume
+                    if len(ims) == presize:
+                        raise ExtractionError(f"Parser made no progress on stream: {ex}") from ex
                     continue
 
 


### PR DESCRIPTION
- added a length check before/after the msgParsator call to check if no bytes were consumed and then raise an error so that tests don't hang 
- Hanging tests occurred when bumping the version to keri 2.0 because msgParsator raises an error if parser is v2 but you are passing v1 message codes and that error is not caught just and continued the while loop forever in groupParsator
- I tested bumping the kering.py version to v2 and the tests completed (with many failures naturally) but that is correct because it didn't hang