### PR TITLE
feat: --registry-name opt for multisig join

### DIFF
--- a/src/keri/app/cli/commands/multisig/join.py
+++ b/src/keri/app/cli/commands/multisig/join.py
@@ -29,6 +29,8 @@ parser.add_argument('--group', '-g', help='human-readable name for the multisig 
 parser.add_argument('--passcode', '-p', help='21 character encryption passcode for keystore (is not saved)',
                     dest="bran", default=None)  # passcode => bran
 parser.add_argument("--auto", "-Y", help="auto approve any delegation request non-interactively", action="store_true")
+parser.add_argument('--registry-name', '-r', help='human-readable name for a registry inception approval',
+                    default=None)
 
 
 def join(args):
@@ -43,8 +45,9 @@ def join(args):
     bran = args.bran
     auto = args.auto
     group = args.group
+    registryName = args.registry_name
 
-    joinDoer = JoinDoer(name=name, base=base, bran=bran, group=group, auto=auto)
+    joinDoer = JoinDoer(name=name, base=base, bran=bran, group=group, auto=auto, registryName=registryName)
 
     doers = [joinDoer]
     return doers
@@ -55,7 +58,7 @@ class JoinDoer(doing.DoDoer):
 
     """
 
-    def __init__(self, name, base, bran, group, auto=False):
+    def __init__(self, name, base, bran, group, auto=False, registryName=None):
         """ Create doer for polling for group multisig events and either approve automatically or prompt user
 
         Parameters:
@@ -65,8 +68,10 @@ class JoinDoer(doing.DoDoer):
             group (str): human-readable name for the multisig identifier prefix
             auto (bool): non-interactively auto approve any inception, rotation, interaction, or other event
                          while using the default group of "default-group"
+            registryName (str): optional local registry name to use when approving a registry inception
         """
         self.group = group
+        self.registryName = registryName
         self.hby = existing.setupHby(name=name, base=base, bran=bran)
         self.rgy = credentialing.Regery(hby=self.hby, name=name, base=base)
         self.hbyDoer = habbing.HaberyDoer(habery=self.hby)  # setup doer
@@ -630,7 +635,7 @@ class JoinDoer(doing.DoDoer):
 
         if approve:
             # Create and parse the event with "their" signatures
-            registryName = input("Name for Registry: ")
+            registryName = self._registryName()
             anc = embeds["anc"]
             aserder = serdering.SerderKERI(sad=anc)
             anc = bytearray(aserder.raw) + pathed["anc"]
@@ -671,6 +676,12 @@ class JoinDoer(doing.DoDoer):
             return True
 
         return False
+
+    def _registryName(self):
+        if self.registryName is not None:
+            return self.registryName
+
+        return input("Name for Registry: ")
 
     def iss(self, attrs):
         """  Handle issue messages

--- a/tests/app/cli/commands/multisig/test_join.py
+++ b/tests/app/cli/commands/multisig/test_join.py
@@ -1,0 +1,81 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.cli.commands.multisig.test_join module
+"""
+from contextlib import contextmanager
+
+import multicommand
+
+from keri import core
+from keri.app import habbing
+from keri.app.cli import commands
+from keri.app.cli.commands.multisig import join as multisig_join_cmd
+
+
+TMP_BASE_PATH = "base-multisig-join"
+
+
+def isolatedBase(tmp_path):
+    """Return a relative KERI base namespace unique to each pytest test."""
+    return f"{TMP_BASE_PATH}-{tmp_path.parent.name}-{tmp_path.name}"
+
+
+def closeHby(hby, clear=True):
+    """Close Habery and its Configer."""
+    if hby is not None:
+        cf = getattr(hby, "cf", None)
+        hby.close(clear=clear)
+        if clear and cf is not None:
+            cf.close(clear=True)
+
+
+def closeJoinDoer(doer, clear=True):
+    """Close resources opened by JoinDoer."""
+    if getattr(doer, "rgy", None) is not None:
+        doer.rgy.reger.close(clear=clear)
+    if getattr(doer, "notifier", None) is not None:
+        doer.notifier.noter.close(clear=clear)
+    closeHby(getattr(doer, "hby", None), clear=clear)
+
+
+@contextmanager
+def openJoinDoers(args):
+    """Open JoinDoer through command handler and close its resources."""
+    doers = args.handler(args)
+    try:
+        yield doers
+    finally:
+        for doer in doers:
+            closeJoinDoer(doer)
+
+
+def test_multisig_join_registry_name_avoids_auto_prompt(tmp_path, monkeypatch):
+    name = "prompt"
+    base = isolatedBase(tmp_path)
+    salt = core.Salter(raw=b'0123456789abcdef').qb64
+
+    with habbing.openHby(name=name, base=base, temp=False, clear=True, salt=salt):
+        pass
+
+    parser = multicommand.create_parser(commands)
+    args = parser.parse_args(["multisig", "join",
+                              "--name", name,
+                              "--base", base,
+                              "--group", "g",
+                              "--auto",
+                              "--registry-name", "r1"])
+
+    with openJoinDoers(args) as doers:
+        doer = doers[0]
+        assert isinstance(doer, multisig_join_cmd.JoinDoer)
+        assert doer.registryName == "r1"
+
+        # Monkeypatching just used to prove registryName skips interactive input.
+        monkeypatch.setattr("builtins.input",
+                            lambda prompt: (_ for _ in ()).throw(AssertionError("unexpected prompt")))
+        assert doer._registryName() == "r1"
+
+        doer.registryName = None
+        # Monkeypatching just used to provide deterministic interactive CLI input.
+        monkeypatch.setattr("builtins.input", lambda prompt: "typed-r1")
+        assert doer._registryName() == "typed-r1"


### PR DESCRIPTION
Allows "kli multisig join" to be non-interactive (no CLI input) by specifying --registry-name

This is one of a sequence of PRs for the export and import behavior.