### PR TITLE
feat: backport kli vc schema import from main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'multidict>=6.0.5',
         'ordered-set>=4.1.0',
         'hio>=0.6.14,<0.6.18',
-        'multicommand>=1.0.0',
+        'multicommand==2.0.1',
         'jsonschema>=4.21.1',
         'falcon>=3.1.3',
         'hjson>=3.1.0',
@@ -111,4 +111,3 @@ setup(
         ]
     },
 )
-

--- a/src/keri/app/cli/commands/vc/schema/__init__.py
+++ b/src/keri/app/cli/commands/vc/schema/__init__.py
@@ -1,0 +1,8 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.vc.schema package
+
+"""
+
+from .import_ import ImportDoer

--- a/src/keri/app/cli/commands/vc/schema/import/__init__.py
+++ b/src/keri/app/cli/commands/vc/schema/import/__init__.py
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.vc.schema.import package
+
+"""
+
+from keri.app.cli.commands.vc.schema import import_
+
+parser = import_.importParser

--- a/src/keri/app/cli/commands/vc/schema/import_.py
+++ b/src/keri/app/cli/commands/vc/schema/import_.py
@@ -1,0 +1,75 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.vc.schema.import_ module
+
+"""
+import argparse
+
+from hio.base import doing
+
+from keri import help, kering
+from keri.app.cli.common import existing
+from keri.core.scheming import Schemer
+from keri.db.subing import SchemerSuber
+
+logger = help.ogler.getLogger()
+
+importParser = argparse.ArgumentParser(description="Import ACDC JSON schema file into the schema database")
+importParser.set_defaults(handler=lambda args: import_schema(args),
+                          transferable=True)
+importParser.add_argument("--name", "-n", help="keystore name and file location of KERI keystore", required=True)
+importParser.add_argument("--base", "-b", help="additional optional prefix to file location of KERI keystore",
+                          required=False, default="")
+importParser.add_argument("--passcode", "-p", help="21 character encryption passcode for keystore (is not saved)",
+                          dest="bran", default=None)
+importParser.add_argument("--schema", "-s", help="path to ACDC JSON schema file to import", required=True)
+
+
+def import_schema(args):
+    """Command line handler for importing ACDC JSON schema files."""
+    idoer = ImportDoer(name=args.name,
+                       base=args.base,
+                       bran=args.bran,
+                       schema=args.schema)
+    return [idoer]
+
+
+def importSchema(schemerSuber: SchemerSuber, path: str):
+    """
+    Imports a schema file from a given path to a provided schema DB.
+    """
+    try:
+        with open(path, "rb") as f:
+            raw = f.read()
+        schemer = Schemer(raw=raw)
+        schemerSuber.pin(keys=(schemer.said,), val=schemer)
+        return schemer.said
+    except FileNotFoundError:
+        raise kering.ConfigurationError(f"Schema file not found: {path}")
+    except kering.DeserializeError as ex:
+        raise kering.ConfigurationError(f"Invalid JSON in schema file: {ex}") from ex
+    except kering.ValidationError as ex:
+        raise kering.ConfigurationError(f"Schema validation failed: {ex}") from ex
+    except ValueError as ex:
+        raise kering.ConfigurationError(f"Error importing schema: {ex}") from ex
+
+
+class ImportDoer(doing.DoDoer):
+    """DoDoer that imports one ACDC JSON schema into an existing Habery."""
+
+    def __init__(self, name, base, bran, schema, **kwa):
+        self.schemaPath = schema
+        self.hby = existing.setupHby(name=name, base=base, bran=bran)
+
+        doers = [doing.doify(self.importDo)]
+        super(ImportDoer, self).__init__(doers=doers, **kwa)
+
+    def importDo(self, tymth, tock=0.0, **kwa):
+        """Import ACDC JSON schema file into the schema database."""
+        self.wind(tymth)
+        self.tock = tock
+        _ = (yield self.tock)
+
+        said = importSchema(self.hby.db.schema, self.schemaPath)
+        print(f"Schema successfully imported with SAID: {said}")

--- a/tests/app/cli/commands/vc/schema/test_import.py
+++ b/tests/app/cli/commands/vc/schema/test_import.py
@@ -1,0 +1,144 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.cli.test_kli_vc_schema_import module
+"""
+import multicommand
+import pytest
+
+from keri import kering
+from keri.app import directing, habbing
+from keri.app.cli import commands
+from keri.app.cli.common import existing
+from keri.app.cli.commands.vc.schema import import_ as import_cmd
+from keri.core import coring, scheming
+from keri.db import dbing, subing
+
+
+GLEIF_SCHEMA_SAID = "EMQWEcCnVRk1hatTNyK3sIykYSrrFvafX3bHQ9Gkk1kC"
+TMP_BASE_PATH = "base-schema-import"
+
+
+def isolatedBase(tmp_path):
+    """Return a relative KERI base namespace unique to each pytest test."""
+    return f"{TMP_BASE_PATH}-{tmp_path.parent.name}-{tmp_path.name}"
+
+
+def closeHby(hby, clear=True):
+    """Close Habery and its Configer."""
+    if hby is not None:
+        cf = getattr(hby, "cf", None)
+        hby.close(clear=clear)
+        if clear and cf is not None:
+            cf.close(clear=True)
+
+
+def importArgs(name="test", base=TMP_BASE_PATH, schema=None):
+    """Construct schema import args with the command parser."""
+    return import_cmd.importParser.parse_args(["--name", name,
+                                               "--base", base,
+                                               "--schema", schema])
+
+
+def seedSchemaFile(tmp_path, seeder):
+    """Write seed schema file to disk so we can test importing it with `kli vc schema import`"""
+    with habbing.openHby(name="schema-import-source", temp=True) as hby:
+        seeder.seedSchema(hby.db)
+        schemer = hby.db.schema.get(GLEIF_SCHEMA_SAID)
+        schema_path = tmp_path / "gleif-vlei-credential-schema.json"
+        schema_path.write_bytes(schemer.raw)
+        return schema_path, schemer
+
+
+def test_schema_import_cmd_name_correct(tmp_path):
+    parser = multicommand.create_parser(commands)
+    schema_path = tmp_path / "schema.json"
+
+    # "kli vc schema import" should work
+    args = parser.parse_args(["vc", "schema", "import",
+                              "--name", "test",
+                              "--schema", str(schema_path)])
+    assert args.handler is not None
+    assert args.name == "test"
+    assert args.schema == str(schema_path)
+    assert args.base == ""
+    assert args.bran is None
+    assert args.transferable is True
+
+    # "kli vc schema import_" should fail (trailing underscore invalid)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["vc", "schema", "import_", "--name", "test"])
+
+
+def test_schema_import_requires_schema_argument():
+    parser = multicommand.create_parser(commands)
+
+    with pytest.raises(SystemExit) as ex:
+        parser.parse_args(["vc", "schema", "import", "--name", "test"])
+
+    assert ex.value.code == 2
+
+
+def test_import_pins_to_schema_db(tmp_path, seeder):
+    schema_path, schemer = seedSchemaFile(tmp_path, seeder)
+    assert schemer.said == GLEIF_SCHEMA_SAID
+
+    with dbing.openLMDB(name="schema-import") as db:
+        schema = subing.SchemerSuber(db=db, subkey="schema.")
+        said = import_cmd.importSchema(schema, str(schema_path))
+
+        actual = schema.get(keys=(schemer.said,))
+        assert said == schemer.said
+        assert isinstance(actual, scheming.Schemer)
+        assert actual.said == schemer.said
+
+
+def test_schema_import_doer_pins_to_target_habery_db(tmp_path, seeder):
+    schema_path, schemer = seedSchemaFile(tmp_path, seeder)
+    salt = coring.Salter(raw=b'0123456789abcdef').qb64
+
+    with habbing.openHby(name="schema-import-target", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=salt) as hby:
+        try:
+            # assert schema is not in db prior to running import
+            assert hby.db.schema.get(keys=(schemer.said,)) is None
+            name = hby.name
+            base = hby.base
+            closeHby(hby, clear=False)
+
+            doers = import_cmd.import_schema(importArgs(name=name,
+                                                        base=base,
+                                                        schema=str(schema_path)))
+            # Run `kli vc schema import`
+            try:
+                directing.runController(doers=doers)
+            finally:
+                for doer in doers:
+                    closeHby(getattr(doer, "hby", None), clear=False)
+
+            rhby = existing.setupHby(name=name, base=base)
+            # assert schema is in DB after import command
+            try:
+                actual = rhby.db.schema.get(keys=(schemer.said,))
+                assert isinstance(actual, scheming.Schemer)
+                assert actual.said == schemer.said
+            finally:
+                closeHby(rhby, clear=False)
+        finally:
+            closeHby(hby)
+
+
+def test_import_missing_file_raises(tmp_path):
+    with dbing.openLMDB(name="schema-import-missing") as db:
+        schema = subing.SchemerSuber(db=db, subkey="schema.")
+        with pytest.raises(kering.ConfigurationError):
+            import_cmd.importSchema(schema, str(tmp_path / "missing.json"))
+
+
+def test_schema_import_invalid_json_raises_configuration_error(tmp_path):
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{bad json")
+
+    with dbing.openLMDB(name="schema-import-invalid") as db:
+        schema = subing.SchemerSuber(db=db, subkey="schema.")
+        with pytest.raises(kering.ConfigurationError):
+            import_cmd.importSchema(schema, str(schema_path))


### PR DESCRIPTION
Backports `kli vc schema import` from `main` to `1.1.44`. Credit to Phil for the [original impl](https://github.com/WebOfTrust/keripy/pull/1168).

This is part of a sequence of PRs for the export and import behavior.