### PR TITLE
Fix replay version handling and related tests.

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -216,7 +216,7 @@ class Receiptor(doing.DoDoer):
         client, clientDoer = httpClient(hab, wit)
         self.extend([clientDoer])
 
-        for fmsg in hab.db.clonePreIter(pre=pre):
+        for fmsg in hab.db.clonePreIter(pre=pre, version=hab.kever.serder.pvrsn):
             streamCESRRequests(client=client, dest=wit, ims=bytearray(fmsg))
             while not client.responses:
                 yield self.tock
@@ -374,7 +374,7 @@ class WitnessReceiptor(doing.DoDoer):
 
                         if ser.ked['t'] in (coring.Ilks.icp, coring.Ilks.dip) or \
                                 "ba" in ser.ked and wit in ser.ked["ba"]:  # Newly added witness, must send full KEL to catch up
-                            for fmsg in hab.db.clonePreIter(pre=pre):
+                            for fmsg in hab.db.clonePreIter(pre=pre, version=ser.pvrsn):
                                 witer.msgs.append(bytearray(fmsg))
 
                         witer.msgs.append(bytearray(msg))  # make a copy

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -199,7 +199,8 @@ class Anchorer(doing.DoDoer):
                     raise ValidationError("no proxy to send messages for delegation")
 
                 try:
-                    evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
+                    evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said,
+                                             version=serder.pvrsn)
                 except (MissingEntryError, SerializeError) as ex:
                     logger.debug("Problem cloning message=\n%s\n", serder.pretty())
                     raise

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -165,7 +165,8 @@ class Poster(doing.DoDoer):
     def sendEventToDelegator(self, sender, hab, fn=0):
         """ Returns generator for sending event and waiting until send is complete """
         # Send KEL event for processing
-        icp = self.hby.db.cloneEvtMsg(pre=hab.pre, fn=fn, dig=hab.kever.serder.saidb)
+        icp = self.hby.db.cloneEvtMsg(pre=hab.pre, fn=fn, dig=hab.kever.serder.saidb,
+                                      version=hab.kever.serder.pvrsn)
         ser = SerderKERI(raw=icp)
         del icp[:ser.size]
 

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -604,7 +604,7 @@ def introduce(hab, wit):
 
     if not found:  # no receipt from remote so pre-send own inception
         # no vrcs or rct of own icp from remote so send own inception
-        for msg in hab.db.clonePreIter(pre=hab.pre):
+        for msg in hab.db.clonePreIter(pre=hab.pre, version=hab.kever.serder.pvrsn):
             msgs.extend(msg)
         for msg in hab.db.cloneDelegation(hab.kever):
             msgs.extend(msg)

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -648,7 +648,7 @@ class Multiplexor:
         self.kvy = Kevery(db=self.hby.db, lax=False, local=False, rvy=self.rvy)
         self.kvy.registerReplyRoutes(router=self.rtr)
         self.psr = Parser(framed=True, kvy=self.kvy, rvy=self.rvy,
-                                  exc=self.exc, version=Vrsn_1_0)
+                                  exc=self.exc, version=self.hby.version)
 
         self.notifier = notifier
 

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1899,7 +1899,7 @@ class BaseHab:
         return msg
 
 
-    def replay(self, pre=None, fn=0, gvrsn=Vrsn_1_0, *, version=None):
+    def replay(self, pre=None, fn=0, gvrsn=Version, *, version=None):
         """Return replay of FEL (first-seen event log) for ``pre`` starting
         from ``fn``. Default pre is own ``.pre``.
 
@@ -1929,7 +1929,7 @@ class BaseHab:
         return msgs
 
 
-    def replayAll(self, gvrsn=Vrsn_1_0, *, version=None):
+    def replayAll(self, gvrsn=Version, *, version=None):
         """Return replay of FEL (first-seen event log) for all prefixes.
 
         Parameters:

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -1280,6 +1280,7 @@ class QueryEnd:
             evnts = bytearray()
 
             sn = req.get_param_as_int("sn")
+            vrsn = self.hab.kevers[pre].serder.pvrsn if pre in self.hab.kevers else Version
             if sn is not None: ## query for event with seq-num >= sn
                 dig = self.hab.db.kels.getLast(keys=pre, on=sn)
                 if dig is None:
@@ -1287,12 +1288,12 @@ class QueryEnd:
                 for dig in self.hab.db.kels.getAllIter(keys=pre, on=sn):
                     try:
                         dig = dig.encode("utf-8")
-                        msg = self.hab.db.cloneEvtMsg(pre=pre, fn=0, dig=dig)
+                        msg = self.hab.db.cloneEvtMsg(pre=pre, fn=0, dig=dig, version=vrsn)
                     except Exception:
                         continue  # skip this event
                     evnts.extend(msg)
             else:
-                for msg in self.hab.db.clonePreIter(pre=pre):
+                for msg in self.hab.db.clonePreIter(pre=pre, version=vrsn):
                     evnts.extend(msg)
 
 

--- a/src/keri/cli/commands/challenge/respond.py
+++ b/src/keri/cli/commands/challenge/respond.py
@@ -77,7 +77,7 @@ class RespondDoer(doing.DoDoer):
         self.recp = recp
         self.version = version
 
-        self.hby = setupHby(name=name, base=base, bran=bran)
+        self.hby = setupHby(name=name, base=base, bran=bran, version=self.version)
         self.postman = Poster(hby=self.hby, version=version, kind=Kinds.json)
         self.hbyDoer = HaberyDoer(habery=self.hby)  # setup doer
         self.org = Organizer(hby=self.hby)

--- a/src/keri/cli/commands/challenge/verify.py
+++ b/src/keri/cli/commands/challenge/verify.py
@@ -70,7 +70,7 @@ class VerifyDoer(doing.DoDoer):
         self.strength = strength
         self.out = out
         self.signer = signer
-        self.hby = setupHby(name=name, base=base, bran=bran)
+        self.hby = setupHby(name=name, base=base, bran=bran, version=version)
         self.exc = Exchanger(hby=self.hby, handlers=[])
         self.org = Organizer(hby=self.hby)
         signaler = Signaler()

--- a/src/keri/cli/commands/ends/add.py
+++ b/src/keri/cli/commands/ends/add.py
@@ -61,7 +61,7 @@ class RoleDoer(doing.DoDoer):
         self.version = version
         self.replyKwargs = dict(version=version, gvrsn=version, kind=Kinds.json) if version is not None else {}
 
-        self.hby = setupHby(name=name, base=base, bran=bran)
+        self.hby = setupHby(name=name, base=base, bran=bran, version=self.version)
         self.hab = self.hby.habByName(alias)
         self.witpub = WitnessPublisher(hby=self.hby)
         self.postman = Poster(hby=self.hby, version=version, kind=Kinds.json)

--- a/src/keri/cli/commands/import_.py
+++ b/src/keri/cli/commands/import_.py
@@ -11,7 +11,6 @@ from hio.base import doing
 
 from ..common import Parsery, setupHby
 
-from ...kering import Vrsn_1_0, Vrsn_2_0
 from ...app import HaberyDoer
 from ...core import Parser
 
@@ -65,8 +64,7 @@ class ImportDoer(doing.DoDoer):
 
         with open(self.file, 'rb') as f:
             ims = f.read()
-            Parser(kvy=self.hby.kvy, rvy=self.hby.rvy, local=False,
-                   version=Vrsn_1_0).parse(ims=ims)
+            Parser(kvy=self.hby.kvy, rvy=self.hby.rvy, local=False).parse(ims=ims)
             self.hby.kvy.processEscrows()
 
         self.exit()

--- a/src/keri/cli/commands/import_.py
+++ b/src/keri/cli/commands/import_.py
@@ -11,6 +11,7 @@ from hio.base import doing
 
 from ..common import Parsery, setupHby
 
+from ...kering import Vrsn_1_0
 from ...app import HaberyDoer
 from ...core import Parser
 
@@ -64,7 +65,8 @@ class ImportDoer(doing.DoDoer):
 
         with open(self.file, 'rb') as f:
             ims = f.read()
-            Parser(kvy=self.hby.kvy, rvy=self.hby.rvy, local=False).parse(ims=ims)
+            Parser(kvy=self.hby.kvy, rvy=self.hby.rvy, local=False,
+                   version=Vrsn_1_0).parse(ims=ims)
             self.hby.kvy.processEscrows()
 
         self.exit()

--- a/src/keri/cli/commands/ipex/admit.py
+++ b/src/keri/cli/commands/ipex/admit.py
@@ -9,7 +9,6 @@ from hio.base import doing
 
 from ...common import existing, Parsery
 
-from .... import Vrsn_1_0
 from ....app import (Notifier, Organizer, GroupHab,
                      Multiplexor, MailboxDirector,
                      WitnessInquisitor, StreamPoster,
@@ -63,7 +62,7 @@ class AdmitDoer(doing.DoDoer):
         self.tvy = Tevery(db=self.hby.db, reger=self.rgy.reger)
         self.vry = Verifier(hby=self.hby, reger=self.rgy.reger)
 
-        self.psr = Parser(kvy=self.kvy, tvy=self.tvy, vry=self.vry, version=Vrsn_1_0)
+        self.psr = Parser(kvy=self.kvy, tvy=self.tvy, vry=self.vry)
 
         notifier = Notifier(self.hby)
         mux = Multiplexor(self.hby, notifier=notifier)
@@ -127,7 +126,7 @@ class AdmitDoer(doing.DoDoer):
         msg = bytearray(exn.raw)
         msg.extend(atc)
 
-        Parser(version=Vrsn_1_0).parseOne(ims=bytes(msg), exc=self.exc)
+        Parser().parseOne(ims=bytes(msg), exc=self.exc)
 
         sender = self.hab
         if isinstance(self.hab, GroupHab):

--- a/src/keri/cli/commands/ipex/grant.py
+++ b/src/keri/cli/commands/ipex/grant.py
@@ -9,7 +9,6 @@ from hio.base import doing
 
 from ...common import Parsery, setupHby
 
-from ....kering import Vrsn_1_0
 from ....app import (Notifier, StreamPoster, Organizer,
                      GroupHab, Multiplexor, MailboxDirector,
                      serialize, multisigExn)
@@ -127,7 +126,7 @@ class GrantDoer(doing.DoDoer):
         msg = bytearray(exn.raw)
         msg.extend(atc)
 
-        parsing.Parser(version=Vrsn_1_0).parseOne(ims=bytes(msg), exc=self.exc)
+        parsing.Parser().parseOne(ims=bytes(msg), exc=self.exc)
 
         sender = self.hab
         if isinstance(self.hab, GroupHab):

--- a/src/keri/cli/commands/ipex/grant.py
+++ b/src/keri/cli/commands/ipex/grant.py
@@ -9,6 +9,7 @@ from hio.base import doing
 
 from ...common import Parsery, setupHby
 
+from ....kering import Vrsn_1_0
 from ....app import (Notifier, StreamPoster, Organizer,
                      GroupHab, Multiplexor, MailboxDirector,
                      serialize, multisigExn)
@@ -126,7 +127,7 @@ class GrantDoer(doing.DoDoer):
         msg = bytearray(exn.raw)
         msg.extend(atc)
 
-        parsing.Parser().parseOne(ims=bytes(msg), exc=self.exc)
+        parsing.Parser(version=Vrsn_1_0).parseOne(ims=bytes(msg), exc=self.exc)
 
         sender = self.hab
         if isinstance(self.hab, GroupHab):

--- a/src/keri/cli/commands/ipex/spurn.py
+++ b/src/keri/cli/commands/ipex/spurn.py
@@ -10,7 +10,6 @@ from hio.base import doing
 
 from ...common import Parsery, setupHby
 
-from ....kering import Vrsn_1_0
 from ....app import (Notifier, StreamPoster, Organizer,
                      GroupHab, Multiplexor, MailboxDirector,
                      multisigExn)
@@ -58,7 +57,7 @@ class SpurnDoer(doing.DoDoer):
         tvy = Tevery(db=self.hby.db, reger=self.rgy.reger)
         vry = Verifier(hby=self.hby, reger=self.rgy.reger)
 
-        self.psr = Parser(kvy=kvy, tvy=tvy, vry=vry, version=Vrsn_1_0)
+        self.psr = Parser(kvy=kvy, tvy=tvy, vry=vry)
 
         notifier = Notifier(self.hby)
         mux = Multiplexor(self.hby, notifier=notifier)
@@ -105,7 +104,7 @@ class SpurnDoer(doing.DoDoer):
         msg = bytearray(exn.raw)
         msg.extend(atc)
 
-        Parser(version=Vrsn_1_0).parseOne(ims=bytes(msg), exc=self.exc)
+        Parser().parseOne(ims=bytes(msg), exc=self.exc)
 
         spurn, _ = cloneMessage(self.hby, exn.said)
         if spurn is None:

--- a/src/keri/cli/commands/location/add.py
+++ b/src/keri/cli/commands/location/add.py
@@ -63,7 +63,7 @@ class LocationDoer(doing.DoDoer):
         self.version = version
         self.replyKwargs = dict(version=version, gvrsn=version, kind=Kinds.json) if version is not None else {}
 
-        self.hby = setupHby(name=name, base=base, bran=bran)
+        self.hby = setupHby(name=name, base=base, bran=bran, version=self.version)
         self.hab = self.hby.habByName(alias)
         self.witpub = WitnessPublisher(hby=self.hby)
         self.postman = forwarding.Poster(hby=self.hby, version=version, kind=Kinds.json)

--- a/src/keri/cli/commands/mailbox/add.py
+++ b/src/keri/cli/commands/mailbox/add.py
@@ -11,7 +11,7 @@ from hio.help import Hict, ogler
 
 from ...common import Parsery, setupHby
 
-from ....kering import Roles, Version, Vrsn_1_0, Vrsn_2_0
+from ....kering import Roles
 from ....app import (Organizer, GroupHab,
                      WitnessPublisher, httpClient)
 
@@ -88,7 +88,7 @@ class AddDoer(doing.DoDoer):
         if isinstance(self.hab, GroupHab):
             raise ValueError("watchers for multisig AIDs not currently supported")
 
-        kel = self.hab.replay(version=Vrsn_1_0)
+        kel = self.hab.replay()
         data = dict(cid=self.hab.pre,
                     role=Roles.mailbox,
                     eid=self.mailbox)

--- a/src/keri/cli/commands/multisig/continue_.py
+++ b/src/keri/cli/commands/multisig/continue_.py
@@ -36,10 +36,10 @@ class ContinueDoer(doing.DoDoer):
     """ DoDoer running the doers for recovering pending multisig events. """
 
     def __init__(self, name, base, bran, alias, version=None):
-        self.hby = setupHby(name=name, base=base, bran=bran)
         self.alias = alias
         self.version = version
         self.kind = Kinds.json
+        self.hby = setupHby(name=name, base=base, bran=bran, version=self.version)
         self.counselor = Counselor(hby=self.hby, version=version, kind=Kinds.json)
         self.witq = WitnessInquisitor(hby=self.hby)
         kwa = dict(version=version, gvrsn=version, kind=self.kind) if version is not None else {}

--- a/src/keri/cli/commands/oobi/resolve.py
+++ b/src/keri/cli/commands/oobi/resolve.py
@@ -58,7 +58,7 @@ class OobiDoer(doing.DoDoer):
         self.processed = 0
         self.oobi = oobi
         self.force = force
-        self.hby = setupHby(name=name, base=base, bran=bran)
+        self.hby = setupHby(name=name, base=base, bran=bran, version=version)
         self.hbyDoer = HaberyDoer(habery=self.hby)
 
         obr = OobiRecord(date=helping.nowIso8601())

--- a/src/keri/cli/commands/watcher/add.py
+++ b/src/keri/cli/commands/watcher/add.py
@@ -118,7 +118,8 @@ class AddDoer(doing.DoDoer):
             serder = SerderKERI(raw=msg)
             postman.send(serder=serder, attachment=msg[serder.size:])
 
-        for msg in self.hab.db.clonePreIter(pre=self.hab.pre):
+        for msg in self.hab.db.clonePreIter(pre=self.hab.pre,
+                                            version=self.hab.kever.serder.pvrsn):
             serder = SerderKERI(raw=msg)
             postman.send(serder=serder, attachment=msg[serder.size:])
 

--- a/src/keri/cli/commands/witness/authenticate.py
+++ b/src/keri/cli/commands/witness/authenticate.py
@@ -91,14 +91,16 @@ class AuthDoer(doing.DoDoer):
         _ = (yield self.tock)
 
         body = bytearray()
-        for msg in self.hab.db.clonePreIter(pre=self.hab.pre):
+        for msg in self.hab.db.clonePreIter(pre=self.hab.pre, version=self.hab.kever.serder.pvrsn):
             body.extend(msg)
 
         fargs = dict([("kel", body.decode("utf-8"))])
 
         if self.hab.kever.delegated:
             delkel = bytearray()
-            for msg in self.hab.db.clonePreIter(self.hab.kever.delpre):
+            dkever = self.hab.kevers[self.hab.kever.delpre]
+            for msg in self.hab.db.clonePreIter(self.hab.kever.delpre,
+                                                version=dkever.serder.pvrsn):
                 delkel.extend(msg)
 
             fargs['delkel'] = delkel.decode("utf-8")

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5626,8 +5626,8 @@ class Kevery:
                 msgs.append(msg)
 
             if kever.delpre:
-                delkever = self.kevers[kever.delpre]  # Get the delegator's kever so we can set the version for the iterator
-                cloner = self.db.clonePreIter(pre=kever.delpre, fn=0, version=delkever.serder.pvrsn)  # create iterator at 0
+                dkever = self.kevers[kever.delpre]  # Get the delegator's kever so we can set the version for the iterator
+                cloner = self.db.clonePreIter(pre=kever.delpre, fn=0, version=dkever.serder.pvrsn)  # create iterator at 0
                 for msg in cloner:
                     msgs.append(msg)
 

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5622,11 +5622,12 @@ class Kevery:
                     raise QueryNotFoundError(msg)
 
             msgs = list()  # outgoing messages
-            for msg in self.db.clonePreIter(pre=pre, fn=fn):
+            for msg in self.db.clonePreIter(pre=pre, fn=fn, version=kever.serder.pvrsn):
                 msgs.append(msg)
 
             if kever.delpre:
-                cloner = self.db.clonePreIter(pre=kever.delpre, fn=0)  # create iterator at 0
+                delkever = self.kevers[kever.delpre]  # Get the delegator's kever so we can set the version for the iterator
+                cloner = self.db.clonePreIter(pre=kever.delpre, fn=0, version=delkever.serder.pvrsn)  # create iterator at 0
                 for msg in cloner:
                     msgs.append(msg)
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1897,18 +1897,23 @@ class Baser(LMDBer):
         #return msg
 
 
-    def cloneDelegation(self, kever, gvrsn=Version, *, version=None):
+    def cloneDelegation(self, kever, gvrsn=None, *, version=None):
         """
         Recursively clone delegation chain from AID of Kever if one exists.
 
         Parameters:
             kever (Kever): Kever from which to clone the delegator's AID.
-            gvrsn (Versionage): CESR genus version for attachments
+            gvrsn (Versionage | None): CESR genus version for attachments.
+                None means derive from ``kever.serder.gvrsn`` or
+                ``kever.serder.pvrsn`` so V1 KELs are not rebuilt with the
+                global V2 default.
             version (Versionage): legacy alias for gvrsn
 
         """
         if version is not None:
             gvrsn = version
+        if gvrsn is None:
+            gvrsn = kever.serder.gvrsn or kever.serder.pvrsn
         if kever.delegated and kever.delpre in self.kevers:
             dkever = self.kevers[kever.delpre]
             yield from self.cloneDelegation(dkever, gvrsn=gvrsn)

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1899,7 +1899,7 @@ class Baser(LMDBer):
         """
         Search through a KEL for the event that contains a specific anchored
         SealEvent type of provided seal but in dict form and is also fully
-        witnessed. Searchs from sn forward (default = 0).Searches all events in
+        witnessed. Searches from sn forward (default = 0). Searches all events in
         KEL of pre including disputed and/or superseded events.
         Returns the Serder of the first event with the anchored SealEvent seal,
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1510,7 +1510,7 @@ class Baser(LMDBer):
         return migrations
 
 
-    def clean(self):
+    def clean(self, gvrsn=Version, *, version=None):
         """
         Clean database by creating re-verified cleaned cloned copy
         and then replacing original with cleaned cloned copy
@@ -1518,8 +1518,15 @@ class Baser(LMDBer):
         Database usage should be offline during cleaning as it will be cloned in
         readonly mode
 
+        Parameters:
+            gvrsn (Versionage): CESR genus version for clone attachments and parser
+            version (Versionage): legacy alias for gvrsn
+
         """
         from ..core import parsing
+
+        if version is not None:
+            gvrsn = version
 
         # create copy to clone into
         with openDB(name=self.name,
@@ -1540,8 +1547,8 @@ class Baser(LMDBer):
                 # need new method cloneObjAllPreIter()
                 # process event doesn't capture exceptions so we can more easily
                 # detect in the cloning that some events did not make it through
-                psr = parsing.Parser(kvy=kvy, version=Vrsn_1_0)
-                for msg in self.cloneAllPreIter(version=Vrsn_1_0):  # clone into copy
+                psr = parsing.Parser(kvy=kvy, version=gvrsn)
+                for msg in self.cloneAllPreIter(gvrsn=gvrsn):  # clone into copy
                     psr.parseOne(ims=msg)
 
                 # This is the list of non-set based databases that are not created as part of event processing.

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1541,7 +1541,7 @@ class Baser(LMDBer):
                 # process event doesn't capture exceptions so we can more easily
                 # detect in the cloning that some events did not make it through
                 psr = parsing.Parser(kvy=kvy, version=Vrsn_1_0)
-                for msg in self.cloneAllPreIter():  # clone into copy
+                for msg in self.cloneAllPreIter(version=Vrsn_1_0):  # clone into copy
                     psr.parseOne(ims=msg)
 
                 # This is the list of non-set based databases that are not created as part of event processing.
@@ -1637,7 +1637,7 @@ class Baser(LMDBer):
             shutil.rmtree(copy.path)
 
 
-    def clonePreIter(self, pre, fn=0, version=Vrsn_1_0):
+    def clonePreIter(self, pre, fn=0, version=Version):
         """
         Returns iterator of first seen event messages with attachments for the
         identifier prefix pre starting at first seen order number, fn.
@@ -1662,7 +1662,7 @@ class Baser(LMDBer):
             yield msg
 
 
-    def cloneAllPreIter(self, version=Vrsn_1_0):
+    def cloneAllPreIter(self, version=Version):
         """
         Returns iterator of first seen event messages with attachments for all
         identifier prefixes starting at key. If key == b'' then start at first
@@ -1687,7 +1687,7 @@ class Baser(LMDBer):
 
 
 
-    def cloneEvtMsg(self, pre, fn, dig, version=Vrsn_1_0):
+    def cloneEvtMsg(self, pre, fn, dig, version=Version):
         """
         Clones Event as Serialized CESR Message with Body and attached Foot
 

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -20,7 +20,7 @@ from hio import base
 from hio.core import http, wiring
 from hio.help import ogler
 
-from ..kering import Roles, Schemes, Version, Vrsn_1_0, Vrsn_2_0
+from ..kering import Roles, Schemes
 
 from ..core import Cigar, Siger
 from ..help import helping
@@ -604,7 +604,7 @@ class OOBIEnd:
         msgs = hab.replyToOobi(aid=aid, role=role, eids=eids)
         if not msgs and role is None:
             msgs = hab.replyToOobi(aid=aid, role=Roles.witness, eids=eids)
-            msgs.extend(hab.replay(aid, version=Vrsn_1_0))
+            msgs.extend(hab.replay(aid))
 
         if msgs:
             rep.status = falcon.HTTP_200  # This is the default status

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -60,7 +60,8 @@ class Regery:
         self.reger = reger if reger is not None else Reger(name=self.name, base=base, db=self.hby.db, temp=temp,
                                                            reopen=True)
         self.tvy = Tevery(reger=self.reger, db=self.hby.db, local=True, lax=True)
-        self.psr = Parser(framed=True, kvy=self.hby.kvy, tvy=self.tvy, version=Vrsn_1_0)
+        self.psr = Parser(framed=True, kvy=self.hby.kvy, tvy=self.tvy,
+                                  version=self.hby.version)
 
         self.regs = {}  # List of local registries
         self.inited = False

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -11,7 +11,7 @@ from typing import Type
 
 from hio.help import decking, ogler
 
-from ..kering import (Vrsn_1_0, Ilks, MissingChainError,
+from ..kering import (Ilks, MissingChainError,
                       MissingRegistryError, MissingSchemaError,
                       ValidationError, FailedSchemaValidationError,
                       MissingChainError, RevokedChainError)
@@ -66,7 +66,7 @@ class Verifier:
         """
         self.tvy = Tevery(reger=self.reger, db=self.hby.db, local=False)
         self.psr = Parser(framed=True, kvy=self.hby.kvy, tvy=self.tvy,
-                                  version=Vrsn_1_0)
+                                  version=self.hby.version)
         self.resolver = CacheResolver(db=self.hby.db)
 
         self.inited = True

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -107,7 +107,7 @@ def anchorer_test_do(tymth=None, tock=0.0, **opts):
         yield tock
 
     witDoer.cues.popleft()
-    msg = next(wesHab.db.clonePreIter(pre=palHab.pre))
+    msg = next(wesHab.db.clonePreIter(pre=palHab.pre, version=palHab.kever.serder.pvrsn))
     kvy = Kevery(db=delHby.db, local=True)
     Parser(version=Vrsn_1_0).parseOne(ims=bytearray(msg), kvy=kvy, local=True)
 
@@ -134,7 +134,7 @@ def anchorer_test_do(tymth=None, tock=0.0, **opts):
     # Get the value of the seal created when delegation is anchored
     couple = Seqner(sn=palHab.kever.sn).qb64b + palHab.kever.serder.saidb
 
-    msg = next(wesHab.db.clonePreIter(pre=palHab.pre, fn=1))
+    msg = next(wesHab.db.clonePreIter(pre=palHab.pre, fn=1, version=palHab.kever.serder.pvrsn))
     kvy = Kevery(db=delHby.db, local=True)
     Parser(version=Vrsn_1_0).parseOne(ims=bytearray(msg), kvy=kvy, local=True)
 

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -313,7 +313,7 @@ class QueryTestDoer(doing.Doer):
         while not witDoer.cues:
             yield self.tock
 
-        msg = next(wesHab.db.clonePreIter(pre=palHab.pre))
+        msg = next(wesHab.db.clonePreIter(pre=palHab.pre, version=palHab.kever.serder.pvrsn))
 
 
         # Test valid KEL query with 'pre'

--- a/tests/core/test_keystate.py
+++ b/tests/core/test_keystate.py
@@ -117,7 +117,7 @@ def test_keystate(mockHelpingNowUTC):
         assert cue["ksn"]["i"] == bobHab.pre
 
         msgs = bytearray()  # outgoing messages
-        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, local=True)
@@ -184,7 +184,7 @@ def test_keystate(mockHelpingNowUTC):
         assert cue["ksn"]["i"] == bobHab.pre
 
         msgs = bytearray()  # outgoing messages
-        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, local=True)
@@ -283,7 +283,7 @@ def test_keystate(mockHelpingNowUTC):
         Parser(version=Vrsn_1_0).parse(ims=bytearray(liveKsn), kvy=bamKvy, rvy=bamRvy, local=True)
 
         msgs = bytearray()  # outgoing messages
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy, local=True)

--- a/tests/core/test_witness.py
+++ b/tests/core/test_witness.py
@@ -642,7 +642,7 @@ def test_out_of_order_witnessed_events():
 
         # Get the receipted rotation event and pass, out of order to Bam
         msgs = bytearray()
-        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=1):
+        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=1, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         bamKvy = Kevery(db=bamHby.db, lax=False, local=False)
@@ -655,7 +655,8 @@ def test_out_of_order_witnessed_events():
 
         # Pass the icp to Bam, process escrows and see if the fully
         # receipted event lands in Bam's Kevery
-        msg = wesHby.db.cloneEvtMsg(pre=bobHab.pre, fn=0, dig=iserder.saidb)
+        msg = wesHby.db.cloneEvtMsg(pre=bobHab.pre, fn=0, dig=iserder.saidb,
+                                    version=bobHab.kever.serder.pvrsn)
 
         Parser(version=Vrsn_1_0).parse(ims=msg, kvy=bamKvy)
         bamKvy.processEscrows()

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -1952,7 +1952,7 @@ def test_clean_baser():
         # Nat's kever and the signatory kever
         assert len(natHab.kevers) == 2
         # now clean it
-        natHab.db.clean()
+        natHab.db.clean(version=version)
 
         # see if kevers dict is back to what it was before
         assert natHab.kever.sn == 6

--- a/tests/end/test_ending.py
+++ b/tests/end/test_ending.py
@@ -489,7 +489,8 @@ def test_get_oobi():
 
         # Approve the delegation manually
         delhab.interact(data=[dict(i=hab.pre, s="0", d=hab.pre)], framed=True, **CUE_KWA)
-        for msg in delhab.db.clonePreIter(pre=delhab.pre, fn=0):
+        for msg in delhab.db.clonePreIter(pre=delhab.pre, fn=0,
+                                          version=delhab.kever.serder.pvrsn):
             hab.psr.parse(ims=msg)
 
         rep = client.simulate_get('/oobi', )

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -39,7 +39,7 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC, mockCoringRandomNonce):
 
         # Gather up Bob's key event log
         msgs = bytearray()
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         # pass key event log to Bam
@@ -153,7 +153,7 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC, mockCoringRandomNonce):
 
         # Gather up Bob's key event log
         msgs = bytearray()
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
@@ -219,7 +219,7 @@ def test_tsn_from_witness(mockHelpingNowUTC, mockCoringRandomNonce):
         # Create Bob's icp, pass to Wes.
         wesKvy = Kevery(db=wesHby.db, lax=False, local=False)
 
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=wesKvy, local=True)
             iserder = SerderKERI(raw=bytearray(msg))
             wesHab.receipt(serder=iserder, framed=True, gvrsn=Vrsn_1_0, **KWA)
@@ -277,7 +277,7 @@ def test_tsn_from_witness(mockHelpingNowUTC, mockCoringRandomNonce):
         assert wesHab.pre in bamHby.db.kevers
 
         msgs = bytearray()
-        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in wesHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy, local=True)
@@ -345,7 +345,7 @@ def test_tsn_from_no_one(mockHelpingNowUTC, mockCoringRandomNonce):
         # Create Bob's icp, pass to Wes.
         wesKvy = Kevery(db=wesHby.db, lax=False, local=False)
 
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=wesKvy)
 
         assert bobHab.pre in wesHab.kevers
@@ -388,7 +388,7 @@ def test_tsn_from_no_one(mockHelpingNowUTC, mockCoringRandomNonce):
         bamTvy.registerReplyRoutes(router=bamRtr)
 
         msgs = bytearray()
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
@@ -498,7 +498,7 @@ def test_credential_tsn_message(mockHelpingNowUTC, mockCoringRandomNonce, mockHe
 
         # Gather up Bob's key event log
         msgs = bytearray()
-        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0):
+        for msg in bobHby.db.clonePreIter(pre=bobHab.pre, fn=0, version=bobHab.kever.serder.pvrsn):
             msgs.extend(msg)
 
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -346,7 +346,7 @@ def test_verifier_chained_credential(seeder):
         ianverfer = Verifier(hby=ianHby, reger=ianreg.reger)
 
         # Now process all the events that Ron's issuer has generated so far
-        for msg in ron.db.clonePreIter(pre=ron.pre):
+        for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=iankvy, tvy=iantvy)
         for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=iankvy, tvy=iantvy)
@@ -479,7 +479,7 @@ def test_verifier_chained_credential(seeder):
         victvy = Tevery(reger=vicreg.reger, db=vic.db, local=False)
         vicverfer = Verifier(hby=vicHby, reger=vicreg.reger)
 
-        for msg in ron.db.clonePreIter(pre=ron.pre):
+        for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
         for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
@@ -495,7 +495,7 @@ def test_verifier_chained_credential(seeder):
 
         # Vic should be able to verify Han's credential
         # Get Ian's icp into Vic's db
-        for msg in ian.db.clonePreIter(pre=ian.pre):
+        for msg in ian.db.clonePreIter(pre=ian.pre, version=ian.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
         for msg in ianverfer.reger.clonePreIter(pre=ianiss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
@@ -525,7 +525,7 @@ def test_verifier_chained_credential(seeder):
                          saider=diger)
         ronreg.processEscrows()
 
-        for msg in ron.db.clonePreIter(pre=ron.pre):
+        for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
         for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)


### PR DESCRIPTION
- baser clone functions version set to global default
- explicit version passed in where necessary in tests and other usages

All tests are now passing again.

#NOTE: This does NOT yet fix all v1 hard-coded sites (there's at least one more in Baser.clean), or fix the common args issue (separate PR to come).