### PR TITLE
fix: write Consoler output as bytes

### DIFF
--- a/src/keri/app/apping.py
+++ b/src/keri/app/apping.py
@@ -78,7 +78,7 @@ class Consoler(doing.Doer):
         chunks = line.lower().split()
 
         if not chunks:
-            self.console.put("Try one of: l[eft] r[ight] w[alk] s[top]\n")
+            self.console.put(b"Try one of: l[eft] r[ight] w[alk] s[top]\n")
             return False
         verb = chunks[0]
 
@@ -95,11 +95,13 @@ class Consoler(doing.Doer):
             command = ('stop', '')
 
         else:
-            self.console.put("Invalid command: {0}\n".format(verb))
-            self.console.put("Try one of: t[urn] s[top] w[alk]\n")
+            self.console.put(b"Invalid command: " + verb + b"\n")
+            self.console.put(b"Try one of: l[eft] r[ight] w[alk] s[top]\n")
             return False
 
-        self.console.put("Did: {} {}\n".format(command[0], command[1]).encode("utf-8"))
+        self.console.put(b"Did: " +
+                         command[0].encode("utf-8") + b" " +
+                         str(command[1]).encode("utf-8") + b"\n")
 
         return False
 

--- a/tests/app/test_apping.py
+++ b/tests/app/test_apping.py
@@ -4,9 +4,38 @@ tests.app.apping module
 
 """
 
-from hio.base import doing
 
 from keri.app import Consoler
+
+
+class FakeConsole:
+    """Deterministic fake console for testing Consoler without a real terminal.
+
+    Attributes:
+        opened (bool): True when the console is open.
+        inputs (list): Queue of bytearray lines to return from get().
+        outputs (list): All bytes written via put().
+    """
+
+    def __init__(self, inputs=None):
+        self.opened = False
+        self.inputs = list(inputs) if inputs else []
+        self.outputs = []
+
+    def reopen(self):
+        self.opened = True
+        return True
+
+    def get(self):
+        if not self.inputs:
+            return bytearray()
+        return self.inputs.pop(0)
+
+    def put(self, data=b'\n'):
+        self.outputs.append(data)
+
+    def close(self):
+        self.opened = False
 
 
 def test_app():
@@ -16,35 +45,74 @@ def test_app():
 
 
 def test_consoler():
-    """
-    Test Consoler class
+    """Test Consoler with deterministic fake console."""
 
-    Must run in WindIDE with Debug I/O configured as external console
-    This test really is only meant for manual testing.
-    For automated unit tests we will have to mock the serial port interface
-    with a string or file of command lines for the input.
+    # 1. enter() opens the console
+    fake = FakeConsole()
+    doer = Consoler(console=fake)
+    doer.enter()
+    assert fake.opened is True
 
-    """
-    tock = 0.03125
-    ticks = 8
-    limit = tock * ticks
-    doist = doing.Doist(tock=tock, real=True, limit=limit)
-    assert doist.tyme == 0.0  # on next cycle
-    assert doist.tock == tock == 0.03125
-    assert doist.real == True
-    assert doist.limit == limit
-    assert doist.doers == []
+    # 2. no input returns False and produces no output
+    assert doer.recur(0.0) is False
+    assert fake.outputs == []
 
-    doer = Consoler()
+    # 3. truly empty input (Enter on blank line) — no output
+    fake.inputs.append(bytearray(b''))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == []
 
-    doers = [doer]
-    try:
-        doist.do(doers=doers)
-        assert doist.tyme == limit
-    except IOError:  # pytest runner blocks opening of console have to test manually
-        pass
+    # 4. whitespace-only input produces bytes guidance
+    fake.inputs.append(bytearray(b'  '))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == [b"Try one of: l[eft] r[ight] w[alk] s[top]\n"]
 
-    assert doer.console.opened == False
+    # 5. right produces the expected bytes output
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'right'))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == [b"Did: turn right\n"]
+
+    # 6. left produces the expected bytes output
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'left'))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == [b"Did: turn left\n"]
+
+    # 7. walk produces the expected bytes output
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'walk'))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == [b"Did: walk 1\n"]
+
+    # 8. stop produces the expected bytes output
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'stop'))
+    assert doer.recur(0.0) is False
+    assert fake.outputs == [b"Did: stop \n"]
+
+    # 9. invalid input produces both expected messages
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'jump'))
+    assert doer.recur(0.0) is False
+    assert len(fake.outputs) == 2
+    assert fake.outputs[0] == b"Invalid command: jump\n"
+    assert fake.outputs[1] == b"Try one of: l[eft] r[ight] w[alk] s[top]\n"
+
+    # 10. every captured output is bytes
+    for out in fake.outputs:
+        assert isinstance(out, (bytes, bytearray))
+
+    # 11. recur() continues to return False
+    fake.outputs.clear()
+    fake.inputs.append(bytearray(b'right'))
+    for _ in range(5):
+        assert doer.recur(0.0) is False
+    assert len(fake.outputs) == 1
+
+    # 12. exit() closes the console
+    doer.exit()
+    assert fake.opened is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes `Consoler` output paths that passed `str` values to HIO's byte-oriented
`Console.put()` API.

## Problem

`hio.core.serial.serialing.Console.put()` delegates directly to `os.write()` and
requires bytes. Several empty/invalid-command responses in
`keri.app.apping.Consoler.recur()` passed strings, resulting in:

```
TypeError: a bytes-like object is required, not 'str'
```

The existing test used the real interactive console and was documented as
manual-only, so this behavior was not covered deterministically.

## Changes

- send bytes on every `Consoler` output path
- add a `FakeConsole` class for deterministic test coverage
- test valid, empty, whitespace, and invalid commands
- verify all emitted output is bytes
- remove dependence on a real terminal for automated coverage

## Validation

- `tests/app/test_apping.py`: passed
- repeated `test_consoler`: 5/5 passed
- `tests/app/test_apping.py` + `tests/app/test_directing.py`: passed
- `git diff --check`: passed
- ruff: all checks passed

The full pre-push pytest suite was bypassed on this push using the same
documented baseline-failure exception as the Ogler fix (PR #1510).  All
other hooks ran normally.

## Scope

Focused Keripy runtime and test correction. No HIO changes.

