### PR TITLE
Propagate CESR genus versions through replay and OOBI responses

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -18,7 +18,7 @@ from .httping import Clienter, streamCESRRequests, CESR_DESTINATION_HEADER
 
 from ..kering import (Schemes, Roles,
                       MissingEntryError, ConfigurationError)
-from ..core import Counter, eventing, parsing, coring, serdering, Codens
+from ..core import eventing, parsing, coring, serdering
 
 
 logger = ogler.getLogger()
@@ -73,13 +73,13 @@ class Receiptor(doing.DoDoer):
 
         hab = self.hby.habs[pre]
         sn = sn if sn is not None else hab.kever.sner.num
-        wits = hab.kever.wits
-
-        if len(wits) == 0:
-            return
 
         msg = hab.msgOwnEvent(sn=sn, framed=True)
         ser = serdering.SerderKERI(raw=msg)
+        wits = [wit.qb64 for wit in hab.kvy.fetchWitnessState(ser.pre, ser.sn)]
+
+        if len(wits) == 0:
+            return
 
         # If we are a rotation event, may need to catch new witnesses up to current key state
         if ser.ked['t'] in (coring.Ilks.rot,):
@@ -111,21 +111,20 @@ class Receiptor(doing.DoDoer):
 
             rep = client.respond()
             if rep.status == 200:
-                rct = bytearray(rep.body)
-                hab.psr.parseOne(bytearray(rct))
-                rserder = serdering.SerderKERI(raw=rct)
-                del rct[:rserder.size]
-
-                # pull off the count code
-                Counter(qb64b=rct, strip=True, version=rserder.pvrsn)
-                rcts[wit] = rct
+                hab.psr.parseOne(bytearray(rep.body))
+                rcts[wit] = None
             else:
                 print(f"invalid response {rep.status} from witnesses {wit}")
 
+        wigers = hab.db.wigs.get(keys=(ser.preb, ser.saidb))
+        wigerByWit = {wits[wiger.index]: wiger for wiger in wigers}
+
         # send retrieved receipts to all other witnesses
         for wit in rcts:
-            ewits = [w for w in rcts if w != wit] # get complement of all other witnesses
-            wigers = [rcts[w] for w in ewits] # all other witness signatures
+            ewits = [w for w in wits if w != wit and w in wigerByWit]
+            wigers = [wigerByWit[w] for w in ewits]
+            if not wigers:
+                continue
 
             msg = bytearray()
             if ser.ked['t'] in (coring.Ilks.icp, coring.Ilks.dip):  # introduce new witnesses
@@ -139,11 +138,8 @@ class Receiptor(doing.DoDoer):
                                        said=ser.said,
                                        version=ser.pvrsn,
                                        kind=ser.kind)
-            msg.extend(rserder.raw)
-            msg.extend(Counter(Codens.NonTransReceiptCouples,
-                                    count=len(wigers), version=ser.pvrsn).qb64b)
-            for wiger in wigers:
-                msg.extend(wiger)
+            msg.extend(eventing.messagize(serder=rserder, wigers=wigers,
+                                          framed=True, gvrsn=ser.pvrsn))
 
             client = clients[wit]
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1899,7 +1899,7 @@ class BaseHab:
         return msg
 
 
-    def replay(self, pre=None, fn=0, version=Vrsn_1_0):
+    def replay(self, pre=None, fn=0, gvrsn=Vrsn_1_0, *, version=None):
         """Return replay of FEL (first-seen event log) for ``pre`` starting
         from ``fn``. Default pre is own ``.pre``.
 
@@ -1907,7 +1907,8 @@ class BaseHab:
             pre (str or None): qb64 str or bytes of identifier prefix.
                 Default is own ``.pre``.
             fn (int): first-seen ordering number to start from.
-            version (Versionage): CESR Genus version for attachment group codes
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
             bytearray: serialized event log messages.
@@ -1915,28 +1916,33 @@ class BaseHab:
         if not pre:
             pre = self.pre
 
+        if version is not None:
+            gvrsn = version
         msgs = bytearray()
         kever = self.kevers[pre]
-        for msg in self.db.cloneDelegation(kever=kever):
+        for msg in self.db.cloneDelegation(kever=kever, gvrsn=gvrsn):
             msgs.extend(msg)
 
-        for msg in self.db.clonePreIter(pre=pre, fn=fn, version=version):
+        for msg in self.db.clonePreIter(pre=pre, fn=fn, gvrsn=gvrsn):
             msgs.extend(msg)
 
         return msgs
 
 
-    def replayAll(self, version=Vrsn_1_0):
+    def replayAll(self, gvrsn=Vrsn_1_0, *, version=None):
         """Return replay of FEL (first-seen event log) for all prefixes.
 
         Parameters:
-            version (Versionage): CESR Genus version for attachment group codes
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
             bytearray: serialized event log messages for all prefixes.
         """
+        if version is not None:
+            gvrsn = version
         msgs = bytearray()
-        for msg in self.db.cloneAllPreIter(version=version):
+        for msg in self.db.cloneAllPreIter(gvrsn=gvrsn):
             msgs.extend(msg)
         return msgs
 
@@ -2197,7 +2203,8 @@ class BaseHab:
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
                 kind (str): serialization kind.
 
         Returns::
@@ -2212,10 +2219,7 @@ class BaseHab:
 
         kwa["pre"] = self.pre
         if gvrsn is Version:
-            if "gvrsn" in kwa:
-                gvrsn = kwa["gvrsn"]
-            else:
-                gvrsn = pvrsn
+            gvrsn = pvrsn
         return self.endorse(eventing.reply(**kwa), framed=framed, nested=nested,
                             gvrsn=gvrsn, genusify=genusify)
 
@@ -2234,7 +2238,9 @@ class BaseHab:
             stamp (str or None): date-time-stamp RFC-3339 profile of iso8601
                 datetime. None means use now.
             **kwa: keyword arguments forwarded to ``eventing.reply``, including:
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for attachments
                 kind (str): serialization kind.
 
         Returns:
@@ -2337,7 +2343,9 @@ class BaseHab:
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for attachments
                 kind (str): serialization kind.
 
 
@@ -2367,7 +2375,9 @@ class BaseHab:
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for attachments
                 kind (str): serialization kind.
 
 
@@ -2489,7 +2499,9 @@ class BaseHab:
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for stream attachments
                 kind (str): serialization kind.
 
         Returns::
@@ -2503,7 +2515,10 @@ class BaseHab:
         if cid not in self.kevers:
             return msgs
 
-        msgs.extend(self.replay(cid, version=Vrsn_1_0))
+        gvrsn = kwa.get("gvrsn")
+        msgs.extend(self.replay(
+            cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
+        ))
 
         kever = self.kevers[cid]
         witness = self.pre in kever.wits  # see if we are cid's witness
@@ -2515,14 +2530,17 @@ class BaseHab:
                     if eid == self.pre:
                         msgs.extend(self.replyLocScheme(eid=eid, scheme=scheme, **kwa))
                     else:
-                        msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme))
+                        msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
+                                                       gvrsn=gvrsn))
                     if not witness:  # we are not witness, send auth records
                         msgs.extend(self.makeEndRole(eid=eid, role=role, **kwa))
 
         for (_, erole, eid), end in self.db.ends.getTopItemIter(keys=(cid,)):
             if (end.enabled or end.allowed) and (not role or role == erole) and (not eids or eid in eids):
-                msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme))
-                msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole))
+                msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
+                                               gvrsn=gvrsn))
+                msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole,
+                                             gvrsn=gvrsn))
 
         return msgs
 
@@ -2550,7 +2568,9 @@ class BaseHab:
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for stream attachments
                 kind (str): serialization kind.
 
         Returns::
@@ -3548,7 +3568,9 @@ class SignifyHab(BaseHab):
                 route (str): route path string indicating the data flow handler.
                 data (list): dicts of committed data such as seals.
                 dts (str): date-time-stamp of message at time of creation.
-                version (Version): version instance.
+                version (Versionage): default KERI protocol version
+                pvrsn (Versionage): KERI protocol version
+                gvrsn (Versionage): CESR genus version for stream attachments
                 kind (str): serialization kind.
 
         Returns::
@@ -3560,8 +3582,12 @@ class SignifyHab(BaseHab):
         if eids is None:
             eids = []
 
+        gvrsn = kwa.get("gvrsn")
+
         # introduce yourself, please
-        msgs.extend(self.replay(cid))
+        msgs.extend(self.replay(
+            cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
+        ))
 
         if role == Roles.witness:
             if kever := self.kevers[cid] if cid in self.kevers else None:
@@ -3570,17 +3596,24 @@ class SignifyHab(BaseHab):
                 # latest key state for cid
                 for eid in kever.wits:
                     if not eids or eid in eids:
-                        msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme))
+                        msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
+                                                       gvrsn=gvrsn))
                         if not witness:  # we are not witness, send auth records
                             msgs.extend(self.makeEndRole(eid=eid, role=role, **kwa))
                 if witness:  # we are witness, set KEL as authz
-                    msgs.extend(self.replay(cid))
+                    msgs.extend(self.replay(
+                        cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
+                    ))
 
         for (_, erole, eid), end in self.db.ends.getTopItemIter(keys=(cid,)):
             if (end.enabled or end.allowed) and (not role or role == erole) and (not eids or eid in eids):
-                msgs.extend(self.replay(eid))
-                msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme))
-                msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole))
+                msgs.extend(self.replay(
+                    eid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
+                ))
+                msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
+                                               gvrsn=gvrsn))
+                msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole,
+                                             gvrsn=gvrsn))
 
         return msgs
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1637,7 +1637,7 @@ class Baser(LMDBer):
             shutil.rmtree(copy.path)
 
 
-    def clonePreIter(self, pre, fn=0, version=Vrsn_1_0):
+    def clonePreIter(self, pre, fn=0, gvrsn=Vrsn_1_0, *, version=None):
         """
         Returns iterator of first seen event messages with attachments for the
         identifier prefix pre starting at first seen order number, fn.
@@ -1646,7 +1646,8 @@ class Baser(LMDBer):
         Parameters:
             pre is bytes of itdentifier prefix
             fn is int fn to resume replay. Earliset is fn=0
-            version (Versionage): CESR Genus version for attachment group codes
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
            msgs (Iterator): over all items with pre starting at fn
@@ -1654,15 +1655,17 @@ class Baser(LMDBer):
         #if hasattr(pre, 'encode'):
             #pre = pre.encode("utf-8")
 
+        if version is not None:
+            gvrsn = version
         for keys, fn, dig in self.fels.getAllItemIter(keys=pre, on=fn):
             try:
-                msg = self.cloneEvtMsg(pre=pre, fn=fn, dig=dig, version=version)
+                msg = self.cloneEvtMsg(pre=pre, fn=fn, dig=dig, gvrsn=gvrsn)
             except (MissingEntryError, SerializeError) as ex:
                 continue  # skip this event
             yield msg
 
 
-    def cloneAllPreIter(self, version=Vrsn_1_0):
+    def cloneAllPreIter(self, gvrsn=Vrsn_1_0, *, version=None):
         """
         Returns iterator of first seen event messages with attachments for all
         identifier prefixes starting at key. If key == b'' then start at first
@@ -1671,23 +1674,26 @@ class Baser(LMDBer):
         set of FELs.
 
         Parameters:
-            version (Versionage): CESR Genus version for attachment group codes
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
            msgs (Iterator): over all items in db
 
         """
+        if version is not None:
+            gvrsn = version
         for keys, fn, dig in self.fels.getAllItemIter(keys=b'', on=0):
             pre = keys[0].encode() if isinstance(keys[0], str) else keys[0]
             try:
-                msg = self.cloneEvtMsg(pre=pre, fn=fn, dig=dig, version=version)
+                msg = self.cloneEvtMsg(pre=pre, fn=fn, dig=dig, gvrsn=gvrsn)
             except (MissingEntryError, SerializeError) as ex:
                 continue  # skip this event
             yield msg
 
 
 
-    def cloneEvtMsg(self, pre, fn, dig, version=Vrsn_1_0):
+    def cloneEvtMsg(self, pre, fn, dig, gvrsn=Vrsn_1_0, *, version=None):
         """
         Clones Event as Serialized CESR Message with Body and attached Foot
 
@@ -1695,12 +1701,16 @@ class Baser(LMDBer):
             pre (bytes): identifier prefix of event
             fn (int): first seen number (ordinal) of event
             dig (bytes): digest of event
-            version (Versionage): CESR Genus version for attachment group codes
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
             msg (bytearray): message body with attachments
         """
         from ..core import Prefixer, Number, Diger, SealSource, FirstSeen, messagize
+
+        if version is not None:
+            gvrsn = version
 
         keys = (pre, dig)
 
@@ -1760,7 +1770,7 @@ class Baser(LMDBer):
 
 
         msg = messagize(serder=serder, sigers=sigers, wigers=wigers,
-                        cigars=cigars, rsgs=rsgs, bonds=bonds, gvrsn=version)
+                        cigars=cigars, rsgs=rsgs, bonds=bonds, gvrsn=gvrsn)
         return msg
 
 
@@ -1880,19 +1890,23 @@ class Baser(LMDBer):
         #return msg
 
 
-    def cloneDelegation(self, kever):
+    def cloneDelegation(self, kever, gvrsn=Vrsn_1_0, *, version=None):
         """
-        Recursively clone delegation chain from AID of Kever if one exits.
+        Recursively clone delegation chain from AID of Kever if one exists.
 
         Parameters:
             kever (Kever): Kever from which to clone the delegator's AID.
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         """
+        if version is not None:
+            gvrsn = version
         if kever.delegated and kever.delpre in self.kevers:
             dkever = self.kevers[kever.delpre]
-            yield from self.cloneDelegation(dkever)
+            yield from self.cloneDelegation(dkever, gvrsn=gvrsn)
 
-            for dmsg in self.clonePreIter(pre=kever.delpre, fn=0, version=Vrsn_1_0):
+            for dmsg in self.clonePreIter(pre=kever.delpre, fn=0, gvrsn=gvrsn):
                 yield dmsg
 
     def fetchAllSealingEventByEventSeal(self, pre, seal, sn=0):

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -244,6 +244,11 @@ class BaseRegistry:
         return self.tever.serder
 
     @property
+    def versionSerder(self):
+        """Return the registry serder that defines event version and kind."""
+        return self.vcp if self.vcp is not None else self.regser
+
+    @property
     def registries(self):
         return self.reger.registries
 
@@ -342,15 +347,17 @@ class Registry(BaseRegistry):
         if self.noBackers:
             raise ValueError("Attempt to rotate registry {} that does not support backers".format(self.regk))
 
-        serder = rotateEvent(dig=self.regser.said,
+        regser = self.regser
+        vserder = self.versionSerder
+        serder = rotateEvent(dig=regser.said,
                              regk=self.regk,
                              sn=self.regi + 1,
                              toad=toad,
                              baks=self.baks,
                              adds=adds,
                              cuts=cuts,
-                             version=self.vcp.pvrsn,
-                             kind=self.vcp.kind)
+                             version=vserder.pvrsn,
+                             kind=vserder.kind)
 
         self.processEvent(serder=serder)
         return serder
@@ -365,17 +372,19 @@ class Registry(BaseRegistry):
         Returns:
             SerderKERI: The SerderKERI of the credential issuance event
         """
+        regser = self.regser
+        vserder = self.versionSerder
         if self.noBackers:
             serder = issueEvent(vcdig=said, regk=self.regk, dt=dt,
-                                version=self.vcp.pvrsn, kind=self.vcp.kind)
+                                version=vserder.pvrsn, kind=vserder.kind)
         else:
             serder = backerIssue(vcdig=said,
                                           regk=self.regk,
                                           regsn=self.regi,
-                                          regd=self.regser.said,
+                                          regd=regser.said,
                                           dt=dt,
-                                          version=self.vcp.pvrsn,
-                                          kind=self.vcp.kind)
+                                          version=vserder.pvrsn,
+                                          kind=vserder.kind)
 
         self.processEvent(serder=serder)
         return serder
@@ -400,17 +409,19 @@ class Registry(BaseRegistry):
         ievt = self.reger.tvts.get(keys=dgKey(pre=vci, dig=vcser))
         iserder = SerderKERI(raw=ievt.encode("utf-8"))
 
+        regser = self.regser
+        vserder = self.versionSerder
         if self.noBackers:
             serder = revokeEvent(vcdig=vci, regk=self.regk, dig=iserder.said, dt=dt,
-                                 version=self.vcp.pvrsn, kind=self.vcp.kind)
+                                 version=vserder.pvrsn, kind=vserder.kind)
         else:
             serder = backerRevoke(vcdig=vci,
                                   regk=self.regk,
                                   regsn=self.regi,
-                                  regd=self.regser.said,
+                                  regd=regser.said,
                                   dig=iserder.said, dt=dt,
-                                  version=self.vcp.pvrsn,
-                                  kind=self.vcp.kind)
+                                  version=vserder.pvrsn,
+                                  kind=vserder.kind)
 
         self.processEvent(serder=serder)
         return serder
@@ -432,6 +443,7 @@ class SignifyRegistry(BaseRegistry):
             regser (SerderKERI): Regsitry inception event
         """
         pre = self.hab.pre
+        self.vcp = regser
         self.regk = regser.pre
         self.regd = regser.said
         self.registries.add(self.regk)
@@ -473,14 +485,16 @@ class SignifyRegistry(BaseRegistry):
         Returns:
             SerderKERI: The SerderKERI of the credential issuance event
         """
+        regser = self.regser
+        vserder = self.versionSerder
         if self.noBackers:
             serder = issueEvent(vcdig=said, regk=self.regk, dt=dt,
-                                version=self.vcp.pvrsn, kind=self.vcp.kind)
+                                version=vserder.pvrsn, kind=vserder.kind)
         else:
-            serder = backerIssue(vcdig=said, regk=self.regk, regsn=self.regi, regd=self.regser.said,
+            serder = backerIssue(vcdig=said, regk=self.regk, regsn=self.regi, regd=regser.said,
                                           dt=dt,
-                                          version=self.vcp.pvrsn,
-                                          kind=self.vcp.kind)
+                                          version=vserder.pvrsn,
+                                          kind=vserder.kind)
 
         self.processEvent(serder=serder)
         return serder
@@ -505,14 +519,16 @@ class SignifyRegistry(BaseRegistry):
         ievt = self.reger.tvts.get(keys=dgKey(pre=vci, dig=vcser))
         iserder = SerderACDC(raw=ievt.encode("utf-8"))
 
+        regser = self.regser
+        vserder = self.versionSerder
         if self.noBackers:
             serder = revokeEvent(vcdig=vci, regk=self.regk, dig=iserder.said, dt=dt,
-                                 version=self.vcp.pvrsn, kind=self.vcp.kind)
+                                 version=vserder.pvrsn, kind=vserder.kind)
         else:
-            serder = backerRevoke(vcdig=vci, regk=self.regk, regsn=self.regi, regd=self.regser.said,
+            serder = backerRevoke(vcdig=vci, regk=self.regk, regsn=self.regi, regd=regser.said,
                                   dig=iserder.said, dt=dt,
-                                  version=self.vcp.pvrsn,
-                                  kind=self.vcp.kind)
+                                  version=vserder.pvrsn,
+                                  kind=vserder.kind)
 
         self.processEvent(serder=serder)
         return serder
@@ -888,6 +904,7 @@ class Credentialer(doing.DoDoer):
             raise ConfigurationError("Credential registry {} does not exist.  It must be created before issuing "
                                             "credentials".format(regname))
 
+        vserder = registry.versionSerder
         creder = credential(issuer=registry.hab.pre,
                             schema=schema,
                             recipient=recp,
@@ -897,7 +914,9 @@ class Credentialer(doing.DoDoer):
                             private_credential_nonce=private_credential_nonce,
                             private_subject_nonce=private_subject_nonce,
                             rules=rules,
-                            status=registry.regk)
+                            status=registry.regk,
+                            version=vserder.pvrsn,
+                            kind=vserder.kind)
         self.validate(creder)
         return creder
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -4,19 +4,194 @@ tests.app.agenting module
 
 """
 import time
+from types import SimpleNamespace
 
 import pytest
 from hio.base import doing, tyming
 
 from keri.kering import Schemes, Vrsn_1_0, Vrsn_2_0, Kinds
-from keri.core import Salter
-from keri.app import (WitnessReceiptor, WitnessPublisher, WitnessInquisitor,
+from keri.core import Counter, Codens, Salter, SerderKERI, Siger
+from keri.app import (Receiptor, WitnessReceiptor, WitnessPublisher, WitnessInquisitor,
                       runController, openHby, setupWitness)
+from keri.app import agenting
 from keri.help import nowIso8601
 
 TEST_VERSION = Vrsn_1_0
 KWA = dict(version=TEST_VERSION, kind=Kinds.json)
 CUE_KWA = dict(**KWA, gvrsn=TEST_VERSION)
+
+
+def test_receiptor_v2_propagates_witness_receipts(monkeypatch, seeder, witnessPorter):
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+    propagated = []
+    streamCESRRequests = agenting.streamCESRRequests
+
+    def capturePropagation(client, ims, dest, path=None, headers=None):
+        if path != "/receipts":
+            propagated.append((dest, bytes(ims)))
+        return streamCESRRequests(client=client, ims=ims, dest=dest,
+                                  path=path, headers=headers)
+
+    monkeypatch.setattr(agenting, "streamCESRRequests", capturePropagation)
+
+    with openHby(name="wan-v2", salt=Salter(raw=b'wann-the-witness').qb64,
+                 version=Vrsn_2_0) as wanHby, \
+            openHby(name="wil-v2", salt=Salter(raw=b'will-the-witness').qb64,
+                    version=Vrsn_2_0) as wilHby, \
+            openHby(name="wes-v2", salt=Salter(raw=b'wess-the-witness').qb64,
+                    version=Vrsn_2_0) as wesHby, \
+            openHby(name="pal-v2", salt=Salter(raw=b'0123456789abcdef').qb64,
+                    version=Vrsn_2_0) as palHby:
+        witnessPorts, witnessUrls = witnessPorter("wan-v2", "wil-v2", "wes-v2")
+        witnessDoers = []
+        for alias, hby in (("wan-v2", wanHby), ("wil-v2", wilHby), ("wes-v2", wesHby)):
+            witnessDoers.extend(setupWitness(alias=alias, hby=hby,
+                                             tcpPort=witnessPorts[alias]["tcp"],
+                                             httpPort=witnessPorts[alias]["http"],
+                                             **kwa))
+
+        witHabs = [wanHby.habByName("wan-v2"),
+                   wilHby.habByName("wil-v2"),
+                   wesHby.habByName("wes-v2")]
+        seeder.seedWitEnds(palHby.db, witHabs=witHabs,
+                           protocols=[Schemes.http], witnessUrls=witnessUrls,
+                           **kwa)
+        singleHab = palHby.makeHab(name="single-v2", wits=[witHabs[0].pre],
+                                   transferable=True, **kwa)
+        palHab = palHby.makeHab(name="pal-v2",
+                                wits=[witHab.pre for witHab in witHabs],
+                                transferable=True, **kwa)
+        receiptor = Receiptor(hby=palHby)
+        receiptor.msgs.append(dict(pre=singleHab.pre))
+
+        doist = doing.Doist(limit=5.0, tock=0.03125,
+                            doers=witnessDoers + [receiptor])
+        doist.enter()
+        tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
+        while not (receiptor.cues or tymer.expired):
+            doist.recur()
+            time.sleep(doist.tock)
+
+        assert receiptor.cues
+        receiptor.cues.popleft()
+        singleSerder = singleHab.kever.serder
+        wigers = witHabs[0].db.wigs.get(keys=(singleSerder.preb, singleSerder.saidb))
+        assert {wiger.index for wiger in wigers} == {0}
+        assert propagated == []
+
+        receiptor.msgs.append(dict(pre=palHab.pre))
+        tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
+        while not (receiptor.cues or tymer.expired):
+            doist.recur()
+            time.sleep(doist.tock)
+        doist.exit()
+
+        assert receiptor.cues
+        serder = palHab.kever.serder
+        assert serder.pvrsn == Vrsn_2_0
+        assert serder.gvrsn == Vrsn_2_0
+
+        expected = {0, 1, 2}
+        for witHab in witHabs:
+            wigers = witHab.db.wigs.get(keys=(serder.preb, serder.saidb))
+            assert {wiger.index for wiger in wigers} == expected
+
+        assert {dest for dest, _ in propagated} == {witHab.pre for witHab in witHabs}
+        for _, stream in propagated:
+            ims = bytearray(stream)
+            receiptAttachments = []
+            while ims:
+                rserder = SerderKERI(raw=ims)
+                del ims[:rserder.size]
+                attachments = bytearray()
+                while ims and ims[0] != ord("{"):
+                    attachments.append(ims.pop(0))
+                if rserder.ked["t"] == "rct":
+                    receiptAttachments.append(attachments)
+
+            assert len(receiptAttachments) == 1
+            attachments = receiptAttachments[0]
+            counter = Counter(qb64b=attachments, version=Vrsn_2_0)
+            assert counter.name == Codens.WitnessIdxSigs
+            assert counter.count == (len(attachments) - len(counter.qb64b)) // 4
+
+
+@pytest.mark.parametrize("version", [Vrsn_1_0, Vrsn_2_0])
+def test_receiptor_propagates_only_verified_receipts(monkeypatch, version):
+    kwa = dict(version=version, kind=Kinds.json)
+    propagated = {}
+
+    class FakeClient:
+        def __init__(self, body):
+            self.responses = [SimpleNamespace(status=200, body=body)]
+
+        def respond(self):
+            return self.responses.pop(0)
+
+    with openHby(name="wan-bad", salt=Salter(raw=b'wann-the-witness').qb64,
+                 version=version) as wanHby, \
+            openHby(name="wil-bad", salt=Salter(raw=b'will-the-witness').qb64,
+                    version=version) as wilHby, \
+            openHby(name="wes-bad", salt=Salter(raw=b'wess-the-witness').qb64,
+                    version=version) as wesHby, \
+            openHby(name="pal-bad", salt=Salter(raw=b'0123456789abcdef').qb64,
+                    version=version) as palHby:
+        witHabs = [wanHby.makeHab(name="wan-bad", transferable=False, **kwa),
+                   wilHby.makeHab(name="wil-bad", transferable=False, **kwa),
+                   wesHby.makeHab(name="wes-bad", transferable=False, **kwa)]
+        palHab = palHby.makeHab(name="pal-bad",
+                                wits=[witHab.pre for witHab in witHabs],
+                                transferable=True, **kwa)
+        serder = palHab.kever.serder
+        receipts = [witHab.receipt(serder=serder, framed=True,
+                                   gvrsn=version, **kwa)
+                    for witHab in witHabs]
+        receipts[2][-1] = ord("A") if receipts[2][-1] != ord("A") else ord("B")
+        clients = {witHab.pre: FakeClient(receipt)
+                   for witHab, receipt in zip(witHabs, receipts)}
+
+        def fakeHttpClient(hab, wit):
+            return clients[wit], doing.Doer()
+
+        def capturePropagation(client, ims, dest, path=None, headers=None):
+            if path != "/receipts":
+                propagated[dest] = bytes(ims)
+            return 0
+
+        monkeypatch.setattr(agenting, "httpClient", fakeHttpClient)
+        monkeypatch.setattr(agenting, "streamCESRRequests", capturePropagation)
+
+        receiptor = Receiptor(hby=palHby)
+        dog = receiptor.receipt(palHab.pre)
+        with pytest.raises(StopIteration) as ex:
+            while True:
+                next(dog)
+
+        assert list(ex.value.value) == [witHab.pre for witHab in witHabs]
+        wigers = palHab.db.wigs.get(keys=(serder.preb, serder.saidb))
+        assert {wiger.index for wiger in wigers} == {0, 1}
+
+        expected = {
+            witHabs[0].pre: {1},
+            witHabs[1].pre: {0},
+            witHabs[2].pre: {0, 1},
+        }
+        assert propagated.keys() == expected.keys()
+        for wit, msg in propagated.items():
+            ims = bytearray(msg)
+            rserder = SerderKERI(raw=ims)
+            del ims[:rserder.size]
+            attachmentSize = len(ims)
+            counter = Counter(qb64b=ims, strip=True, version=version)
+            assert counter.name == Codens.WitnessIdxSigs
+            if version == Vrsn_1_0:
+                assert counter.count == len(expected[wit])
+            else:
+                assert counter.count == (attachmentSize - len(counter.qb64b)) // 4
+            indices = set()
+            while ims:
+                indices.add(Siger(qb64b=ims, strip=True).index)
+            assert indices == expected[wit]
 
 
 def test_witness_receiptor(seeder, witnessPorter):

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -8,7 +8,7 @@ import falcon
 from hio.base import doing
 from hio.core import http
 
-from keri.kering import Vrsn_1_0, Vrsn_2_0, Roles, Schemes, Version
+from keri.kering import Vrsn_1_0, Vrsn_2_0, Roles, Schemes, Version, Kinds
 from keri.app import (Notifier, Oobiery, Authenticator,
                       Result, openHab, openHby,
                       oobiRequestExn)
@@ -216,7 +216,8 @@ def test_oobiery_parser_version_uses_explicit_or_habery_default():
 
 def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
     with openHby(name="oobi-src", version=Vrsn_1_0) as src, \
-            openHby(name="oobi-dst", version=Vrsn_1_0) as dst:
+            openHby(name="oobi-dst", version=Vrsn_1_0) as dst, \
+            openHby(name="oobi-dst-v2", version=Vrsn_2_0) as dst2:
         hab = src.makeHab(name="wit", isith="1", icount=1,
                           transferable=False, **KWA)
         msgs = bytearray()
@@ -241,6 +242,19 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
         dst.psr.parse(ims=oobi)
 
         locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
+        assert locer is not None
+        assert locer.url == "http://127.0.0.1:5555"
+
+        oobi = hab.replyToOobi(aid=hab.pre,
+                               role=Roles.controller,
+                               eids=[hab.pre],
+                               pvrsn=Vrsn_2_0,
+                               kind=Kinds.json,
+                               gvrsn=Vrsn_2_0)
+        dst2.psr.parse(ims=oobi)
+
+        assert not oobi
+        locer = dst2.db.locs.get(keys=(hab.pre, Schemes.http))
         assert locer is not None
         assert locer.url == "http://127.0.0.1:5555"
 

--- a/tests/vdr/test_credentialing.py
+++ b/tests/vdr/test_credentialing.py
@@ -3,17 +3,97 @@
 tests.vdr.test_credentialing module
 
 """
-from keri.kering import ValidationError, Vrsn_1_0, Kinds
+from keri.kering import Ilks, ValidationError, Vrsn_1_0, Vrsn_2_0, Kinds
 
-from keri.core import Number, Saider, Diger, SerderKERI, SealEvent
+from keri.core import Number, Saider, Diger, SerderKERI, SealEvent, TraitDex
 
 from keri.app import openKS
 from keri.db import openDB
-from keri.vdr import Regery, Registrar
+from keri.vdr import Credentialer, Regery, Registrar
+from keri.vdr.eventing import incept
 
 from tests.vdr import buildHab
 
 from tests.common import KWA
+
+
+def test_v1_registry_version_across_lifecycle_with_v2_identifier():
+    with openDB(temp=True) as db, openKS(temp=True) as kpr:
+        hby, hab = buildHab(db, kpr, version=Vrsn_2_0, kind=Kinds.json)
+        for registry_type in ("standard", "signify"):
+            rgy = Regery(hby=hby, name=registry_type, temp=True)
+            try:
+                if registry_type == "standard":
+                    registry = rgy.makeRegistry(
+                        name="legacy",
+                        prefix=hab.pre,
+                        noBackers=True,
+                        version=Vrsn_1_0,
+                        kind=Kinds.json,
+                    )
+                    vcp = registry.vcp
+                else:
+                    vcp = incept(
+                        pre=hab.pre,
+                        cnfg=[TraitDex.NoBackers],
+                        version=Vrsn_1_0,
+                        kind=Kinds.json,
+                    )
+                    registry = rgy.makeSignifyRegistry(
+                        name="legacy",
+                        prefix=hab.pre,
+                        regser=vcp,
+                    )
+
+                credentialer = Credentialer(
+                    hby=hby,
+                    rgy=rgy,
+                    registrar=None,
+                    verifier=None,
+                )
+                credentialer.validate = lambda creder: True
+
+                def create_credential():
+                    return credentialer.create(
+                        regname="legacy",
+                        recp=None,
+                        schema="EAllThM1rLBSMZ_ozM1uAnFvSfC0N1jaQ42aKU5sCZ5Q",
+                        source=None,
+                        rules=None,
+                        data={"name": "Test"},
+                    )
+
+                creder = create_credential()
+                assert creder.pvrsn == Vrsn_1_0
+                assert creder.sad["ri"] == registry.regk
+
+                seal = SealEvent(i=registry.regk, s="0", d=registry.regd)
+                msg = hab.interact(
+                    data=[seal._asdict()],
+                    framed=True,
+                    gvrsn=Vrsn_2_0,
+                )
+                anchor = SerderKERI(raw=msg)
+                rgy.tvy.processEvent(
+                    serder=vcp,
+                    seqner=Number(num=anchor.sn),
+                    saider=Saider(qb64=anchor.said),
+                )
+
+                if registry_type == "standard":
+                    rgy.regs.clear()
+                    rgy.loadRegistries()
+                    registry = rgy.registryByName("legacy")
+
+                creder = create_credential()
+                assert creder.pvrsn == Vrsn_1_0
+                assert creder.sad["ri"] == registry.regk
+
+                iserder = registry.issue(said=creder.said)
+                assert iserder.pvrsn == Vrsn_1_0
+                assert iserder.ilk == Ilks.iss
+            finally:
+                rgy.close()
 
 
 def test_tpwe():


### PR DESCRIPTION
- now uses the most recent version from regser (current TEL state) when self.vcp is not available (it can be 'None' on reload when reconstructing regrey from disk after a restart)
- support for v1 registries with v2 identifiers
- use the witness set for the event being receipted instead of the identifier’s current witness set
- propagate verified witness receipts in Receiptor with messagize instead of rebuilding attachment groups manually
- pass the CESR genus version through KEL, delegation, and OOBI replay
- add v2 credentialing, receipting, replay, and OOBI tests