### PR TITLE
fix: pin CI Python version to 3.14 and bump deprecated actions

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12.6+
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '>=3.12.6'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -146,10 +146,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12.6+
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '>=3.12.6'
+          python-version: '3.14'
 
       - name: Install libsodium (macOS)
         if: runner.os == 'macOS'
@@ -181,11 +181,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.12.6+
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
         with:
-          python-version: '>=3.12.6'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -203,11 +203,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.12.6+
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
         with:
-          python-version: '>=3.12.6'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Closes #1478

Pins CI `python-version` from `'>=3.12.6'` to `'3.14'` in four jobs (lint, test, coverage, scripts). Also bumps deprecated `actions/checkout@v3` → `@v4` and `actions/setup-python@v2` → `@v5` in the coverage and scripts jobs.

## Problem

`setup.py` declares `python_requires='>=3.14.0'`, but CI jobs used `python-version: '>=3.12.6'`. The range permits interpreters below the supported floor — keripy does not import on Python < 3.14 due to deferred annotation semantics (PEP 649/749). CI only passes because `setup-python` resolves the range to the highest available version, but the spec is misleading and fragile.

## Changes

- Lint job: `'>=3.12.6'` → `'3.14'` (already `@v5`)
- Test job: `'>=3.12.6'` → `'3.14'` (already `@v5`)  
- Coverage job: `'>=3.12.6'` → `'3.14'`, `@v3/@v2` → `@v4/@v5`
- Scripts job: `'>=3.12.6'` → `'3.14'`, `@v3/@v2` → `@v4/@v5`

Docs job already uses `'3.14'` — no change needed.