### PR TITLE
docs: clean up selected core and database docstrings

### DIFF
--- a/src/keri/core/indexing.py
+++ b/src/keri/core/indexing.py
@@ -233,7 +233,17 @@ class Indexer:
     def __init__(self, raw=None, code=IdrDex.Ed25519_Sig, index=0, ondex=None,
                  qb64b=None, qb64=None, qb2=None, strip=False, **kwa):
         """
-        Validate as fully qualified
+        Validate as fully qualified.
+
+        Initialize from either raw cryptographic material with a valid
+        derivation code, or from fully qualified material.
+
+        Needs either (raw and code) or qb64b or qb64 or qb2.
+        Otherwise raises EmptyMaterialError.
+        When raw and code are provided, index defaults to 0 and the code
+        is validated against the length of raw, then .raw is assigned.
+        When qb64b, qb64, or qb2 is provided, .raw, .code, .index, and
+        .ondex are extracted from the qualified material.
 
         Parameters:
             raw (bytes): unqualified crypto material usable for crypto operations
@@ -241,17 +251,10 @@ class Indexer:
             index (int): main index offset into list or length of material
             ondex (int | None): other index offset into list or length of material
             qb64b (bytes): fully qualified Base64 crypto material
-            qb64 (str | bytes):  fully qualified Base64 crypto material
+            qb64 (str | bytes): fully qualified Base64 crypto material
             qb2 (bytes): fully qualified binary crypto material
             strip (bool): True means strip counter contents from input stream
                 bytearray after parsing qb64b or qb2. False means do not strip
-
-        Needs either (raw and code and index) or qb64b or qb64 or qb2
-        Otherwise raises EmptyMaterialError
-        When raw and code provided then validate that code is correct
-        for length of raw  and assign .raw
-        Else when qb64b or qb64 or qb2 provided, extract and assign .raw,
-        .code, .index, and .ondex.
 
         """
         if raw is not None:  # raw provided

--- a/src/keri/core/indexing.py
+++ b/src/keri/core/indexing.py
@@ -233,7 +233,7 @@ class Indexer:
     def __init__(self, raw=None, code=IdrDex.Ed25519_Sig, index=0, ondex=None,
                  qb64b=None, qb64=None, qb2=None, strip=False, **kwa):
         """
-        Validate as fully qualified.
+        Validate as fully qualified
 
         Parameters:
             raw (bytes): unqualified crypto material usable for crypto operations
@@ -246,13 +246,12 @@ class Indexer:
             strip (bool): True means strip counter contents from input stream
                 bytearray after parsing qb64b or qb2. False means do not strip
 
-        Notes:
-            Needs either (raw and code and index) or qb64b or qb64 or qb2.
-            Otherwise raises EmptyMaterialError.
-            When raw and code provided then validate that code is correct for
-            length of raw and assign .raw.
-            Else when qb64b or qb64 or qb2 provided extract and assign .raw,
-            .code, .index, .ondex.
+        Needs either (raw and code and index) or qb64b or qb64 or qb2
+        Otherwise raises EmptyMaterialError
+        When raw and code provided then validate that code is correct
+        for length of raw  and assign .raw
+        Else when qb64b or qb64 or qb2 provided, extract and assign .raw,
+        .code, .index, and .ondex.
 
         """
         if raw is not None:  # raw provided

--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -283,7 +283,7 @@ class Schemer:
     Hidden Attributes:
         ._raw (bytes): of serialized schema only
         ._sed (JSON): schema dict
-        ._kind (schema): kind string value (see namedtuple coring.Serials), supported kinds are 'JSONSchema'
+        ._kind (schema): kind string value (see namedtuple coring.Serials). Supported kinds: 'JSONSchema'.
         ._code (default): code for .saider
         ._saider (Saider): instance of digest of .raw
 
@@ -301,11 +301,11 @@ class Schemer:
         Parameters:
             raw (bytes): of serialized schema
             sed (dict): dict or None
-                if None its deserialized from raw
+                  if None its deserialized from raw
             typ (JSONSchema): type of schema
             kind (serialization): kind string value or None (see namedtuple coring.Serials)
-                supported kinds are 'json', 'cbor', 'msgpack', 'binary'
-                if kind (None): then its extracted from ked or raw
+                supported kinds are 'json', 'cbor', 'msgpack', 'binary';
+                if kind is None, then it is extracted from ked or raw
             code (MtrDex): default digest code
             verify (bool): True means verify said(s) of given raw or sad.
                            Raises ValidationError if verification fails

--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -283,7 +283,8 @@ class Schemer:
     Hidden Attributes:
         ._raw (bytes): of serialized schema only
         ._sed (JSON): schema dict
-        ._kind (schema): kind string value (see namedtuple coring.Serials). Supported kinds: 'JSONSchema'.
+        ._kind (str): serialization kind string value (see Kinds in keri.kering).
+            Supported kinds: 'JSON', 'MGPK', 'CBOR'.
         ._code (default): code for .saider
         ._saider (Saider): instance of digest of .raw
 
@@ -301,11 +302,12 @@ class Schemer:
         Parameters:
             raw (bytes): of serialized schema
             sed (dict): dict or None
-                  if None its deserialized from raw
-            typ (JSONSchema): type of schema
-            kind (serialization): kind string value or None (see namedtuple coring.Serials)
-                supported kinds are 'json', 'cbor', 'msgpack', 'binary';
-                if kind is None, then it is extracted from ked or raw
+                if None it is deserialized from raw
+            typ (JSONSchema): schema handler used for serialization and
+                deserialization
+            kind (str | None): serialization kind (see Kinds in keri.kering).
+                Supported: 'JSON', 'MGPK', 'CBOR'.
+                If None, serialization defaults to JSON.
             code (MtrDex): default digest code
             verify (bool): True means verify said(s) of given raw or sad.
                            Raises ValidationError if verification fails

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -329,11 +329,15 @@ class LMDBer(filing.Filer):
         headDirPath is head directory path
         path is full directory path
         perm is numeric os permissions for directory and/or file(s)
-        filed (bool): True means .path ends in file; False means .path ends in directory
+        filed (bool): True means .path ends in file.
+                       False means .path ends in directory
+
         mode (str): file open mode if filed
         fext (str): file extension if filed
         file (File)
-        opened is Boolean, True means directory created and if file then file is opened. False otherwise
+
+        opened is Boolean, True means directory created and if file then file
+                is opened. False otherwise
 
     Attributes:
         env (lmdb.env): LMDB main (super) database environment


### PR DESCRIPTION
## Summary

Cleans up selected docstrings in three files:

- `src/keri/core/indexing.py`
- `src/keri/core/scheming.py`
- `src/keri/db/dbing.py`

## Changes

- Reformat the `Indexer` initialization notes as direct docstring prose.
- Clarify `Schemer` hidden-attribute and parameter descriptions.
- Reflow `LMDBer` file/open-state descriptions for clearer generated documentation.

## Scope

- Documentation and docstring formatting only.
- No runtime logic, imports, signatures, tests, configuration, or dependency changes.
- No Ruff or `noqa` suppressions.

## Validation

- The current PR diff contains exactly the three files listed above.
- `git diff --check` passed.
