### PR TITLE
Fix Poller keeping caller-supplied msgs deck

### DIFF
--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -777,7 +777,7 @@ class Poller(doing.DoDoer):
         self.version = version
         self.gvrsn = version if gvrsn is None else gvrsn
         self.kind = kind
-        self.msgs = None if msgs is not None else decking.Deck()
+        self.msgs = msgs if msgs is not None else decking.Deck()
         self.times = dict()
 
         doers = [doing.doify(self.eventDo)]

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -859,7 +859,7 @@ class Poller(doing.DoDoer):
                         logger.error(f"bad mailbox event: {evt}")
                         continue
 
-                    self.msgs.append(msg.encode("utf=8"))
+                    self.msgs.append(msg.encode("utf-8"))
                     yield self.tock
 
                     witrec.topics[tpc] = int(idx)

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -486,6 +486,23 @@ def test_query_end_reuses_injected_reger():
     assert qe.reger is mock_reger
 
 
+def test_poller_keeps_supplied_msgs_deck():
+    """Poller must keep a caller-supplied msgs deck instead of discarding it.
+    See #1500.
+    """
+    from keri.app.indirecting import Poller
+    from unittest.mock import MagicMock
+
+    mock_hab = MagicMock()
+    msgs = decking.Deck()
+
+    poller = Poller(hab=mock_hab, witness="wit", topics=["/receipt"], msgs=msgs)
+    assert poller.msgs is msgs
+
+    poller = Poller(hab=mock_hab, witness="wit", topics=["/receipt"])
+    assert isinstance(poller.msgs, decking.Deck)
+
+
 if __name__ == "__main__":
     test_mailbox_iter()
     test_qrymailbox_iter()


### PR DESCRIPTION
`Poller.__init__` had an inverted None-check: `self.msgs = None if msgs is not None else decking.Deck()`. When a caller passes their own deck, it was discarded and `self.msgs` became `None`, so the later `self.msgs.append(...)` in `eventDo` raises `AttributeError`. This flips it to `msgs if msgs is not None else decking.Deck()`, matching the idiom every other class in `agenting.py`/`watching.py` already uses.

Added a regression test alongside the existing `QueryEnd` injection test (I couldn't get the full suite building locally because of the pysodium/libsodium native dep, but the test mirrors that neighbor and CI will run it).

Closes #1500
