### PR TITLE
feat: kli vc registry rename

### DIFF
--- a/src/keri/app/cli/commands/vc/registry/rename.py
+++ b/src/keri/app/cli/commands/vc/registry/rename.py
@@ -1,0 +1,124 @@
+# -*- encoding: utf-8 -*-
+"""
+KERI
+keri.kli.commands.vc.registry.rename module
+
+"""
+import argparse
+
+from hio.base import doing
+
+from keri.app.cli.common import existing
+from keri.vdr import credentialing, viring
+
+parser = argparse.ArgumentParser(description='Rename a local credential registry')
+parser.set_defaults(handler=lambda args: handler(args),
+                    transferable=True)
+parser.add_argument('--name', '-n', help='keystore name and file location of keystore', required=True)
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of keystore',
+                    required=False, default="")
+parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
+                    dest="bran", default=None)
+parser.add_argument('--registry-name', '-r', help='current local registry name', required=False, default=None)
+parser.add_argument('--registry-said', help='current registry SAID', required=False, default=None)
+parser.add_argument('--new-name', help='new local registry name', required=True)
+
+
+def handler(args):
+    if args.registry_said is None and args.registry_name is None:
+        parser.error("--registry-name or --registry-said is required")
+
+    return [RenameDoer(name=args.name,
+                       base=args.base,
+                       bran=args.bran,
+                       registryName=args.registry_name,
+                       registrySaid=args.registry_said,
+                       newName=args.new_name)]
+
+
+class RenameDoer(doing.Doer):
+    """Doer that renames a local credential registry."""
+
+    def __init__(self, name, base, bran, registryName, registrySaid, newName):
+        self.name = name
+        self.base = base
+        self.bran = bran
+        self.registryName = registryName
+        self.registrySaid = registrySaid
+        self.newName = newName
+
+        self.hby = existing.setupHby(name=self.name, base=self.base, bran=self.bran)
+        self.rgy = credentialing.Regery(hby=self.hby, name=self.name, base=self.base)
+
+        super(RenameDoer, self).__init__()
+
+    def recur(self, tyme):
+        """Command line registry rename handler."""
+        self.renameRegistry()
+        return True
+
+    def exit(self):
+        super(RenameDoer, self).exit()
+        self.close()
+
+    def renameRegistry(self):
+        """Rename the registry record in the local registry store."""
+        newName = self.newName
+        regs = self.rgy.reger.regs
+
+        oldName, regrec = self._registryRecord()
+        if regrec is None:
+            name = self.registrySaid if self.registrySaid is not None else self.registryName
+            print(f"Registry {name} not found")
+            return -1
+
+        if oldName == newName:
+            print(f"Registry {oldName} already has requested name")
+            return
+
+        existingReg = regs.get(keys=newName)
+        if existingReg is not None:
+            if existingReg.registryKey != regrec.registryKey or existingReg.prefix != regrec.prefix:
+                print(f"Registry name {newName} already exists")
+                return -1
+            regs.rem(keys=oldName)
+            print(f"Registry {oldName} renamed to {newName}")
+            return
+
+        ok = regs.put(keys=newName,
+                      val=viring.RegistryRecord(registryKey=regrec.registryKey,
+                                                prefix=regrec.prefix))
+        if not ok:
+            print(f"Unable to create registry name {newName}")
+            return -1
+
+        regs.rem(keys=oldName)
+        print(f"Registry {oldName} renamed to {newName}")
+
+    def _registryRecord(self):
+        """Return the local registry-name key and record to rename."""
+        regs = self.rgy.reger.regs
+
+        if self.registrySaid is not None:
+            regrec = regs.get(keys=self.registrySaid)
+            if regrec is not None and regrec.registryKey == self.registrySaid:
+                return self.registrySaid, regrec
+
+            for (name,), regrec in regs.getItemIter():
+                if regrec.registryKey == self.registrySaid:
+                    return name, regrec
+
+            return None, None
+
+        if self.registryName is None:
+            return None, None
+
+        return self.registryName, regs.get(keys=self.registryName)
+
+    def close(self):
+        if self.rgy is not None:
+            self.rgy.close()
+            self.rgy = None
+        if self.hby is not None:
+            self.hby.close(clear=self.hby.temp)
+            self.hby = None

--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -90,7 +90,13 @@ class rbdict(dict):
 
 @dataclass
 class RegistryRecord:
-    """ Registry Key keyed by Registry name
+    """Local registry-name mapping.
+
+    Attributes:
+        registryKey (str): qb64 registry identifier, stored from the registry
+            inception event prefix/SAID (`reg.regk`, VCP `i`/`pre`).
+        prefix (str): qb64 identifier prefix of the local issuer/controller
+            AID that owns the registry (`hab.pre`).
     """
     registryKey: str
     prefix: str

--- a/tests/app/cli/commands/vc/__init__.py
+++ b/tests/app/cli/commands/vc/__init__.py
@@ -1,0 +1,2 @@
+# -*- encoding: utf-8 -*-
+"""VC command tests."""

--- a/tests/app/cli/commands/vc/registry/__init__.py
+++ b/tests/app/cli/commands/vc/registry/__init__.py
@@ -1,0 +1,2 @@
+# -*- encoding: utf-8 -*-
+"""VC registry command tests."""

--- a/tests/app/cli/commands/vc/registry/test_rename.py
+++ b/tests/app/cli/commands/vc/registry/test_rename.py
@@ -1,0 +1,237 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.cli.commands.vc.registry.test_rename module
+"""
+from keri.app.cli.common import existing
+from keri import core
+import pytest
+
+from keri.app import directing, habbing
+from keri.app.cli.commands.vc.registry import rename as rename_cmd
+from keri.vdr import credentialing, viring
+
+# Temp Base Path for this test file's temporary LMDB and Configer paths.
+TMP_BASE_PATH = "base-reg-rename"
+
+
+def isolatedBase(tmp_path):
+    """
+    Return a relative KERI base namespace string unique to this pytest test.
+    Supports parallelization.
+
+    pytest's tmp_path is a per-test filesystem path, for example:
+    /.../pytest-42/test_registry_rename_branches0
+
+    KERI's base must be relative, so this helper uses only the final directory names:
+        tmp_path.parent.name  # "pytest-42"
+        tmp_path.name         # "test_registry_rename_branches0"
+
+    Result:
+        base-reg-rename-pytest-42-test_registry_rename_branches0
+
+    When openHby(..., name="rename", base=<base>, temp=False) opens KERI resources,
+    KERI/HIO combines this relative base with each resource tail:
+      - /usr/local/var/keri/ks/<base>/rename/data.mdb
+      - /usr/local/var/keri/db/<base>/rename/data.mdb
+      - /usr/local/var/keri/cf/<base>/rename/rename.json
+      - /usr/local/var/keri/reg/<base>/rename/data.mdb
+      - and so forth
+    For temp=True paths get created under /tmp/...
+    """
+    return f"{TMP_BASE_PATH}-{tmp_path.parent.name}-{tmp_path.name}"
+
+
+def closeRegery(rgy, clear=True):
+    """
+    Closes Regery
+    Needed to avoid LMDB's recently added strict double open errors (used to be just warnings).
+    """
+    reger = getattr(rgy, "reger", None)
+    if reger is not None and (reger.opened or clear):
+        reger.close(clear=clear)
+
+
+def closeHby(hby, clear=True):
+    """
+    Closes Habery and its Configer.
+    Needed to avoid LMDB's new strict double open errors.
+    """
+    if hby is not None:
+        cf = getattr(hby, "cf", None)
+        hby.close(clear=clear)
+        if clear and cf is not None:
+            cf.close(clear=True)
+
+
+def renameArgs(registry_name="old", new_name="new", name="test", base=TMP_BASE_PATH, registry_said=None):
+    """Constructs array of correct registry rename options for multicommand parser"""
+    args = ["--name", name,
+            "--base", base,
+            "--new-name", new_name]
+    if registry_name is not None:
+        args.extend(["--registry-name", registry_name])
+    if registry_said is not None:
+        args.extend(["--registry-said", registry_said])
+    return rename_cmd.parser.parse_args(args)
+
+
+def test_registry_rename_requires_new_name(capsys):
+    with pytest.raises(SystemExit) as ex:
+        rename_cmd.parser.parse_args(["--name", "test", "--registry-name", "old"])
+
+    assert ex.value.code == 2
+    assert "--new-name" in capsys.readouterr().err
+
+
+def test_registry_rename(tmp_path, capsys):
+    # Purpose: cover registry rename outcomes against a persistent keystore.
+    salt = core.Salter(raw=b'0123456789abcdef').qb64
+    with habbing.openHby(name="rename", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=salt) as hby:
+        rgy = None
+
+        def reopenRegistry():
+            rhby = existing.setupHby(name=hby.name, base=hby.base)
+            rrgy = credentialing.Regery(hby=rhby, name=rhby.name, base=rhby.base)
+            return rhby, rrgy
+
+        try:
+            # initial setup
+            hab = hby.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            rgy = credentialing.Regery(hby=hby, name=hby.name, base=hby.base)
+            reg = rgy.makeRegistry(prefix=hab.pre, name="old", noBackers=True)
+            record = viring.RegistryRecord(registryKey=reg.regk, prefix=hab.pre)
+            closeRegery(rgy, clear=False)
+            closeHby(hby, clear=False)
+
+            # missing registry
+            rhby, rrgy = reopenRegistry()
+            try:
+                assert rrgy.reger.regs.get(keys="old") == record
+                rrgy.reger.regs.rem(keys="old")
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs("missing", "new", name=hby.name, base=hby.base)))
+            assert capsys.readouterr().out == "Registry missing not found\n"
+
+            # registry already exists under new name
+            rhby, rrgy = reopenRegistry()
+            try:
+                rrgy.reger.regs.pin(keys="old", val=record)
+                rrgy.makeRegistry(prefix=hab.pre, name="new", noBackers=True)
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs("old", "new", name=hby.name, base=hby.base)))
+            assert capsys.readouterr().out == "Registry name new already exists\n"
+
+            # already exists with name
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs("old", "old", name=hby.name, base=hby.base)))
+            assert capsys.readouterr().out == "Registry old already has requested name\n"
+
+
+            # success when target name already maps to the same registry
+            rhby, rrgy = reopenRegistry()
+            try:
+                assert rrgy.reger.regs.get(keys="old") == record
+                rrgy.reger.regs.pin(keys="new", val=record)
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs("old", "new", name=hby.name, base=hby.base)))
+            assert capsys.readouterr().out == "Registry old renamed to new\n"
+
+            # success when target name does not exist yet
+            rhby, rrgy = reopenRegistry()
+            try:
+                # clean up from prior tests
+                assert rrgy.reger.regs.get(keys="old") is None
+                assert rrgy.reger.regs.get(keys="new") == record
+                rrgy.reger.regs.rem(keys="new")
+                rrgy.reger.regs.pin(keys="old", val=record)
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs("old", "new", name=hby.name, base=hby.base)))
+            assert capsys.readouterr().out == "Registry old renamed to new\n"
+
+            # Final assertions, that registry record exists in expected state and old one does not
+            rhby, rrgy = reopenRegistry()
+            try:
+                assert rrgy.reger.regs.get(keys="old") is None
+                assert rrgy.reger.regs.get(keys="new") == record
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+        finally:
+            closeRegery(rgy)
+            closeHby(hby)
+
+
+def test_registry_rename_accepts_registry_said(tmp_path, capsys):
+    # Purpose: verify registry rename can target the stable registry SAID, not only the current local name.
+    # Imported registries are initially keyed by SAID, so this is the production recovery path for friendly names.
+    salt = core.Salter(raw=b'0123456789abcdef').qb64
+    with habbing.openHby(name="rename-said", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=salt) as hby:
+        rgy = None
+        try:
+            # Initial setup
+            hab = hby.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            rgy = credentialing.Regery(hby=hby, name=hby.name, base=hby.base)
+            reg = rgy.makeRegistry(prefix=hab.pre, name="old", noBackers=True)
+            record = viring.RegistryRecord(registryKey=reg.regk, prefix=hab.pre)
+            closeRegery(rgy, clear=False)
+            closeHby(hby, clear=False)
+
+            # Rename by SAID lookup
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs(registry_name="missing",
+                           registry_said=reg.regk,
+                           new_name="new",
+                           name=hby.name,
+                           base=hby.base)))
+            assert capsys.readouterr().out == "Registry old renamed to new\n"
+
+            # setup for next test, reset registry record, store by SAID
+            rhby = existing.setupHby(name=hby.name, base=hby.base)
+            rrgy = credentialing.Regery(hby=rhby, name=rhby.name, base=rhby.base)
+            try:
+                assert rrgy.reger.regs.get(keys="old") is None
+                assert rrgy.reger.regs.get(keys="new") == record
+
+                rrgy.reger.regs.rem(keys="new")
+                rrgy.reger.regs.pin(keys=reg.regk, val=record)
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+
+            # Rename should work when registry_name is set to None (exists by SAID, not name)
+            directing.runController(doers=rename_cmd.handler(
+                renameArgs(registry_name=None,
+                           registry_said=reg.regk,
+                           new_name="renamed",
+                           name=hby.name,
+                           base=hby.base)))
+            assert capsys.readouterr().out == f"Registry {reg.regk} renamed to renamed\n"
+
+            # Assertions that registry record exists in expected state and old one does not
+            rhby = existing.setupHby(name=hby.name, base=hby.base)
+            rrgy = credentialing.Regery(hby=rhby, name=rhby.name, base=rhby.base)
+            try:
+                assert rrgy.reger.regs.get(keys=reg.regk) is None
+                assert rrgy.reger.regs.get(keys="renamed") == record
+            finally:
+                closeRegery(rrgy, clear=False)
+                closeHby(rhby, clear=False)
+        finally:
+            closeRegery(rgy)
+            closeHby(hby)


### PR DESCRIPTION
Adds support for renaming a registry. Can look up a registry by SAID or name. This is a part of a sequence of PRs for the export and import behavior