### PR TITLE
changed logger calls to be more robust passing in ex not ex.args[0] s…

### DIFF
--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -551,15 +551,15 @@ class Parser:
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser sized group error: %s", ex.args[0])
+                    logger.exception("Parser sized group error: %s", ex)
                 else:
-                    logger.error("Parser sized group error: %s", ex.args[0])
+                    logger.error("Parser sized group error: %s", ex)
 
             except (ColdStartError, ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s", ex.args[0])
+                    logger.exception("Parser msg extraction error: %s", ex)
                 else:
-                    logger.error("Parser msg extraction error: %s", ex.args[0])
+                    logger.error("Parser msg extraction error: %s", ex)
                 del ims[:]  # delete rest of stream to force cold restart
 
             except (ValidationError, Exception) as ex:  # non Extraction Error
@@ -635,15 +635,15 @@ class Parser:
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery sized group error: %s", ex.args[0])
+                    logger.exception("Kevery sized group error: %s", ex)
                 else:
-                    logger.error("Kevery sized group error: %s", ex.args[0])
+                    logger.error("Kevery sized group error: %s", ex)
 
             except (ColdStartError, ExtractionError, Exception) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Kevery msg extraction error: %s", ex.args[0])
+                    logger.exception("Kevery msg extraction error: %s", ex)
                 else:
-                    logger.error("Kevery msg extraction error: %s", ex.args[0])
+                    logger.error("Kevery msg extraction error: %s", ex)
                 del ims[:]  # delete rest of stream to force cold restart
 
             if processive:
@@ -744,24 +744,24 @@ class Parser:
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser sized group error: %s", ex.args[0])
+                    logger.exception("Parser sized group error: %s", ex)
                 else:
-                    logger.error("Parser sized group error: %s", ex.args[0])
+                    logger.error("Parser sized group error: %s", ex)
 
             except (ColdStartError, ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Parser msg extraction error: %s", ex.args[0])
+                    logger.exception("Parser msg extraction error: %s", ex)
                 else:
-                    logger.error("Parser msg extraction error: %s", ex.args[0])
+                    logger.error("Parser msg extraction error: %s", ex)
                 del ims[:]  # delete rest of stream to force cold restart
 
             except (ValidationError, Exception) as ex:  # non Extraction Error
                 # Non extraction errors happen after successfully extracted from stream
                 # so we don't flush rest of stream just resume
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.exception("Parser msg non-extraction error: %s", ex.args[0])
+                    logger.exception("Parser msg non-extraction error: %s", ex)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.error("Parser msg non-extraction error: %s", ex.args[0])
+                    logger.error("Parser msg non-extraction error: %s", ex)
             yield
 
         return result  # should never return


### PR DESCRIPTION
…ince an exection that is raise without args will then raise an error in the logger call when logging ex.args[0] instead of ex.