### PR TITLE
fix(eventing): make escrowQueryNotFoundEvent idempotent (avoid per-pass re-write/fsync)

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5604,6 +5604,14 @@ class Kevery:
         """
         cigars = cigars if cigars is not None else []
         dgkey = dgKey(prefixer.qb64b, serder.saidb)
+        if self.db.dtss.get(keys=dgkey) is not None:
+            # Already escrowed. processQueryNotFound re-runs this on every loop pass
+            # while the queried KEL is absent; the writes below are then all no-ops
+            # (put is overwrite=False, qnfs.add dedups) but each still opens a write
+            # transaction whose commit fsyncs. Returning here keeps the escrow and its
+            # first-seen datetime (so TimeoutQNF still fires) without re-fsyncing the
+            # entry every pass.
+            return
         self.db.dtss.put(keys=dgkey, val=Dater())
         self.db.sigs.put(keys=dgkey, vals=sigers)
         self.db.evts.put(keys=(prefixer.qb64b, serder.saidb), val=serder)

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -170,3 +170,51 @@ def test_query_not_found_escrow():
 
         subHab.kvy.processQueryNotFound()
         assert subHab.db.qnfs.get(dgkey) == []
+
+
+def test_query_not_found_escrow_is_idempotent():
+    """A qry the node cannot answer is re-processed on every loop pass; escrowing it must
+    be idempotent so the loop does not re-write (and re-fsync) an unchanged escrow each
+    pass. Once escrowed, re-processing performs NO further escrow writes, the entry and its
+    first-seen datetime are untouched, and a later-arriving KEL still resolves it."""
+    with openHby() as hby, openHby() as hby1, openHby() as hby2:
+        inqHab = hby.makeHab(name="inquisitor")
+        subHab = hby1.makeHab(name="subject")
+        tgtHab = hby2.makeHab(name="target")  # an AID the subject does NOT have
+
+        # subject must know the inquisitor's KEL to verify the query's source signature
+        subHab.psr.parseOne(ims=inqHab.msgOwnInception(framed=True))
+        assert inqHab.pre in subHab.kevers
+        assert tgtHab.pre not in subHab.kevers  # so the query is genuinely unanswerable
+
+        # drive the real query path: keripy parks it via escrowQueryNotFoundEvent
+        qry = inqHab.query(tgtHab.pre, route="ksn", src=inqHab.pre)
+        serder = SerderKERI(raw=qry)
+        dgkey = dgKey(inqHab.pre, serder.saidb)
+        qkeys = (inqHab.pre, serder.said)
+        subHab.psr.parseOne(ims=bytearray(qry))
+        assert subHab.db.qnfs.get(keys=qkeys)  # keripy parked it
+        dt0 = subHab.db.dtss.get(keys=dgkey)
+        assert dt0 is not None
+
+        # Spy on the escrow datetime write: re-processing an already-escrowed entry must
+        # not write it again. Without the idempotency guard, escrowQueryNotFoundEvent re-runs
+        # every pass and re-issues dtss.put (a no-op overwrite=False put, but still a write
+        # transaction that commits+fsyncs) -- the churn this fix removes.
+        writes = []
+        orig_put = subHab.db.dtss.put
+        subHab.db.dtss.put = lambda *a, **k: (writes.append(1), orig_put(*a, **k))[1]
+        try:
+            for _ in range(5):
+                subHab.kvy.processQueryNotFound()
+        finally:
+            subHab.db.dtss.put = orig_put
+        assert writes == []  # no re-write of the already-escrowed entry across 5 passes
+        assert subHab.db.qnfs.get(keys=qkeys)                   # entry still parked
+        assert subHab.db.dtss.get(keys=dgkey).qb64 == dt0.qb64  # datetime untouched
+
+        # once the queried KEL arrives, the escrow still resolves and is removed
+        subHab.psr.parseOne(ims=tgtHab.msgOwnInception(framed=True))
+        assert tgtHab.pre in subHab.kevers
+        subHab.kvy.processQueryNotFound()
+        assert subHab.db.qnfs.get(keys=qkeys) == []


### PR DESCRIPTION
## Problem

Fixes #1473.

A `qry` a node cannot answer (a `/query` for an AID whose KEL it does not hold) is parked in `db.qnfs` and re-processed on **every loop pass** via `processEscrows → processQueryNotFound → processQuery`. While the queried KEL is absent, each pass re-runs `escrowQueryNotFoundEvent`, which re-issues four writes — `dtss.put` / `sigs.put` / `evts.put` / `qnfs.add`. All four are **no-ops** (the `put`s are `overwrite=False` and the keys already exist; `qnfs.add` dedups), yet each still opens a `write=True` LMDB transaction whose commit **fsyncs** (env opened with the default `sync=True`).

So a single unanswerable query drives redundant no-op commits+fsyncs on the loop thread **every tick for the escrow's full `TimeoutQNF` (300 s) lifetime** — sustained write/fsync churn on a node continually queried for AIDs it does not hold (e.g. a witness hit by scanners / mailbox pollers), badly amplified where fsync is slow (macOS `F_FULLFSYNC`).

The datetime is **first-seen, not re-stamped** (`put` does not overwrite), so `TimeoutQNF` still purges the entry — this is wasteful repeated I/O, **not** an unbounded leak.

## Fix

Make `escrowQueryNotFoundEvent` idempotent: if the entry is already escrowed (its datetime is present), return without re-writing.

```python
dgkey = dgKey(prefixer.qb64b, serder.saidb)
if self.db.dtss.get(keys=dgkey) is not None:
    return
```

The first escrow, the resolution path (when the queried KEL later arrives, `processQuery` answers and unescrows), and the timeout (first-seen datetime preserved) are all unchanged — only the redundant per-pass re-writes are removed.

## Test

Adds `tests/app/test_querying.py::test_query_not_found_escrow_is_idempotent`: parks a **genuinely unanswerable** query through the real path (signed `qry` parsed by the subject's `Kevery`, so keripy parks it via `escrowQueryNotFoundEvent`), then asserts that re-processing it for several passes performs **no further escrow writes** (spying on `dtss.put`), the entry and its datetime are untouched, and a later-arriving KEL still resolves and removes the escrow. The test fails without the guard and passes with it.

## Verification

Against `main` (2.0.0-dev): `tests/app/test_querying.py`, `tests/core/test_kevery.py`, `tests/core/test_escrow.py`, `tests/core/test_witness.py` all pass (20 + 3). Mechanism also confirmed empirically on the pinned `1.2.13` line.
