### PR TITLE
Log kli witness start failures and prevent startup stalls (#238) — v1.2 backport

### DIFF
--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -7,11 +7,15 @@ Witness command line interface
 """
 import argparse
 import logging
+import sys
 
 from keri import __version__
 from keri import help
+from keri import kering
 from keri.app import directing, indirecting, habbing, keeping, configing
 from keri.app.cli.common import existing
+
+logger = help.ogler.getLogger()
 
 d = "Runs KERI witness controller.\n"
 d += "Example:\nwitness -H 5631 -t 5632\n"
@@ -51,14 +55,18 @@ parser.add_argument("--loglevel", action="store", required=False, default="CRITI
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 parser.add_argument("--logfile", action="store", required=False, default=None,
                     help="path of the log file. If not defined, logs will not be written to the file.")
+parser.add_argument("--no-prompt", action="store_true", default=None, required=False,
+                    help="Disable interactive prompt", dest="noPrompt")
 
 
 def launch(args):
-    help.ogler.level = logging.getLevelName(args.loglevel)
+    # Normalize level case; avoid invalid lowercase values that silently break level filtering
+    help.ogler.level = logging.getLevelName(args.loglevel.upper())
     if args.logfile is not None:
         help.ogler.headDirPath = args.logfile
         help.ogler.reopen(name=args.name, temp=False, clear=True)
-    logger = help.ogler.getLogger()
+
+    help.ogler.getLogger()  # re-applies ogler.level to the shared logger
 
     logger.info("\n******* Starting Witness for %s listening: http/%s, tcp/%s "
                 ".******\n\n", args.name, args.http, args.tcp)
@@ -73,17 +81,20 @@ def launch(args):
                configFile=args.configFile,
                keypath=args.keypath,
                certpath=args.certpath,
-               cafilepath=args.cafilepath)
+               cafilepath=args.cafilepath,
+               noPrompt=args.noPrompt)
 
     logger.info("\n******* Ended Witness for %s listening: http/%s, tcp/%s"
                 ".******\n\n", args.name, args.http, args.tcp)
 
 
 def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http=5632, expire=0.0,
-               configDir="", configFile="", keypath=None, certpath=None, cafilepath=None):
+               configDir="", configFile="", keypath=None, certpath=None, cafilepath=None,
+               noPrompt=None):
     """
     Setup and run one witness
     """
+    noPrompt = noPrompt if noPrompt is not None else not sys.stdin.isatty()  # When not TTY then do not prompt
 
     ks = keeping.Keeper(name=name,
                         base=base,
@@ -96,24 +107,38 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
     cf = None
     if configFile is not None:
         cf = configing.Configer(name=configFile, headDirPath=configDir, temp=False, reopen=True, clear=False)
-    
-    aids  = cf.get("aids", default=None) if cf is not None else None
 
-    if aeid is None:
-        hby = habbing.Habery(name=name, base=base, bran=bran, cf=cf)
-    else:
-        hby = existing.setupHby(name=name, base=base, bran=bran, cf=cf)
+    aids = cf.get("aids", default=None) if cf is not None else None
 
-    hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
-    doers = [hbyDoer]
+    hby = None
+    try:
+        if aeid is None:
+            hby = habbing.Habery(name=name, base=base, bran=bran, cf=cf)
+        else:
+            # Prompt only for TTY; fail fast for no passcode on script/service witness start
+            if not bran and noPrompt:
+                raise kering.AuthError(f"passcode required for keystore {name!r} but prompting is disabled. "
+                                       f"pass --passcode or omit --no-prompt in an interactive terminal..")
+            hby = existing.setupHby(name=name, base=base, bran=bran, cf=cf, noPrompt=noPrompt)
 
-    doers.extend(indirecting.setupWitness(alias=alias,
-                                          hby=hby,
-                                          aids=aids,
-                                          tcpPort=tcp,
-                                          httpPort=http,
-                                          keypath=keypath,
-                                          certpath=certpath,
-                                          cafilepath=cafilepath))
+        hbyDoer = habbing.HaberyDoer(habery=hby)  # setup doer
+        doers = [hbyDoer]
 
-    directing.runController(doers=doers, expire=expire)
+        doers.extend(indirecting.setupWitness(alias=alias,
+                                              hby=hby,
+                                              aids=aids,
+                                              tcpPort=tcp,
+                                              httpPort=http,
+                                              keypath=keypath,
+                                              certpath=certpath,
+                                              cafilepath=cafilepath))
+
+        directing.runController(doers=doers, expire=expire)
+    except Exception:
+        # Log startup failures at CRITICAL with traceback so they surface at the default loglevel.
+        logger.critical("Witness %r failed to start", name, exc_info=True)
+        raise
+    finally:
+        # Close Habery LMDB to avoid leftover locks on failed start blocking next start attempt
+        if hby is not None:
+            hby.close()

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -7,6 +7,7 @@ Witness command line interface
 """
 import argparse
 import logging
+import os
 import sys
 
 from keri import __version__
@@ -53,8 +54,12 @@ parser.add_argument("--certpath", action="store", required=False, default=None)
 parser.add_argument("--cafilepath", action="store", required=False, default=None)
 parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL",
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument("--logdir", action="store", required=False, default=None,
+                    help="directory under which the witness writes its log file. "
+                         "If not defined, logs are not written to a file.")
 parser.add_argument("--logfile", action="store", required=False, default=None,
-                    help="path of the log file. If not defined, logs will not be written to the file.")
+                    help="DEPRECATED: use --logdir. Path to a log file; only its directory is used "
+                         "(the file name and log subdirectory are derived internally).")
 parser.add_argument("--no-prompt", action="store_true", default=None, required=False,
                     help="Disable interactive prompt", dest="noPrompt")
 
@@ -62,9 +67,17 @@ parser.add_argument("--no-prompt", action="store_true", default=None, required=F
 def launch(args):
     # Normalize level case; avoid invalid lowercase values that silently break level filtering
     help.ogler.level = logging.getLevelName(args.loglevel.upper())
-    if args.logfile is not None:
-        help.ogler.headDirPath = args.logfile
+
+    logdir = args.logdir
+    if args.logfile:  # deprecated: only its directory is used
+        logdir = os.path.dirname(args.logfile) or "."
+
+    if logdir is not None:  # Must reopen
+        help.ogler.headDirPath = logdir
         help.ogler.reopen(name=args.name, temp=False, clear=True)
+
+    if args.logfile:  # print after reopen so ogler.path is the resolved log path
+        print(f"--logfile is deprecated; use --logdir. Logging to {help.ogler.path}", file=sys.stderr)
 
     help.ogler.getLogger()  # re-applies ogler.level to the shared logger
 

--- a/src/keri/app/cli/common/existing.py
+++ b/src/keri/app/cli/common/existing.py
@@ -12,7 +12,7 @@ from keri import kering
 from keri.app import habbing, keeping
 
 
-def setupHby(name, base="", bran=None, cf=None, temp=False):
+def setupHby(name, base="", bran=None, cf=None, temp=False, noPrompt=False):
     """ Create Habery off of existing directory
 
     Parameters:
@@ -21,6 +21,7 @@ def setupHby(name, base="", bran=None, cf=None, temp=False):
         bran(str): optional passcode if the Habery was created encrypted
         cf (Configer): optional configuration for loading reference data
         temp (bool): True means create database in /tmp
+        noPrompt (bool): True means do not prompt for a passcode; raise instead. Default False
 
     Returns:
           Habery:  the configured habery
@@ -49,6 +50,8 @@ def setupHby(name, base="", bran=None, cf=None, temp=False):
             break
         except (kering.AuthError, ValueError) as e:
             print(e)
+            if noPrompt:
+                raise e
             if retries >= 3:
                 raise kering.AuthError("too many attempts")
             print("Valid passcode required, try again...")

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -1,19 +1,21 @@
 import json
+import logging
 import os
 
 import multicommand
 import pytest
 
 
-from keri.kering import ValidationError
+from keri.kering import ValidationError, AuthError
 
-from keri import core
+from keri import core, help
 from keri.core import coring
 
-from keri.app import directing
+from keri.app import directing, habbing
 
 from keri.app.cli import commands
 from keri.app.cli.common import existing
+from keri.app.cli.commands.witness import start as witness_start
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -325,6 +327,117 @@ def test_incept_and_rotate_opts(helpers, capsys):
     doers = args.handler(args)
 
     directing.runController(doers=doers)
+
+
+# --- kli witness start logging & startup behavior (WebOfTrust/keripy#238) ---
+
+def _parse(argv):
+    return multicommand.create_parser(commands).parse_args(argv)
+
+
+def test_launch_normalizes_loglevel(monkeypatch):
+    """launch() must turn a lowercase --loglevel into a numeric level (the .upper()
+    fix); without it getLevelName('debug') returns the string 'Level debug', which
+    silently breaks level filtering."""
+    # ogler is a process-global singleton; snapshot so this test does not leak its
+    # level into later tests (monkeypatch restores on teardown).
+    monkeypatch.setattr(help.ogler, "level", help.ogler.level)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    args = _parse(["witness", "start", "--alias", "wit", "--loglevel", "debug"])
+    args.handler(args)  # -> launch(args)
+
+    assert help.ogler.level == logging.DEBUG
+
+
+def test_run_failure_is_logged_and_hby_closed(helpers, monkeypatch):
+    """A failure during setup/run (e.g. a port-bind error from setupWitness) must be
+    logged at CRITICAL (visible at the default --loglevel) AND the Habery closed in
+    the finally block, so no stale LMDB lock is left behind."""
+    name = "bug238witerr"
+    helpers.remove_test_dirs(name)
+
+    logged = []
+    monkeypatch.setattr(witness_start.logger, "critical",
+                        lambda *a, **k: logged.append((a, k)))
+
+    closed = []
+    real_close = habbing.Habery.close
+
+    def spy_close(self, clear=False):
+        closed.append(True)
+        return real_close(self, clear=clear)
+    monkeypatch.setattr(habbing.Habery, "close", spy_close)
+
+    def _boom(**kw):
+        raise RuntimeError("cannot create http server on port 5631")
+    monkeypatch.setattr(witness_start.indirecting, "setupWitness", _boom)
+
+    try:
+        # unencrypted keystore path (aeid is None) so no passcode is required;
+        # configFile=None matches what the CLI passes (launch -> args.configFile)
+        with pytest.raises(RuntimeError):
+            witness_start.runWitness(name=name, base="", alias="wit", bran="", configFile=None)
+
+        assert logged, "startup failure must be logged at CRITICAL"
+        assert "failed" in logged[0][0][0]
+        assert closed, "Habery must be closed in the finally block on failure"
+    finally:
+        helpers.remove_test_dirs(name)
+
+
+def test_encrypted_keystore_non_tty_fails_fast(helpers, monkeypatch):
+    """Starting an encrypted keystore with no passcode on a non-TTY must fail fast
+    with a logged AuthError instead of stalling on an interactive getpass prompt."""
+    name = "bug238witenc"
+
+    # ensure TTY false regardless of how the test harness started
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    # Defensive: getpass must never be called on a non-TTY start
+    def _boom(*a, **k):
+        raise AssertionError("getpass must not be called on a non-TTY start")
+    monkeypatch.setattr("keri.app.cli.common.existing.getpass.getpass", _boom)
+
+    helpers.remove_test_dirs(name)
+    try:
+        # create an encrypted keystore so that aeid is set
+        hby = habbing.Habery(name=name, base="", bran="0123456789abcdefghijk", temp=False)
+        hby.close()
+
+        with pytest.raises(AuthError, match="passcode required"):
+            witness_start.runWitness(name=name, base="", alias="wit", bran="", configFile=None)
+    finally:
+        helpers.remove_test_dirs(name)
+
+
+def test_witness_start_non_tty_wrong_passcode_raises(helpers, monkeypatch):
+    """A non-TTY witness start with the wrong passcode must raise rather than
+    re-prompting (noPrompt propagates into setupHby)."""
+    name = "bug238witwrong"
+    correct = "0123456789abcdefghijk"
+    wrong = "abcdefghijk0123456789"
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    # launch() sets ogler.level from --loglevel on the shared logger; restore it so a
+    # DEBUG level does not leak into later tests.
+    saved_level = help.ogler.level
+    helpers.remove_test_dirs(name)
+    try:
+        hby = habbing.Habery(name=name, base="", bran=correct, temp=False)
+        hby.close()
+
+        args = _parse(["witness", "start", "--name", name, "--alias", "wit",
+                       "--passcode", wrong, "--loglevel", "debug"])
+        # noPrompt guard re-raises the original AuthError ("Last seed missing"),
+        # not the retry-exhausted "too many attempts" error.
+        with pytest.raises(AuthError, match="Last seed missing"):
+            args.handler(args)
+    finally:
+        help.ogler.level = saved_level
+        help.ogler.getLogger()  # re-apply restored level to the shared logger
+        helpers.remove_test_dirs(name)
 
 
 

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -440,5 +440,65 @@ def test_witness_start_non_tty_wrong_passcode_raises(helpers, monkeypatch):
         helpers.remove_test_dirs(name)
 
 
+# --- kli witness start: --logfile deprecation in favor of --logdir (#238) ---
+
+def test_witness_start_arg_parsing():
+    """--logdir is the current option; --logfile is retained as a deprecated alias."""
+    args = _parse(["witness", "start", "--alias", "wit",
+                   "--loglevel", "debug", "--logdir", "/tmp/wlogs"])
+    assert args.handler is not None
+    assert args.loglevel == "debug"
+    assert args.logdir == "/tmp/wlogs"
+    assert args.logfile is None
+
+    args = _parse(["witness", "start", "--alias", "wit"])
+    assert args.loglevel == "CRITICAL"
+    assert args.logdir is None
+    assert args.logfile is None
+
+
+def test_launch_routes_logdir(monkeypatch, tmp_path):
+    """launch() must route --logdir straight to ogler.headDirPath."""
+    monkeypatch.setattr(help.ogler, "level", help.ogler.level)
+    monkeypatch.setattr(help.ogler, "headDirPath", help.ogler.headDirPath)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    args = _parse(["witness", "start", "--alias", "wit", "--logdir", str(tmp_path)])
+    args.handler(args)  # -> launch(args)
+
+    assert help.ogler.headDirPath == str(tmp_path)
+
+
+def test_launch_logfile_extracts_dirname(monkeypatch, tmp_path):
+    """The deprecated --logfile must contribute only its *directory* as the log dir
+    (hio derives the filename from --name), never the file path itself."""
+    monkeypatch.setattr(help.ogler, "level", help.ogler.level)
+    monkeypatch.setattr(help.ogler, "headDirPath", help.ogler.headDirPath)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    logfile = tmp_path / "witness.log"
+    args = _parse(["witness", "start", "--alias", "wit", "--logfile", str(logfile)])
+    args.handler(args)
+
+    assert help.ogler.headDirPath == str(tmp_path)
+
+
+def test_logfile_emits_deprecation_warning(monkeypatch, capsys, tmp_path):
+    """Passing the deprecated --logfile must print a deprecation notice to stderr
+    (visible regardless of --loglevel); using the current --logdir must not."""
+    monkeypatch.setattr(help.ogler, "level", help.ogler.level)
+    monkeypatch.setattr(help.ogler, "headDirPath", help.ogler.headDirPath)
+    monkeypatch.setattr(witness_start, "runWitness", lambda **kw: None)
+
+    args = _parse(["witness", "start", "--alias", "wit",
+                   "--logfile", str(tmp_path / "witness.log")])
+    args.handler(args)
+    assert "deprecated" in capsys.readouterr().err, "expected a --logfile deprecation notice"
+
+    args = _parse(["witness", "start", "--alias", "wit", "--logdir", str(tmp_path)])
+    args.handler(args)
+    assert "deprecated" not in capsys.readouterr().err
+
+
 
 


### PR DESCRIPTION
## Summary

Backport of #1477 to the **1.2 line** (base `v1.2.14`). `kli witness start` could
stall during startup and did not reliably log error conditions (#238). This PR
makes the command log every startup/runtime failure visibly, eliminates the
interactive-prompt stall, and deprecates the mis-named `--logfile` in favor of the
accurate `--logdir`. Fixes #238.

The change is split into two commits so the CLI rename can be dropped
independently:

1. **Log failures + prevent non-TTY stalls (#238).** Startup/runtime failures are
   logged at CRITICAL with a traceback (so they surface at the default
   `--loglevel`), the `Habery` is closed in a `finally` so a failed start leaves
   no stale LMDB lock, and an encrypted keystore started with no passcode on a
   non-TTY fails fast with a logged `AuthError` instead of blocking on an
   interactive `getpass`. `--loglevel` is normalized with `.upper()` so a
   lowercase level (e.g. `debug`) is honored.
2. **Deprecate `--logfile` in favor of `--logdir` (#238).** The logging backend
   derives the file name from `--name` and the subdirectory from its own prefix,
   so only the directory is meaningful; the old code mis-assigned the whole file
   path as the log head directory. `--logfile` is retained as a deprecated alias
   whose directory portion is used, with a stderr deprecation notice. Droppable
   if you'd rather not change the CLI surface in a patch release.

Unlike the 1.3 backport, no boot-Keeper `ks.close()` commit is needed — the 1.2
line already has that fix.

## Tests

Regression + unit tests added to `tests/app/cli/test_kli_commands.py`, covering
CRITICAL failure logging + `Habery` cleanup, the non-TTY fast-fail (both the
no-passcode and wrong-passcode paths), `--loglevel` normalization, and
`--logdir`/`--logfile` directory handling + the deprecation notice. Each
assertion was mutation-checked — reverting the corresponding fix turns the
targeted test red.

## Notes

- **Version:** left `__version__` untouched; happy to bump to `1.2.14` or leave
  the release cut to you — your call.
- Pre-existing, out of scope: `runWitness`'s `aids = cf.get("aids", default=None)`
  would raise on this branch if a `--config-file` is actually loaded, because
  1.2.13's `Configer.get()` takes no `default=` kwarg. This PR doesn't touch that
  behavior (it only moves the line inside the new `try`, so it would now be logged
  at CRITICAL rather than surfacing bare). Flagging in case you want a follow-up.

## Relationship to #1477

Same fix as the approved #1477 (base `main`, 2.0), adapted to the 1.2 CLI layout
(`keri.app.cli.*`, absolute imports, `help.ogler`, the `aids` setup path). Opened
per your request on #1477.

---

This code was developed with Claude (using the Opus 4.8 model, mostly). However,
I (Daniel the human) have read, reviewed, and worked the code, and I stand behind
it and take responsibility for it.
