### PR TITLE
Log kli witness start failures and prevent startup stalls (#238)

### DIFF
--- a/ref/ChangeLog.md
+++ b/ref/ChangeLog.md
@@ -2,6 +2,17 @@
 
 ## 2.0.0-dev6
 
+*** kli witness start now logs startup/runtime failures at CRITICAL (with traceback) so
+they are visible even at the default --loglevel, and closes the Habery on failure so a
+failed start leaves no stale LMDB lock. An encrypted keystore started with no passcode on
+a non-TTY now fails fast with a logged AuthError instead of stalling on an interactive
+getpass prompt. --loglevel is normalized so a lowercase level (e.g. debug) is honored.
+See WebOfTrust/keripy#238.
+
+*** kli witness start: --logfile is deprecated in favor of --logdir. The witness writes
+its log file under the given directory; --logfile is retained as an alias whose directory
+portion is used (it previously mis-set the log head directory to the file path itself).
+
 *** peer.exchange has been replaced with a combination of either core.eventing.exchange
 or peer.specialExhange. peer.specialExchange supports the embeds and diger parameters
 and returns a tuple of (exn, atc) exn Serder instance and atc attachments bytearray.

--- a/src/keri/cli/commands/witness/start.py
+++ b/src/keri/cli/commands/witness/start.py
@@ -7,6 +7,8 @@ Witness command line interface
 """
 import argparse
 import logging
+import os
+import sys
 
 from hio.help import ogler
 
@@ -16,6 +18,9 @@ from ...common import Parsery, setupHby
 
 from ....app import (Habery, HaberyDoer, Keeper, Configer,
                      runController, setupWitness)
+from ....kering import AuthError
+
+logger = ogler.getLogger()
 
 
 d = "Runs KERI witness controller.\n"
@@ -50,16 +55,42 @@ parser.add_argument("--certpath", action="store", required=False, default=None)
 parser.add_argument("--cafilepath", action="store", required=False, default=None)
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument("--logdir", action="store", required=False, default=None,
+                    help="directory under which the witness writes its log file. "
+                         "If not defined, logs are not written to a file.")
 parser.add_argument("--logfile", action="store", required=False, default=None,
-                    help="path of the log file. If not defined, logs will not be written to the file.")
+                    help="DEPRECATED: use --logdir. Path to a log file; only its directory is used "
+                         "(the file name and log subdirectory are derived internally).")
 
 
 def launch(args):
-    ogler.level = logging.getLevelName(args.loglevel)
-    if args.logfile is not None:
-        ogler.headDirPath = args.logfile
+    # Normalize (.upper()) so getLevelName returns a numeric level; a lowercase
+    # value would otherwise become the invalid string "Level debug" and silently
+    # break level filtering. The ogler.getLogger() call below applies this level to
+    # the shared logger every keri module holds. (Fatal startup failures are logged
+    # at CRITICAL in runWitness so they remain visible at the default level.)
+    ogler.level = logging.getLevelName(args.loglevel.upper())
+
+    logdir = args.logdir
+    deprecatedLogfile = args.logfile is not None
+    if deprecatedLogfile:
+        # --logfile is deprecated: ogler derives the log file name from --name and
+        # its subdirectory from its own prefix, so only the directory is meaningful.
+        logdir = os.path.dirname(args.logfile) or "."
+
+    if logdir is not None:
+        ogler.headDirPath = logdir
         ogler.reopen(name=args.name, temp=False, clear=True)
-    logger = ogler.getLogger()
+
+    # Re-fetch so the configured level and any newly attached file handler are
+    # applied to the shared logger used throughout this command.
+    ogler.getLogger()
+
+    if deprecatedLogfile:
+        # Print (not log) so the notice is visible regardless of --loglevel, and
+        # report the actual resolved path so operators know where the log landed.
+        print(f"kli witness start: --logfile is deprecated; use --logdir. "
+              f"Logging to {ogler.path}", file=sys.stderr)
 
     logger.info("\n******* Starting Witness for %s listening: http/%s, tcp/%s "
                 ".******\n\n", args.name, args.http, args.tcp)
@@ -98,20 +129,41 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
     if configFile:
         cf = Configer(name=configFile, headDirPath=configDir, temp=False, reopen=True, clear=False)
 
-    if aeid is None:
-        hby = Habery(name=name, base=base, bran=bran, cf=cf)
-    else:
-        hby = setupHby(name=name, base=base, bran=bran, cf=cf)
+    hby = None
+    try:
+        if aeid is None:
+            hby = Habery(name=name, base=base, bran=bran, cf=cf)
+        else:
+            # Encrypted keystore requires a passcode. Only prompt interactively when
+            # attached to a TTY; a witness started from a script/service with no
+            # passcode must fail fast instead of stalling on getpass for input.
+            if not bran and not sys.stdin.isatty():
+                raise AuthError(f"Witness {name!r} keystore is encrypted but no passcode "
+                                f"was provided and stdin is not a TTY; pass --passcode "
+                                f"to start non-interactively.")
+            hby = setupHby(name=name, base=base, bran=bran, cf=cf)
 
-    hbyDoer = HaberyDoer(habery=hby)  # setup doer
-    doers = [hbyDoer]
+        hbyDoer = HaberyDoer(habery=hby)  # setup doer
+        doers = [hbyDoer]
 
-    doers.extend(setupWitness(alias=alias,
-                              hby=hby,
-                              tcpPort=tcp,
-                              httpPort=http,
-                              keypath=keypath,
-                              certpath=certpath,
-                              cafilepath=cafilepath))
+        doers.extend(setupWitness(alias=alias,
+                                  hby=hby,
+                                  tcpPort=tcp,
+                                  httpPort=http,
+                                  keypath=keypath,
+                                  certpath=certpath,
+                                  cafilepath=cafilepath))
 
-    runController(doers=doers, expire=expire)
+        runController(doers=doers, expire=expire)
+    except Exception:
+        # Log at CRITICAL (with the traceback via exc_info) so a failed start is
+        # visible even at the default --loglevel CRITICAL; a lower level would be
+        # suppressed. Without this the failure surfaces only as a bare traceback
+        # or a terse "ERR:" print from the CLI dispatcher.
+        logger.critical("Witness %r failed to start", name, exc_info=True)
+        raise
+    finally:
+        # Release the keystore/database LMDB env so a failed start does not leave
+        # a stale lock that would block the next start attempt.
+        if hby is not None:
+            hby.close()

--- a/src/keri/cli/commands/witness/start.py
+++ b/src/keri/cli/commands/witness/start.py
@@ -70,13 +70,15 @@ def launch(args):
     ogler.level = logging.getLevelName(args.loglevel.upper())
 
     logdir = args.logdir
-    if args.logfile:
-        print(f"--logfile is deprecated; use --logdir. Logging to {ogler.path}", file=sys.stderr)
+    if args.logfile:  # deprecated: only its directory is used
         logdir = os.path.dirname(args.logfile) or "."
 
     if logdir is not None:  # Must reopen
         ogler.headDirPath = logdir
         ogler.reopen(name=args.name, temp=False, clear=True)
+
+    if args.logfile:  # print after reopen so ogler.path is the resolved log path
+        print(f"--logfile is deprecated; use --logdir. Logging to {ogler.path}", file=sys.stderr)
 
     ogler.getLogger()  # re-applies ogler.level, replaces handlers, binding to "logger" var
 

--- a/src/keri/cli/commands/witness/start.py
+++ b/src/keri/cli/commands/witness/start.py
@@ -61,36 +61,24 @@ parser.add_argument("--logdir", action="store", required=False, default=None,
 parser.add_argument("--logfile", action="store", required=False, default=None,
                     help="DEPRECATED: use --logdir. Path to a log file; only its directory is used "
                          "(the file name and log subdirectory are derived internally).")
+parser.add_argument("--no-prompt", action="store_true", default=None, required=False,
+                    help="Disable interactive prompt", dest="noPrompt")
 
 
 def launch(args):
-    # Normalize (.upper()) so getLevelName returns a numeric level; a lowercase
-    # value would otherwise become the invalid string "Level debug" and silently
-    # break level filtering. The ogler.getLogger() call below applies this level to
-    # the shared logger every keri module holds. (Fatal startup failures are logged
-    # at CRITICAL in runWitness so they remain visible at the default level.)
+    # Normalize level case; avoid invalid lowercase values that silently break level filtering
     ogler.level = logging.getLevelName(args.loglevel.upper())
 
     logdir = args.logdir
-    deprecatedLogfile = args.logfile is not None
-    if deprecatedLogfile:
-        # --logfile is deprecated: ogler derives the log file name from --name and
-        # its subdirectory from its own prefix, so only the directory is meaningful.
+    if args.logfile:
+        print(f"--logfile is deprecated; use --logdir. Logging to {ogler.path}", file=sys.stderr)
         logdir = os.path.dirname(args.logfile) or "."
 
-    if logdir is not None:
+    if logdir is not None:  # Must reopen
         ogler.headDirPath = logdir
         ogler.reopen(name=args.name, temp=False, clear=True)
 
-    # Re-fetch so the configured level and any newly attached file handler are
-    # applied to the shared logger used throughout this command.
-    ogler.getLogger()
-
-    if deprecatedLogfile:
-        # Print (not log) so the notice is visible regardless of --loglevel, and
-        # report the actual resolved path so operators know where the log landed.
-        print(f"kli witness start: --logfile is deprecated; use --logdir. "
-              f"Logging to {ogler.path}", file=sys.stderr)
+    ogler.getLogger()  # re-applies ogler.level, replaces handlers, binding to "logger" var
 
     logger.info("\n******* Starting Witness for %s listening: http/%s, tcp/%s "
                 ".******\n\n", args.name, args.http, args.tcp)
@@ -105,17 +93,20 @@ def launch(args):
                configFile=args.configFile,
                keypath=args.keypath,
                certpath=args.certpath,
-               cafilepath=args.cafilepath)
+               cafilepath=args.cafilepath,
+               noPrompt=args.noPrompt)
 
     logger.info("\n******* Ended Witness for %s listening: http/%s, tcp/%s"
                 ".******\n\n", args.name, args.http, args.tcp)
 
 
 def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http=5632, expire=0.0,
-               configDir="", configFile=None, keypath=None, certpath=None, cafilepath=None):
+               configDir="", configFile=None, keypath=None, certpath=None, cafilepath=None,
+               noPrompt=None):
     """
     Setup and run one witness
     """
+    noPrompt = noPrompt if noPrompt is not None else not sys.stdin.isatty()  # When not TTY then do not prompt
 
     ks = Keeper(name=name,
                 base=base,
@@ -134,14 +125,11 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
         if aeid is None:
             hby = Habery(name=name, base=base, bran=bran, cf=cf)
         else:
-            # Encrypted keystore requires a passcode. Only prompt interactively when
-            # attached to a TTY; a witness started from a script/service with no
-            # passcode must fail fast instead of stalling on getpass for input.
-            if not bran and not sys.stdin.isatty():
-                raise AuthError(f"Witness {name!r} keystore is encrypted but no passcode "
-                                f"was provided and stdin is not a TTY; pass --passcode "
-                                f"to start non-interactively.")
-            hby = setupHby(name=name, base=base, bran=bran, cf=cf)
+            # Prompt only for TTY; fail fast for no passcode on script/service witness start
+            if not bran and noPrompt:
+                raise AuthError(f"passcode required for keystore {name!r} but prompting is disabled. "
+                                f"pass --passcode or omit --no-prompt in an interactive terminal..")
+            hby = setupHby(name=name, base=base, bran=bran, cf=cf, noPrompt=noPrompt)
 
         hbyDoer = HaberyDoer(habery=hby)  # setup doer
         doers = [hbyDoer]
@@ -156,14 +144,10 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
 
         runController(doers=doers, expire=expire)
     except Exception:
-        # Log at CRITICAL (with the traceback via exc_info) so a failed start is
-        # visible even at the default --loglevel CRITICAL; a lower level would be
-        # suppressed. Without this the failure surfaces only as a bare traceback
-        # or a terse "ERR:" print from the CLI dispatcher.
+        # Log startup failures at CRITICAL with traceback.
         logger.critical("Witness %r failed to start", name, exc_info=True)
         raise
     finally:
-        # Release the keystore/database LMDB env so a failed start does not leave
-        # a stale lock that would block the next start attempt.
+        # Close Habery LMDB to avoid leftover locks on failed start blocking next start attempt
         if hby is not None:
             hby.close()

--- a/src/keri/cli/common/existing.py
+++ b/src/keri/cli/common/existing.py
@@ -12,7 +12,8 @@ from ...kering import AuthError
 from ...app import Habery, Keeper
 from keri.kering import Version
 
-def setupHby(name, base="", bran=None, cf=None, temp=False, version=None):
+
+def setupHby(name, base="", bran=None, cf=None, temp=False, noPrompt=False, version=None):
     """ Create Habery off of existing directory
 
     Parameters:
@@ -21,6 +22,7 @@ def setupHby(name, base="", bran=None, cf=None, temp=False, version=None):
         bran(str): optional passcode if the Habery was created encrypted
         cf (Configer): optional configuration for loading reference data
         temp (bool): True means create database in /tmp
+        noPrompt (bool): True means not prompt. Default to False
 
     Returns:
           Habery:  the configured habery
@@ -49,6 +51,8 @@ def setupHby(name, base="", bran=None, cf=None, temp=False, version=None):
             break
         except (AuthError, ValueError) as e:
             print(e)
+            if noPrompt:
+                raise e
             if retries >= 3:
                 raise AuthError("too many attempts")
             print("Valid passcode required, try again...")

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -25,21 +25,23 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_standalone_kli_commands(helpers, capsys):
-    helpers.remove_test_dirs("test")
-    assert os.path.isdir("/usr/local/var/keri/ks/test") is False
+    # Unique keystore name (not the generic "test") so this test's non-temp store at
+    # /usr/local/var/keri/ks/ is isolated from other tests under pytest-xdist -n auto
+    helpers.remove_test_dirs("test-standalone-kli")
+    assert os.path.isdir("/usr/local/var/keri/ks/test-standalone-kli") is False
 
     parser = multicommand.create_parser(commands)
     salt = Salter(raw=b'0123456789abcdef').qb64
-    args = parser.parse_args(["init", "--name", "test", "--nopasscode", "--salt", salt])
+    args = parser.parse_args(["init", "--name", "test-standalone-kli", "--nopasscode", "--salt", salt])
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
 
-    with existingHby("test") as hby:
+    with existingHby("test-standalone-kli") as hby:
         assert os.path.isdir(hby.db.path) is True
 
-    args = parser.parse_args(["incept", "--name", "test", "--alias", "non-trans", "--file",
+    args = parser.parse_args(["incept", "--name", "test-standalone-kli", "--alias", "non-trans", "--file",
                               os.path.join(TEST_DIR, "non-transferable-sample.json")])
     assert args.handler is not None
     doers = args.handler(args)
@@ -47,10 +49,10 @@ def test_standalone_kli_commands(helpers, capsys):
     runController(doers=doers)
 
     # Create non-transferable identifier
-    with existingHab(name="test", alias="non-trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="non-trans") as (hby, hab):
         assert hab.pre == 'BI81UmEUu6Vrii26PxQagwdkWJzJm3Q6PERtUw1c_y9K'
 
-    args = parser.parse_args(["rotate", "--name", "test", "--alias", "non-trans"])
+    args = parser.parse_args(["rotate", "--name", "test-standalone-kli", "--alias", "non-trans"])
     assert args.handler is not None
     doers = args.handler(args)
 
@@ -59,7 +61,7 @@ def test_standalone_kli_commands(helpers, capsys):
         runController(doers=doers)
 
     # Create transferable identifier
-    args = parser.parse_args(["incept", "--name", "test", "--alias", "trans", "--transferable", "--file",
+    args = parser.parse_args(["incept", "--name", "test-standalone-kli", "--alias", "trans", "--transferable", "--file",
                               os.path.join(TEST_DIR, "transferable-sample.json")])
     assert args.handler is not None
     doers = args.handler(args)
@@ -67,25 +69,25 @@ def test_standalone_kli_commands(helpers, capsys):
     runController(doers=doers)
 
     xpre = 'EF0bnfg4smFm9Q_OKlKUYRRQctGhTBWUU3rXf7zuA9GU'  # 'EORLw1VyVyBqNCHMUTYctinMDCba9o6Ut-34YFpiLBFK'
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
 
-    args = parser.parse_args(["rotate", "--name", "test", "--alias", "trans"])
+    args = parser.parse_args(["rotate", "--name", "test-standalone-kli", "--alias", "trans"])
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
         assert hab.kever.sn == 1
 
-    args = parser.parse_args(["rotate", "--name", "test", "--alias", "trans", "--data",
+    args = parser.parse_args(["rotate", "--name", "test-standalone-kli", "--alias", "trans", "--data",
                               "@" + os.path.join(TEST_DIR, "anchor.json")])
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
         assert hab.kever.sn == 2
         assert hab.kever.ilk == Ilks.rot
@@ -97,13 +99,13 @@ def test_standalone_kli_commands(helpers, capsys):
              }
         ]
 
-    args = parser.parse_args(["interact", "--name", "test", "--alias", "trans", "--data",
+    args = parser.parse_args(["interact", "--name", "test-standalone-kli", "--alias", "trans", "--data",
                               "@" + os.path.join(TEST_DIR, "anchor.json")])
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
         assert hab.kever.sn == 3
         assert hab.kever.ilk == Ilks.ixn
@@ -115,14 +117,14 @@ def test_standalone_kli_commands(helpers, capsys):
              }
         ]
 
-    rotate_args = ["rotate", "--name", "test", "--alias", "trans", "--next-count", "3", "--nsith", "2"]
+    rotate_args = ["rotate", "--name", "test-standalone-kli", "--alias", "trans", "--next-count", "3", "--nsith", "2"]
     args = parser.parse_args(rotate_args)
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
 
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
         assert hab.kever.sn == 4
         assert hab.kever.ilk == Ilks.rot
@@ -134,7 +136,7 @@ def test_standalone_kli_commands(helpers, capsys):
 
     runController(doers=doers)
 
-    with existingHab(name="test", alias="trans") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="trans") as (hby, hab):
         assert hab.pre == xpre
         assert hab.kever.sn == 5
         assert hab.kever.ilk == Ilks.rot
@@ -146,7 +148,7 @@ def test_standalone_kli_commands(helpers, capsys):
     # Skipping sign and verify, they rely on console output.
 
     # Establishment Only
-    args = parser.parse_args(["incept", "--name", "test", "--alias", "est-only", "--transferable", "--file",
+    args = parser.parse_args(["incept", "--name", "test-standalone-kli", "--alias", "est-only", "--transferable", "--file",
                               os.path.join(TEST_DIR, "estonly-sample.json")])
     assert args.handler is not None
     doers = args.handler(args)
@@ -154,11 +156,11 @@ def test_standalone_kli_commands(helpers, capsys):
     runController(doers=doers)
 
     epre = 'EMZ09JgN6Kr_rZH4Q7SovW-bxYXjiQX2XdSIQYpZnHsJ'
-    with existingHab(name="test", alias="est-only") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="est-only") as (hby, hab):
         assert hab.pre == epre
         assert hab.kever.sn == 0
 
-    args = parser.parse_args(["interact", "--name", "test", "--alias", "est-only", "--data",
+    args = parser.parse_args(["interact", "--name", "test-standalone-kli", "--alias", "est-only", "--data",
                               "@" + os.path.join(TEST_DIR, "anchor.json")])
     assert args.handler is not None
     doers = args.handler(args)
@@ -166,22 +168,22 @@ def test_standalone_kli_commands(helpers, capsys):
     with pytest.raises(ValidationError):
         runController(doers=doers)
 
-    args = parser.parse_args(["rotate", "--name", "test", "--alias", "est-only"])
+    args = parser.parse_args(["rotate", "--name", "test-standalone-kli", "--alias", "est-only"])
     assert args.handler is not None
     doers = args.handler(args)
 
     runController(doers=doers)
-    with existingHab(name="test", alias="est-only") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="est-only") as (hby, hab):
         assert hab.pre == epre
         assert hab.kever.sn == 1
         assert hab.kever.ilk == Ilks.rot
 
-    args = parser.parse_args(["rotate", "--name", "test", "--alias", "est-only", "--data",
+    args = parser.parse_args(["rotate", "--name", "test-standalone-kli", "--alias", "est-only", "--data",
                               "@" + os.path.join(TEST_DIR, "anchor.json")])
     assert args.handler is not None
     doers = args.handler(args)
     runController(doers=doers)
-    with existingHab(name="test", alias="est-only") as (hby, hab):
+    with existingHab(name="test-standalone-kli", alias="est-only") as (hby, hab):
         assert hab.pre == epre
         assert hab.kever.sn == 2
         assert hab.kever.ilk == Ilks.rot
@@ -195,7 +197,7 @@ def test_standalone_kli_commands(helpers, capsys):
 
     # Clear output buffer so far
     capsys.readouterr()
-    args = parser.parse_args(["sign", "--name", "test", "--alias", "trans", "--text", "this is test data to sign"])
+    args = parser.parse_args(["sign", "--name", "test-standalone-kli", "--alias", "trans", "--text", "this is test data to sign"])
     assert args.handler is not None
     doers = args.handler(args)
     runController(doers=doers)
@@ -210,7 +212,7 @@ def test_standalone_kli_commands(helpers, capsys):
                            '3. '
                            'ACCLl9pVv7OM4Y261GZkpPWQu__1mw8ffzcFY1lJ62CGjiEh3mvESu_N7a01YOCKqicqEe5TOXSf0j_8qBxPKxwO\n')
 
-    args = parser.parse_args(["verify", "--name", "test",
+    args = parser.parse_args(["verify", "--name", "test-standalone-kli",
                               "--prefix",
                               'EF0bnfg4smFm9Q_OKlKUYRRQctGhTBWUU3rXf7zuA9GU',
                               "--text",
@@ -225,7 +227,7 @@ def test_standalone_kli_commands(helpers, capsys):
     capsigs = capsys.readouterr()
     assert capsigs.out == 'Signature 1 is valid.\n'
 
-    args = parser.parse_args(["status", "--name", "test", "--alias", "trans"])
+    args = parser.parse_args(["status", "--name", "test-standalone-kli", "--alias", "trans"])
     assert args.handler is not None
     doers = args.handler(args)
     runController(doers=doers)
@@ -292,7 +294,7 @@ def test_standalone_kli_commands(helpers, capsys):
 
 
     """
-    #args = parser.parse_args(["escrow", "list", "--name", "test"])
+    #args = parser.parse_args(["escrow", "list", "--name", "test-standalone-kli"])
     #assert args.handler is not None
     #doers = args.handler(args)
     #directing.runController(doers=doers)

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -1,12 +1,15 @@
+import logging
 import os
 import multicommand
 import pytest
 
 
-from keri.kering import Ilks, ValidationError
+from hio.help import ogler
+
+from keri.kering import Ilks, ValidationError, AuthError
 from keri.core import Salter
 
-from keri.app import runController
+from keri.app import runController, habbing
 from keri.cli.commands.witness import start as witness_start
 
 from keri.cli import commands
@@ -392,3 +395,138 @@ def test_run_witness_closes_boot_keeper_before_reopen(monkeypatch):
 
     assert close_called, "Keeper.close() was never called before Habery re-open"
     assert stopped, "runController was never reached"
+
+
+# --- kli witness start logging & startup behavior (WebOfTrust/keripy#238) ---
+
+def _parse(argv):
+    return multicommand.create_parser(commands).parse_args(argv)
+
+
+def test_witness_start_arg_parsing():
+    """--logdir is the current option; --logfile is retained as a deprecated alias."""
+    args = _parse(["witness", "start", "--alias", "wit",
+                   "--loglevel", "debug", "--logdir", "/tmp/wlogs"])
+    assert args.handler is not None
+    assert args.loglevel == "debug"
+    assert args.logdir == "/tmp/wlogs"
+    assert args.logfile is None
+
+    args = _parse(["witness", "start", "--alias", "wit"])
+    assert args.loglevel == "CRITICAL"
+    assert args.logdir is None
+    assert args.logfile is None
+
+
+def test_launch_normalizes_loglevel_and_logdir(monkeypatch, tmp_path):
+    """launch() must turn a lowercase --loglevel into a numeric level (the .upper()
+    fix) and route --logdir straight to ogler.headDirPath."""
+    # ogler is a process-global singleton; snapshot so this test does not leak
+    # its level/headDirPath into later tests (monkeypatch restores on teardown).
+    monkeypatch.setattr(ogler, "level", ogler.level)
+    monkeypatch.setattr(ogler, "headDirPath", ogler.headDirPath)
+
+    captured = {}
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: captured.update(kw))
+
+    args = _parse(["witness", "start", "--alias", "wit",
+                   "--loglevel", "debug", "--logdir", str(tmp_path)])
+    args.handler(args)  # -> launch(args)
+
+    # Without .upper(), getLevelName("debug") returns the string "Level debug",
+    # which silently breaks level filtering. It must be the numeric DEBUG level.
+    assert ogler.level == logging.DEBUG
+    assert ogler.headDirPath == str(tmp_path)
+    assert captured["alias"] == "wit"
+
+
+def test_launch_logfile_extracts_dirname(monkeypatch, tmp_path):
+    """The deprecated --logfile must contribute only its *directory* as the log
+    dir (hio derives the filename from --name), never the file path itself."""
+    monkeypatch.setattr(ogler, "level", ogler.level)
+    monkeypatch.setattr(ogler, "headDirPath", ogler.headDirPath)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    logfile = tmp_path / "witness.log"
+    args = _parse(["witness", "start", "--alias", "wit", "--logfile", str(logfile)])
+    args.handler(args)
+
+    assert ogler.headDirPath == str(tmp_path)
+
+
+def test_logfile_emits_deprecation_warning(monkeypatch, capsys, tmp_path):
+    """Passing the deprecated --logfile must print a deprecation notice to stderr
+    (visible regardless of --loglevel); using the current --logdir must not."""
+    monkeypatch.setattr(ogler, "level", ogler.level)
+    monkeypatch.setattr(ogler, "headDirPath", ogler.headDirPath)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    args = _parse(["witness", "start", "--alias", "wit",
+                   "--logfile", str(tmp_path / "witness.log")])
+    args.handler(args)
+    assert "deprecated" in capsys.readouterr().err, "expected a --logfile deprecation notice"
+
+    args = _parse(["witness", "start", "--alias", "wit", "--logdir", str(tmp_path)])
+    args.handler(args)
+    assert "deprecated" not in capsys.readouterr().err
+
+
+def test_run_failure_is_logged_and_hby_closed(helpers, monkeypatch):
+    """A failure during setup/run (e.g. a port-bind RuntimeError from setupWitness)
+    must be logged at CRITICAL (visible at the default --loglevel) AND the Habery
+    closed in the finally block, so no stale LMDB lock is left behind."""
+    name = "bug238witerr"
+    helpers.remove_test_dirs(name)
+
+    logged = []
+    monkeypatch.setattr(witness_start.logger, "critical",
+                        lambda *a, **k: logged.append((a, k)))
+
+    closed = []
+    real_close = habbing.Habery.close
+
+    def spy_close(self, clear=False):
+        closed.append(True)
+        return real_close(self, clear=clear)
+    monkeypatch.setattr(habbing.Habery, "close", spy_close)
+
+    def _boom(**kw):
+        raise RuntimeError("cannot create http server on port 5631")
+    monkeypatch.setattr(witness_start, "setupWitness", _boom)
+
+    try:
+        # unencrypted keystore path (aeid is None) so no passcode is required
+        with pytest.raises(RuntimeError):
+            witness_start.runWitness(name=name, base="", alias="wit", bran="")
+
+        assert logged, "startup failure must be logged at CRITICAL"
+        assert "failed" in logged[0][0][0]
+        assert closed, "Habery must be closed in the finally block on failure"
+    finally:
+        helpers.remove_test_dirs(name)
+
+
+def test_encrypted_keystore_non_tty_fails_fast(helpers, monkeypatch):
+    """An encrypted keystore started with no passcode on a non-TTY must fail fast
+    with a logged AuthError instead of stalling on an interactive getpass prompt."""
+    name = "bug238witenc"
+    helpers.remove_test_dirs(name)
+    try:
+        # create an encrypted keystore so that aeid is set
+        hby = habbing.Habery(name=name, base="", bran="0123456789abcdefghijk", temp=False)
+        hby.close()
+
+        # guarantee the non-interactive condition regardless of how the test runner
+        # wires stdin
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        # the guard must short-circuit *before* any interactive prompt; if getpass
+        # is ever reached the witness could block waiting on stdin (the stall bug)
+        def _boom(*a, **k):
+            raise AssertionError("getpass must not be called on a non-TTY start")
+        monkeypatch.setattr("keri.cli.common.existing.getpass.getpass", _boom)
+
+        with pytest.raises(AuthError):
+            witness_start.runWitness(name=name, base="", alias="wit", bran="")
+    finally:
+        helpers.remove_test_dirs(name)

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -711,6 +711,7 @@ def test_run_failure_is_logged_and_hby_closed(helpers, monkeypatch):
     name = "bug238witerr"
     helpers.remove_test_dirs(name)
 
+    # set up CRITICAL logger so we can assert its contents
     logged = []
     monkeypatch.setattr(witness_start.logger, "critical",
                         lambda *a, **k: logged.append((a, k)))
@@ -740,26 +741,49 @@ def test_run_failure_is_logged_and_hby_closed(helpers, monkeypatch):
 
 
 def test_encrypted_keystore_non_tty_fails_fast(helpers, monkeypatch):
-    """An encrypted keystore started with no passcode on a non-TTY must fail fast
-    with a logged AuthError instead of stalling on an interactive getpass prompt."""
+    """Starting encrypted keystore with no passcode on a non-TTY must fail fast with no prompt"""
     name = "bug238witenc"
+
+    # ensure TTY false regardless of test harness start (sometimes IDE starts set TTY=True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    # Defensive raise on getpass, testing that we never call it for this test since no TTY
+    def _boom(*a, **k):
+        raise AssertionError("getpass must not be called on a non-TTY start")
+    monkeypatch.setattr("keri.cli.common.existing.getpass.getpass", _boom)
+
     helpers.remove_test_dirs(name)
     try:
         # create an encrypted keystore so that aeid is set
         hby = habbing.Habery(name=name, base="", bran="0123456789abcdefghijk", temp=False)
         hby.close()
 
-        # guarantee the non-interactive condition regardless of how the test runner
-        # wires stdin
-        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-
-        # the guard must short-circuit *before* any interactive prompt; if getpass
-        # is ever reached the witness could block waiting on stdin (the stall bug)
-        def _boom(*a, **k):
-            raise AssertionError("getpass must not be called on a non-TTY start")
-        monkeypatch.setattr("keri.cli.common.existing.getpass.getpass", _boom)
-
-        with pytest.raises(AuthError):
+        with pytest.raises(AuthError, match="passcode required"):
             witness_start.runWitness(name=name, base="", alias="wit", bran="")
     finally:
         helpers.remove_test_dirs(name)
+
+
+def test_witness_start_non_tty_wrong_passcode_raises(helpers, monkeypatch):
+    """When starting a witness with no TTY and with wrong passcode, should err."""
+    name = "bug238witwrong"
+    correct = "0123456789abcdefghijk"
+    wrong = "thisisasecretpasscode"
+
+    # ensure TTY false regardless of test harness start (sometimes IDE starts set TTY=True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    helpers.remove_test_dirs(name)
+    try:
+        # Create keystore with correct passcode to later trigger noPrompt + wrong passcode err
+        hby = habbing.Habery(name=name, base="", bran=correct, temp=False)
+        hby.close()
+
+        args = _parse(["witness", "start", "--name", name, "--alias", "wit",
+                       "--passcode", wrong,
+                       "--loglevel", "debug", "--logdir", "/tmp/wlogs"])
+        with pytest.raises(AuthError, match="Last seed missing"):
+            args.handler(args)
+    finally:
+        helpers.remove_test_dirs(name)
+

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -773,6 +773,9 @@ def test_witness_start_non_tty_wrong_passcode_raises(helpers, monkeypatch):
     # ensure TTY false regardless of test harness start (sometimes IDE starts set TTY=True)
     monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
+    # launch() sets ogler.level from --loglevel on the shared logger; restore it so the
+    # DEBUG level does not leak into other tests (which would surface latent format bugs)
+    saved_level = ogler.level
     helpers.remove_test_dirs(name)
     try:
         # Create keystore with correct passcode to later trigger noPrompt + wrong passcode err
@@ -785,5 +788,7 @@ def test_witness_start_non_tty_wrong_passcode_raises(helpers, monkeypatch):
         with pytest.raises(AuthError, match="Last seed missing"):
             args.handler(args)
     finally:
+        ogler.level = saved_level
+        ogler.getLogger()  # re-apply restored level to the shared logger
         helpers.remove_test_dirs(name)
 


### PR DESCRIPTION
## Summary

`kli witness start` could stall during startup and did not reliably log error
conditions (#238). This PR makes the command log every startup/runtime failure
visibly, eliminates the interactive-prompt stall, and fixes a few related
logging-correctness defects. Fixes #238.

## Changes

**Error logging & startup stalls** (`src/keri/cli/commands/witness/start.py`)
- Startup/runtime failures (e.g. an HTTP/TCP port already in use) are now logged
  at **CRITICAL with a traceback**, so they surface even at the default
  `--loglevel CRITICAL`, and the `Habery` is closed in a `finally` block so a
  failed start no longer leaves a stale LMDB lock behind.
- An encrypted keystore started with **no passcode on a non-TTY** now fails fast
  with a logged `AuthError` instead of blocking on an interactive `getpass`
  prompt — the literal "stalled in startup" symptom for witnesses run under
  systemd/docker/scripts.
- `--loglevel` is normalized with `.upper()`, so a lowercase level such as
  `debug` is honored instead of silently becoming an invalid level string.

**`--logfile` → `--logdir`**
- `--logfile` is deprecated in favor of the accurately-named `--logdir`. The
  logging backend derives the log file name from `--name` and the subdirectory
  from its own prefix, so only the directory is meaningful; the old code
  mis-assigned the whole file path as the log *head directory*. `--logfile` is
  retained as an alias (its directory portion is used), and a deprecation notice
  is printed to stderr reporting the actual resolved log path.

## Tests

Regression tests added to `tests/app/cli/test_kli_commands.py` (co-located with
the existing witness-start test), covering: loglevel normalization,
`--logdir`/`--logfile` handling and directory extraction, the stderr deprecation
notice, CRITICAL-level failure logging + `Habery` cleanup, and the non-TTY
fail-fast guard. Each assertion was mutation-checked — reverting the
corresponding fix turns the test red on the targeted assertion.

## Notes for reviewers

- The default `--loglevel` is unchanged (still `CRITICAL`); fatal failures are
  logged at CRITICAL specifically so they remain visible without making the
  witness verbose by default.
- The non-TTY guard is placed at the witness (daemon) layer. `setupHby` — shared
  by many *interactive* `kli` commands — is the underlying `getpass` choke point,
  but making it non-interactive globally is out of scope here and would change
  behavior for commands that legitimately prompt.

---

This code was developed with claude (using the Opus 4.8 model, mostly). However, I (Daniel the human) have read, reviewed, and worked the code, and I stand behind it and take responsibility for it.
