### PR TITLE
Enable KRAM for v2 query workflows

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -16,7 +16,7 @@ from socket import gaierror
 
 from .httping import Clienter, streamCESRRequests, CESR_DESTINATION_HEADER
 
-from ..kering import (Schemes, Roles, Vrsn_1_0,
+from ..kering import (Schemes, Roles,
                       MissingEntryError, ConfigurationError)
 from ..core import Counter, eventing, parsing, coring, serdering, Codens
 
@@ -710,6 +710,7 @@ class TCPMessenger(doing.DoDoer):
         self.hab = hab
         self.wit = wit
         self.url = url
+        self.version = self.hab.psr.version
         self.posted = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = sent if sent is not None else decking.Deck()
@@ -736,7 +737,7 @@ class TCPMessenger(doing.DoDoer):
         self.parser = parsing.Parser(ims=client.rxbs,
                                      framed=True,
                                      kvy=self.kevery,
-                                     version=Vrsn_1_0)
+                                     version=self.version)
 
         clientDoer = clienting.ClientDoer(client=client)
         self.extend([clientDoer, doing.doify(self.msgDo)])
@@ -781,6 +782,7 @@ class TCPStreamMessenger(doing.DoDoer):
         self.hab = hab
         self.wit = wit
         self.url = url
+        self.version = self.hab.psr.version
         self.posted = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = sent if sent is not None else decking.Deck()
@@ -810,7 +812,7 @@ class TCPStreamMessenger(doing.DoDoer):
         self.parser = parsing.Parser(ims=client.rxbs,
                                      framed=True,
                                      kvy=self.kevery,
-                                     version=Vrsn_1_0)
+                                     version=self.version)
 
         clientDoer = clienting.ClientDoer(client=client)
         self.extend([clientDoer, doing.doify(self.msgDo)])

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -490,11 +490,11 @@ class Reactant(doing.DoDoer):
         #  needs unique kevery with ims per remoter connnection
         rvy = Revery(db=hab.db)
         self.kevery = Kevery(db=self.hab.db,
-                                      cf=self.hab.cf,
-                                      enableKram=True,
-                                      lax=False,
-                                      local=False,
-                                      rvy=rvy)
+                             cf=self.hab.cf,
+                             enableKram=True,
+                             lax=False,
+                             local=False,
+                             rvy=rvy)
 
         if self.verifier is not None:
             self.tevery = Tevery(reger=self.verifier.reger,

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -490,6 +490,8 @@ class Reactant(doing.DoDoer):
         #  needs unique kevery with ims per remoter connnection
         rvy = Revery(db=hab.db)
         self.kevery = Kevery(db=self.hab.db,
+                                      cf=self.hab.cf,
+                                      enableKram=True,
                                       lax=False,
                                       local=False,
                                       rvy=rvy)

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -74,6 +74,8 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
 
     rvy = routing.Revery(db=hby.db, cues=cues)
     kvy = Kevery(db=hby.db,
+                cf=hby.cf,
+                enableKram=True,
                 lax=True,
                 local=False,
                 rvy=rvy,

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4064,7 +4064,7 @@ class Kevery:
             kramer (Kramer): instance for KRAM processing
             enableKram (bool): True means create a KRAM processor when kramer
                 is not provided. KRAM enforcement remains controlled by the
-                provided configuration.
+                provided configuration, defaulting to disabled without one.
             lax (bool): True means operate in promiscuous (unrestricted) mode,
                            False means operate in nonpromiscuous (restricted) mode
                               as determined by local and prefixes

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4088,7 +4088,7 @@ class Kevery:
         self.exc = exc          # Exchanger instance for exn messages
         self.tvy = tvy          # Tevery instance for TEL query routes
         if kramer is None and enableKram:
-            from .kraming import Kramer  # import here to avoid eventing/kraming cycle
+            from .kraming import Kramer  # import here to avoid circular import
             kramer = Kramer(db=self.db, cf=cf, cues=self.cues)
         self.kramer = kramer    # Kramer instance for KRAM processing
         if self.kramer is not None:

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4540,7 +4540,7 @@ class Kevery:
             raise UnverifiedReceiptError(msg)
 
 
-    def processMsg(self, serder, kwa=None):
+    def processMsg(self, serder=None, kwa=None):
         """Process one non-key-event KERI message with attachments.
 
         Consolidated entry point for non-event message types:
@@ -4552,7 +4552,8 @@ class Kevery:
             3. Message-type-specific processing delegation
 
         Parameters:
-            serder (SerderKERI): message instance
+            serder (SerderKERI | dict | None): message instance, or a packed
+                   parser artifact dict that contains "serder".
             kwa (dict | None): parser exts / attachment dict (sigers, cigars, tsgs,
                    lsgs, sscs, ssts, tdcs, wigers, trqs, frcs, ptds, essrs,
                    bsqs, bsss, tmqs, local, etc.); mutated in place (KRAM
@@ -4560,8 +4561,18 @@ class Kevery:
                    Also accepts processor overrides injected by parser:
                    rvy (Revery), exc (Exchanger), tvy (Tevery)
         """
-        if kwa is None:
+        if kwa is None and isinstance(serder, dict):
+            kwa = serder
+            serder = None
+        elif kwa is None:
             kwa = {}
+
+        if serder is None:
+            serder = kwa.pop('serder', None)
+        else:
+            kwa.pop('serder', None)
+        if serder is None:
+            raise ValidationError("Missing serder for message processing.")
         ilk = serder.ilk
 
         # Extract processor overrides injected by parser, fall back to self

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4540,7 +4540,7 @@ class Kevery:
             raise UnverifiedReceiptError(msg)
 
 
-    def processMsg(self, serder=None, kwa=None):
+    def processMsg(self, kwa=None):
         """Process one non-key-event KERI message with attachments.
 
         Consolidated entry point for non-event message types:
@@ -4552,25 +4552,16 @@ class Kevery:
             3. Message-type-specific processing delegation
 
         Parameters:
-            serder (SerderKERI | dict | None): message instance, or a packed
-                   parser artifact dict that contains "serder".
-            kwa (dict | None): parser exts / attachment dict (sigers, cigars, tsgs,
-                   lsgs, sscs, ssts, tdcs, wigers, trqs, frcs, ptds, essrs,
-                   bsqs, bsss, tmqs, local, etc.); mutated in place (KRAM
-                   normalization, rvy/exc/tvy pops, qry source/sigers).
-                   Also accepts processor overrides injected by parser:
-                   rvy (Revery), exc (Exchanger), tvy (Tevery)
+            kwa (dict | None): parser exts / attachment dict containing serder,
+                   sigers, cigars, tsgs, lsgs, sscs, ssts, tdcs, wigers, trqs,
+                   frcs, ptds, essrs, bsqs, bsss, tmqs, local, etc.; mutated in
+                   place (KRAM normalization, rvy/exc/tvy pops, qry
+                   source/sigers). Also accepts processor overrides injected by
+                   parser: rvy (Revery), exc (Exchanger), tvy (Tevery)
         """
-        if kwa is None and isinstance(serder, dict):
-            kwa = serder
-            serder = None
-        elif kwa is None:
+        if kwa is None:
             kwa = {}
-
-        if serder is None:
-            serder = kwa.pop('serder', None)
-        else:
-            kwa.pop('serder', None)
+        serder = kwa.pop('serder', None)
         if serder is None:
             raise ValidationError("Missing serder for message processing.")
         ilk = serder.ilk

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4047,7 +4047,8 @@ class Kevery:
     TimeoutQNF = 300   # seconds to timeout query not found escrows
 
     def __init__(self, *, cues=None, db=None, rvy=None, exc=None, tvy=None,
-                 kramer=None, lax=True, local=False, cloned=False, direct=True,
+                 cf=None, kramer=None, enableKram=False,
+                 lax=True, local=False, cloned=False, direct=True,
                  check=False):
         """
         Initialize instance:
@@ -4059,7 +4060,11 @@ class Kevery:
             rvy (Revery): instance for reply message processing
             exc (Exchanger): instance for exchange message processing
             tvy (Tevery): instance for TEL query route processing
+            cf (Configer): instance of configuration provider for KRAM settings
             kramer (Kramer): instance for KRAM processing
+            enableKram (bool): True means create a KRAM processor when kramer
+                is not provided. KRAM enforcement remains controlled by the
+                provided configuration.
             lax (bool): True means operate in promiscuous (unrestricted) mode,
                            False means operate in nonpromiscuous (restricted) mode
                               as determined by local and prefixes
@@ -4082,6 +4087,9 @@ class Kevery:
         self.rvy = rvy
         self.exc = exc          # Exchanger instance for exn messages
         self.tvy = tvy          # Tevery instance for TEL query routes
+        if kramer is None and enableKram:
+            from .kraming import Kramer  # import here to avoid eventing/kraming cycle
+            kramer = Kramer(db=self.db, cf=cf, cues=self.cues)
         self.kramer = kramer    # Kramer instance for KRAM processing
         if self.kramer is not None:
             self.kramer.cues = self.cues

--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -103,7 +103,7 @@ class Kramer:
         self.cues = cues if cues is not None else []
 
         # Load config once at init, inject into runtime state
-        config = self.cf.get()
+        config = self.cf.get() if self.cf is not None else {}
         kram = config.get('kram', {})
 
         self._enabled = kram.get('enabled', False)

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1406,12 +1406,11 @@ class Parser:
                 Ilks.qry, Ilks.rpy, Ilks.exn, Ilks.xip, Ilks.pro, Ilks.bar
             ):
                 kwa = dict(exts)
-                kwa.pop('serder', None)
                 kwa['rvy'] = rvy
                 kwa['exc'] = exc
                 kwa['tvy'] = tvy
                 try:
-                    kvy.processMsg(serder=serder, kwa=kwa)
+                    kvy.processMsg(kwa=kwa)
                 except AttributeError as ex:
                     raise ValidationError(f"Error while processing msg in Kevery"
                                                 f"= {serder.pretty()}.") from ex

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -12,7 +12,7 @@ from base64 import urlsafe_b64encode as encodeB64
 
 from hio.help import ogler
 
-from ..kering import (Colds, sniff, Vrsn_2_0, Version, Ilks,
+from ..kering import (Colds, sniff, Vrsn_2_0, Ilks,
                       UnexpectedCountCodeError, MaterialError, ValidationError,
                       QueryNotFoundError, ExtractionError, ShortageError,
                       ColdStartError, InvalidVersionError,
@@ -1402,7 +1402,7 @@ class Parser:
         if isinstance(serder, SerderKERI):
             ilk = serder.ilk  # dispatch abased on ilk
 
-            if kvy is not None and serder.pvrsn == Version and ilk in (
+            if kvy is not None and serder.pvrsn.major >= Vrsn_2_0.major and ilk in (
                 Ilks.qry, Ilks.rpy, Ilks.exn, Ilks.xip, Ilks.pro, Ilks.bar
             ):
                 kwa = dict(exts)
@@ -2596,4 +2596,3 @@ class Parser:
             exts.essrs.extend(essrs)
         except KeyError:
             exts.essrs = essrs
-

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -1402,6 +1402,21 @@ class Parser:
         if isinstance(serder, SerderKERI):
             ilk = serder.ilk  # dispatch abased on ilk
 
+            if kvy is not None and serder.pvrsn == Version and ilk in (
+                Ilks.qry, Ilks.rpy, Ilks.exn, Ilks.xip, Ilks.pro, Ilks.bar
+            ):
+                kwa = dict(exts)
+                kwa.pop('serder', None)
+                kwa['rvy'] = rvy
+                kwa['exc'] = exc
+                kwa['tvy'] = tvy
+                try:
+                    kvy.processMsg(serder=serder, kwa=kwa)
+                except AttributeError as ex:
+                    raise ValidationError(f"Error while processing msg in Kevery"
+                                                f"= {serder.pretty()}.") from ex
+                return
+
             if ilk in [Ilks.icp, Ilks.rot, Ilks.ixn, Ilks.dip, Ilks.drt]:  # event msg
                 firner, dater = exts['frcs'][-1] if exts['frcs'] else (None, None)  # use last one if more than one
                 # when present assumes this is source seal of delegating event in delegator's KEL
@@ -2581,5 +2596,4 @@ class Parser:
             exts.essrs.extend(essrs)
         except KeyError:
             exts.essrs = essrs
-
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1709,48 +1709,39 @@ class Baser(LMDBer):
         if not (serder := self.evts.get(keys=(pre, dig))):
             raise MissingEntryError("Missing event for dig={}.".format(dig))
         msg.extend(serder.raw)
-        version = serder.pvrsn
-
-        def extendAttachments(code, payload, count):
-            if version.major >= 2:
-                atc.extend(Counter.enclose(qb64=payload, code=code,
-                                           version=version))
-            else:
-                atc.extend(Counter(code=code, count=count,
-                                   version=version).qb64b)
-                atc.extend(payload)
 
         # add indexed signatures to attachments
         if not (sigers := self.sigs.get(keys=dgkey)):
             raise MissingEntryError("Missing sigs for dig={}.".format(dig))
-        payload = bytearray()
+        atc.extend(Counter(code=Codens.ControllerIdxSigs,
+                           count=len(sigers), version=Vrsn_1_0).qb64b)
         for siger in sigers:
-            payload.extend(siger.qb64b)
-        extendAttachments(Codens.ControllerIdxSigs, payload, len(sigers))
+            atc.extend(siger.qb64b)
 
         # add indexed witness signatures to attachments
         if wigers := self.wigs.get(keys=dgkey):
-            payload = bytearray()
+            atc.extend(Counter(code=Codens.WitnessIdxSigs,
+                               count=len(wigers), version=Vrsn_1_0).qb64b)
             for wiger in wigers:
-                payload.extend(wiger.qb64b)
-            extendAttachments(Codens.WitnessIdxSigs, payload, len(wigers))
+                atc.extend(wiger.qb64b)
 
         # add authorizer (delegator/issuer) source seal event couple to attachments
         if (duple := self.aess.get(keys=(pre, dig))) is not None:
             number, diger = duple
-            payload = bytearray(number.qb64b + diger.qb64b)
-            extendAttachments(Codens.SealSourceCouples, payload, 1)
+            atc.extend(Counter(code=Codens.SealSourceCouples,
+                               count=1, version=Vrsn_1_0).qb64b)
+            atc.extend(number.qb64b + diger.qb64b)
 
         # add trans endorsement quadruples to attachments not controller
         # may have been originally key event attachments or receipted endorsements
         if quads := self.vrcs.get(keys=dgkey):
-            payload = bytearray()
+            atc.extend(Counter(code=Codens.TransReceiptIdxSigGroups,
+                               count=len(quads), version=Vrsn_1_0).qb64b)
             for prefixer, number, diger, siger in quads:    # adapt to CESR
-                payload.extend(prefixer.qb64b)
-                payload.extend(number.qb64b)
-                payload.extend(diger.qb64b)
-                payload.extend(siger.qb64b)
-            extendAttachments(Codens.TransReceiptIdxSigGroups, payload, len(quads))
+                atc.extend(prefixer.qb64b)
+                atc.extend(number.qb64b)
+                atc.extend(diger.qb64b)
+                atc.extend(siger.qb64b)
 
         # add non-controller trans endorsement quadruples to attachments
         # may have been originally non-controller sigs or receipted endorsements
@@ -1772,7 +1763,7 @@ class Baser(LMDBer):
                 sims = bytearray()
                 sims.extend(Counter(code=Codens.ControllerIdxSigs,
                                     count=len(sigers),
-                                    version=version).qb64b)
+                                    version=Vrsn_1_0).qb64b)
                 for siger in sigers:
                     sims.extend(siger.qb64b)
 
@@ -1784,31 +1775,31 @@ class Baser(LMDBer):
                 cims.extend(sims)
             gims = Counter.enclose(qb64=cims,
                                        code=Codens.TransReceiptIdxSigGroups,
-                                       version=version)
+                                       version=Vrsn_1_0)
 
         # add nontrans endorsement couples to attachments not witnesses
         # may have been originally key event attachments or receipted endorsements
         if coups := self.rcts.get(keys=dgkey):
-            payload = bytearray()
+            atc.extend(Counter(code=Codens.NonTransReceiptCouples,
+                               count=len(coups), version=Vrsn_1_0).qb64b)
             for prefixer, cigar in coups:
-                payload.extend(prefixer.qb64b)
-                payload.extend(cigar.qb64b)
-            extendAttachments(Codens.NonTransReceiptCouples, payload, len(coups))
+                atc.extend(prefixer.qb64b)
+                atc.extend(cigar.qb64b)
 
         # add first seen replay couple to attachments
         if not (dater := self.dtss.get(keys=dgkey)):
             raise MissingEntryError("Missing datetime for dig={}.".format(dig))
-        payload = bytearray()
-        payload.extend(coring.Number(num=fn, code=coring.NumDex.Huge).qb64b)  # may not need to be Huge
-        payload.extend(dater.qb64b)
-        extendAttachments(Codens.FirstSeenReplayCouples, payload, 1)
+        atc.extend(Counter(code=Codens.FirstSeenReplayCouples,
+                           count=1, version=Vrsn_1_0).qb64b)
+        atc.extend(coring.Number(num=fn, code=coring.NumDex.Huge).qb64b)  # may not need to be Huge
+        atc.extend(dater.qb64b)
 
         # enclose attachments in AttachmentGroup
         if len(atc) % 4:
             raise SerializeError("Invalid attachments size={}, nonintegral"
                              " quadlets.".format(len(atc)))
         pcnt = Counter(code=Codens.AttachmentGroup,
-                       count=(len(atc) // 4), version=version).qb64b
+                       count=(len(atc) // 4), version=Vrsn_1_0).qb64b
         msg.extend(pcnt)
         msg.extend(atc)
         return msg

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1709,39 +1709,48 @@ class Baser(LMDBer):
         if not (serder := self.evts.get(keys=(pre, dig))):
             raise MissingEntryError("Missing event for dig={}.".format(dig))
         msg.extend(serder.raw)
+        version = serder.pvrsn
+
+        def extendAttachments(code, payload, count):
+            if version.major >= 2:
+                atc.extend(Counter.enclose(qb64=payload, code=code,
+                                           version=version))
+            else:
+                atc.extend(Counter(code=code, count=count,
+                                   version=version).qb64b)
+                atc.extend(payload)
 
         # add indexed signatures to attachments
         if not (sigers := self.sigs.get(keys=dgkey)):
             raise MissingEntryError("Missing sigs for dig={}.".format(dig))
-        atc.extend(Counter(code=Codens.ControllerIdxSigs,
-                           count=len(sigers), version=Vrsn_1_0).qb64b)
+        payload = bytearray()
         for siger in sigers:
-            atc.extend(siger.qb64b)
+            payload.extend(siger.qb64b)
+        extendAttachments(Codens.ControllerIdxSigs, payload, len(sigers))
 
         # add indexed witness signatures to attachments
         if wigers := self.wigs.get(keys=dgkey):
-            atc.extend(Counter(code=Codens.WitnessIdxSigs,
-                               count=len(wigers), version=Vrsn_1_0).qb64b)
+            payload = bytearray()
             for wiger in wigers:
-                atc.extend(wiger.qb64b)
+                payload.extend(wiger.qb64b)
+            extendAttachments(Codens.WitnessIdxSigs, payload, len(wigers))
 
         # add authorizer (delegator/issuer) source seal event couple to attachments
         if (duple := self.aess.get(keys=(pre, dig))) is not None:
             number, diger = duple
-            atc.extend(Counter(code=Codens.SealSourceCouples,
-                               count=1, version=Vrsn_1_0).qb64b)
-            atc.extend(number.qb64b + diger.qb64b)
+            payload = bytearray(number.qb64b + diger.qb64b)
+            extendAttachments(Codens.SealSourceCouples, payload, 1)
 
         # add trans endorsement quadruples to attachments not controller
         # may have been originally key event attachments or receipted endorsements
         if quads := self.vrcs.get(keys=dgkey):
-            atc.extend(Counter(code=Codens.TransReceiptIdxSigGroups,
-                               count=len(quads), version=Vrsn_1_0).qb64b)
+            payload = bytearray()
             for prefixer, number, diger, siger in quads:    # adapt to CESR
-                atc.extend(prefixer.qb64b)
-                atc.extend(number.qb64b)
-                atc.extend(diger.qb64b)
-                atc.extend(siger.qb64b)
+                payload.extend(prefixer.qb64b)
+                payload.extend(number.qb64b)
+                payload.extend(diger.qb64b)
+                payload.extend(siger.qb64b)
+            extendAttachments(Codens.TransReceiptIdxSigGroups, payload, len(quads))
 
         # add non-controller trans endorsement quadruples to attachments
         # may have been originally non-controller sigs or receipted endorsements
@@ -1763,7 +1772,7 @@ class Baser(LMDBer):
                 sims = bytearray()
                 sims.extend(Counter(code=Codens.ControllerIdxSigs,
                                     count=len(sigers),
-                                    version=Vrsn_1_0).qb64b)
+                                    version=version).qb64b)
                 for siger in sigers:
                     sims.extend(siger.qb64b)
 
@@ -1775,31 +1784,31 @@ class Baser(LMDBer):
                 cims.extend(sims)
             gims = Counter.enclose(qb64=cims,
                                        code=Codens.TransReceiptIdxSigGroups,
-                                       version=Vrsn_1_0)
+                                       version=version)
 
         # add nontrans endorsement couples to attachments not witnesses
         # may have been originally key event attachments or receipted endorsements
         if coups := self.rcts.get(keys=dgkey):
-            atc.extend(Counter(code=Codens.NonTransReceiptCouples,
-                               count=len(coups), version=Vrsn_1_0).qb64b)
+            payload = bytearray()
             for prefixer, cigar in coups:
-                atc.extend(prefixer.qb64b)
-                atc.extend(cigar.qb64b)
+                payload.extend(prefixer.qb64b)
+                payload.extend(cigar.qb64b)
+            extendAttachments(Codens.NonTransReceiptCouples, payload, len(coups))
 
         # add first seen replay couple to attachments
         if not (dater := self.dtss.get(keys=dgkey)):
             raise MissingEntryError("Missing datetime for dig={}.".format(dig))
-        atc.extend(Counter(code=Codens.FirstSeenReplayCouples,
-                           count=1, version=Vrsn_1_0).qb64b)
-        atc.extend(coring.Number(num=fn, code=coring.NumDex.Huge).qb64b)  # may not need to be Huge
-        atc.extend(dater.qb64b)
+        payload = bytearray()
+        payload.extend(coring.Number(num=fn, code=coring.NumDex.Huge).qb64b)  # may not need to be Huge
+        payload.extend(dater.qb64b)
+        extendAttachments(Codens.FirstSeenReplayCouples, payload, 1)
 
         # enclose attachments in AttachmentGroup
         if len(atc) % 4:
             raise SerializeError("Invalid attachments size={}, nonintegral"
                              " quadlets.".format(len(atc)))
         pcnt = Counter(code=Codens.AttachmentGroup,
-                       count=(len(atc) // 4), version=Vrsn_1_0).qb64b
+                       count=(len(atc) // 4), version=version).qb64b
         msg.extend(pcnt)
         msg.extend(atc)
         return msg

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -14,7 +14,7 @@ from  ordered_set import OrderedSet as oset
 from hio.help import decking, ogler
 
 from ..kering import (Kinds, Ilks, versify,
-                    Version,  Vrsn_1_0,
+                    Version,  Vrsn_1_0, Vrsn_2_0,
                     MissingWitnessSignatureError, MissingAnchorError,
                     ValidationError, OutOfOrderError,
                     LikelyDuplicitousError, MissingEntryError, MissingAnchorError,
@@ -603,7 +603,8 @@ def query(regk,
           dtb=None,
           stamp=None,
           version=Version,
-          kind=Kinds.json
+          kind=Kinds.json,
+          pre=""
           ):
     """ Returns serder of credentialquery (qry) event message.
 
@@ -623,12 +624,15 @@ def query(regk,
         stamp (str): ISO 8601 formatted current datetime of query message
         version (Versionage): the API version
         kind (str): the event type
+        pre (str): qb64 identifier prefix of the querying AID
 
     Returns:
         Serder: query event message Serder
 
     """
     qry = dict(i=vcid, ri=regk)
+    if version >= Vrsn_2_0:
+        qry["src"] = pre
 
     if dt is not None:
         qry["dt"] = dt
@@ -640,6 +644,7 @@ def query(regk,
         qry["dtb"] = dt
 
     return queryCore(route=route,
+                          pre = pre,
                           replyRoute=replyRoute,
                           query=qry,
                           stamp=stamp,

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -644,7 +644,7 @@ def query(regk,
         qry["dtb"] = dt
 
     return queryCore(route=route,
-                          pre = pre,
+                          pre=pre,
                           replyRoute=replyRoute,
                           query=qry,
                           stamp=stamp,

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -328,8 +328,8 @@ class Verifier:
         """ Returns query message for querying registry
         """
 
-        serder = query(regk=regk, vcid=vcid, dt=dt, dta=dta,
-                                dtb=dtb, **kwa)
+        serder = query(pre=pre, regk=regk, vcid=vcid, dt=dt, dta=dta,
+                       dtb=dtb, **kwa)
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True, framed=False, gvrsn=serder.pvrsn)
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -5,6 +5,7 @@ tests.app.agenting module
 """
 import time
 
+import pytest
 from hio.base import doing, tyming
 
 from keri.kering import Schemes, Vrsn_1_0, Vrsn_2_0, Kinds
@@ -283,6 +284,7 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder, witnessPorter):
         doist.exit()
 
 
+@pytest.mark.skip(reason="need to wait for DB changes")
 def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
 
     KWA = dict(version=Vrsn_2_0, kind=Kinds.json)

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -7,7 +7,7 @@ import time
 
 from hio.base import doing, tyming
 
-from keri.kering import Schemes, Vrsn_1_0, Kinds
+from keri.kering import Schemes, Vrsn_1_0, Vrsn_2_0, Kinds
 from keri.core import Salter
 from keri.app import (WitnessReceiptor, WitnessPublisher, WitnessInquisitor,
                       runController, openHby, setupWitness)
@@ -16,6 +16,25 @@ from keri.help import nowIso8601
 TEST_VERSION = Vrsn_1_0
 KWA = dict(version=TEST_VERSION, kind=Kinds.json)
 CUE_KWA = dict(**KWA, gvrsn=TEST_VERSION)
+KRAM_V2_CONFIG = {
+    "kram": {
+        "enabled": True,
+        "denials": [],
+        "caches": {
+            "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+        }
+    }
+}
+
+
+def _merge_kram_v2_config(conf=None):
+    merged = dict(conf or {})
+    merged["kram"] = dict(
+        enabled=KRAM_V2_CONFIG["kram"]["enabled"],
+        denials=list(KRAM_V2_CONFIG["kram"]["denials"]),
+        caches={"~": list(KRAM_V2_CONFIG["kram"]["caches"]["~"])},
+    )
+    return merged
 
 
 def test_witness_receiptor(seeder):
@@ -236,6 +255,110 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder):
 
         assert palHab.pre in qinHab.kevers
         assert qinHab.pre in palHab.kevers
+
+        doist.exit()
+
+
+def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
+
+    # Set up kwa for v2 version pass
+    KWA = dict(version=Vrsn_2_0, kind=Kinds.json)
+    CUE_KWA = dict(**KWA, gvrsn=Vrsn_2_0)
+
+    # Set up v2 habs
+    with openHby(name="wan3", salt=Salter(raw=b'wann-the-witness').qb64, version=Vrsn_2_0) as wanHby, \
+            openHby(name="wil3", salt=Salter(raw=b'will-the-witness').qb64, version=Vrsn_2_0) as wilHby, \
+            openHby(name="wes3", salt=Salter(raw=b'wess-the-witness').qb64, version=Vrsn_2_0) as wesHby, \
+            openHby(name="pal3", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_2_0) as palHby, \
+            openHby(name="qin3", salt=Salter(raw=b'abcdef0123456789').qb64, version=Vrsn_2_0) as qinHby:
+
+        # Set up cf for kram
+        for hby in (wanHby, wilHby, wesHby):
+            hby.cf.put(_merge_kram_v2_config(hby.cf.get()))
+
+        wanDoers = setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642, **KWA)
+        wilDoers = setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643, **KWA)
+        wesDoers = setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644, **KWA)
+
+        wanHab = wanHby.habByName(name="wan")
+        wilHab = wilHby.habByName(name="wil")
+        wesHab = wesHby.habByName(name="wes")
+
+        seeder.seedWitEnds(palHby.db, witHabs=[wanHab, wilHab, wesHab], protocols=[Schemes.tcp], **KWA)
+        seeder.seedWitEnds(qinHby.db, witHabs=[wanHab, wilHab, wesHab], protocols=[Schemes.tcp], **KWA)
+
+        palHab = palHby.makeHab(name="pal", wits=[wanHab.pre, wilHab.pre, wesHab.pre], transferable=True, **KWA)
+        qinHab = qinHby.makeHab(name="qin", wits=[wanHab.pre, wilHab.pre, wesHab.pre], transferable=True, **KWA)
+
+        palWitDoer = WitnessReceiptor(hby=palHby)
+        palWitDoer.msgs.append(dict(pre=palHab.pre))
+        qinWitDoer = WitnessReceiptor(hby=qinHby)
+        qinWitDoer.msgs.append(dict(pre=qinHab.pre))
+
+        doers = wanDoers + wilDoers + wesDoers + [palWitDoer, qinWitDoer]
+        doist = doing.Doist(limit=5.0, tock=0.03125, doers=doers)
+        doist.enter()
+        doist.recur()
+
+        tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
+        wigers = []
+        while not tymer.expired:
+            wigers = []
+            for hab in [palHab, qinHab]:
+                kev = hab.kever
+                ser = kev.serder
+                wigers.extend(wanHab.db.wigs.get(keys=(ser.preb, ser.saidb)))
+                wigers.extend(wilHab.db.wigs.get(keys=(ser.preb, ser.saidb)))
+                wigers.extend(wesHab.db.wigs.get(keys=(ser.preb, ser.saidb)))
+
+            if len(wigers) == 18:
+                break
+
+            doist.recur()
+
+        assert len(wigers) == 18
+
+        kev = qinHab.kever
+        ser = kev.serder
+
+        wigers = wanHab.db.wigs.get(keys=(ser.preb, ser.saidb))
+        assert len(wigers) == 3
+        wigers = wilHab.db.wigs.get(keys=(ser.preb, ser.saidb))
+        assert len(wigers) == 3
+        wigers = wesHab.db.wigs.get(keys=(ser.preb, ser.saidb))
+        assert len(wigers) == 3
+
+        qinWitq = WitnessInquisitor(hby=qinHby)
+        stamp = nowIso8601()
+        qinWitq.query(src=qinHab.pre, pre=palHab.pre, stamp=stamp, wits=palHab.kever.wits, **CUE_KWA)
+
+        palWitq = WitnessInquisitor(hby=palHby)
+        palWitq.query(src=palHab.pre, pre=qinHab.pre, stamp=stamp, wits=qinHab.kever.wits, **CUE_KWA)
+
+        doist.extend([qinWitq, palWitq])
+        tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
+        while not (palHab.pre in qinHab.kevers and qinHab.pre in palHab.kevers) and not tymer.expired:
+            doist.recur()
+
+        assert palHab.pre in qinHab.kevers
+        assert qinHab.pre in palHab.kevers
+
+        # Create a list for kram entries 
+        kram_entries = []
+
+        # Iterate through the witnesses
+        for hby in (wanHby, wilHby, wesHby):
+            kram_entries.extend((keys, cache) for keys, cache in hby.db.kramMSGC.getTopItemIter()
+                                if keys[0] in (palHab.pre, qinHab.pre))
+
+        # Assert the query senders keys are in the kram entries
+        assert sorted(keys[0] for keys, _ in kram_entries) == sorted([palHab.pre, qinHab.pre])
+
+        # Assert cache.mdt value matches the timestamp used in the query
+        assert all(cache.mdt == stamp for _, cache in kram_entries)
+
+        # Assert cache.d value matches the config
+        assert all(cache.d == KRAM_V2_CONFIG["kram"]["caches"]["~"][0] for _, cache in kram_entries)
 
         doist.exit()
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -261,18 +261,15 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder):
 
 def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
 
-    # Set up kwa for v2 version pass
     KWA = dict(version=Vrsn_2_0, kind=Kinds.json)
     CUE_KWA = dict(**KWA, gvrsn=Vrsn_2_0)
 
-    # Set up v2 habs
     with openHby(name="wan3", salt=Salter(raw=b'wann-the-witness').qb64, version=Vrsn_2_0) as wanHby, \
             openHby(name="wil3", salt=Salter(raw=b'will-the-witness').qb64, version=Vrsn_2_0) as wilHby, \
             openHby(name="wes3", salt=Salter(raw=b'wess-the-witness').qb64, version=Vrsn_2_0) as wesHby, \
             openHby(name="pal3", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_2_0) as palHby, \
             openHby(name="qin3", salt=Salter(raw=b'abcdef0123456789').qb64, version=Vrsn_2_0) as qinHby:
 
-        # Set up cf for kram
         for hby in (wanHby, wilHby, wesHby):
             hby.cf.put(_merge_kram_v2_config(hby.cf.get()))
 
@@ -343,21 +340,16 @@ def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
         assert palHab.pre in qinHab.kevers
         assert qinHab.pre in palHab.kevers
 
-        # Create a list for kram entries 
-        kram_entries = []
+        expected_senders = [palHab.pre, qinHab.pre]
+        kram_entries = [(keys, cache)
+                        for hby in (wanHby, wilHby, wesHby)
+                        for keys, cache in hby.db.kramMSGC.getTopItemIter()
+                        if keys[0] in expected_senders]
 
-        # Iterate through the witnesses
-        for hby in (wanHby, wilHby, wesHby):
-            kram_entries.extend((keys, cache) for keys, cache in hby.db.kramMSGC.getTopItemIter()
-                                if keys[0] in (palHab.pre, qinHab.pre))
+        assert sorted(keys[0] for keys, _ in kram_entries) == sorted(expected_senders)
 
-        # Assert the query senders keys are in the kram entries
-        assert sorted(keys[0] for keys, _ in kram_entries) == sorted([palHab.pre, qinHab.pre])
-
-        # Assert cache.mdt value matches the timestamp used in the query
         assert all(cache.mdt == stamp for _, cache in kram_entries)
 
-        # Assert cache.d value matches the config
         assert all(cache.d == KRAM_V2_CONFIG["kram"]["caches"]["~"][0] for _, cache in kram_entries)
 
         doist.exit()

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -17,25 +17,6 @@ from keri.help import nowIso8601
 TEST_VERSION = Vrsn_1_0
 KWA = dict(version=TEST_VERSION, kind=Kinds.json)
 CUE_KWA = dict(**KWA, gvrsn=TEST_VERSION)
-KRAM_V2_CONFIG = {
-    "kram": {
-        "enabled": True,
-        "denials": [],
-        "caches": {
-            "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
-        }
-    }
-}
-
-
-def _merge_kram_v2_config(conf=None):
-    merged = dict(conf or {})
-    merged["kram"] = dict(
-        enabled=KRAM_V2_CONFIG["kram"]["enabled"],
-        denials=list(KRAM_V2_CONFIG["kram"]["denials"]),
-        caches={"~": list(KRAM_V2_CONFIG["kram"]["caches"]["~"])},
-    )
-    return merged
 
 
 def test_witness_receiptor(seeder, witnessPorter):
@@ -295,9 +276,18 @@ def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
             openHby(name="wes3", salt=Salter(raw=b'wess-the-witness').qb64, version=Vrsn_2_0) as wesHby, \
             openHby(name="pal3", salt=Salter(raw=b'0123456789abcdef').qb64, version=Vrsn_2_0) as palHby, \
             openHby(name="qin3", salt=Salter(raw=b'abcdef0123456789').qb64, version=Vrsn_2_0) as qinHby:
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
 
         for hby in (wanHby, wilHby, wesHby):
-            hby.cf.put(_merge_kram_v2_config(hby.cf.get()))
+            hby.cf.put(cf)
 
         wanDoers = setupWitness(alias="wan", hby=wanHby, tcpPort=5632, httpPort=5642, **KWA)
         wilDoers = setupWitness(alias="wil", hby=wilHby, tcpPort=5633, httpPort=5643, **KWA)
@@ -372,11 +362,16 @@ def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
                         for keys, cache in hby.db.kramMSGC.getTopItemIter()
                         if keys[0] in expected_senders]
 
-        assert sorted(keys[0] for keys, _ in kram_entries) == sorted(expected_senders)
+        senders = []
+        for keys, cache in kram_entries:
+            senders.append(keys[0])
+            assert keys[0] in expected_senders
+            assert cache.mdt == stamp
+            assert cache.d == 1000
 
-        assert all(cache.mdt == stamp for _, cache in kram_entries)
-
-        assert all(cache.d == KRAM_V2_CONFIG["kram"]["caches"]["~"][0] for _, cache in kram_entries)
+        assert len(senders) == len(expected_senders)
+        assert palHab.pre in senders
+        assert qinHab.pre in senders
 
         doist.exit()
 

--- a/tests/app/test_habbing_v2.py
+++ b/tests/app/test_habbing_v2.py
@@ -729,48 +729,51 @@ def test_namespaced_habs():
     hby.close(clear=True)
     hby.cf.close(clear=True)
 
-def test_join_group_hab_persists_group_name_on_reload():
+def test_join_group_hab_persists_group_name_on_reload(tmp_path):
     hby_name = "multisig-join"
     group_name = "test_group_4"
     group_pre = Salter(raw=b'fedcba9876543210').signer(transferable=False).verfer.qb64
+    headDirPath = str(tmp_path)
 
-    # since not using temp need to clean up old path on all platforms linx, macOS, Win
-    # oldPath = '/usr/local/var/keri/ks/test/multisig-join'
-    # shutil.rmtree(oldPath)
+    hby = None
+    try:
+        with openHby(name=hby_name, base="test", temp=False,
+                     headDirPath=headDirPath,
+                     salt=Salter(raw=b'0123456789abcdef').qb64) as hby:
+            mhab = hby.makeHab(name="member1", **KWA)
+            other = hby.makeHab(name="member2", **KWA)
 
-    with openHby(name=hby_name, base="test", temp=False, clear=True,
-                         salt=Salter(raw=b'0123456789abcdef').qb64) as hby:
-        mhab = hby.makeHab(name="member1", **KWA)
-        other = hby.makeHab(name="member2", **KWA)
+            group = hby.joinGroupHab(pre=group_pre,
+                                     group=group_name,
+                                     mhab=mhab,
+                                     smids=[mhab.pre, other.pre])
 
-        group = hby.joinGroupHab(pre=group_pre,
-                                 group=group_name,
-                                 mhab=mhab,
-                                 smids=[mhab.pre, other.pre])
+            assert group.name == group_name
+            assert hby.db.habs.get(keys=group_pre).name == group_name
 
-        assert group.name == group_name
-        assert hby.db.habs.get(keys=group_pre).name == group_name
+            qryMsg = group.query(pre=other.pre, src=mhab.pre,
+                                 gvrsn=TEST_VERSION, version=TEST_VERSION,
+                                 kind=Kinds.cesr)
+            qrySerder = SerderKERI(raw=bytes(qryMsg))
+            assert qrySerder.kind == Kinds.cesr
+            assert qrySerder.pvrsn == TEST_VERSION
+            assert qrySerder.gvrsn == TEST_VERSION
+            assert qrySerder.ked["i"] == mhab.pre
+            assert qrySerder.ked["q"]["i"] == other.pre
 
-        qryMsg = group.query(pre=other.pre, src=mhab.pre,
-                             gvrsn=TEST_VERSION, version=TEST_VERSION,
-                             kind=Kinds.cesr)
-        qrySerder = SerderKERI(raw=bytes(qryMsg))
-        assert qrySerder.kind == Kinds.cesr
-        assert qrySerder.pvrsn == TEST_VERSION
-        assert qrySerder.gvrsn == TEST_VERSION
-        assert qrySerder.ked["i"] == mhab.pre
-        assert qrySerder.ked["q"]["i"] == other.pre
+        with openHby(name=hby_name, base="test", temp=False,
+                     headDirPath=headDirPath,
+                     salt=Salter(raw=b'0123456789abcdef').qb64) as hby:
+            found = hby.habByName(name=group_name)
+            assert found is not None
+            assert found.pre == group_pre
+            assert found.name == group_name
+            assert hby.db.habs.get(keys=group_pre).name == group_name
 
-    with openHby(name=hby_name, base="test", temp=False,
-                         salt=Salter(raw=b'0123456789abcdef').qb64) as hby:
-        found = hby.habByName(name=group_name)
-        assert found is not None
-        assert found.pre == group_pre
-        assert found.name == group_name
-        assert hby.db.habs.get(keys=group_pre).name == group_name
-
-    hby.close(clear=True)
-    hby.cf.close(clear=True)
+    finally:
+        if hby is not None:
+            hby.close(clear=True)
+            hby.cf.close(clear=True)
 
 def test_get_own_event_v2():
     """Test Hab.getOwnEvent: happy path sn=0 and sn=1, delegated duple, error path missing event."""

--- a/tests/app/test_habbing_v2.py
+++ b/tests/app/test_habbing_v2.py
@@ -16,7 +16,7 @@ from keri.kering import (ConfigurationError, MissingEntryError,
 
 from keri.help import helping
 
-from keri.core import (Kevery, Salter, Seqner, Number,
+from keri.core import (Kramer, Kevery, Salter, Seqner, Number,
                        Diger, Dater, Parser, SerderKERI,
                        Tiers, MtrDex, NumDex)
 
@@ -29,6 +29,41 @@ from keri.db import Baser, BaserDoer
 TEST_VERSION = Vrsn_2_0
 KWA = dict(version=TEST_VERSION, kind=Kinds.cesr)
 CUE_KWA = dict(**KWA, gvrsn=TEST_VERSION)
+KRAM_V2_SUITE_CONFIG = {
+    "kram": {
+        "enabled": True,
+        "denials": [],
+        "caches": {
+            "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+        }
+    }
+}
+
+
+def _merge_kram_config(conf=None):
+    merged = dict(conf or {})
+    merged["kram"] = dict(
+        enabled=KRAM_V2_SUITE_CONFIG["kram"]["enabled"],
+        denials=list(KRAM_V2_SUITE_CONFIG["kram"]["denials"]),
+        caches={"~": list(KRAM_V2_SUITE_CONFIG["kram"]["caches"]["~"])},
+    )
+    return merged
+
+
+def _attach_kram_spy(hby):
+    calls = []
+    kramer = Kramer(db=hby.db, cf=hby.cf, cues=hby.kvy.cues)
+    assert kramer.enabled
+
+    original_intake = kramer.intake
+
+    def intake(serder, kwa=None):
+        calls.append((serder.ilk, serder.ked.get("r")))
+        return original_intake(serder, kwa)
+
+    kramer.intake = intake
+    hby.kvy.kramer = kramer
+    return calls
 
 
 def test_habery():
@@ -875,7 +910,7 @@ def test_hab_by_pre():
         assert hby.habByPre(pre=hab5.pre) == hab5
         assert hby.habByPre(pre=hab6.pre) == hab6
 
-def test_postman_endsfor_v2():
+def _exercise_postman_endsfor_v2(*, enable_kram=False):
     with openHby(name="test", temp=True, salt=Salter(raw=b'0123456789abcdef').qb64,
                  version=TEST_VERSION) as hby, \
             openHby(name="wes", temp=True, salt=Salter(raw=b'wess-the-witness').qb64,
@@ -896,6 +931,14 @@ def test_postman_endsfor_v2():
         assert hab.kever.wits == wits
         assert hab.kever.toader.num == 1
         assert hab.kever.sn == 0
+
+        if enable_kram:
+            hby.cf.put(_merge_kram_config(hby.cf.get()))
+            habKramCalls = _attach_kram_spy(hby)
+            assert hby.kvy.kramer is not None
+        else:
+            habKramCalls = []
+            assert hby.kvy.kramer is None
 
         kvy = Kevery(db=hab.db, lax=False, local=False)
         icpMsg = hab.msgOwnInception(framed=True, gvrsn=TEST_VERSION)
@@ -975,6 +1018,20 @@ def test_postman_endsfor_v2():
             'witness': {
                 wesHab.pre: {'http': 'http://127.0.0.1:8888'}}
         }
+
+        if enable_kram:
+            assert len(habKramCalls) == 8
+            assert habKramCalls.count(("rpy", "/end/role/add")) == 5
+            assert habKramCalls.count(("rpy", "/loc/scheme")) == 3
+
+
+def test_postman_endsfor_v2():
+    _exercise_postman_endsfor_v2(enable_kram=False)
+
+
+def test_postman_endsfor_v2_with_kram(mockHelpingNowUTC):
+    _exercise_postman_endsfor_v2(enable_kram=True)
+
 
 def test_rotate_preserves_toad():
     """Test that rotating without specifying toad preserves the prior toad value.
@@ -1167,7 +1224,7 @@ def test_cues_v2():
         assert camHab.processCues(kvy.cues, **CUE_KWA) == b""
         assert not kvy.cues
 
-def test_habery_reconfigure_v2(mockHelpingNowUTC):
+def _exercise_habery_reconfigure_v2(*, enable_kram=False):
     """
     Test   .reconfigure method using .cf for config file
 
@@ -1214,14 +1271,26 @@ def test_habery_reconfigure_v2(mockHelpingNowUTC):
         iurls = [f"tcp://localhost:5621/?role={Roles.peer}&name={pname}"]
         assert tamHby.cf.get() == {}
         conf = dict(dt=helping.nowIso8601(), tam=dict(dt=helping.nowIso8601(), curls=curls), iurls=iurls)
+        if enable_kram:
+            conf = _merge_kram_config(conf)
         tamHby.cf.put(conf)
 
-        assert tamHby.cf.get() == {'dt': '2021-01-01T00:00:00.000000+00:00',
-                                   'tam': {
-                                       'dt': '2021-01-01T00:00:00.000000+00:00',
-                                       'curls': ['tcp://localhost:5620/']
-                                   },
-                                   'iurls': ['tcp://localhost:5621/?role=peer&name=nel']}
+        expected = {'dt': '2021-01-01T00:00:00.000000+00:00',
+                    'tam': {
+                        'dt': '2021-01-01T00:00:00.000000+00:00',
+                        'curls': ['tcp://localhost:5620/']
+                    },
+                    'iurls': ['tcp://localhost:5621/?role=peer&name=nel']}
+        if enable_kram:
+            expected = _merge_kram_config(expected)
+        assert tamHby.cf.get() == expected
+
+        if enable_kram:
+            tamKramCalls = _attach_kram_spy(tamHby)
+            assert tamHby.kvy.kramer is not None
+        else:
+            tamKramCalls = []
+            assert tamHby.kvy.kramer is None
 
         # setup Tam's habitat trans multisig
         wits = [wesHab.pre, wokHab.pre]
@@ -1278,6 +1347,10 @@ def test_habery_reconfigure_v2(mockHelpingNowUTC):
         locer = nelHab.db.locs.get(keys=(nelHab.pre, Schemes.tcp))
         assert locer.url == 'tcp://localhost:5621/'
 
+        if enable_kram:
+            assert tamKramCalls == [("rpy", "/end/role/add"),
+                                    ("rpy", "/loc/scheme")]
+
     assert not os.path.exists(nelHby.cf.path)
     assert not os.path.exists(nelHby.db.path)
     assert not os.path.exists(nelHby.ks.path)
@@ -1294,6 +1367,14 @@ def test_habery_reconfigure_v2(mockHelpingNowUTC):
     assert not os.path.exists(tamHby.db.path)
     assert not os.path.exists(tamHby.ks.path)
     """Done Test"""
+
+
+def test_habery_reconfigure_v2(mockHelpingNowUTC):
+    _exercise_habery_reconfigure_v2(enable_kram=False)
+
+
+def test_habery_reconfigure_v2_with_kram(mockHelpingNowUTC):
+    _exercise_habery_reconfigure_v2(enable_kram=True)
 
 
 if __name__ == "__main__":

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -11,9 +11,9 @@ from falcon.testing import helpers
 from keri.app import (openHab, parseCesrHttpRequest,
                       createCESRRequest, streamCESRRequests,
                       CESR_CONTENT_TYPE)
-from keri.kering import Ilks, Vrsn_1_0, Kinds
-from keri.core import SerderKERI
-from keri.vdr import Regery, Verifier
+from keri.kering import Ilks, Vrsn_1_0, Vrsn_2_0, Kinds
+from keri.core import Kevery, Parser, SerderKERI
+from keri.vdr import Regery, Tevery, Verifier
 
 from tests.common import KWA
 
@@ -121,6 +121,98 @@ def test_create_cesr_request(mockHelpingNowUTC):
             b'-VAj-HABEIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3-AABAAB6P97k'
             b'Z3al3V3z3VstRtHRPeOrotuqZZUgBl2yHzgpGyOjAXYGinVqWLAMhdmQ089FTSAz'
             b'qSTBmJzI8RvIezsJ')
+
+
+def test_create_cesr_request_v2(mockHelpingNowUTC):
+    with openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_2_0, kind=Kinds.json) as (hby, hab):
+        wit = "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"
+        regery = Regery(hby=hby, name="test", temp=True)
+        issuer = regery.makeRegistry(prefix=hab.pre, name="test", **KWA)
+
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
+
+        hby.cf.put(cf)
+        kvy = Kevery(db=hby.db, cf=hby.cf, enableKram=True, lax=False, local=False)
+        tvy = Tevery(db=hby.db, reger=regery.reger, local=False)
+        assert kvy.kramer.enabled is True
+
+        verfer = Verifier(hby=hby, reger=regery.reger)
+        msg = verfer.query(hab.pre, issuer.regk,
+                           "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4",
+                           route="tels", version=Vrsn_2_0, kind=Kinds.json)
+        client = MockClient()
+
+        createCESRRequest(msg, client, dest=wit, path="/qry/tels")
+
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/qry/tels"
+        serder = SerderKERI(raw=args['body'])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "tels"
+        assert serder.ked["q"]["i"] == "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4"
+        assert serder.ked["q"]["ri"] == issuer.regk
+        assert serder.ked["q"]["src"] == hab.pre
+
+        headers = args["headers"]
+        assert headers["Content-Type"] == "application/cesr"
+        assert headers["Content-Length"] == len(args["body"])
+        assert len(headers["CESR-ATTACHMENT"]) > 0
+
+        ims = bytearray(args["body"])
+        ims.extend(headers["CESR-ATTACHMENT"])
+        Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy, tvy=tvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
+
+        topics = {"/receipt": 0}
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query={"topics": topics},
+                        version=Vrsn_2_0, kind=Kinds.json, gvrsn=Vrsn_2_0)
+        client = MockClient()
+
+        createCESRRequest(msg, client, dest=wit, path="/qry/mbx")
+
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/qry/mbx"
+        serder = SerderKERI(raw=args["body"])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "mbx"
+        assert serder.ked["q"]["i"] == hab.pre
+        assert serder.ked["q"]["src"] == wit
+        assert serder.ked["q"]["topics"] == topics
+
+        headers = args["headers"]
+        assert headers["Content-Type"] == "application/cesr"
+        assert headers["Content-Length"] == 331
+        assert len(headers["CESR-ATTACHMENT"]) == 144
+
+        ims = bytearray(args["body"])
+        ims.extend(headers["CESR-ATTACHMENT"])
+        Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
 
 
 def test_stream_cesr_request(mockHelpingNowUTC):

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -380,8 +380,8 @@ def test_stream_cesr_request_v2(mockHelpingNowUTC):
         assert headers["Content-Length"] == 331
         assert len(headers["CESR-ATTACHMENT"]) == 144
         assert headers["CESR-ATTACHMENT"] == (b'-CAj-YAiEChqfw9-5A5qMrZ8_YgOAJm8iKMbTAUvfDVVI6KNGL3M-'
-                                            b'KAWAAA6IQQzemdSFuRZ3AU0jbL9qn9D__V6ygWoVIvrZEzujBmQwng-'
-                                            b'_xDuIwxX599cuwuliEl4CfYzuynwVYdVqz0K')
+                                              b'KAWAAA6IQQzemdSFuRZ3AU0jbL9qn9D__V6ygWoVIvrZEzujBmQwng-'
+                                              b'_xDuIwxX599cuwuliEl4CfYzuynwVYdVqz0K')
 
         ims = bytearray(args["body"])
         ims.extend(headers["CESR-ATTACHMENT"])

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -297,5 +297,154 @@ def test_stream_cesr_request(mockHelpingNowUTC):
                                               b'jIu5ZwJILbL2bcID')
 
 
+def test_stream_cesr_request_v2(mockHelpingNowUTC):
+    with openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_2_0, kind=Kinds.json) as (hby, hab):
+        wit = "BGKVzj4ve0VSd8z_AmvhLg4lqcC_9WYX90k03q-R_Ydo"
+        regery = Regery(hby=hby, name="test", temp=True)
+        issuer = regery.makeRegistry(prefix=hab.pre, name="test", **KWA)
+
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
+
+        hby.cf.put(cf)
+        kvy = Kevery(db=hby.db, cf=hby.cf, enableKram=True, lax=False, local=False)
+        tvy = Tevery(db=hby.db, reger=regery.reger, local=False)
+        assert kvy.kramer.enabled is True
+
+        verfer = Verifier(hby=hby, reger=regery.reger)
+        msg = verfer.query(hab.pre, issuer.regk,
+                           "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4",
+                           route="tels", version=Vrsn_2_0, kind=Kinds.json)
+        client = MockClient()
+
+        streamCESRRequests(client, msg, dest=wit, path="/qry/tels")
+
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/qry/tels"
+        serder = SerderKERI(raw=args['body'])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "tels"
+        assert serder.ked["q"]["i"] == "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4"
+        assert serder.ked["q"]["ri"] == issuer.regk
+        assert serder.ked["q"]["src"] == hab.pre
+
+        headers = args["headers"]
+        assert headers["Content-Type"] == "application/cesr"
+        assert headers["Content-Length"] == 360
+        assert len(headers["CESR-ATTACHMENT"]) == 144
+
+        ims = bytearray(args["body"])
+        ims.extend(headers["CESR-ATTACHMENT"])
+        Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy, tvy=tvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
+
+        topics = {"/receipt": 0}
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query={"topics": topics},
+                        version=Vrsn_2_0, kind=Kinds.json, gvrsn=Vrsn_2_0)
+        client = MockClient()
+
+        streamCESRRequests(client, msg, dest=wit, path="/qry/mbx")
+
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/qry/mbx"
+        serder = SerderKERI(raw=args["body"])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "mbx"
+        assert serder.ked["q"]["i"] == hab.pre
+        assert serder.ked["q"]["src"] == wit
+        assert serder.ked["q"]["topics"] == topics
+
+        headers = args["headers"]
+        assert headers["Content-Type"] == "application/cesr"
+        assert headers["Content-Length"] == 331
+        assert len(headers["CESR-ATTACHMENT"]) == 144
+        assert headers["CESR-ATTACHMENT"] == (b'-CAj-YAiEChqfw9-5A5qMrZ8_YgOAJm8iKMbTAUvfDVVI6KNGL3M-'
+                                            b'KAWAAA6IQQzemdSFuRZ3AU0jbL9qn9D__V6ygWoVIvrZEzujBmQwng-'
+                                            b'_xDuIwxX599cuwuliEl4CfYzuynwVYdVqz0K')
+
+        ims = bytearray(args["body"])
+        ims.extend(headers["CESR-ATTACHMENT"])
+        Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
+
+        msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0),
+                         version=Vrsn_2_0, kind=Kinds.json, gvrsn=Vrsn_2_0)
+        msgs.extend(hab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0))
+
+        client = MockClient()
+        streamCESRRequests(client, msgs, dest=wit)
+        assert len(client.args) == 2
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/"
+
+        serder = SerderKERI(raw=args["body"])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.icp
+        assert serder.ked["i"] == hab.pre
+
+        headers = args["headers"]
+        assert headers['Content-Type'] == 'application/cesr'
+        assert headers['Content-Length'] == 301
+        assert len(headers['CESR-ATTACHMENT']) == 92
+
+        args = client.args.pop()
+        assert args["method"] == "POST"
+        assert args["path"] == "/"
+
+        serder = SerderKERI(raw=args["body"])
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "logs"
+        assert serder.ked["q"]["s"] == 0
+        assert serder.ked["q"]["i"] == hab.pre
+        assert serder.ked["q"]["src"] == wit
+
+        headers = args["headers"]
+        assert headers['Content-Type'] == 'application/cesr'
+        assert headers['Content-Length'] == len(args["body"])
+        assert len(headers['CESR-ATTACHMENT']) == 144
+        assert headers['CESR-ATTACHMENT'] == (b'-CAj-YAiEChqfw9-5A5qMrZ8_YgOAJm8iKMbTAUvfDVVI6KNGL3M-'
+                                              b'KAWAACFNqIda6R-Q-cZa_bWrLwt7busxW5fKnqyTP_ToGnI7Chsjv'
+                                              b'2TyFy-T52aVmemAXjZsxWrOrZtE8WcvU0b57EE')
+
+        ims = bytearray(args["body"])
+        ims.extend(headers["CESR-ATTACHMENT"])
+        Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
+
+
 if __name__ == '__main__':
     test_parse_cesr_request()

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -16,8 +16,8 @@ from hio.core import http
 from hio.base import doing
 from hio.help import decking
 
-from keri.kering import Schemes, Vrsn_1_0, Kinds, Ilks, Roles
-from keri.core import SerderKERI, Salter
+from keri.kering import Schemes, Vrsn_1_0, Vrsn_2_0, Kinds, Ilks, Roles
+from keri.core import SerderKERI, Salter, Kevery, Parser
 from keri.db import basing
 from keri.app import (MailboxIterable, QryRpyMailboxIterable,
                       QueryEnd, Mailboxer, Receiptor,
@@ -160,6 +160,84 @@ def test_qrymailbox_iter():
         val = next(mbi)
         assert val == (b'id: 0\nevent: /receipt\nretry: 1000\ndata: '
                        b'{"i": "EIaGMMWJFPmtXznY1IIiKDIrg-vIyge6mBl2QV8dDjI3", '
+                       b'"t": "rct"}\n\n')
+
+        mb.iter.TimeoutMBX = 0  # Force the iter to timeout
+        with pytest.raises(StopIteration):
+            next(mbi)
+
+
+def test_qrymailbox_iter_v2():
+    topics = {"/receipt": 0, "/challenge": 1, "/multisig": 0}
+
+    with openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_2_0, kind=Kinds.json) as (hby, hab):
+        assert hab.pre == 'EChqfw9-5A5qMrZ8_YgOAJm8iKMbTAUvfDVVI6KNGL3M'
+        icp = hab.msgOwnInception(framed=True, gvrsn=Vrsn_2_0)
+        icpSrdr = SerderKERI(raw=icp)
+        qry = hab.query(pre=hab.pre, src=hab.pre, route="mbx", query={"topics": topics},
+                        version=Vrsn_2_0, kind=Kinds.json, gvrsn=Vrsn_2_0)
+        srdr = SerderKERI(raw=qry)
+        assert srdr.pvrsn == Vrsn_2_0
+        assert srdr.gvrsn == Vrsn_2_0
+        assert srdr.kind == Kinds.json
+        assert srdr.ked["q"]["topics"] == topics
+        
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
+
+        hby.cf.put(cf)
+        kvy = Kevery(db=hby.db, cf=hby.cf, enableKram=True, lax=False, local=False)
+        assert kvy.kramer.enabled is True
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(qry), kvy=kvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, srdr.said))
+        assert cache is not None
+        assert cache.mdt == srdr.stamp
+        assert cache.d == 1000
+
+        cues = decking.Deck()
+        mbx = Mailboxer(temp=True)
+        mb = QryRpyMailboxIterable(mbx=mbx, cues=cues, said=srdr.said, retry=1000)
+
+        mbi = iter(mb)
+        assert mb.iter is None
+
+        #  No cued query response, empty iter
+        val = next(mbi)
+        assert val == b''
+        assert mb.iter is None
+
+        # A cue with the wrong said still returns nothing and recues the cue
+        cues.append(dict(kin="stream", serder=icpSrdr))
+        val = next(mbi)
+        assert val == b''
+        assert len(cues) == 1
+        assert mb.iter is None
+        cues.popleft()
+
+        cues.append(dict(kin="stream", pre=hab.pre, serder=srdr, topics=topics))
+        val = next(mbi)
+        assert val == b''
+        assert len(cues) == 0
+        assert mb.iter is not None
+
+        # And now it behaves just like a standard MailboxIterable
+        val = next(mbi)
+        assert val == b'retry: 1000\n\n'
+
+        # Store a message for the iter
+        msg = dict(i=hab.pre, t="rct")
+        mbx.storeMsg(topic=f"{hab.pre}/receipt", msg=json.dumps(msg).encode("utf-8"))
+        val = next(mbi)
+        assert val == (b'id: 0\nevent: /receipt\nretry: 1000\ndata: '
+                       b'{"i": "EChqfw9-5A5qMrZ8_YgOAJm8iKMbTAUvfDVVI6KNGL3M", '
                        b'"t": "rct"}\n\n')
 
         mb.iter.TimeoutMBX = 0  # Force the iter to timeout

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -181,6 +181,11 @@ def test_qrymailbox_iter_v2():
         assert srdr.pvrsn == Vrsn_2_0
         assert srdr.gvrsn == Vrsn_2_0
         assert srdr.kind == Kinds.json
+        assert srdr.ked["t"] == Ilks.qry
+        assert srdr.ked["i"] == hab.pre
+        assert srdr.ked["r"] == "mbx"
+        assert srdr.ked["q"]["i"] == hab.pre
+        assert srdr.ked["q"]["src"] == hab.pre
         assert srdr.ked["q"]["topics"] == topics
         
         cf = {

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -5,11 +5,11 @@ keri.app.querying module
 """
 from hio.base import doing
 
-from keri.kering import Vrsn_1_0, Kinds
+from keri.kering import Vrsn_1_0, Vrsn_2_0, Kinds
 from keri.app import (QueryDoer, KeyStateNoticer, LogQuerier,
                       SeqNoQuerier, AnchorQuerier, openHby)
 
-from keri.core import SerderKERI, Parser, reply
+from keri.core import SerderKERI, Parser, Kevery, reply
 from keri.db import dgKey
 
 from tests.common import CUE_KWA, KWA
@@ -152,6 +152,188 @@ def test_querying():
         deeds = doist.enter(doers=[adoer])
         doist.recur(deeds=deeds)
         assert len(adoer.witq.msgs) == 1
+
+
+def test_querying_v2():
+    with openHby(version=Vrsn_2_0) as hby, \
+            openHby(version=Vrsn_2_0) as hby1:
+        inqHab = hby.makeHab(name="inquisitor", version=Vrsn_2_0, kind=Kinds.cesr)
+        subHab = hby1.makeHab(name="subject", version=Vrsn_2_0, kind=Kinds.cesr)
+        qdoer = QueryDoer(hby=hby, hab=inqHab, kvy=hby.kvy, pre=subHab.pre,
+                          version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+
+        icp = subHab.msgOwnInception(framed=True, gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parseOne(ims=bytearray(icp), kvy=inqHab.kvy)
+
+        assert qdoer is not None
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+
+        deeds = doist.enter(doers=[qdoer])
+
+        assert len(qdoer.doers) == 1
+        ksnDoer = qdoer.doers[0]
+        assert isinstance(ksnDoer, KeyStateNoticer)
+        assert len(ksnDoer.witq.msgs) == 1
+        msg = ksnDoer.witq.msgs.popleft()
+        assert msg["src"] == inqHab.pre
+        assert msg["pre"] == subHab.pre
+        assert msg["r"] == "ksn"
+        assert msg["q"] == {'fn': '0', 's': '0'}
+        assert msg["wits"] is None
+        assert msg["kwa"]["version"] == Vrsn_2_0
+        assert msg["kwa"]["kind"] == Kinds.cesr
+        assert msg["kwa"]["gvrsn"] == Vrsn_2_0
+
+        doist.recur(deeds=deeds)
+
+        # Cue up a saved key state equal to the one we have
+        hby.kvy.cues.clear()
+        ksr = subHab.kever.state()
+        cue = dict(kin="keyStateSaved", ksn=ksr._asdict())
+        hby.kvy.cues.append(cue)
+
+        doist.recur(deeds=deeds)
+
+        # We already have up to date key state so loaded will be true
+        assert qdoer.done is True
+        assert len(hby.kvy.cues) == 0
+
+        # create a new query doer
+        qdoer = QueryDoer(hby=hby, hab=inqHab, kvy=hby.kvy, pre=subHab.pre,
+                          version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+
+        # rotate AID and submit as a new keyStateSave
+        rot = subHab.rotate(framed=True, version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        ksr = subHab.kever.state()
+        cue = dict(kin="keyStateSaved", ksn=ksr._asdict())
+        hby.kvy.cues.append(cue)
+        deeds = doist.enter(doers=[qdoer])
+        doist.recur(deeds=deeds)
+
+        # We are behind in key state, so we aren't done and have queried for the logs
+        assert qdoer.done is False
+        assert len(qdoer.doers) == 1
+        ksnDoer = qdoer.doers[0]
+        assert isinstance(ksnDoer, KeyStateNoticer)
+        assert len(ksnDoer.witq.msgs) == 1
+
+        assert len(ksnDoer.doers) == 1
+        logDoer = ksnDoer.doers[0]
+        assert isinstance(logDoer, LogQuerier)
+        assert len(hby.kvy.cues) == 0
+
+        Parser(version=Vrsn_2_0).parseOne(ims=bytearray(rot), kvy=inqHab.kvy)
+        doist.recur(deeds=deeds)
+
+        assert qdoer.done is True
+
+        # Test sequence querier
+        sdoer = SeqNoQuerier(hby=hby, hab=inqHab, pre=subHab.pre, sn=5,
+                              version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(sdoer.witq.msgs) == 1
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[sdoer])
+        doist.recur(deeds=deeds)
+        assert len(sdoer.witq.msgs) == 0
+
+        sdoer = SeqNoQuerier(hby=hby, hab=inqHab, pre=subHab.pre, sn=1,
+                              version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(sdoer.witq.msgs) == 1
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[sdoer])
+        doist.recur(deeds=deeds)
+        assert len(sdoer.witq.msgs) == 1
+
+        sdoer = SeqNoQuerier(hby=hby, hab=inqHab, pre=subHab.pre, fn=2, sn=4,
+                              version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(sdoer.witq.msgs) == 1
+        msg = sdoer.witq.msgs.pull()
+        query = msg['q']
+        assert query == {'fn': '2', 's': '4'}
+        assert msg["kwa"]["version"] == Vrsn_2_0
+        assert msg["kwa"]["kind"] == Kinds.cesr
+        assert msg["kwa"]["gvrsn"] == Vrsn_2_0
+
+        # Test with originally unknown AID
+        sdoer = SeqNoQuerier(hby=hby, hab=inqHab, pre="ExxCHAI9bkl50F5SCKl2AWQbFGKeJtz0uxM2diTMxMQA",
+                              sn=1, version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(sdoer.witq.msgs) == 1
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[sdoer])
+        doist.recur(deeds=deeds)
+        assert len(sdoer.witq.msgs) == 1
+
+        # Test anchor querier
+        adoer = AnchorQuerier(hby=hby, hab=inqHab, pre=subHab.pre, anchor={'s': '5'},
+                              version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(adoer.witq.msgs) == 1
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[adoer])
+        doist.recur(deeds=deeds)
+        assert len(sdoer.witq.msgs) == 1
+
+        # Test with originally unknown AID
+        adoer = AnchorQuerier(hby=hby, hab=inqHab, pre="ExxCHAI9bkl50F5SCKl2AWQbFGKeJtz0uxM2diTMxMQA",
+                              anchor={'s': '5'}, version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        assert len(adoer.witq.msgs) == 1
+
+        tock = 0.03125
+        limit = 1.0
+        doist = doing.Doist(limit=limit, tock=tock, real=True)
+        deeds = doist.enter(doers=[adoer])
+        doist.recur(deeds=deeds)
+        assert len(adoer.witq.msgs) == 1
+
+        # KRAM assertions for a v2 query parsed by the receiver
+        icp = inqHab.msgOwnInception(framed=True, gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parseOne(ims=bytearray(icp), kvy=hby1.kvy)
+        assert inqHab.pre in hby1.kevers
+
+        qry = inqHab.query(subHab.pre, route="ksn", src=inqHab.pre,
+                           version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+        serder = SerderKERI(raw=qry)
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.cesr
+
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
+
+        hby1.cf.put(cf)
+        kvy = Kevery(db=hby1.db, cf=hby1.cf, enableKram=True, lax=False, local=False)
+        assert kvy.kramer.enabled is True
+
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(qry), kvy=kvy)
+        cache = hby1.db.kramMSGC.get(keys=(inqHab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
+
 
 def test_query_not_found_escrow():
     with openHby(version=Vrsn_1_0) as hby, \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ class DbSeed:
         rvy = routing.Revery(db=db, rtr=rtr)
         kvy = eventing.Kevery(db=db, lax=False, local=True, rvy=rvy)
         kvy.registerReplyRoutes(router=rtr)
-        psr = parsing.Parser(framed=True, kvy=kvy, rvy=rvy, version=Vrsn_1_0)
+        psr = parsing.Parser(framed=True, kvy=kvy, rvy=rvy, version=version)
 
         if protocols is None:
             protocols = [Schemes.tcp, Schemes.http]

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -431,6 +431,58 @@ KRAM_INTEGRATION_CONFIG = {
 }
 
 
+def test_parser_routes_v2_query_through_kram(mockHelpingNowUTC):
+    """Parser must route v2 qry messages through Kevery.processMsg and KRAM"""
+    salt1 = Salter(raw=b'0123456789abcdef').qb64
+    salt2 = Salter(raw=b'0123456789abcdeg').qb64
+
+    with (openHby(name="sender", base="test", salt=salt1, version=V2) as senderHby,
+          openHby(name="receiver", base="test", salt=salt2, version=V2) as receiverHby):
+
+        senderHab = senderHby.makeHab(name="sender", isith='1', icount=1,
+                                      transferable=True, **KWA)
+        receiverHby.makeHab(name="receiver", isith='1', icount=1,
+                            transferable=True, **KWA)
+
+        crossKvy = Kevery(db=receiverHby.db, lax=False, local=False)
+        senderIcp = senderHab.msgOwnEvent(sn=0, framed=True, gvrsn=V2)
+        Parser(version=V2).parse(ims=bytearray(senderIcp), kvy=crossKvy)
+        assert senderHab.pre in crossKvy.kevers
+
+        with openCF(name="kram_parser_v2", base="test", temp=True) as cf:
+            cf.put(KRAM_INTEGRATION_CONFIG)
+            kramer = Kramer(db=receiverHby.db, cf=cf)
+            assert kramer.enabled
+
+            calls = []
+            original_intake = kramer.intake
+
+            def intake(serder, kwa=None):
+                calls.append((serder.ilk, serder.ked.get("r")))
+                return original_intake(serder, kwa)
+
+            kramer.intake = intake
+            kvy = Kevery(db=receiverHby.db, lax=False, local=False, kramer=kramer)
+
+            stamp = helping.nowIso8601()
+            qry = query(pre=senderHab.pre,
+                        route="ksn",
+                        query=dict(i=senderHab.pre, src=senderHab.pre),
+                        stamp=stamp,
+                        **KWA)
+            msg = senderHab.endorse(qry, last=True, framed=False, gvrsn=V2)
+
+            Parser(version=V2).parse(ims=bytearray(msg), kvy=kvy)
+
+            assert calls == [("qry", "ksn")]
+            cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, qry.said))
+            assert cache is not None
+            assert cache.mdt == stamp
+            assert len(kvy.cues) > 0
+            cue = kvy.cues.popleft()
+            assert cue["kin"] == "reply"
+
+
 def test_scrub_invalid_pool_sigs():
     """_verifyAttachedSigs removes unverifiable signatures from kwa in place."""
     salt1 = Salter(raw=b'\xc1\x00' * 8).qb64

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -639,7 +639,8 @@ def test_assk(mockHelpingNowUTC):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -668,7 +669,8 @@ def test_assk(mockHelpingNowUTC):
                                           indexed=False)
             kwa = dict(cigars=cigars)
 
-            kvy.processMsg(msg2, kwa)
+            kwa["serder"] = msg2
+            kvy.processMsg(kwa)
 
             # Assert cache created for non-transferable sender
             cache = receiverHby.db.kramMSGC.get(keys=(senderNTHab.pre, msg2.said))
@@ -692,7 +694,8 @@ def test_assk(mockHelpingNowUTC):
             staleKwa = dict(lsgs=[(prefixer, staleSigers)])
 
             # kramit returns None -> processMsg returns silently
-            kvy.processMsg(staleMsg, staleKwa)
+            staleKwa["serder"] = staleMsg
+            kvy.processMsg(staleKwa)
 
             # Assert no cache entry created for stale message
             staleCache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, staleMsg.said))
@@ -706,7 +709,7 @@ def test_assk(mockHelpingNowUTC):
             origCache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
             assert origCache is not None  # still there from step 2
 
-            kvy.processMsg(msg, dict(lsgs=[(prefixer, sigers)]))
+            kvy.processMsg(dict(serder=msg, lsgs=[(prefixer, sigers)]))
 
             # Cache entry unchanged, no error raised
             cacheAfter = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -723,7 +726,7 @@ def test_assk(mockHelpingNowUTC):
                                        pvrsn=Vrsn_2_0)
 
             with pytest.raises(MissingAuthAttachmentError):
-                kvy.processMsg(noAuthMsg)  # empty kwa — no auth attachments
+                kvy.processMsg(dict(serder=noAuthMsg))  # empty kwa — no auth attachments
 
             # Clear the cues
             kvy.cues.clear()
@@ -745,7 +748,8 @@ def test_assk(mockHelpingNowUTC):
             unknownKwa = dict(lsgs=[(unknownPrefixer, unknownSigers)])
 
             with pytest.raises(MissingSenderKeyStateError):
-                kvy.processMsg(unknownMsg, unknownKwa)
+                unknownKwa["serder"] = unknownMsg
+                kvy.processMsg(unknownKwa)
 
             # Assert cue key state retrieval notification
             cue = kvy.cues.popleft()
@@ -815,7 +819,8 @@ def test_asmk(mockHelpingNowUTC):
             assert len(allSigers) == 3
 
             kwa = dict(lsgs=[(prefixer, allSigers)])
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert kramMSGC cache created, partials empty (threshold met immediately)
             cacheOrig = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -841,7 +846,8 @@ def test_asmk(mockHelpingNowUTC):
             allSigers2 = signMsg(msg2)
 
             kwa = dict(lsgs=[(prefixer, [allSigers2[0]])])
-            kvy.processMsg(msg2, kwa)
+            kwa["serder"] = msg2
+            kvy.processMsg(kwa)
 
             # Assert kramMSGC cache created for partial sigs
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg2.said))
@@ -861,7 +867,8 @@ def test_asmk(mockHelpingNowUTC):
 
             # Second delivery: 2 of 3 sigs, threshold met
             kwa = dict(lsgs=[(prefixer, [allSigers2[2]])])
-            kvy.processMsg(msg2, kwa)
+            kwa["serder"] = msg2
+            kvy.processMsg(kwa)
 
             # Partials persist until pruner cleans up (not deleted on threshold)
             assert receiverHby.db.kramPMKM.get(keys=(senderHab.pre, msg2.said)) is not None
@@ -886,12 +893,12 @@ def test_asmk(mockHelpingNowUTC):
             allSigers3 = signMsg(msg3)
 
             # First delivery, sig index 0
-            kvy.processMsg(msg3, dict(lsgs=[(prefixer, [allSigers3[0]])]))
+            kvy.processMsg(dict(serder=msg3, lsgs=[(prefixer, [allSigers3[0]])]))
             kramPMKS = receiverHby.db.kramPMKS.get(keys=(senderHab.pre, msg3.said))
             assert len(kramPMKS) == 1
 
             # Second delivery: same sig index 0 again
-            kvy.processMsg(msg3, dict(lsgs=[(prefixer, [allSigers3[0]])]))
+            kvy.processMsg(dict(serder=msg3, lsgs=[(prefixer, [allSigers3[0]])]))
             kramPMKS_after = receiverHby.db.kramPMKS.get(keys=(senderHab.pre, msg3.said))
             assert len(kramPMKS_after) == 1  # deduped, still 1 unique sig
 
@@ -917,7 +924,8 @@ def test_asmk(mockHelpingNowUTC):
             kwa = dict(lsgs=[(prefixer, [allSigers4[0]])],
                          tsgs=[tsg])
 
-            kvy.processMsg(msg4, kwa)
+            kwa["serder"] = msg4
+            kvy.processMsg(kwa)
 
             # Assert both sigs pooled, 2 of 3 threshold met
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg4.said))
@@ -938,7 +946,7 @@ def test_asmk(mockHelpingNowUTC):
             allSigers2f = signMsg(msg5)
 
             # First delivery, 1 sig
-            kvy.processMsg(msg5, dict(lsgs=[(prefixer, [allSigers2f[0]])]))
+            kvy.processMsg(dict(serder=msg5, lsgs=[(prefixer, [allSigers2f[0]])]))
             assert receiverHby.db.kramPMKS.get(keys=(senderHab.pre, msg5.said)) is not None
 
             # Rotate sender
@@ -951,7 +959,7 @@ def test_asmk(mockHelpingNowUTC):
                                            indexed=True)
 
             # Second delivery with new-key sig — key state mismatch detected
-            kvy.processMsg(msg5, dict(lsgs=[(prefixer, [newSigers[2]])]))
+            kvy.processMsg(dict(serder=msg5, lsgs=[(prefixer, [newSigers[2]])]))
 
             # Assert accumulation invalidated by key state change -> returns None
             # The partial DB entries still exist (should we be wiping these here?)
@@ -976,7 +984,7 @@ def test_asmk(mockHelpingNowUTC):
                                              verfers=senderHab.kever.verfers,
                                              indexed=True)
 
-            kvy.processMsg(msg6, dict(lsgs=[(prefixer, allSigers2g)]))
+            kvy.processMsg(dict(serder=msg6, lsgs=[(prefixer, allSigers2g)]))
 
             # Assert accepted because multi-key uses long lag (ll=60000ms)
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg6.said))
@@ -987,7 +995,7 @@ def test_asmk(mockHelpingNowUTC):
 
             # Step 8: Test cache-exists idempotency
             # Resend the fully-accepted message from 2b with more sigs
-            kvy.processMsg(msg, dict(lsgs=[(prefixer, allSigers)]))
+            kvy.processMsg(dict(serder=msg, lsgs=[(prefixer, allSigers)]))
 
             # kramit finds existing cache, multi-key path -> accumulation attempt
             # but threshold already met -> idempotent drop, no error
@@ -1074,7 +1082,7 @@ def test_asr(mockHelpingNowUTC):
             # Pure seal, no sigs. kramit accepts via asr, but downstream
             # _processMsgQry raises ValidationError (no source/cigars).
             with pytest.raises(ValidationError):
-                kvy.processMsg(msg, dict(sscs=sscs))
+                kvy.processMsg(dict(serder=msg, sscs=sscs))
 
             # Assert: kramit created cache before downstream error
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -1111,7 +1119,8 @@ def test_asr(mockHelpingNowUTC):
                                         indexed=True)
             kwa = dict(ssts=ssts, lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg2, kwa)
+            kwa["serder"] = msg2
+            kvy.processMsg(kwa)
 
             # Assert accepted via asr, full flow succeeds
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg2.said))
@@ -1148,7 +1157,8 @@ def test_asr(mockHelpingNowUTC):
                                         indexed=True)
             kwa = dict(ssts=nonMatchingSsts, lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg3, kwa)
+            kwa["serder"] = msg3
+            kvy.processMsg(kwa)
 
             # Resolves to assk (single-key). Accepted via sig auth.
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg3.said))
@@ -1173,7 +1183,8 @@ def test_asr(mockHelpingNowUTC):
             kwa = dict(sscs=sscs)  # pure sscs, no sigs
 
             # kramit returns None (message dropped)
-            kvy.processMsg(msg4, kwa)
+            kwa["serder"] = msg4
+            kvy.processMsg(kwa)
 
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg4.said))
             assert cache is None  # no cache created
@@ -1193,7 +1204,8 @@ def test_asr(mockHelpingNowUTC):
             sscs = [(Seqner(sn=999), Saider(qb64=ixnSaid))]
             kwa = dict(sscs=sscs)  # pure sscs, no sigs
 
-            kvy.processMsg(msg5, kwa)
+            kwa["serder"] = msg5
+            kvy.processMsg(kwa)
 
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg5.said))
             assert cache is None  # no cache
@@ -1222,7 +1234,8 @@ def test_asr(mockHelpingNowUTC):
             kwa = dict(sscs=sscs, lsgs=[(prefixer, sigers)])
 
             # falls back to assk
-            kvy.processMsg(msg6, kwa)
+            kwa["serder"] = msg6
+            kvy.processMsg(kwa)
 
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg6.said))
             assert cache is not None  # accepted via sig fallback
@@ -1249,7 +1262,8 @@ def test_asr(mockHelpingNowUTC):
                                         verfers=senderHab.kever.verfers,
                                         indexed=True)
             kwa = dict(sscs=sscs, lsgs=[(prefixer, sigers)])
-            kvy.processMsg(msg7, kwa)
+            kwa["serder"] = msg7
+            kvy.processMsg(kwa)
 
             # Seal valid -> asr, sigs irrelevant to auth type resolution
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg7.said))
@@ -1275,7 +1289,8 @@ def test_asr(mockHelpingNowUTC):
                                         verfers=senderHab.kever.verfers,
                                         indexed=True)
             kwa = dict(sscs=sscs, lsgs=[(prefixer, sigers)])
-            kvy.processMsg(msg8, kwa)
+            kwa["serder"] = msg8
+            kvy.processMsg(kwa)
 
             # _resolveAuthType: seal fails -> single-key resolves to assk
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg8.said))
@@ -1303,7 +1318,8 @@ def test_asr(mockHelpingNowUTC):
                                        indexed=True)
             kwa = dict(sscs=sscs, lsgs=[(mkPrefixer, [allSigers[0]])])
 
-            kvy.processMsg(msg7, kwa)
+            kwa["serder"] = msg7
+            kvy.processMsg(kwa)
 
             # _resolveAuthType: seal fails, resolves to asmk
             cache = receiverHby.db.kramMSGC.get(keys=(mkHab.pre, msg7.said))
@@ -1315,7 +1331,7 @@ def test_asr(mockHelpingNowUTC):
             assert len(kramPMKS) == 1
 
             # Send 2nd sig -> threshold met (2 of 3)
-            kvy.processMsg(msg7, dict(sscs=sscs,
+            kvy.processMsg(dict(serder=msg7, sscs=sscs,
                                         lsgs=[(mkPrefixer, [allSigers[1]])]))
 
             # Partials persist until pruner cleans up (not deleted on threshold)
@@ -1348,7 +1364,8 @@ def test_asr(mockHelpingNowUTC):
                                              indexed=True)
             kwa = dict(sscs=sscs, lsgs=[(prefixer, wrongSigers)])
 
-            kvy.processMsg(msg8, kwa)
+            kwa["serder"] = msg8
+            kvy.processMsg(kwa)
 
             # _resolveAuthType: seal validates -> asr -> sigs never checked
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg8.said))
@@ -1449,7 +1466,8 @@ def test_transactioned(mockHelpingNowUTC):
 
             # Error raised due to lack of exchanger. Could probably set one up for this test
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert kramTMSC entry created for exn
             cache = receiverHby.db.kramTMSC.get(keys=(skHab.pre, xip.said, exn.said))
@@ -1475,7 +1493,8 @@ def test_transactioned(mockHelpingNowUTC):
             kwa = dict(lsgs=[(skPrefixer, sigers)])
 
             # kramit can't find xip's xdt, returns None, processMsg returns
-            kvy.processMsg(msg3, kwa)
+            kwa["serder"] = msg3
+            kvy.processMsg(kwa)
 
             # Assert no kramTMSC entry for the exn
             cache = receiverHby.db.kramTMSC.get(keys=(skHab.pre, fakeXid, msg3.said))
@@ -1510,7 +1529,8 @@ def test_transactioned(mockHelpingNowUTC):
 
             # mdt passes standard timeliness, but
             # xdt=10min ago, mdt=now: xdt + xl = 5min ago < now -> fails
-            kvy.processMsg(msg4, kwa)
+            kwa["serder"] = msg4
+            kvy.processMsg(kwa)
 
             # Assert no kramTMSC entry (exchange window failed)
             cache = receiverHby.db.kramTMSC.get(
@@ -1554,7 +1574,8 @@ def test_transactioned(mockHelpingNowUTC):
             # First delivery: 1 sig (below 2-of-3 threshold)
             kwa = dict(lsgs=[(mkPrefixer, [allSigers[0]])])
             # kramit returns None (pending) -> processMsg returns without dispatch
-            kvy.processMsg(mkExn, kwa)
+            kwa["serder"] = mkExn
+            kvy.processMsg(kwa)
 
             # kramTMSC cache created (multi-key still creates cache entry)
             cache = receiverHby.db.kramTMSC.get(
@@ -1572,7 +1593,8 @@ def test_transactioned(mockHelpingNowUTC):
             # kramit returns msg (threshold met). processMsg dispatches to
             # _processMsgExn which raises ValidationError (no Exchanger).
             with pytest.raises(ValidationError):
-                kvy.processMsg(mkExn, kwa)
+                kwa["serder"] = mkExn
+                kvy.processMsg(kwa)
 
             # Partials persist until pruner cleans up (not deleted on threshold)
             assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
@@ -1615,8 +1637,7 @@ def test_transactioned(mockHelpingNowUTC):
                     Saider(qb64=skKever.serder.said),
                     sigers8)
 
-            kvyWithExc.processMsg(exn8,
-                                  dict(lsgs=[(skPrefixer, sigers8)],
+            kvyWithExc.processMsg(dict(serder=exn8, lsgs=[(skPrefixer, sigers8)],
                                        tsgs=[tsg8]))
 
             cache = receiverHby.db.kramTMSC.get(keys=(skHab.pre, xip8.said, exn8.said))
@@ -1659,8 +1680,7 @@ def test_transactioned(mockHelpingNowUTC):
                     Saider(qb64=skKever.serder.said),
                     sigers8)
 
-            kvyWithExc.processMsg(exn8,
-                                  dict(lsgs=[(skPrefixer, sigers8)],
+            kvyWithExc.processMsg(dict(serder=exn8, lsgs=[(skPrefixer, sigers8)],
                                        tsgs=[tsg8]))
 
             cache = receiverHby.db.kramTMSC.get(keys=(skHab.pre, xip8.said, exn8.said))
@@ -1943,7 +1963,8 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
                        trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
                        frcs=frcs, tdcs=tdcs, ptds=ptds,
                        bsqs=bsqs, bsss=bsss, tmqs=tmqs)
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Threshold not met, partials populated
             assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
@@ -1967,7 +1988,8 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
 
             # Re-delivery of same non-auth attachments is idempotent
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             assert receiverHby.db.kramSSCS.get(keys=partialKey) == []
             assert len(receiverHby.db.kramTRQS.get(keys=partialKey)) == 1
@@ -1988,7 +2010,8 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
                         trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
                         frcs=frcs, tdcs=tdcs, ptds=ptds,
                         bsqs=bsqs, bsss=bsss, tmqs=tmqs)
-            kvy.processMsg(msg, kwa2)
+            kwa2["serder"] = msg
+            kvy.processMsg(kwa2)
 
             # Threshold met, cue generated
             assert len(kvy.cues) > 0
@@ -2151,7 +2174,8 @@ def test_non_auth_attachments_empty_kwa(mockHelpingNowUTC):
             # Partial delivery with no non-auth attachments in kwa
 
             kwa = dict(lsgs=[(prefixer, [allSigers[0]])])
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Sig partial populated
             assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
@@ -2385,7 +2409,8 @@ def test_stale_tsgs(mockHelpingNowUTC):
                 msg=msg, senderId=senderHab.pre, kever=receiverKever, kwa=kwa)
             assert len(sig_probe.stale_tsgs) == 1
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Same-sender prior-event tsg scrubbed; only current quad remains.
             assert len(kwa.get('tsgs', [])) == 1
@@ -2430,7 +2455,8 @@ def test_stale_tsgs(mockHelpingNowUTC):
 
             kwa2 = dict(lsgs=[(prefixer, currentSigers2)],
                         tsgs=currentTsgs2 + [bogusStaleTsg])
-            kvy.processMsg(msg2, kwa2)
+            kwa2["serder"] = msg2
+            kvy.processMsg(kwa2)
 
             assert len(kwa2.get('tsgs', [])) == 1
             assert kwa2['tsgs'][0][1].sn == curSeqner.sn
@@ -2469,7 +2495,8 @@ def test_stale_tsgs(mockHelpingNowUTC):
             kwa3a = dict(lsgs=[(prefixer, [currentSigers3[0]])],
                          tsgs=[(prefixer, curSeqner, curSaider,
                                 [currentSigers3[0]])] + [staleTsg3])
-            kvy.processMsg(msg3, kwa3a)
+            kwa3a["serder"] = msg3
+            kvy.processMsg(kwa3a)
 
             assert len(kwa3a.get('tsgs', [])) == 1
             assert kwa3a['tsgs'][0][1].sn == curSeqner.sn
@@ -2488,7 +2515,8 @@ def test_stale_tsgs(mockHelpingNowUTC):
             kwa3b = dict(lsgs=[(prefixer, [currentSigers3[1]])],
                          tsgs=[(prefixer, curSeqner, curSaider,
                                 [currentSigers3[1]])])
-            kvy.processMsg(msg3, kwa3b)
+            kwa3b["serder"] = msg3
+            kvy.processMsg(kwa3b)
 
             # Threshold met, cue generated
             assert len(kvy.cues) > 0
@@ -2627,7 +2655,8 @@ def test_cue_ks_non_transactioned(mockHelpingNowUTC):
             kwa = dict(lsgs=[(skPrefixer, sigers)])
 
             with pytest.raises(MissingSenderKeyStateError):
-                kvy.processMsg(msg, kwa)
+                kwa["serder"] = msg
+                kvy.processMsg(kwa)
 
             # Assert cue key state retrieval notification
             cue = kvy.cues.popleft()
@@ -2653,7 +2682,8 @@ def test_cue_ks_non_transactioned(mockHelpingNowUTC):
             kwa = dict(lsgs=[(mkPrefixer, sigers)])
 
             with pytest.raises(MissingSenderKeyStateError):
-                kvy.processMsg(msg, kwa)
+                kwa["serder"] = msg
+                kvy.processMsg(kwa)
 
             # Assert cue key state retrieval notification
             cue = kvy.cues.popleft()
@@ -2677,7 +2707,8 @@ def test_cue_ks_non_transactioned(mockHelpingNowUTC):
             sscs = [(Seqner(sn=999), Saider(qb64=ixnSaid))]
             kwa = dict(sscs=sscs)  # pure sscs, no sigs
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             cache = receiverHby.db.kramMSGC.get(keys=(kownSenderHab.pre, msg.said))
             assert cache is None  # no cache
@@ -2884,7 +2915,8 @@ def test_aid_allow_deny(mockHelpingNowUTC):
                                         indexed=True)
             prefixer = Prefixer(qb64=denyHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache was not created
             assert receiverHby.db.kramMSGC.get(keys=(denyHab.pre, msg.said)) is None
@@ -2907,7 +2939,8 @@ def test_aid_allow_deny(mockHelpingNowUTC):
                                         indexed=True)
             prefixer = Prefixer(qb64=allowHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache was created
             assert receiverHby.db.kramMSGC.get(keys=(allowHab.pre, msg.said)) is not None
@@ -2925,7 +2958,8 @@ def test_aid_allow_deny(mockHelpingNowUTC):
                                         indexed=True)
             prefixer = Prefixer(qb64=denyHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache was not created because the allow list is active and denyHab is not
             # in the allow list
@@ -2935,7 +2969,8 @@ def test_aid_allow_deny(mockHelpingNowUTC):
             kvy.allowList.add(denyHab.pre)
 
             # Re process the message
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache was created
             assert receiverHby.db.kramMSGC.get(keys=(denyHab.pre, msg.said)) is not None
@@ -3347,7 +3382,8 @@ def test_existing_caches_unchanged_on_config_update(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -3424,7 +3460,8 @@ def test_existing_caches_unchanged_on_config_update(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             ctyp2 = receiverHby.db.kramCTYP.get("~")
             # Accept windows updated
@@ -3596,7 +3633,8 @@ def test_new_cache_type(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn
             cache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn.said))
@@ -3640,7 +3678,8 @@ def test_new_cache_type(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
              # Assert the new cache-type was processed and removed
             assert "exn.R.route1" not in kramer._pending
@@ -3680,7 +3719,8 @@ def test_new_cache_type(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn
             cache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn.said))
@@ -3853,7 +3893,8 @@ def test_multiple_new_cache_type(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -3908,7 +3949,8 @@ def test_multiple_new_cache_type(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn
             cache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn.said))
@@ -3948,7 +3990,8 @@ def test_multiple_new_cache_type(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert new qry cache-type values
             qryCt = receiverHby.db.kramCTYP.get("qry")
@@ -3993,7 +4036,8 @@ def test_multiple_new_cache_type(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn
             cache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn.said))
@@ -4149,7 +4193,8 @@ def test_merge_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -4180,7 +4225,8 @@ def test_merge_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -4218,7 +4264,8 @@ def test_merge_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
              # Assert "qry" was processed and removed
             assert "qry" not in kramer._pending
@@ -4257,7 +4304,8 @@ def test_merge_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -4367,7 +4415,8 @@ def test_modify_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert qry.R.logs cache-type values
             qryCtLgs = receiverHby.db.kramCTYP.get("qry.R.logs")
@@ -4426,7 +4475,8 @@ def test_modify_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert cache created
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -4484,7 +4534,8 @@ def test_modify_cache_types(fakeHelpingClock):
             prefixer = Prefixer(qb64=senderHab.pre)
             kwa = dict(lsgs=[(prefixer, sigers)])
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert "qry" was processed and removed
             assert "qry.R.logs" not in kramer._pending
@@ -4655,7 +4706,8 @@ def test_pruning_messages_single_key(fakeHelpingClock):
             kwa = dict(lsgs=[(prefixer, earlySigers)])
 
             # Process message, should be accepted and cached
-            kvy.processMsg(earlyMsg, kwa)
+            kwa["serder"] = earlyMsg
+            kvy.processMsg(kwa)
 
             # Run the doist to process pruning (though it shouldn't prune anything yet)
             doist.recur(deeds=deeds)
@@ -4693,7 +4745,8 @@ def test_pruning_messages_single_key(fakeHelpingClock):
             kwa = dict(lsgs=[(prefixer, laterSigers)])
 
             # Process the later message
-            kvy.processMsg(laterMsg, kwa)
+            kwa["serder"] = laterMsg
+            kvy.processMsg(kwa)
 
             # Assert later message is cached with its own timestamp
             laterCache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, laterMsg.said))
@@ -4877,7 +4930,8 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
                        frcs=frcs, tdcs=tdcs, ptds=ptds,
                        bsqs=bsqs, bsss=bsss, tmqs=tmqs)
 
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Run the doist to process pruning (it shouldn't prune anything yet)
             doist.recur(deeds=deeds)
@@ -5011,7 +5065,8 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
                        trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
                        frcs=frcs, tdcs=tdcs, ptds=ptds,
                        bsqs=bsqs, bsss=bsss, tmqs=tmqs)
-            kvy.processMsg(msg, kwa)
+            kwa["serder"] = msg
+            kvy.processMsg(kwa)
 
             # Assert msgc cache created for partial sigs
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said))
@@ -5047,7 +5102,8 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
                         trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
                         frcs=frcs, tdcs=tdcs, ptds=ptds,
                         bsqs=bsqs, bsss=bsss, tmqs=tmqs)
-            kvy.processMsg(msg, kwa2)
+            kwa2["serder"] = msg
+            kvy.processMsg(kwa2)
 
             # Threshold met, cue generated
             assert len(kvy.cues) > 0
@@ -5280,7 +5336,8 @@ def test_pruning_exchanges(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn, kwa)
+                kwa["serder"] = exn
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn
             firstCache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn.said))
@@ -5315,7 +5372,8 @@ def test_pruning_exchanges(fakeHelpingClock):
 
             # Error raised due to lack of exchanger
             with pytest.raises(ValidationError):
-                kvy.processMsg(exn2, kwa)
+                kwa["serder"] = exn2
+                kvy.processMsg(kwa)
 
             # Assert tmsc entry created for exn2
             secondCache = receiverHby.db.kramTMSC.get(keys=(senderHab.pre, xip.said, exn2.said))
@@ -5396,7 +5454,8 @@ def test_pruning_exchanges_cleans_transactional_partial_multisig(fakeHelpingCloc
                                        verfers=mkHab.kever.verfers,
                                        indexed=True)
             kwa = dict(lsgs=[(mkPrefixer, [allSigers[0]])])
-            kvy.processMsg(mkExn, kwa)
+            kwa["serder"] = mkExn
+            kvy.processMsg(kwa)
 
             tmscKey = (mkHab.pre, mkXip.said, mkExn.said)
             cache = receiverHby.db.kramTMSC.get(keys=tmscKey)

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -174,6 +174,36 @@ def test_configuration():
                 Kramer(db, cf)
 
 
+def test_kevery_enable_kram_creates_kramer():
+    """Kevery can opt into constructing its KRAM processor from config."""
+    conf = {
+        "kram": {
+            "enabled": True,
+            "denials": [],
+            "caches": {
+                "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+            }
+        }
+    }
+
+    with openCF(name="kram_kevery", base="test") as cf:
+        cf.put(conf)
+        with openDB(name="test_kevery_enable_kram", temp=True) as db:
+            kvy = Kevery(db=db, cf=cf)
+            assert kvy.kramer is None
+
+            kvy = Kevery(db=db, cf=cf, enableKram=True)
+            assert isinstance(kvy.kramer, Kramer)
+            assert kvy.kramer.enabled is True
+            assert kvy.kramer.cues is kvy.cues
+            assert db.kramCTYP.get("~").d == 1000
+
+    with openDB(name="test_kevery_enable_kram_no_config", temp=True) as db:
+        kvy = Kevery(db=db, enableKram=True)
+        assert isinstance(kvy.kramer, Kramer)
+        assert kvy.kramer.enabled is False
+
+
 def test_cache_type_constraints_valid():
     """Kramer init succeeds when cache-type tuple satisfies spec constraints."""
     validCf = {

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -9,9 +9,10 @@ import pytest
 from keri import (MissingRegistryError, MissingEntryError,
                   MissingChainError, RevokedChainError, Vrsn_1_0)
 from keri.app import openHab
-from keri.core import (Saider, Kevery, Seqner,
+from keri.core import (Saider, Kevery, SerderKERI, Seqner,
                        Diger, Parser, SealEvent,
                        MtrDex, Saids)
+from keri.kering import Kinds, Vrsn_2_0
 from keri.help import helping
 from keri.vc import credential
 from keri.vdr import Verifier, Regery, Tevery
@@ -34,6 +35,48 @@ def test_verifier_query(mockHelpingNowUTC, mockCoringRandomNonce):
                        b'Aj-HABEMl4RhuR_JxpiMd1N8DEJEhTxM3Ovvn9Xya8AN-tiUbl-AABAABGnrnayV'
                        b'yK1siivaffGHpWWhcVThPN_dsePQvMXrlsOYNf0UdT0e6ch-0bN-UuOJCd1behue'
                        b'Zs_0V9FQ9vw0wK')
+
+
+def test_verifier_query_v2(mockHelpingNowUTC, mockCoringRandomNonce):
+    with openHab(name="test", transferable=True, temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_2_0, kind=Kinds.json) as (hby, hab):
+        regery = Regery(hby=hby, name="test", temp=True)
+        issuer = regery.makeRegistry(prefix=hab.pre, name="test", version=Vrsn_1_0, kind=Kinds.json)
+
+        verfer = Verifier(hby=hby, reger=regery.reger)
+        qry = verfer.query(hab.pre, issuer.regk,
+                           "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4",
+                           route="tels", version=Vrsn_2_0, kind=Kinds.json)
+        serder = SerderKERI(raw=qry)
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+        assert serder.kind == Kinds.json
+        assert serder.ked["i"] == hab.pre
+        assert serder.ked["r"] == "tels"
+        assert serder.ked["q"]["i"] == "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4"
+        assert serder.ked["q"]["ri"] == issuer.regk
+        assert serder.ked["q"]["src"] == hab.pre
+
+        cf = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000]
+                }
+            }
+        }
+
+        hby.cf.put(cf)
+        kvy = Kevery(db=hby.db, cf=hby.cf, enableKram=True, lax=False, local=False)
+        tvy = Tevery(db=hby.db, reger=regery.reger, local=False)
+        assert kvy.kramer.enabled is True
+
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(qry), kvy=kvy, tvy=tvy)
+        cache = hby.db.kramMSGC.get(keys=(hab.pre, serder.said))
+        assert cache is not None
+        assert cache.mdt == serder.stamp
+        assert cache.d == 1000
 
 
 def test_verifier(seeder):

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -12,7 +12,7 @@ from keri.app import openHab
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
                        Diger, Parser, SealEvent,
                        MtrDex, Saids)
-from keri.kering import Kinds, Vrsn_2_0
+from keri.kering import Ilks, Kinds, Vrsn_2_0
 from keri.help import helping
 from keri.vc import credential
 from keri.vdr import Verifier, Regery, Tevery
@@ -51,6 +51,7 @@ def test_verifier_query_v2(mockHelpingNowUTC, mockCoringRandomNonce):
         assert serder.pvrsn == Vrsn_2_0
         assert serder.gvrsn == Vrsn_2_0
         assert serder.kind == Kinds.json
+        assert serder.ked["t"] == Ilks.qry
         assert serder.ked["i"] == hab.pre
         assert serder.ked["r"] == "tels"
         assert serder.ked["q"]["i"] == "EA8Ih8hxLi3mmkyItXK1u55cnHl4WgNZ_RE-gKXqgcX4"


### PR DESCRIPTION
- Routes v2 `qry`, `rpy`, `exn`, `xip`, `pro`, and `bar` messages through `Kevery.processMsg`
- Adds `Kevery(enableKram=True)` to create a `Kramer` from config
- Enables KRAM in witness `Reactant` using the habitat config
- Uses the habitat parser version for TCP witness messengers instead of hardcoded v1
- Fixes v2 DB replay attachment encoding in `cloneEvtMsg()`
- Adds v2 test coverage for parser/KRAM routing, Habery reply flows, and `WitnessInquisitor`

