### PR TITLE
feat: --all-registries, --all-credentials for kli vc export

### DIFF
--- a/src/keri/app/cli/commands/vc/export.py
+++ b/src/keri/app/cli/commands/vc/export.py
@@ -36,6 +36,18 @@ parser.add_argument("--chains", help="export any chained credentials", action="s
 parser.add_argument("--full", help="export credential, signatures, tels, kels and full chains", action="store_true")
 parser.add_argument("--files", help="export artifacts to individual files keyed off of AIDs or SAIDS, default is "
                                     "stdout", action="store_true")
+# Supports full state sync for late-joining multisig members
+parser.add_argument("--all-registries", action="store_true",
+                    help="Export all registries the controller has for the --alias (the group or AID), "
+                         "along with their full registry TEL events (VCP + anc history). Combine with --kels "
+                         "to also pull anchoring KEL events.")
+parser.add_argument("--all-credentials", action="store_true",
+                    help="Export all credentials (ACDCs + ACDC TELs (ISS/REV) + anchors) the controller has "
+                         "for the --alias. Combine with --tels/--kels/--full as usual.")
+parser.add_argument("--include-revoked", action="store_true",
+                    help="When using --all-credentials (or the default all-creds walk), include revoked ACDCs "
+                         "and their REV TEL events. Default (flag absent): only un-revoked/current credentials. "
+                         "The default is the safe choice for bringing a new multisig member up to date.")
 
 
 def export_credentials(args):
@@ -57,18 +69,25 @@ def export_credentials(args):
                     tels=tels,
                     kels=kels,
                     chains=chains,
-                    files=args.files)
+                    files=args.files,
+                    allRegs=args.all_registries,
+                    allCreds=args.all_credentials,
+                    inclRev=args.include_revoked)
     return [ed]
 
 
 class ExportDoer(doing.DoDoer):
 
-    def __init__(self, name, alias, base, bran, said, tels, kels, chains, files):
+    def __init__(self, name, alias, base, bran, said, tels, kels, chains, files,
+                 allRegs=False, allCreds=False, inclRev=False):
         self.said = said
         self.tels = tels
         self.kels = kels
         self.chains = chains
         self.files = files
+        self.allRegs = allRegs
+        self.allCreds = allCreds
+        self.inclRev = inclRev
 
         self.hby = existing.setupHby(name=name, base=base, bran=bran)
         self.hab = self.hby.habByName(alias)
@@ -77,6 +96,23 @@ class ExportDoer(doing.DoDoer):
         doers = [doing.doify(self.exportDo)]
 
         super(ExportDoer, self).__init__(doers=doers)
+
+    def exit(self, deeds=None):
+        """Close command-owned resources on completion."""
+        super(ExportDoer, self).exit(deeds=deeds)
+        self.close()
+
+    def close(self):
+        """Release command-owned resources."""
+        if self.rgy is not None:
+            self.rgy.close()
+            self.rgy = None
+
+        if self.hby is not None:
+            self.hby.close(clear=self.hby.temp)
+            self.hby = None
+
+        self.hab = None
 
     def exportDo(self, tymth, tock=0.0, **kwa):
         """ Export credential from store and any related material
@@ -94,14 +130,29 @@ class ExportDoer(doing.DoDoer):
         self.tock = tock
         _ = (yield self.tock)
 
-        if self.said is None:
-            for (said,), _ in self.rgy.reger.creds.getItemIter():
-                self.outputCred(said=said)
+        # walk registries for this hab, emit TELs (+ anchors via kels).
+        if self.allRegs:
+            self.outputAllRegistriesForHab()
 
-        else:
+        # walk credentials, respecting --include-revoked.
+        doAllCreds = self.allCreds or (self.said is None and not self.allRegs)
+        if doAllCreds:
+            for (said,), _ in self.rgy.reger.creds.getItemIter():
+                if not self.inclRev and self._isRevoked(said):
+                    continue
+                self.outputCred(said=said)
+        elif self.said is not None:
             self.outputCred(said=self.said)
 
     def outputCred(self, said):
+        """
+        Outputs the following for a single ACDC credential, depending on:
+        - issuer KEL events   (if --kels)
+        - registry TEL events (if --tels)
+        - ACDC TEL events     (if --tels)
+        - ACDCs chained on ACDC identified by SAID
+        - ACDC anchors for issuance and revocation events
+        """
         creder, *_ = self.rgy.reger.cloneCred(said=said)
 
         if self.kels:
@@ -130,12 +181,39 @@ class ExportDoer(doing.DoDoer):
 
         (prefixer, seqner, saider) = self.rgy.reger.cancs.get(keys=(creder.said,))
         if self.files:
-            f = open(f"{creder.said}-acdc.cesr", 'w')
-            f.write(signing.serialize(creder, prefixer, seqner, saider))
-            f.close()
+            with open(f"{creder.said}-acdc.cesr", 'wb') as f:
+                f.write(signing.serialize(creder, prefixer, seqner, saider))
         else:
             sys.stdout.write(signing.serialize(creder, prefixer, seqner, saider).decode("utf-8"))
             sys.stdout.flush()
+
+    def outputAllRegistriesForHab(self):
+        """Export all registries and full TELs for the target hab."""
+        if self.hab is None:
+            return
+        pre = self.hab.pre
+        # Walk regs Komer (name -> RegistryRecord with registryKey and prefix).
+        for (name,), regrec in self.rgy.reger.regs.getItemIter():
+            if regrec.prefix != pre:
+                continue
+            regk = regrec.registryKey
+            self.outputTEL(regk)
+            # If --kels, also emit gid's KEL to get IXNs for the VCP, ISS/REV, etc.
+            if self.kels:
+                self.outputKEL(pre)
+
+    def _isRevoked(self, said):
+        """Return True if the credential identified by said has a revocation event in its TEL."""
+        try:
+            for msg in self.rgy.reger.clonePreIter(pre=said):
+                serder = serdering.SerderKERI(raw=msg)
+                ilk = serder.ked.get("t")
+                if ilk in ("rev", "brv"):
+                    return True
+        except Exception:
+            # If we cannot walk the TEL for any reason, be conservative and do not filter it out.
+            return False
+        return False
 
     def outputTEL(self, regk):
         f = None

--- a/tests/app/cli/commands/vc/test_export.py
+++ b/tests/app/cli/commands/vc/test_export.py
@@ -1,0 +1,250 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.app.cli.commands.vc.test_export module
+"""
+import os
+from contextlib import contextmanager
+
+from keri import core
+from keri.app import directing, habbing
+from keri.app.cli.commands.vc import export as export_cmd
+from keri.vdr import credentialing
+
+
+CLI_BASE = "test-vc-export"
+
+
+def isolatedBase(tmp_path):
+    """Return a command-addressable base namespace unique to this pytest test."""
+    return f"{CLI_BASE}-{tmp_path.parent.name}-{tmp_path.name}"
+
+
+def closeRegery(rgy, clear=True):
+    reger = getattr(rgy, "reger", None)
+    if reger is not None and (reger.opened or clear):
+        reger.close(clear=clear)
+
+
+def closeHby(hby, clear=True):
+    if hby is not None:
+        cf = getattr(hby, "cf", None)
+        hby.close(clear=clear)
+        if clear and cf is not None:
+            cf.close(clear=True)
+
+
+@contextmanager
+def pushd(path):
+    """Temporarily run file-writing command helpers from path."""
+    cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
+
+
+@contextmanager
+def openExportDoer(*args, **kwa):
+    """Open ExportDoer for direct method tests and close command-owned resources."""
+    doer = None
+    try:
+        doer = export_cmd.ExportDoer(*args, **kwa)
+        yield doer
+    finally:
+        if doer is not None:
+            doer.close()
+
+
+def test_export_credentials_full_sets_related_flags(tmp_path, seeder):
+    # Purpose: keep parser-to-doer flag expansion honest for the new full state-sync export options.
+    with habbing.openHby(name="export-flags", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=core.Salter(raw=b'0123456789abcdef').qb64) as source:
+        doer = None
+        try:
+            source.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            seeder.seedSchema(source.db)
+            closeHby(source, clear=False)
+
+            args = export_cmd.parser.parse_args(["--name", source.name,
+                                                 "--base", source.base,
+                                                 "--alias", "issuer",
+                                                 "--full",
+                                                 "--all-registries",
+                                                 "--all-credentials",
+                                                 "--include-revoked"])
+
+            doers = export_cmd.export_credentials(args)
+            assert len(doers) == 1
+            doer = doers[0]
+            assert doer.tels is True
+            assert doer.kels is True
+            assert doer.chains is True
+            assert doer.allRegs is True
+            assert doer.allCreds is True
+            assert doer.inclRev is True
+
+            doer.close()
+            assert doer.hby is None
+            assert doer.rgy is None
+            assert doer.hab is None
+            doer.close()
+        finally:
+            if doer is not None:
+                doer.close()
+            closeHby(source)
+
+
+def test_export_selection_revocation_and_registry_file_branches(tmp_path, seeder, helpers):
+    # Purpose: verify ExportDoer selects the right registry and credential material for file bundles.
+    with habbing.openHby(name="export-selection", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=core.Salter(raw=b'0123456789abcdef').qb64) as source:
+        rgy = None
+        try:
+            hab = source.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            other = source.makeHab(name="other", icount=1, isith="1", ncount=1, nsith="1")
+            seeder.seedSchema(source.db)
+            rgy = credentialing.Regery(hby=source, name=source.name, base=source.base)
+            rgy, active_issuer = helpers.makeRegistry(source, hab, name="active", rgy=rgy)
+            active, *_ = helpers.issueCredential(source, hab, issuer=active_issuer,
+                                                 subject=dict(LEI="active"), rgy=rgy)
+            rgy, revoked_issuer = helpers.makeRegistry(source, hab, name="revoked", rgy=rgy)
+            revoked, *_ = helpers.issueCredential(source, hab, issuer=revoked_issuer,
+                                                  subject=dict(LEI="revoked"), revoked=True, rgy=rgy)
+            other_reg = rgy.makeRegistry(prefix=other.pre, name="other", noBackers=True)
+            closeRegery(rgy, clear=False)
+            closeHby(source, clear=False)
+
+            def acdcPath(out, creder):
+                return out / f"{creder.said}-acdc.cesr"
+
+            def telPath(out, pre):
+                return out / f"{pre}-tel.cesr"
+
+            def kelPath(out, pre):
+                return out / f"{pre}-kel.cesr"
+
+            def runExport(dirname, **kwa):
+                out = tmp_path / dirname
+                out.mkdir()
+                opts = dict(name=source.name,
+                            alias="issuer",
+                            base=source.base,
+                            bran=None,
+                            said=None,
+                            tels=False,
+                            kels=False,
+                            chains=False,
+                            files=True)
+                opts.update(kwa)
+                with pushd(out):
+                    doer = export_cmd.ExportDoer(**opts)
+                    directing.runController(doers=[doer])
+                    assert doer.hby is None
+                    assert doer.rgy is None
+                    assert doer.hab is None
+                return out
+
+            default = runExport("default")
+            assert acdcPath(default, active).exists()
+            assert not acdcPath(default, revoked).exists()
+
+            include_revoked = runExport("include-revoked", inclRev=True)
+            assert acdcPath(include_revoked, active).exists()
+            assert acdcPath(include_revoked, revoked).exists()
+
+            all_regs = runExport("all-regs", allRegs=True, kels=True)
+            assert telPath(all_regs, active_issuer.regk).exists()
+            assert telPath(all_regs, revoked_issuer.regk).exists()
+            assert kelPath(all_regs, hab.pre).exists()
+            assert not telPath(all_regs, other_reg.regk).exists()
+            assert not acdcPath(all_regs, active).exists()
+
+            regs_and_creds = runExport("regs-and-creds", allRegs=True, allCreds=True, tels=True, kels=True)
+            assert telPath(regs_and_creds, active_issuer.regk).exists()
+            assert telPath(regs_and_creds, active.said).exists()
+            assert acdcPath(regs_and_creds, active).exists()
+            assert not acdcPath(regs_and_creds, revoked).exists()
+
+            selected = runExport("selected", said=active.said)
+            assert acdcPath(selected, active).exists()
+            assert not acdcPath(selected, revoked).exists()
+        finally:
+            closeRegery(rgy)
+            closeHby(source)
+
+
+def test_export_output_file_and_stdout_paths(tmp_path, capsys, seeder, helpers):
+    # Purpose: cover the two operator-facing output modes for exported KEL/TEL/ACDC material.
+    with habbing.openHby(name="export-paths", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=core.Salter(raw=b'0123456789abcdef').qb64) as source:
+        rgy = None
+        try:
+            hab = source.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            seeder.seedSchema(source.db)
+            rgy = credentialing.Regery(hby=source, name=source.name, base=source.base)
+            rgy, issuer = helpers.makeRegistry(source, hab, rgy=rgy)
+            creder, *_ = helpers.issueCredential(source, hab, issuer=issuer,
+                                                 subject=dict(LEI="254900OPPU84GM83MG36"), rgy=rgy)
+            closeRegery(rgy, clear=False)
+            closeHby(source, clear=False)
+
+            with openExportDoer(name=source.name, alias="issuer", base=source.base, bran=None,
+                                said=None, tels=False, kels=False, chains=False, files=False) as doer:
+                doer.outputTEL(issuer.regk)
+                doer.outputKEL(hab.pre)
+                doer.outputCred(creder.said)
+                out = capsys.readouterr().out
+                assert issuer.regk in out
+                assert hab.pre in out
+                assert creder.said in out
+
+                doer.files = True
+                with pushd(tmp_path):
+                    doer.outputTEL(issuer.regk)
+                    doer.outputKEL(hab.pre)
+                    doer.outputCred(creder.said)
+                assert (tmp_path / f"{issuer.regk}-tel.cesr").read_text()
+                assert (tmp_path / f"{hab.pre}-kel.cesr").read_text()
+                assert (tmp_path / f"{creder.said}-acdc.cesr").read_bytes()
+        finally:
+            closeRegery(rgy)
+            closeHby(source)
+
+
+def test_export_output_credential_related_material_and_chain_branches(tmp_path, capsys, seeder, helpers):
+    # Purpose: verify a credential export can include issuer KELs, registry/credential TELs, and chained ACDCs.
+    with habbing.openHby(name="export-chain-source", base=isolatedBase(tmp_path),
+                         temp=False, clear=True, salt=core.Salter(raw=b'0123456789abcdef').qb64) as source:
+        rgy = None
+        try:
+            hab = source.makeHab(name="issuer", icount=1, isith="1", ncount=1, nsith="1")
+            seeder.seedSchema(source.db)
+            rgy = credentialing.Regery(hby=source, name=source.name, base=source.base)
+            rgy, child_issuer = helpers.makeRegistry(source, hab, name="child", rgy=rgy)
+            child, *_ = helpers.issueCredential(source, hab, issuer=child_issuer,
+                                                subject=dict(LEI="child"), rgy=rgy)
+            rgy, root_issuer = helpers.makeRegistry(source, hab, name="root", rgy=rgy)
+            root, *_ = helpers.issueCredential(source, hab,
+                                               issuer=root_issuer,
+                                               subject=dict(LEI="root"),
+                                               source={"d": child.said,
+                                                       "child": {"n": child.said},
+                                                       "o": "ignored"},
+                                               rgy=rgy)
+            closeRegery(rgy, clear=False)
+            closeHby(source, clear=False)
+
+            with openExportDoer(name=source.name, alias="issuer", base=source.base, bran=None,
+                                said=None, tels=True, kels=True, chains=True, files=False) as doer:
+                doer.outputCred(root.said)
+
+                out = capsys.readouterr().out
+                assert hab.pre in out
+                assert child.regi in out
+                assert child.said in out
+                assert root.regi in out
+                assert root.said in out
+        finally:
+            closeRegery(rgy)
+            closeHby(source)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from keri.help import helping
 from keri import help
 
 from keri.app.cli import commands
+from keri.vc import proving
+from keri.vdr import credentialing, verifying
 
 WitnessUrls = {
     "wan:tcp": "tcp://127.0.0.1:5632/",
@@ -321,6 +323,74 @@ class DbSeed:
 
 
 class Helpers:
+
+    @staticmethod
+    def makeRegistry(hby, hab, name="reg", rgy=None):
+        """Creates a registry for an AID and processes escrows once so registry is in tevers"""
+        rgy = rgy if rgy is not None else credentialing.Regery(hby=hby, name=hby.name, base=hby.base, temp=True)
+        issuer = rgy.makeRegistry(prefix=hab.pre, name=name, noBackers=True)
+        rseal = eventing.SealEvent(issuer.regk, "0", issuer.regd)._asdict()
+        hab.interact(data=[rseal])
+        seqner = coring.Seqner(sn=hab.kever.sn)
+        issuer.anchorMsg(pre=issuer.regk,
+                         regd=issuer.regd,
+                         seqner=seqner,
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        rgy.processEscrows()
+        assert issuer.regk in rgy.reger.tevers
+
+        return rgy, issuer
+
+    @staticmethod
+    def issueCredential(hby, hab, issuer, subject, revoked=False, source=None, rgy=None,
+                        schema="EMQWEcCnVRk1hatTNyK3sIykYSrrFvafX3bHQ9Gkk1kC"):
+        """
+        Issues a credential with a simple subject and schema.
+        Can ask for revoked credential.
+        Processes escrows enough to fully handle issuance related events.
+        """
+        rgy = rgy if rgy is not None else credentialing.Regery(hby=hby,
+                                                               name=hby.name,
+                                                               base=hby.base,
+                                                               reger=issuer.reger,
+                                                               temp=True)
+        subject = dict(subject)
+        subject.setdefault("d", "")
+        subject.setdefault("i", hab.pre)
+        subject.setdefault("dt", helping.nowIso8601())
+        _, data = coring.Saider.saidify(sad=subject, code=coring.MtrDex.Blake3_256, label=coring.Saids.d)
+        creder = proving.credential(issuer=hab.pre,
+                                    schema=schema,
+                                    data=data,
+                                    source=source or {},
+                                    status=issuer.regk)
+
+        iss = issuer.issue(said=creder.said)
+        rseal = eventing.SealEvent(iss.pre, "0", iss.said)._asdict()
+        hab.interact(data=[rseal])
+        issuer.anchorMsg(pre=iss.pre,
+                         regd=iss.said,
+                         seqner=coring.Seqner(sn=hab.kever.sn),
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        rgy.processEscrows()
+
+        if revoked:
+            rev = issuer.revoke(said=creder.said)
+            rseal = eventing.SealEvent(rev.pre, "1", rev.said)._asdict()
+            hab.interact(data=[rseal])
+            issuer.anchorMsg(pre=rev.pre,
+                             regd=rev.said,
+                             seqner=coring.Seqner(sn=hab.kever.sn),
+                             saider=coring.Saider(qb64=hab.kever.serder.said))
+            rgy.processEscrows()
+
+        vry = verifying.Verifier(hby=hby, reger=rgy.reger)
+        prefixer = coring.Prefixer(qb64=creder.said)
+        seqner = coring.Seqner(sn=0)
+        saider = coring.Saider(qb64=iss.said)
+        vry.processCredential(creder, prefixer, seqner, saider)
+
+        return creder, prefixer, seqner, saider
 
     @staticmethod
     def remove_test_dirs(name):


### PR DESCRIPTION
This allows export of all registries and credentials from a keystore so that each does not have to be specified by VC SAID. 
- `--all-registries` exports all registry TEL events for an AID
- `--all-credentials` exports all unrevoked ACDC TEL events and the ACDCs themselves

This includes, of course, the existing KEL plus delegator export behavior in the existing export code.

Includes optional `--include-revoked` flag to export revoked ACDCs, which defaults to false because new multisig members do not need to worry about ACDCs that cannot have further state changes.