### PR TITLE
Fix acdcagg to default to the acg schema, not the act schema

### DIFF
--- a/src/keri/acdc/messaging.py
+++ b/src/keri/acdc/messaging.py
@@ -336,7 +336,7 @@ def acdcagg(israid, uuid=None, regid=None, schema=None, aggregate=None,
     uuid = uuid if uuid is not None else ""
     regid = regid if regid is not None else ""
     if schema is None:
-        ssaid, ssad = actSchemaDefault(kind=kind)
+        ssaid, ssad = acgSchemaDefault(kind=kind)
         schema = ssad
 
     aggregate = aggregate if aggregate is not None else []

--- a/tests/acdc/test_messaging.py
+++ b/tests/acdc/test_messaging.py
@@ -4,6 +4,8 @@ tests.vc.test_messaging module
 
 """
 
+from jsonschema import Draft202012Validator
+
 from keri.kering import Protocols, Kinds, Ilks, Vrsn_2_0
 from keri.core import (GenDex, Noncer, SerderACDC, BlindState, Blinder,
                        Compactor, Aggor)
@@ -553,6 +555,29 @@ def test_schema_defaults():
                                         'type': 'object'}]}},
         'additionalProperties': False
     }
+
+    """Done Test"""
+
+
+def test_acdcagg_default_schema():
+    """Regression: acdcagg must default to the ACG (aggregate) schema, not ACT.
+
+    An acg message carries an aggregate ('A') section, so its default schema must
+    be acgSchemaDefault -- which requires 'A' -- not actSchemaDefault, which
+    requires an attribute 'a' section and forbids extra properties. When acdcagg
+    embedded the act default, an acg ACDC failed validation against the very
+    schema it carried. Guard that with the pypi jsonschema (Draft 2020-12)
+    library so the two cannot drift apart again.
+    """
+    acgSaid, _ = acgSchemaDefault()
+    actSaid, _ = actSchemaDefault()
+    acg = acdcagg(israid='EA2X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ')
+    assert acg.ilk == Ilks.acg
+    # the acg ACDC commits to the acg default schema, not the act one
+    assert acg.sad['s']['$id'] == acgSaid
+    assert acg.sad['s']['$id'] != actSaid
+    # and it validates against the schema it carries (this failed before the fix)
+    Draft202012Validator(acg.sad['s']).validate(acg.sad)
 
     """Done Test"""
 


### PR DESCRIPTION
## Summary

`acdcagg` builds an `acg` (aggregate) ACDC, whose top-level section is the
aggregate `A`. But when no schema was supplied it defaulted to
`actSchemaDefault` — the schema for `act` (attribute) ACDCs, which **requires an
`a` section** and sets `additionalProperties: false`. The result was an `acg`
ACDC that carried, and committed to, a schema it could not itself satisfy: an
independent verifier running JSON Schema validation against the embedded schema
would reject a perfectly well-formed `acg` credential with `'a' is a required
property`.

`acgSchemaDefault` — which requires `A` — already exists and is used by the
`sectionate` dispatch (`messaging.py:545`); `acdcagg` simply called the wrong
one. This one-line change points it at `acgSchemaDefault`.

## Change

- `src/keri/acdc/messaging.py`: in `acdcagg`, default `schema` to
  `acgSchemaDefault` instead of `actSchemaDefault`.
- `tests/acdc/test_messaging.py`: add `test_acdcagg_default_schema`, a
  regression test that validates a default-schema `acg` ACDC against the schema
  it carries, using the pypi `jsonschema` (Draft 2020-12) library, and asserts
  the ACDC commits to the `acg` schema (not the `act` one).

## Blast radius

Minimal. No existing test exercised the `acg` **default-schema** path — every
`acdcagg` test in `test_messaging.py` passes `schema=` explicitly — so **no
pinned SAIDs change**. The full `tests/acdc/` suite plus `tests/test_kering.py`
pass. Note this does change the embedded schema (and therefore the SAID) of an
`acg` ACDC built via `acdcagg` **without** an explicit schema; previously such an
ACDC was self-inconsistent, so any consumer relying on the old default was
relying on an ACDC that failed its own schema.

## How it was found

Surfaced while adding working JSON Schema validation to the worked ACDC examples
(separate, forthcoming PR). The validation immediately flagged that the `acg`
examples did not conform to the schema they carried.

---

This code was developed with claude (using the Opus 4.8 model, mostly). However,
I (Daniel the human) have read, reviewed, and worked the code, and I stand behind
it and take responsibility for it.
