### PR TITLE
Disable KRAM for V2 OOBI service endpoint replies

### DIFF
--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -245,6 +245,7 @@ class Kramer:
     def fullDenials(self):
         """Returns raw denials list from config.
         Each denial is [[major, minor], ilk, route]
+        OOBIs routes /end/role and /loc/scheme are automatically added to the list when KRAM is enabled.
         """
         return self._fullDenials
 

--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -95,6 +95,11 @@ class Kramer:
         denials (list): Compacted denial strings for exempted messages
         fullDenials (list): Raw denial configurations
     """
+    OobiDenials = (
+        [[2, 0], Ilks.rpy, "/end/role"],
+        [[2, 0], Ilks.rpy, "/loc/scheme"],
+    )
+
     def __init__(self, db, cf=None, cues=None):
         self.db = db
         self.cf = cf if cf else None
@@ -108,7 +113,11 @@ class Kramer:
 
         self._enabled = kram.get('enabled', False)
 
-        self._fullDenials = kram.get('denials', [])
+        fullDenials = kram.get('denials', [])
+        if self._enabled:
+            fullDenials = self._mergeOobiDenials(fullDenials)
+
+        self._fullDenials = fullDenials
         self._denials = self._compactDenials(self._fullDenials)
 
         self._kramCTYPCf = kram.get('caches', {})
@@ -116,6 +125,26 @@ class Kramer:
 
         # Staged accept-window increases (see changeConfig, reconcileConfig)
         self._pending = {}
+
+    @classmethod
+    def _mergeOobiDenials(cls, fullDenials):
+        """Add built-in OOBI denial exemptions unless config already covers them.
+
+        OOBI endpoint discovery replies rely on BADA acceptance rather than
+        KRAM replay protection, so V2 service-endpoint reply routes must bypass
+        ``kramit`` even when KRAM is enabled.
+        """
+        merged = list(fullDenials)
+        compact = cls._compactDenials(merged)
+
+        for denial in cls.OobiDenials:
+            bcompact = cls._compactDenials([denial])[0]
+            if any(bcompact.startswith(cdenial) for cdenial in compact):
+                continue
+            merged.append(list(denial))
+            compact.append(bcompact)
+
+        return merged
 
     def _parseValidateCtyp(self, key, val):
         """Parse and validate one cache-type tuple from config.

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -5,10 +5,11 @@ tests.app.test_multisig module
 """
 
 import falcon
+from falcon import testing
 from hio.base import doing
 from hio.core import http
 
-from keri.kering import Vrsn_1_0, Vrsn_2_0, Roles, Schemes, Version
+from keri.kering import Vrsn_1_0, Vrsn_2_0, Roles, Schemes, Version, Kinds
 from keri.app import (Notifier, Oobiery, Authenticator,
                       Result, openHab, openHby,
                       oobiRequestExn)
@@ -243,6 +244,169 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
         locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
         assert locer is not None
         assert locer.url == "http://127.0.0.1:5555"
+
+
+def test_loaded_v2_oobi_endpoint_replies_bypass_kram(mockHelpingNowUTC):
+    cuekwa = dict(version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+    config = {
+        "kram": {
+            "enabled": True,
+            "caches": {
+                "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000],
+            },
+        }
+    }
+
+    with openHby(name="oobi-src-v2", version=Vrsn_2_0) as src, \
+            openHby(name="oobi-dst-v2", version=Vrsn_2_0) as dst:
+        hab = src.makeHab(name="wit", isith="1", icount=1,
+                          transferable=False, version=Vrsn_2_0, kind=Kinds.cesr)
+        msgs = bytearray()
+        msgs.extend(hab.makeEndRole(eid=hab.pre,
+                                    role=Roles.controller,
+                                    stamp=helping.nowIso8601(),
+                                    version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0))
+        msgs.extend(hab.makeLocScheme(url="http://127.0.0.1:5555",
+                                      scheme=Schemes.http,
+                                      stamp=helping.nowIso8601(),
+                                      version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0))
+        hab.psr.parse(ims=msgs)
+
+        dst.cf.put(config)
+        rtr = Router()
+        rvy = Revery(db=dst.db, rtr=rtr)
+        kvy = Kevery(db=dst.db, cf=dst.cf, enableKram=True,
+                     lax=False, local=False, rvy=rvy)
+        kvy.registerReplyRoutes(router=rtr)
+        prs = Parser(framed=True, kvy=kvy, rvy=rvy, version=Vrsn_2_0)
+
+        # Assert Kramer is enabled
+        assert kvy.kramer is not None
+        assert kvy.kramer.enabled is True
+
+        # Create record calls and seen lists to track functions
+        calls = []
+        seen = []
+
+        # Retrieve kramit and processReply functions to wrap and track calls
+        original_kramit = kvy.kramer.kramit
+        original_processReply = rvy.processReply
+
+        def kramit(msg, kwa=None):
+            calls.append((msg.ilk, msg.route))
+            return original_kramit(msg, kwa)
+
+        def processReply(serder, *args, **kwa):
+            seen.append((serder.route, serder.pvrsn))
+            return original_processReply(serder, *args, **kwa)
+
+        kvy.kramer.kramit = kramit
+        rvy.processReply = processReply
+
+        oobi = bytearray()
+        oobi.extend(hab.loadEndRole(cid=hab.pre,
+                                    eid=hab.pre,
+                                    role=Roles.controller))
+        oobi.extend(hab.loadLocScheme(eid=hab.pre,
+                                      scheme=Schemes.http))
+
+        prs.parse(ims=oobi)
+
+        ender = dst.db.ends.get(keys=(hab.pre, Roles.controller, hab.pre))
+        assert ender is not None
+        assert ender.allowed is True
+
+        locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
+        assert locer is not None
+        assert locer.url == "http://127.0.0.1:5555"
+
+
+        # Assert seen and calls lists
+        assert seen == [
+            ("/end/role/add", Vrsn_2_0),
+            ("/loc/scheme", Vrsn_2_0),
+        ]
+        assert calls == []
+        assert list(dst.db.kramMSGC.getTopItemIter()) == []
+
+
+def test_v2_oobi_get_controller_stream_bypasses_kram(mockHelpingNowUTC):
+    config = {
+        "kram": {
+            "enabled": True,
+            "caches": {
+                "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000],
+            },
+        }
+    }
+
+    with openHby(name="oobi-src-v2-http", version=Vrsn_2_0) as src, \
+            openHby(name="oobi-dst-v2-http", version=Vrsn_2_0) as dst:
+        hab = src.makeHab(name="oobi", isith="1", icount=1,
+                          transferable=False, version=Vrsn_2_0, kind=Kinds.cesr)
+        msgs = bytearray()
+        msgs.extend(hab.makeEndRole(eid=hab.pre,
+                                    role=Roles.controller,
+                                    stamp=helping.nowIso8601(),
+                                    version=Vrsn_2_0, 
+                                    kind=Kinds.cesr, 
+                                    gvrsn=Vrsn_2_0))
+        msgs.extend(hab.makeLocScheme(url="http://127.0.0.1:5555",
+                                      scheme=Schemes.http,
+                                      stamp=helping.nowIso8601(),
+                                      version=Vrsn_2_0, 
+                                      kind=Kinds.cesr, 
+                                      gvrsn=Vrsn_2_0))
+        hab.psr.parse(ims=msgs)
+
+        app = falcon.App()
+        loadEndingEnds(app, hby=src, default=hab.pre)
+        client = testing.TestClient(app)
+        rep = client.simulate_get(f"/oobi/{hab.pre}/controller")
+
+        assert rep.status == falcon.HTTP_OK
+        assert rep.content
+
+        dst.cf.put(config)
+        rtr = Router()
+        rvy = Revery(db=dst.db, rtr=rtr)
+        kvy = Kevery(db=dst.db, cf=dst.cf, enableKram=True,
+                     lax=False, local=False, rvy=rvy)
+        kvy.registerReplyRoutes(router=rtr)
+        prs = Parser(framed=True, kvy=kvy, rvy=rvy, version=Vrsn_2_0)
+
+        calls = []
+        seen = []
+        original_kramit = kvy.kramer.kramit
+        original_processReply = rvy.processReply
+
+        def kramit(msg, kwa=None):
+            calls.append((msg.ilk, msg.route))
+            return original_kramit(msg, kwa)
+
+        def processReply(serder, *args, **kwa):
+            seen.append((serder.route, serder.pvrsn))
+            return original_processReply(serder, *args, **kwa)
+
+        kvy.kramer.kramit = kramit
+        rvy.processReply = processReply
+
+        prs.parse(ims=bytearray(rep.content))
+
+        ender = dst.db.ends.get(keys=(hab.pre, Roles.controller, hab.pre))
+        assert ender is not None
+        assert ender.allowed is True
+
+        locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
+        assert locer is not None
+        assert locer.url == "http://127.0.0.1:5555"
+
+        assert seen == [
+            ("/loc/scheme", Vrsn_2_0),
+            ("/end/role/add", Vrsn_2_0),
+        ]
+        assert calls == []
+        assert list(dst.db.kramMSGC.getTopItemIter()) == []
 
 
 def test_introduce(mockHelpingNowUTC):

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -247,7 +247,6 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
 
 
 def test_loaded_v2_oobi_endpoint_replies_bypass_kram(mockHelpingNowUTC):
-    cuekwa = dict(version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
     config = {
         "kram": {
             "enabled": True,

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -426,6 +426,46 @@ def test_intake():
             assert result is serder
 
 
+def test_v2_oobi_service_reply_routes_bypass_kram_by_default():
+    """V2 OOBI endpoint replies use BADA and bypass KRAM without extra config."""
+    enabledCf = {
+        "kram": {
+            "enabled": True,
+            "denials": [],
+            "caches": {},
+        }
+    }
+
+    with openCF(name="kram_oobi_reply", base="test", temp=True) as cf:
+        cf.put(enabledCf)
+        with openDB(name="test_oobi_reply_denials", temp=True) as db:
+            kramer = Kramer(db, cf)
+            v2b64 = Verser.verToB64(major=2, minor=0)
+
+            assert f"{v2b64}.rpy./end/role" in kramer.denials
+            assert f"{v2b64}.rpy./loc/scheme" in kramer.denials
+
+            calls = []
+
+            def mock_kramit(msg, kwa=None):
+                calls.append((msg.ilk, msg.route))
+                return msg
+
+            kramer.kramit = mock_kramit
+
+            serder = reply(
+                pre=TEST_PRE,
+                route="/end/role/add",
+                data=dict(a=1),
+                pvrsn=Vrsn_2_0,
+            )
+
+            result = kramer.intake(serder)
+
+            assert result is serder
+            assert calls == []
+
+
 # The following four tests provide basic coverage for integration with kevery.processMsg() along the various auth paths
 
 KRAM_INTEGRATION_CONFIG = {

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -465,6 +465,18 @@ def test_v2_oobi_service_reply_routes_bypass_kram_by_default():
             assert result is serder
             assert calls == []
 
+            serder = reply(
+                pre=TEST_PRE,
+                route="/loc/scheme",
+                data=dict(a=1),
+                pvrsn=Vrsn_2_0,
+            )
+
+            result = kramer.intake(serder)
+
+            assert result is serder
+            assert calls == []
+
 
 # The following four tests provide basic coverage for integration with kevery.processMsg() along the various auth paths
 


### PR DESCRIPTION
- Add built-in KRAM denials for V2 rpy /end/role and rpy /loc/scheme
- Keep OOBI service-endpoint discovery on the BADA reply path instead of routing through kramit
- Preserve config precedence by only adding the built-in denials when existing config does not already cover them
- Add tests for V2 reply messages with KRAM disabled