### PR TITLE
Isolate per-worker store roots under pytest-xdist to de-flake CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,47 @@ def seeder():
     return DbSeed
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_keri_store_roots(tmp_path_factory):
+    """Give each pytest-xdist worker its own on-disk root for non-temp stores.
+
+    CI runs ``pytest -n auto``. Several tests open persistent (``temp=False``)
+    stores with a fixed name/base (e.g. ``name="test"``), which all resolve to
+    the same on-disk path under the store classes' ``HeadDirPath`` -- or
+    ``AltHeadDirPath`` when the head dir is not writable, as on CI. Under
+    parallel workers those paths collide, so one worker can observe another's
+    half-migrated database ("DB version None; migrations must be run") or a
+    half-written KEL ("Attempt to replay nonexistent pre=..."). Point each
+    worker's store root at its own per-worker temp directory so the paths can
+    never overlap.
+
+    Only active under xdist (where ``PYTEST_XDIST_WORKER`` is set); serial runs
+    are unchanged. ``temp=True`` stores are unaffected -- they already use
+    isolated ``/tmp`` directories. ``LMDBer`` is the base of the db (``Baser``),
+    keystore (``Keeper``) and registry (``Reger``) stores, so patching it covers
+    all three; ``Configer`` covers the config store.
+    """
+    if not os.environ.get("PYTEST_XDIST_WORKER"):
+        yield
+        return
+
+    from keri.db.dbing import LMDBer
+    from keri.app.configing import Configer
+
+    root = str(tmp_path_factory.getbasetemp())  # unique per xdist worker
+    saved = [(cls, cls.HeadDirPath, cls.AltHeadDirPath)
+             for cls in (LMDBer, Configer)]
+    for cls in (LMDBer, Configer):
+        cls.HeadDirPath = root
+        cls.AltHeadDirPath = root
+    try:
+        yield
+    finally:
+        for cls, head, alt in saved:
+            cls.HeadDirPath = head
+            cls.AltHeadDirPath = alt
+
+
 def _unused_tcp_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))


### PR DESCRIPTION
## Summary

CI runs `pytest tests/ … -n auto`. Several tests open persistent (`temp=False`)
stores with a fixed name/base (e.g. `name="test"`), which all resolve to the
same on-disk path under the store classes' `HeadDirPath` — or `AltHeadDirPath`
when the head dir is not writable, as on CI. Under parallel xdist workers those
paths collide, so one worker can observe another's half-migrated database
(`DatabaseError: Database migrations must be run. DB version None`) or a
half-written KEL (`ValueError: Attempt to replay nonexistent pre=…`). This is an
intermittent, platform-sensitive source of CI flakiness (seen recently on
macOS).

## Change

Add an autouse, session-scoped fixture in `tests/conftest.py` that, **when
running under xdist** (`PYTEST_XDIST_WORKER` set), points each worker's store
root at its own per-worker temp directory (`tmp_path_factory.getbasetemp()`), so
the on-disk paths can never overlap. It patches:

- `LMDBer.HeadDirPath` / `AltHeadDirPath` — the base class of the db (`Baser`),
  keystore (`Keeper`) and registry (`Reger`) stores, so all three are covered;
- `Configer.HeadDirPath` / `AltHeadDirPath` — the config store.

Serial runs are unchanged (the fixture is a no-op without xdist). `temp=True`
stores are unaffected — they already use isolated `/tmp` directories. This
mirrors the per-worker isolation already used for TCP ports in the same
conftest.

## Validation

- Under `-n 2`, a `temp=False` store now lands under the per-worker temp root
  (not the shared default) — isolation confirmed.
- `tests/app -n auto`: **159 passed, 1 skipped** (the store-heavy directory
  containing the previously-flaky `test_kli_commands` / `test_habbing_*`).
- No behavior change for serial runs.

## Out of scope

`tests/help/test_ogling.py::{test_init_ogler,test_reset_levels}` also flake under
`-n auto`, but from a different root cause — global logging state when xdist
interleaves the ogling tests with other logging-touching tests (they pass in
isolation and don't touch any store). That's a separate fix and is not addressed
here.

---

This code was developed with claude (using the Opus 4.8 model, mostly). However,
I (Daniel the human) have read, reviewed, and worked the code, and I stand behind
it and take responsibility for it.
