### PR TITLE
fix: default Baser.clean() parser to v2

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1540,8 +1540,8 @@ class Baser(LMDBer):
                 # need new method cloneObjAllPreIter()
                 # process event doesn't capture exceptions so we can more easily
                 # detect in the cloning that some events did not make it through
-                psr = parsing.Parser(kvy=kvy, version=Vrsn_1_0)
-                for msg in self.cloneAllPreIter():  # clone into copy
+                psr = parsing.Parser(kvy=kvy)  # default v2 parser
+                for msg in self.cloneAllPreIter(version=Vrsn_2_0):  # clone v2
                     psr.parseOne(ims=msg)
 
                 # This is the list of non-set based databases that are not created as part of event processing.


### PR DESCRIPTION
Sam's directive from the 2026-07-14 dev call: "As a rule, we just want to get rid of pretty much anywhere that the parser is hard coded to version one."

## Problem

`Baser.clean()` in `db/basing.py` hardcodes `version=Vrsn_1_0` for both the `Parser` and `cloneAllPreIter()`. Sam's `cloneEvtMsg` versioning (commit `8ebf9176`) already made the clone path version-aware, but `clean()` was missed.

## Fix

Two lines in `basing.py`:
- Drop `version=Vrsn_1_0` from `Parser()` — it already defaults to `Vrsn_2_0`
- Pass `version=Vrsn_2_0` to `cloneAllPreIter()` for v2 attachment group codes

## Validation

- Full test suite: **616 passed, 0 failed** (including `test_clean_baser`)
- Single file: `src/keri/db/basing.py` (+2/−2)
- No overlapping work from Phil or Ryan