### PR TITLE
Add V2 IPEX builders and linear dispatcher

### DIFF
--- a/src/keri/acdc/__init__.py
+++ b/src/keri/acdc/__init__.py
@@ -9,3 +9,5 @@ from .messaging import (regcept, blindate, update, acdcmap, acdcatt, acdcagg,
                        sectionate,
                        actSchemaDefault, acgSchemaDefault, acmSchemaDefault)
 
+from .ipexing import (Ipex, IpexHandler, loadHandlers, apply, offer, agree,
+                      grant, admit, spurn)

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -28,7 +28,7 @@ PreviousRoutes = {
     Ipex.agree: (Ipex.offer,),
     Ipex.grant: (Ipex.agree,),
     Ipex.admit: (Ipex.grant,),
-    Ipex.spurn: (Ipex.apply, Ipex.offer, Ipex.agree, Ipex.grant),
+    Ipex.spurn: (Ipex.apply, Ipex.offer, Ipex.agree),
 }
 
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -6,3 +6,539 @@ IPEx protocol service support (Issuance and Presentation Exchange)
 
 """
 
+import os
+from collections import namedtuple
+
+from hio.help import ogler
+
+from .. import Kinds
+from ..kering import Colds, Vrsn_2_0, sniff
+from ..core import (Counter, Codens, Diger, GenDex, Number, Serdery, Texter,
+                    exchange, messagize)
+from ..peer import cloneMessage
+
+logger = ogler.getLogger()
+
+Ipexage = namedtuple("Ipexage", "apply offer agree grant admit spurn")
+Ipex = Ipexage(apply="apply", offer="offer", agree="agree",
+               grant="grant", admit="admit", spurn="spurn")
+
+PreviousRoutes = {
+    Ipex.offer: (Ipex.apply,),
+    Ipex.agree: (Ipex.offer,),
+    Ipex.grant: (Ipex.agree,),
+    Ipex.admit: (Ipex.grant,),
+    Ipex.spurn: (Ipex.apply, Ipex.offer, Ipex.agree, Ipex.grant),
+}
+
+
+def _streamSerder(stream):
+    """Extract the message serder from a bare or nested artifact stream.
+
+    Parameters:
+        stream (Serder | bytes | bytearray): Artifact body, artifact stream, or
+            already-parsed serder-like object.
+
+    Returns:
+        Serder: Deserialized message serder for the provided artifact.
+    """
+
+    # if the input already looks like a serder with .said and .raw, just return it
+    if hasattr(stream, "said") and hasattr(stream, "raw"):
+        return stream
+
+    # If the input has .raw, use that; otherwise treat the input itself as bytes
+    ims = bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+
+    # If the input is a nested stream, unwrap it to get the inner message for parsing
+    if _isNestedStream(ims):
+        ctr = Counter(qb64b=ims, version=Vrsn_2_0, strip=True)
+        if ctr.name in (
+            Codens.NonNativeBodyGroup,
+            Codens.BigNonNativeBodyGroup,
+        ):
+            return Serdery(version=Vrsn_2_0).reap(ims=Texter(qb64b=ims, strip=True).raw,
+                                                  genus=GenDex.KERI,
+                                                  svrsn=Vrsn_2_0)
+        if ims and sniff(ims) != Colds.msg:
+            ctr = Counter(qb64b=ims, version=Vrsn_2_0, strip=True)
+            if ctr.name in (
+                Codens.NonNativeBodyGroup,
+                Codens.BigNonNativeBodyGroup,
+            ):
+                return Serdery(version=Vrsn_2_0).reap(ims=Texter(qb64b=ims, strip=True).raw,
+                                                      genus=GenDex.KERI,
+                                                      svrsn=Vrsn_2_0)
+
+    return Serdery(version=Vrsn_2_0).reap(ims=ims,
+                                          genus=GenDex.KERI,
+                                          svrsn=Vrsn_2_0)
+
+
+def _isNestedStream(stream):
+    """Determine whether a stream already uses a supported nested wrapper.
+
+    Parameters:
+        stream (Serder | bytes | bytearray): Candidate artifact stream to inspect.
+
+    Returns:
+        bool: True when the stream starts with a nested body wrapper supported
+            by the V2 parser, False otherwise.
+    """
+    ims = bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+    if not ims or sniff(ims) == Colds.msg:
+        return False
+
+    try:
+        ctr = Counter(qb64b=ims, version=Vrsn_2_0)
+    except Exception:
+        return False
+
+    return ctr.name in (
+        Codens.BodyWithAttachmentGroup,
+        Codens.BigBodyWithAttachmentGroup,
+        Codens.NonNativeBodyGroup,
+        Codens.BigNonNativeBodyGroup,
+    )
+
+
+def _normalizeNestedStream(stream):
+    """Convert a carried artifact into a parser-friendly V2 nested substream.
+
+    Parameters:
+        stream (Serder | bytes | bytearray): Artifact body or artifact stream to
+            carry inside an outer IPEX exchange.
+
+    Returns:
+        bytearray: V2 nested substream framed as a body-with-attachments group.
+    """
+
+    # Check if already a nested CESR substream, if so return as is
+    if _isNestedStream(stream):
+        return bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+
+    # If not make the input into raw bytes
+    raw = bytes(stream.raw) if hasattr(stream, "raw") else bytes(stream)
+
+    # Parse the raw bytes into a Serder to get the body and attachments
+    serder = _streamSerder(raw)
+
+    body = raw[:serder.size]
+    atc = raw[serder.size:]
+
+    # Check if body is NOT CESR, if so wrap it in a NonNativeBodyGroup counter
+    if serder.kind != Kinds.cesr:
+        body = Counter.enclose(qb64=Texter(raw=body).qb64b,
+                               code=Codens.NonNativeBodyGroup,
+                               version=Vrsn_2_0)
+
+    # Check if attachments are empty, if so create an empty AttachmentGroup counter
+    nested = bytearray(body)
+    if atc:
+        nested.extend(atc)
+    else:
+        empty = Counter.enclose(qb64=b'',
+                                code=Codens.ControllerIdxSigs,
+                                version=Vrsn_2_0)
+        nested.extend(Counter.enclose(qb64=empty,
+                                      code=Codens.AttachmentGroup,
+                                      version=Vrsn_2_0))
+
+    # Return the body and attachments
+    return Counter.enclose(qb64=nested,
+                           code=Codens.BodyWithAttachmentGroup,
+                           version=Vrsn_2_0)
+
+
+def _sign(hab, serder, *, nests=None, gvrsn=None):
+    """Sign and messagize an outer IPEX exchange with optional nested streams.
+
+    Parameters:
+        hab (Hab): Habitat used to sign the outer exchange.
+        serder (Serder): Outer exchange serder to sign.
+        nests (list[bytes | bytearray] | None): Optional nested substreams to
+            append in the outer attachment section.
+        gvrsn (Versionage | None): Optional CESR genus version override for the
+            attachment and nesting groups.
+
+    Returns:
+        bytearray: Full signed exchange stream including the outer message body,
+            attachments, and any nested substreams.
+    """
+    gvrsn = gvrsn if gvrsn is not None else Vrsn_2_0
+    nests = nests if nests else None
+
+    if hab.kever.prefixer.transferable:
+        sigers = hab.sign(ser=serder.raw, indexed=True)
+        tsgs = [(hab.kever.prefixer,
+                 Number(sn=hab.kever.lastEst.s),
+                 Diger(qb64=hab.kever.lastEst.d),
+                 sigers)]
+        return messagize(serder=serder,
+                         tsgs=tsgs,
+                         nests=nests,
+                         framed=False,
+                         gvrsn=gvrsn)
+
+    cigars = hab.sign(ser=serder.raw, indexed=False)
+    return messagize(serder=serder,
+                     cigars=cigars,
+                     nests=nests,
+                     framed=False,
+                     gvrsn=gvrsn)
+
+
+class IpexHandler:
+    """Verify and handle the linear V2 IPEX `exn` workflow."""
+
+    def __init__(self, resource, hby, notifier):
+        """Create a handler for one IPEX route.
+
+        Parameters:
+            resource (str): Route string handled by this instance.
+            hby (Habery): Habitat environment and backing database.
+            notifier: Notifier-like object with an ``add`` method.
+
+        Returns:
+            None
+        """
+        self.resource = resource
+        self.hby = hby
+        self.notifier = notifier
+
+    def verify(self, serder, attachments=None):
+        """Validate the verb, prior link, and single-response rule.
+
+        Parameters:
+            serder (Serder): Incoming IPEX exchange message.
+            attachments (list | None): Parsed attachment payloads, unused in the
+                current linear workflow validation.
+
+        Returns:
+            bool: True when the message is valid for the linear IPEX workflow,
+                False otherwise.
+        """
+        
+        # Get route
+        route = serder.ked["r"]
+        
+        # Get digest of prior
+        dig = serder.ked["p"]
+        
+        # Split the route for validation
+        parts = route.split("/")
+
+        # Reject if route is not shaped like /ipex/<verb>
+        if len(parts) != 3 or parts[:2] != ["", "ipex"]:
+            return False
+        verb = parts[2]
+
+        # Apply starts the flow so there must be no prior
+        if verb == Ipex.apply:
+            return not dig
+        
+        # Offer and Grant can start a flow so empty prior is okay
+        if verb in (Ipex.offer, Ipex.grant):
+            if not dig:
+                return True
+
+        # Admit, Agree and Spurn are not allowed to start a flow so empty prior rejected
+        elif verb in (Ipex.admit, Ipex.agree, Ipex.spurn):
+            if not dig:
+                return False
+        else:
+            return False
+
+        # Load the prior, reject if missing
+        pserder, _ = cloneMessage(self.hby, said=dig)
+        if pserder is None:
+            return False
+        
+        # Retrieve the verb and check if previous route validates
+        proute = pserder.ked["r"]
+        pverb = os.path.basename(os.path.normpath(proute))
+        if pverb not in PreviousRoutes[verb]:
+            return False
+
+        return self.response(pserder) is None
+
+    def response(self, serder):
+        """Look up the recorded response to a prior IPEX exchange.
+
+        Parameters:
+            serder (Serder): Prior IPEX exchange to check for an existing reply.
+
+        Returns:
+            Serder | None: The previously recorded response serder, or None when
+                no response has been recorded.
+        """
+        saider = self.hby.db.erpy.get(keys=(serder.said,))
+        if saider:
+            rserder, _ = cloneMessage(self.hby, saider.qb64)
+            return rserder
+
+        return None
+
+    def handle(self, serder, attachments=None):
+        """Emit a notifier record for an accepted IPEX message.
+
+        Parameters:
+            serder (Serder): Accepted IPEX exchange message.
+            attachments (list | None): Parsed attachment payloads, unused by the
+                current notifier path.
+
+        Returns:
+            None
+        """
+        attrs = serder.ked["a"]
+        self.notifier.add(attrs=dict(
+            r=f"/exn{serder.ked['r']}",
+            d=serder.said,
+            m=attrs["m"],
+        ))
+
+
+def apply(hab, recp, message, schema, attrs, dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``apply`` exchange.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        recp (str): Recipient AID for the application.
+        message (str): Human-readable application message.
+        schema (str | Serder): Schema SAID or schema-like object for the request.
+        attrs (dict): Requested credential attribute payload.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    # Build the body
+    serder = exchange(
+        sender=hab.pre,
+        receiver=recp,
+        route="/ipex/apply",
+        stamp=dt,
+        attributes=dict(
+            m=message,
+            s=schema.said if hasattr(schema, "said") else schema,
+            a=attrs,
+            i=recp,
+        ),
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+    
+    # Sign the full stream
+    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
+    
+    # Strip the body so we only get the attachments
+    del atc[:serder.size]
+
+    return serder, atc
+
+
+def offer(hab, message, acdc, apply=None, dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``offer`` exchange with a nested ACDC stream.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        message (str): Human-readable offer message.
+        acdc (Serder | bytes | bytearray): Offered credential artifact.
+        apply (Serder | None): Optional prior ``apply`` exchange.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    # Get the prior event (apply)
+    prior = apply.said if apply is not None else ""
+    
+    # Build the body
+    serder = exchange(
+        sender=hab.pre,
+        prior=prior,
+        route="/ipex/offer",
+        stamp=dt,
+        attributes=dict(
+            m=message,
+            acdc=_streamSerder(acdc).said,
+        ),
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+
+    # Build attachments
+    nests = [_normalizeNestedStream(acdc)]
+    atc = bytearray(_sign(hab=hab, serder=serder, nests=nests, gvrsn=gvrsn))
+    del atc[:serder.size]
+    return serder, atc
+
+
+def agree(hab, message, offer, dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``agree`` exchange.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        message (str): Human-readable agreement message.
+        offer (Serder): Prior ``offer`` exchange being accepted.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    serder = exchange(
+        sender=hab.pre,
+        prior=offer.said,
+        route="/ipex/agree",
+        stamp=dt,
+        attributes=dict(m=message),
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
+    del atc[:serder.size]
+    return serder, atc
+
+
+def grant(hab, recp, message, acdc, iss=None, anc=None, agree=None,
+          dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``grant`` exchange with nested disclosure artifacts.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        recp (str): Recipient AID for the disclosure.
+        message (str): Human-readable disclosure message.
+        acdc (Serder | bytes | bytearray): Credential artifact to disclose.
+        iss (Serder | bytes | bytearray | None): Optional issuance artifact.
+        anc (Serder | bytes | bytearray | None): Optional anchoring event stream.
+        agree (Serder | None): Optional prior ``agree`` exchange.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    prior = agree.said if agree is not None else ""
+    data = dict(
+        m=message,
+        i=recp,
+        acdc=_streamSerder(acdc).said,
+    )
+    nests = [_normalizeNestedStream(acdc)]
+
+    if iss is not None:
+        data["iss"] = _streamSerder(iss).said
+        nests.append(_normalizeNestedStream(iss))
+
+    if anc is not None:
+        data["anc"] = _streamSerder(anc).said
+        nests.append(_normalizeNestedStream(anc))
+
+    serder = exchange(
+        sender=hab.pre,
+        receiver=recp,
+        prior=prior,
+        route="/ipex/grant",
+        stamp=dt,
+        attributes=data,
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+    atc = bytearray(_sign(hab=hab, serder=serder, nests=nests, gvrsn=gvrsn))
+    del atc[:serder.size]
+    return serder, atc
+
+
+def admit(hab, message, grant, dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``admit`` exchange.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        message (str): Human-readable admission message.
+        grant (Serder): Prior ``grant`` exchange being acknowledged.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    serder = exchange(
+        sender=hab.pre,
+        prior=grant.said,
+        route="/ipex/admit",
+        stamp=dt,
+        attributes=dict(m=message),
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
+    del atc[:serder.size]
+    return serder, atc
+
+
+def spurn(hab, message, spurned, dt=None, kind=None, gvrsn=None):
+    """Create a signed V2 IPEX ``spurn`` exchange.
+
+    Parameters:
+        hab (Hab): Habitat creating and signing the exchange.
+        message (str): Human-readable rejection message.
+        spurned (Serder): Prior exchange being rejected.
+        dt (str | None): Optional RFC-3339 timestamp override.
+        kind (str | None): Optional serialization kind override.
+        gvrsn (Versionage | None): Optional CESR genus version override.
+
+    Returns:
+        tuple[Serder, bytearray]: Outer exchange serder and detached attachment
+            bytes for the signed V2 stream.
+    """
+    serder = exchange(
+        sender=hab.pre,
+        prior=spurned.said,
+        route="/ipex/spurn",
+        stamp=dt,
+        attributes=dict(m=message),
+        pvrsn=Vrsn_2_0,
+        gvrsn=gvrsn if gvrsn is not None else Vrsn_2_0,
+        kind=kind if kind is not None else hab.kever.serder.kind,
+    )
+    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
+    del atc[:serder.size]
+    return serder, atc
+
+
+def loadHandlers(hby, exc, notifier):
+    """Register handlers for the six V2 IPEX verb routes.
+
+    Parameters:
+        hby (Habery): Habitat environment and backing database.
+        exc (Exchanger): Exchange router to register handlers on.
+        notifier: Notifier-like object passed through to each handler.
+
+    Returns:
+        None
+    """
+    exc.addHandler(IpexHandler(resource="/ipex/apply", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/offer", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/agree", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/grant", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/admit", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/spurn", hby=hby, notifier=notifier))
+

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -6,7 +6,6 @@ IPEx protocol service support (Issuance and Presentation Exchange)
 
 """
 
-import os
 from collections import namedtuple
 
 from hio.help import ogler
@@ -30,7 +29,6 @@ PreviousRoutes = {
     Ipex.admit: (Ipex.grant,),
     Ipex.spurn: (Ipex.apply, Ipex.offer, Ipex.agree),
 }
-
 
 def _streamSerder(stream):
     """Extract the message serder from a bare or nested artifact stream.
@@ -83,7 +81,11 @@ def _isNestedStream(stream):
 
     Returns:
         bool: True when the stream starts with a nested body wrapper supported
-            by the V2 parser, False otherwise.
+            by the V2 parser, False when it is a bare message body.
+
+    Raises:
+        ValueError: If the stream starts with an unsupported leading CESR frame
+            that this implementation refuses to reinterpret as a bare artifact.
     """
     ims = bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
     if not ims or sniff(ims) == Colds.msg:
@@ -91,15 +93,18 @@ def _isNestedStream(stream):
 
     try:
         ctr = Counter(qb64b=ims, version=Vrsn_2_0)
-    except Exception:
-        return False
+    except Exception as ex:
+        raise ValueError("unsupported leading frame for nested artifact stream") from ex
 
-    return ctr.name in (
+    if ctr.name in (
         Codens.BodyWithAttachmentGroup,
         Codens.BigBodyWithAttachmentGroup,
         Codens.NonNativeBodyGroup,
         Codens.BigNonNativeBodyGroup,
-    )
+    ):
+        return True
+
+    raise ValueError(f"unsupported leading frame code for nested artifact stream: {ctr.name}")
 
 
 def _normalizeNestedStream(stream):
@@ -225,10 +230,7 @@ class IpexHandler:
         # Get digest of prior
         dig = serder.ked["p"]
         
-        # Split the route for validation
         parts = route.split("/")
-
-        # Reject if route is not shaped like /ipex/<verb>
         if len(parts) != 3 or parts[:2] != ["", "ipex"]:
             return False
         verb = parts[2]
@@ -256,7 +258,10 @@ class IpexHandler:
         
         # Retrieve the verb and check if previous route validates
         proute = pserder.ked["r"]
-        pverb = os.path.basename(os.path.normpath(proute))
+        pparts = proute.split("/")
+        if len(pparts) != 3 or pparts[:2] != ["", "ipex"]:
+            return False
+        pverb = pparts[2]
         if pverb not in PreviousRoutes[verb]:
             return False
 
@@ -541,4 +546,3 @@ def loadHandlers(hby, exc, notifier):
     exc.addHandler(IpexHandler(resource="/ipex/grant", hby=hby, notifier=notifier))
     exc.addHandler(IpexHandler(resource="/ipex/admit", hby=hby, notifier=notifier))
     exc.addHandler(IpexHandler(resource="/ipex/spurn", hby=hby, notifier=notifier))
-

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -346,7 +346,7 @@ def apply(hab, recp, message, schema, attrs, dt=None, kind=None, gvrsn=None):
     return serder, atc
 
 
-def offer(hab, message, acdc, apply=None, dt=None, kind=None, gvrsn=None):
+def offer(hab, message, acdc, apply=None, recp=None, dt=None, kind=None, gvrsn=None):
     """Create a signed V2 IPEX ``offer`` exchange with a nested ACDC stream.
 
     Parameters:
@@ -354,6 +354,9 @@ def offer(hab, message, acdc, apply=None, dt=None, kind=None, gvrsn=None):
         message (str): Human-readable offer message.
         acdc (Serder | bytes | bytearray): Offered credential artifact.
         apply (Serder | None): Optional prior ``apply`` exchange.
+        recp (str | None): Optional recipient AID. Defaults to the prior
+            ``apply`` sender; supply it directly for an offer-first exchange
+            opened with no prior.
         dt (str | None): Optional RFC-3339 timestamp override.
         kind (str | None): Optional serialization kind override.
         gvrsn (Versionage | None): Optional CESR genus version override.
@@ -362,12 +365,14 @@ def offer(hab, message, acdc, apply=None, dt=None, kind=None, gvrsn=None):
         tuple[Serder, bytearray]: Outer exchange serder and detached attachment
             bytes for the signed V2 stream.
     """
-    # Get the prior event (apply)
+    # Get the prior event (apply) and the party to address (its sender)
     prior = apply.said if apply is not None else ""
-    
+    receiver = recp if recp is not None else (apply.ked["i"] if apply is not None else "")
+
     # Build the body
     serder = exchange(
         sender=hab.pre,
+        receiver=receiver,
         prior=prior,
         route="/ipex/offer",
         stamp=dt,
@@ -387,13 +392,15 @@ def offer(hab, message, acdc, apply=None, dt=None, kind=None, gvrsn=None):
     return serder, atc
 
 
-def agree(hab, message, offer, dt=None, kind=None, gvrsn=None):
+def agree(hab, message, offer, recp=None, dt=None, kind=None, gvrsn=None):
     """Create a signed V2 IPEX ``agree`` exchange.
 
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable agreement message.
         offer (Serder): Prior ``offer`` exchange being accepted.
+        recp (str | None): Optional recipient AID. Defaults to the prior
+            ``offer`` sender.
         dt (str | None): Optional RFC-3339 timestamp override.
         kind (str | None): Optional serialization kind override.
         gvrsn (Versionage | None): Optional CESR genus version override.
@@ -402,8 +409,10 @@ def agree(hab, message, offer, dt=None, kind=None, gvrsn=None):
         tuple[Serder, bytearray]: Outer exchange serder and detached attachment
             bytes for the signed V2 stream.
     """
+    receiver = recp if recp is not None else offer.ked["i"]
     serder = exchange(
         sender=hab.pre,
+        receiver=receiver,
         prior=offer.said,
         route="/ipex/agree",
         stamp=dt,
@@ -469,13 +478,15 @@ def grant(hab, recp, message, acdc, iss=None, anc=None, agree=None,
     return serder, atc
 
 
-def admit(hab, message, grant, dt=None, kind=None, gvrsn=None):
+def admit(hab, message, grant, recp=None, dt=None, kind=None, gvrsn=None):
     """Create a signed V2 IPEX ``admit`` exchange.
 
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable admission message.
         grant (Serder): Prior ``grant`` exchange being acknowledged.
+        recp (str | None): Optional recipient AID. Defaults to the prior
+            ``grant`` sender.
         dt (str | None): Optional RFC-3339 timestamp override.
         kind (str | None): Optional serialization kind override.
         gvrsn (Versionage | None): Optional CESR genus version override.
@@ -484,8 +495,10 @@ def admit(hab, message, grant, dt=None, kind=None, gvrsn=None):
         tuple[Serder, bytearray]: Outer exchange serder and detached attachment
             bytes for the signed V2 stream.
     """
+    receiver = recp if recp is not None else grant.ked["i"]
     serder = exchange(
         sender=hab.pre,
+        receiver=receiver,
         prior=grant.said,
         route="/ipex/admit",
         stamp=dt,
@@ -499,13 +512,15 @@ def admit(hab, message, grant, dt=None, kind=None, gvrsn=None):
     return serder, atc
 
 
-def spurn(hab, message, spurned, dt=None, kind=None, gvrsn=None):
+def spurn(hab, message, spurned, recp=None, dt=None, kind=None, gvrsn=None):
     """Create a signed V2 IPEX ``spurn`` exchange.
 
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable rejection message.
         spurned (Serder): Prior exchange being rejected.
+        recp (str | None): Optional recipient AID. Defaults to the spurned
+            message's sender.
         dt (str | None): Optional RFC-3339 timestamp override.
         kind (str | None): Optional serialization kind override.
         gvrsn (Versionage | None): Optional CESR genus version override.
@@ -514,8 +529,10 @@ def spurn(hab, message, spurned, dt=None, kind=None, gvrsn=None):
         tuple[Serder, bytearray]: Outer exchange serder and detached attachment
             bytes for the signed V2 stream.
     """
+    receiver = recp if recp is not None else spurned.ked["i"]
     serder = exchange(
         sender=hab.pre,
+        receiver=receiver,
         prior=spurned.said,
         route="/ipex/spurn",
         stamp=dt,

--- a/src/keri/vc/protocoling.py
+++ b/src/keri/vc/protocoling.py
@@ -456,7 +456,7 @@ def ipexSpurnExn(hab, message, spurned, version=None, pvrsn=None,
     Parameters:
         hab(Hab): identifier environment for issuer of credential
         message(str): Human readable message regarding the admission
-        spurned (Serder): apply, offer, agree or grant received
+        spurned (Serder): apply, offer, or agree received
         version (Versionage | None): explicit KERI protocol version override.
                         When omitted, defaults to the habitat's established version.
         pvrsn (Versionage): explicit KERI protocol version

--- a/src/keri/vc/protocoling.py
+++ b/src/keri/vc/protocoling.py
@@ -456,7 +456,7 @@ def ipexSpurnExn(hab, message, spurned, version=None, pvrsn=None,
     Parameters:
         hab(Hab): identifier environment for issuer of credential
         message(str): Human readable message regarding the admission
-        spurned (Serder): apply, offer, or agree received
+        spurned (Serder): apply, offer, agree or grant received
         version (Versionage | None): explicit KERI protocol version override.
                         When omitted, defaults to the habitat's established version.
         pvrsn (Versionage): explicit KERI protocol version

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -1,0 +1,454 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.acdc.test_ipexing module
+
+"""
+from keri import Kinds, Vrsn_2_0
+from keri.acdc import (acdcmap, apply as ipexApply, admit as ipexAdmit,
+                       agree as ipexAgree, grant as ipexGrant,
+                       loadHandlers, offer as ipexOffer, regcept,
+                       spurn as ipexSpurn, update)
+from keri.app import openHby
+from keri.core import Codens, Counter, GenDex, Parser, Serdery, Texter
+from keri.kering import Colds, sniff
+from keri.peer import Exchanger
+
+# Patch it to a function to assert correct behavior
+class Recorder:
+    """Collect notifier payloads emitted during dispatch tests."""
+
+    def __init__(self):
+        """Initialize an empty recorder."""
+        self.items = []
+
+    def add(self, attrs):
+        """Append one notifier payload."""
+        self.items.append(attrs)
+
+# Helper functions
+def _serder(stream):
+    """Extract the message serder from a bare or nested artifact stream."""
+    ims = bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+    if ims and sniff(ims) != Colds.msg:
+        ctr = Counter(qb64b=ims, version=Vrsn_2_0, strip=True)
+        if ctr.name in (
+            Codens.NonNativeBodyGroup,
+            Codens.BigNonNativeBodyGroup,
+        ):
+            return Serdery(version=Vrsn_2_0).reap(ims=Texter(qb64b=ims, strip=True).raw,
+                                                  genus=GenDex.KERI,
+                                                  svrsn=Vrsn_2_0)
+        if ims and sniff(ims) != Colds.msg:
+            ctr = Counter(qb64b=ims, version=Vrsn_2_0, strip=True)
+            if ctr.name in (
+                Codens.NonNativeBodyGroup,
+                Codens.BigNonNativeBodyGroup,
+            ):
+                return Serdery(version=Vrsn_2_0).reap(ims=Texter(qb64b=ims, strip=True).raw,
+                                                      genus=GenDex.KERI,
+                                                      svrsn=Vrsn_2_0)
+
+    return Serdery(version=Vrsn_2_0).reap(ims=ims,
+                                          genus=GenDex.KERI,
+                                          svrsn=Vrsn_2_0)
+
+
+def _nest(stream):
+    """Wrap an artifact as a parser-friendly V2 nested substream."""
+    raw = bytes(stream.raw) if hasattr(stream, "raw") else bytes(stream)
+    serder = _serder(raw)
+    body = raw[:serder.size]
+    atc = raw[serder.size:]
+    if serder.kind != Kinds.cesr:
+        body = Counter.enclose(qb64=Texter(raw=body).qb64b,
+                               code=Codens.NonNativeBodyGroup,
+                               version=Vrsn_2_0)
+
+    nested = bytearray(body)
+    if atc:
+        nested.extend(atc)
+    else:
+        empty = Counter.enclose(qb64=b'',
+                                code=Codens.ControllerIdxSigs,
+                                version=Vrsn_2_0)
+        nested.extend(Counter.enclose(qb64=empty,
+                                      code=Codens.AttachmentGroup,
+                                      version=Vrsn_2_0))
+    return Counter.enclose(qb64=nested,
+                           code=Codens.BodyWithAttachmentGroup,
+                           version=Vrsn_2_0)
+
+# Tests
+def test_ipex_v2_builders_parse_happypath():
+    """Build each V2 IPEX verb and prove the resulting streams parse cleanly."""
+    with openHby(name="ipex-v2-builders",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+
+        # Create hab
+        hab = hby.makeHab(name="test")
+
+        # Build artifacts
+        registry = regcept(israid=hab.pre)
+        acdc = acdcmap(israid=hab.pre,
+                       regid=registry.said,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=hab.pre)
+        iss = update(regid=registry.said,
+                     prior=registry.said,
+                     acdc=acdc.said,
+                     state="issued")
+        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
+        
+        # Extract schema from acdc
+        schema = acdc.sad["s"]["$id"]
+
+        # Parse anchor event to get the serder
+        ancSerder = _serder(anc)
+
+        # Build apply message
+        applyExn, applyAtc = ipexApply(hab=hab,
+                                          recp=hab.pre,
+                                          message="Please issue a credential",
+                                          schema=schema,
+                                          attrs=dict(role="member"))
+
+        # Build Offer message chained to apply 
+        offerExn, offerAtc = ipexOffer(hab=hab,
+                                          message="Here is the offered credential",
+                                          acdc=acdc,
+                                          apply=applyExn)
+
+        # Build an agree chained to the offer
+        agreeExn, agreeAtc = ipexAgree(hab=hab,
+                                          message="I agree to the offer",
+                                          offer=offerExn)
+
+        # Build the grant chained to the agree
+        grantExn, grantAtc = ipexGrant(hab=hab,
+                                          recp=hab.pre,
+                                          message="Here is the granted credential",
+                                          acdc=acdc,
+                                          iss=_nest(iss),
+                                          anc=anc,
+                                          agree=agreeExn)
+
+        # Build the admit chained to the grant
+        admitExn, admitAtc = ipexAdmit(hab=hab,
+                                          message="Thanks for the credential",
+                                          grant=grantExn)
+
+        # Build the spurn chained to the apply
+        spurnExn, spurnAtc = ipexSpurn(hab=hab,
+                                          message="No thanks",
+                                          spurned=applyExn)
+
+        # Iterate through each message, assert version and receiver field
+        for serder in (applyExn, offerExn, agreeExn,
+                       grantExn, admitExn, spurnExn):
+            assert serder.pvrsn == Vrsn_2_0
+            assert "ri" in serder.ked
+            assert "rp" not in serder.ked
+
+        # Assert fields
+        assert applyExn.ked["a"]["m"] == "Please issue a credential"    # message
+        assert applyExn.ked["a"]["s"] == schema     # schema
+        assert applyExn.ked["a"]["a"] == dict(role="member")
+        assert applyExn.ked["a"]["i"] == hab.pre
+
+        assert offerExn.ked["a"]["m"] == "Here is the offered credential"
+        assert offerExn.ked["p"] == applyExn.said       # prior
+        assert offerExn.ked["a"]["acdc"] == acdc.said
+
+        assert agreeExn.ked["a"]["m"] == "I agree to the offer"
+        assert agreeExn.ked["p"] == offerExn.said
+
+        assert grantExn.ked["a"]["m"] == "Here is the granted credential"
+        assert grantExn.ked["a"]["i"] == hab.pre
+        assert grantExn.ked["a"]["acdc"] == acdc.said
+        assert grantExn.ked["a"]["iss"] == iss.said     # issuance
+        assert grantExn.ked["a"]["anc"] == ancSerder.said       # anchor
+        assert grantExn.ked["p"] == agreeExn.said
+
+        assert admitExn.ked["a"]["m"] == "Thanks for the credential"
+        assert admitExn.ked["p"] == grantExn.said
+
+        assert spurnExn.ked["a"]["m"] == "No thanks"
+        assert spurnExn.ked["p"] == applyExn.said
+
+        # Parse the full stream for each exchange
+        # Apply
+        applyIms = bytearray(applyExn.raw)
+        applyIms.extend(applyAtc)
+        applyResults = Parser(version=Vrsn_2_0).parse(ims=applyIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert applyIms == bytearray()
+        assert len(applyResults) == 1
+        applyResult = applyResults[0]
+
+        assert applyResult.serder.said == applyExn.said
+        assert applyResult.serder.ked["r"] == "/ipex/apply"
+        assert applyResult.serder.ked["a"] == applyExn.ked["a"]
+        assert applyResult.nests == []     # No nested substream
+
+        # Offer
+        offerIms = bytearray(offerExn.raw)
+        offerIms.extend(offerAtc)
+        offerResults = Parser(version=Vrsn_2_0).parse(ims=offerIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert offerIms == bytearray()
+        assert len(offerResults) == 1
+        offerResult = offerResults[0]
+
+        assert offerResult.serder.said == offerExn.said
+        assert offerResult.serder.ked["r"] == "/ipex/offer"
+        assert offerResult.serder.ked["a"] == offerExn.ked["a"]
+        assert offerResult.serder.ked["p"] == applyExn.said
+        assert [nest.serder.said for nest in offerResult.nests] == [acdc.said]
+
+        # Agree
+        agreeIms = bytearray(agreeExn.raw)
+        agreeIms.extend(agreeAtc)
+        agreeResults = Parser(version=Vrsn_2_0).parse(ims=agreeIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert agreeIms == bytearray()
+        assert len(agreeResults) == 1
+        agreeResult = agreeResults[0]
+
+        assert agreeResult.serder.said == agreeExn.said
+        assert agreeResult.serder.ked["r"] == "/ipex/agree"
+        assert agreeResult.serder.ked["a"] == agreeExn.ked["a"]
+        assert agreeResult.serder.ked["p"] == offerExn.said
+        assert agreeResult.nests == []
+        
+        # Grant
+        grantIms = bytearray(grantExn.raw)
+        grantIms.extend(grantAtc)
+        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert grantIms == bytearray()
+        assert len(grantResults) == 1
+        grantResult = grantResults[0]
+
+        assert grantResult.serder.said == grantExn.said
+        assert grantResult.serder.ked["r"] == "/ipex/grant"
+        assert grantResult.serder.ked["a"] == grantExn.ked["a"]
+        assert grantResult.serder.ked["p"] == agreeExn.said
+        assert [nest.serder.said for nest in grantResult.nests] == [
+            acdc.said,
+            iss.said,
+            ancSerder.said,
+        ]
+
+        # Admit
+        admitIms = bytearray(admitExn.raw)
+        admitIms.extend(admitAtc)
+        admitResults = Parser(version=Vrsn_2_0).parse(ims=admitIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert admitIms == bytearray()
+        assert len(admitResults) == 1
+        admitResult = admitResults[0]
+
+        assert admitResult.serder.said == admitExn.said
+        assert admitResult.serder.ked["r"] == "/ipex/admit"
+        assert admitResult.serder.ked["a"] == admitExn.ked["a"]
+        assert admitResult.serder.ked["p"] == grantExn.said
+        assert admitResult.nests == []
+
+        # Spurn
+        spurnIms = bytearray(spurnExn.raw)
+        spurnIms.extend(spurnAtc)
+        spurnResults = Parser(version=Vrsn_2_0).parse(ims=spurnIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert spurnIms == bytearray()
+        assert len(spurnResults) == 1
+        spurnResult = spurnResults[0]
+
+        assert spurnResult.serder.said == spurnExn.said
+        assert spurnResult.serder.ked["r"] == "/ipex/spurn"
+        assert spurnResult.serder.ked["a"] == spurnExn.ked["a"]
+        assert spurnResult.serder.ked["p"] == applyExn.said
+        assert spurnResult.nests == []
+
+
+def test_ipex_v2_dispatch_linear_and_spurn():
+    """Exercise linear routing, rejection, and spurn handling through Exchanger."""
+    with openHby(name="ipex-v2-dispatch",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        registry = regcept(israid=hab.pre)
+        acdc = acdcmap(israid=hab.pre,
+                       regid=registry.said,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=hab.pre)
+        iss = update(regid=registry.said,
+                     prior=registry.said,
+                     acdc=acdc.said,
+                     state="issued")
+        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
+        schema = acdc.sad["s"]["$id"]
+
+        # Create recorder
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        # Build a happy path chain: apply -> offer -> agree -> grant -> admit
+        apply0, apply0Atc = ipexApply(hab=hab,
+                                        recp=hab.pre,
+                                        message="Please issue a credential",
+                                        schema=schema,
+                                        attrs=dict(role="member"))
+        offer0, offer0Atc = ipexOffer(hab=hab,
+                                        message="Here is the offered credential",
+                                        acdc=acdc,
+                                        apply=apply0)
+        agree0, agree0Atc = ipexAgree(hab=hab,
+                                        message="I agree to the offer",
+                                        offer=offer0)
+        grant0, grant0Atc = ipexGrant(hab=hab,
+                                        recp=hab.pre,
+                                        message="Here is the granted credential",
+                                        acdc=acdc,
+                                        iss=iss,
+                                        anc=anc,
+                                        agree=agree0)
+        admit0, admit0Atc = ipexAdmit(hab=hab,
+                                        message="Thanks for the credential",
+                                        grant=grant0)
+
+        # Try to parse the offer before apply
+        offer0Ims = bytearray(offer0.raw)
+        offer0Ims.extend(offer0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=offer0Ims, framed=False, exc=exc)
+        assert offer0Ims == bytearray()
+        
+        # Assert it was rejected and not stored in db since its prior was not accepted yet
+        assert hby.db.exns.get(keys=(offer0.said,)) is None
+
+        # Parse the apply first 
+        apply0Ims = bytearray(apply0.raw)
+        apply0Ims.extend(apply0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=apply0Ims, framed=False, exc=exc)
+        assert apply0Ims == bytearray()
+
+        # Assert that the apply was accepted and stored
+        storedApply = hby.db.exns.get(keys=(apply0.said,))
+        assert storedApply is not None
+        assert storedApply.ked["a"]["m"] == "Please issue a credential"
+        assert storedApply.ked["a"]["a"] == dict(role="member")
+        assert storedApply.ked["a"]["i"] == hab.pre
+
+        # Parse the rest of the chain
+        offer0Ims = bytearray(offer0.raw)
+        offer0Ims.extend(offer0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=offer0Ims, framed=False, exc=exc)
+        assert offer0Ims == bytearray()
+
+        agree0Ims = bytearray(agree0.raw)
+        agree0Ims.extend(agree0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=agree0Ims, framed=False, exc=exc)
+        assert agree0Ims == bytearray()
+
+        grant0Ims = bytearray(grant0.raw)
+        grant0Ims.extend(grant0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=grant0Ims, framed=False, exc=exc)
+        assert grant0Ims == bytearray()
+
+        admit0Ims = bytearray(admit0.raw)
+        admit0Ims.extend(admit0Atc)
+        Parser(version=Vrsn_2_0).parse(ims=admit0Ims, framed=False, exc=exc)
+        assert admit0Ims == bytearray()
+
+        # Assert that they were accepted and stored
+        for serder in (offer0, agree0, grant0, admit0):
+            assert hby.db.exns.get(keys=(serder.said,)) is not None
+
+        storedOffer = hby.db.exns.get(keys=(offer0.said,))
+        assert storedOffer.ked["a"]["m"] == "Here is the offered credential"
+        assert storedOffer.ked["a"]["acdc"] == acdc.said
+        assert storedOffer.ked["p"] == apply0.said
+
+        storedAgree = hby.db.exns.get(keys=(agree0.said,))
+        assert storedAgree.ked["a"]["m"] == "I agree to the offer"
+        assert storedAgree.ked["p"] == offer0.said
+
+        storedGrant = hby.db.exns.get(keys=(grant0.said,))
+        assert storedGrant.ked["a"]["m"] == "Here is the granted credential"
+        assert storedGrant.ked["a"]["i"] == hab.pre
+        assert storedGrant.ked["a"]["acdc"] == acdc.said
+        assert storedGrant.ked["a"]["iss"] == iss.said
+        assert storedGrant.ked["a"]["anc"] == _serder(anc).said
+        assert storedGrant.ked["p"] == agree0.said
+
+        storedAdmit = hby.db.exns.get(keys=(admit0.said,))
+        assert storedAdmit.ked["a"]["m"] == "Thanks for the credential"
+        assert storedAdmit.ked["p"] == grant0.said
+
+        # Build a spurn against apply
+        dupSpurn, dupSpurnAtc = ipexSpurn(hab=hab,
+                                              message="This should be rejected",
+                                              spurned=apply0)
+
+        # Parse it
+        dupSpurnIms = bytearray(dupSpurn.raw)
+        dupSpurnIms.extend(dupSpurnAtc)
+        Parser(version=Vrsn_2_0).parse(ims=dupSpurnIms, framed=False, exc=exc)
+        assert dupSpurnIms == bytearray()
+
+        # Assert it was not accepted 
+        assert hby.db.exns.get(keys=(dupSpurn.said,)) is None
+
+        # Build a bare grant 
+        grant1, grant1Atc = ipexGrant(hab=hab,
+                                        recp=hab.pre,
+                                        message="Bare grant for spurn path",
+                                        acdc=acdc,
+                                        iss=_nest(iss))
+
+        # Build a spurn against that grant
+        spurn1, spurn1Atc = ipexSpurn(hab=hab,
+                                        message="I reject this grant",
+                                        spurned=grant1)
+
+        # Parse both 
+        grant1Ims = bytearray(grant1.raw)
+        grant1Ims.extend(grant1Atc)
+        Parser(version=Vrsn_2_0).parse(ims=grant1Ims, framed=False, exc=exc)
+        assert grant1Ims == bytearray()
+
+        spurn1Ims = bytearray(spurn1.raw)
+        spurn1Ims.extend(spurn1Atc)
+        Parser(version=Vrsn_2_0).parse(ims=spurn1Ims, framed=False, exc=exc)
+        assert spurn1Ims == bytearray()
+
+        # Assert that both were stored
+        assert hby.db.exns.get(keys=(grant1.said,)) is not None
+        assert hby.db.exns.get(keys=(spurn1.said,)) is not None
+
+        # Assert routes and their coressponding message  
+        routes = {item["r"] for item in recorder.items}
+        assert routes == {
+            "/exn/ipex/apply",
+            "/exn/ipex/offer",
+            "/exn/ipex/agree",
+            "/exn/ipex/grant",
+            "/exn/ipex/admit",
+            "/exn/ipex/spurn",
+        }
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/apply", "Please issue a credential"),
+            ("/exn/ipex/offer", "Here is the offered credential"),
+            ("/exn/ipex/agree", "I agree to the offer"),
+            ("/exn/ipex/grant", "Here is the granted credential"),
+            ("/exn/ipex/admit", "Thanks for the credential"),
+            ("/exn/ipex/grant", "Bare grant for spurn path"),
+            ("/exn/ipex/spurn", "I reject this grant"),
+        ]

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -588,3 +588,90 @@ def test_ipex_v2_rejects_unsupported_nested_frame():
             ipexOffer(hab=hab,
                       message="Here is the offered credential",
                       acdc=bad)
+
+
+def test_ipex_v2_responders_set_receiver():
+    """Responder verbs address the prior's sender; offer honors an explicit recp.
+
+    apply and grant already thread ``receiver=recp``; offer, agree, admit, and
+    spurn respond to a prior message whose sender is the party to address, so
+    their receiver derives from that prior's ``i`` field. An offer opened with no
+    prior (the offer-first bootstrap) takes an explicit ``recp`` instead.
+    """
+    with openHby(name="ipex-v2-receiver",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+
+        registry = regcept(israid=holder.pre)
+        acdc = acdcmap(israid=holder.pre,
+                       regid=registry.said,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=holder.pre)
+        iss = update(regid=registry.said,
+                     prior=registry.said,
+                     acdc=acdc.said,
+                     state="issued")
+        anc = holder.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
+        schema = acdc.sad["s"]["$id"]
+
+        # verifier applies to holder
+        applyExn, _ = ipexApply(hab=verifier,
+                                recp=holder.pre,
+                                message="Prove over-21",
+                                schema=schema,
+                                attrs=dict(role="member"))
+        assert applyExn.ked["i"] == verifier.pre
+        assert applyExn.ked["ri"] == holder.pre
+
+        # holder offers, addressing the applicant (apply's sender) by derivation
+        offerExn, _ = ipexOffer(hab=holder,
+                                message="Here are the terms",
+                                acdc=acdc,
+                                apply=applyExn)
+        assert offerExn.ked["i"] == holder.pre
+        assert offerExn.ked["ri"] == verifier.pre
+
+        # verifier agrees, addressing the holder (offer's sender)
+        agreeExn, _ = ipexAgree(hab=verifier,
+                                message="I agree",
+                                offer=offerExn)
+        assert agreeExn.ked["ri"] == holder.pre
+
+        # holder grants to verifier
+        grantExn, _ = ipexGrant(hab=holder,
+                                recp=verifier.pre,
+                                message="Disclosure",
+                                acdc=acdc,
+                                iss=_nest(iss),
+                                anc=anc,
+                                agree=agreeExn)
+        assert grantExn.ked["ri"] == verifier.pre
+
+        # verifier admits, addressing the holder (grant's sender)
+        admitExn, _ = ipexAdmit(hab=verifier,
+                                message="Thanks",
+                                grant=grantExn)
+        assert admitExn.ked["ri"] == holder.pre
+
+        # holder spurns the apply, addressing its sender (verifier)
+        spurnExn, _ = ipexSpurn(hab=holder,
+                                message="No thanks",
+                                spurned=applyExn)
+        assert spurnExn.ked["ri"] == verifier.pre
+
+        # offer-first bootstrap: no prior apply, explicit recp fixes the receiver
+        bootExn, _ = ipexOffer(hab=holder,
+                               message="Opening offer",
+                               acdc=acdc,
+                               recp=verifier.pre)
+        assert bootExn.ked["p"] == ""
+        assert bootExn.ked["ri"] == verifier.pre
+
+        # an explicit recp overrides the derived receiver
+        overrideExn, _ = ipexAgree(hab=verifier,
+                                   message="I agree",
+                                   offer=offerExn,
+                                   recp=holder.pre)
+        assert overrideExn.ked["ri"] == holder.pre

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -406,19 +406,19 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         # Assert it was not accepted 
         assert hby.db.exns.get(keys=(dupSpurn.said,)) is None
 
-        # Build a bare grant 
+        # Build a bare grant
         grant1, grant1Atc = ipexGrant(hab=hab,
                                         recp=hab.pre,
-                                        message="Bare grant for spurn path",
+                                        message="Bare grant without agreement",
                                         acdc=acdc,
                                         iss=_nest(iss))
 
         # Build a spurn against that grant
         spurn1, spurn1Atc = ipexSpurn(hab=hab,
-                                        message="I reject this grant",
+                                        message="Grant spurn should be rejected",
                                         spurned=grant1)
 
-        # Parse both 
+        # Parse both
         grant1Ims = bytearray(grant1.raw)
         grant1Ims.extend(grant1Atc)
         Parser(version=Vrsn_2_0).parse(ims=grant1Ims, framed=False, exc=exc)
@@ -429,9 +429,30 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         Parser(version=Vrsn_2_0).parse(ims=spurn1Ims, framed=False, exc=exc)
         assert spurn1Ims == bytearray()
 
-        # Assert that both were stored
+        # Assert that bare grant is valid but spurn against grant is not
         assert hby.db.exns.get(keys=(grant1.said,)) is not None
-        assert hby.db.exns.get(keys=(spurn1.said,)) is not None
+        assert hby.db.exns.get(keys=(spurn1.said,)) is None
+
+        # Build a bare offer and a valid spurn against that offer
+        offer1, offer1Atc = ipexOffer(hab=hab,
+                                      message="Bare offer for spurn path",
+                                      acdc=acdc)
+        spurn2, spurn2Atc = ipexSpurn(hab=hab,
+                                      message="I reject this offer",
+                                      spurned=offer1)
+
+        offer1Ims = bytearray(offer1.raw)
+        offer1Ims.extend(offer1Atc)
+        Parser(version=Vrsn_2_0).parse(ims=offer1Ims, framed=False, exc=exc)
+        assert offer1Ims == bytearray()
+
+        spurn2Ims = bytearray(spurn2.raw)
+        spurn2Ims.extend(spurn2Atc)
+        Parser(version=Vrsn_2_0).parse(ims=spurn2Ims, framed=False, exc=exc)
+        assert spurn2Ims == bytearray()
+
+        assert hby.db.exns.get(keys=(offer1.said,)) is not None
+        assert hby.db.exns.get(keys=(spurn2.said,)) is not None
 
         # Assert routes and their coressponding message  
         routes = {item["r"] for item in recorder.items}
@@ -449,6 +470,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             ("/exn/ipex/agree", "I agree to the offer"),
             ("/exn/ipex/grant", "Here is the granted credential"),
             ("/exn/ipex/admit", "Thanks for the credential"),
-            ("/exn/ipex/grant", "Bare grant for spurn path"),
-            ("/exn/ipex/spurn", "I reject this grant"),
+            ("/exn/ipex/grant", "Bare grant without agreement"),
+            ("/exn/ipex/offer", "Bare offer for spurn path"),
+            ("/exn/ipex/spurn", "I reject this offer"),
         ]

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -3,6 +3,7 @@
 tests.acdc.test_ipexing module
 
 """
+import pytest
 from keri import Kinds, Vrsn_2_0
 from keri.acdc import (acdcmap, apply as ipexApply, admit as ipexAdmit,
                        agree as ipexAgree, grant as ipexGrant,
@@ -474,3 +475,116 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             ("/exn/ipex/offer", "Bare offer for spurn path"),
             ("/exn/ipex/spurn", "I reject this offer"),
         ]
+
+
+def test_ipex_v2_nontransferable_nested_artifacts():
+    """Exercise the cigar signing path with nested IPEX artifacts."""
+    
+    # Set up non-transferable hab, recorder, exchanger and load IPEX handlers
+    with openHby(name="ipex-v2-nontrans",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test", transferable=False)
+        assert not hab.kever.prefixer.transferable
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        # Registry Inception
+        registry = regcept(israid=hab.pre)
+
+        # Create ACDC, ISS and an ANC
+        acdc = acdcmap(israid=hab.pre,
+                       regid=registry.said,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=hab.pre)
+        iss = update(regid=registry.said,
+                     prior=registry.said,
+                     acdc=acdc.said,
+                     state="issued")
+        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
+        ancSerder = _serder(anc)
+        schema = acdc.sad["s"]["$id"]
+
+        # Build IPEX messages
+        applyExn, applyAtc = ipexApply(hab=hab,
+                                       recp=hab.pre,
+                                       message="Please issue a credential",
+                                       schema=schema,
+                                       attrs=dict(role="member"))
+        offerExn, offerAtc = ipexOffer(hab=hab,
+                                       message="Here is the offered credential",
+                                       acdc=acdc,
+                                       apply=applyExn)
+        agreeExn, agreeAtc = ipexAgree(hab=hab,
+                                       message="I agree to the offer",
+                                       offer=offerExn)
+        grantExn, grantAtc = ipexGrant(hab=hab,
+                                       recp=hab.pre,
+                                       message="Here is the granted credential",
+                                       acdc=acdc,
+                                       iss=iss,
+                                       anc=anc,
+                                       agree=agreeExn)
+
+        # Parse Offer for assertions
+        offerIms = bytearray(offerExn.raw)
+        offerIms.extend(offerAtc)
+        offerResults = Parser(version=Vrsn_2_0).parse(ims=offerIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert offerIms == bytearray()
+        assert len(offerResults) == 1
+        offerResult = offerResults[0]
+        assert offerResult.nests[0].serder.said == acdc.said
+
+        # Parse Grant for assertions
+        grantIms = bytearray(grantExn.raw)
+        grantIms.extend(grantAtc)
+        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert grantIms == bytearray()
+        assert len(grantResults) == 1
+        grantResult = grantResults[0]
+        assert grantResult.nests[0].serder.said == acdc.said
+        assert grantResult.nests[1].serder.said == iss.said
+        assert grantResult.nests[2].serder.said == ancSerder.said
+
+        # Dispatch the whole chain
+        for exn, atc in ((applyExn, applyAtc),
+                         (offerExn, offerAtc),
+                         (agreeExn, agreeAtc),
+                         (grantExn, grantAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        # Assert they were all processed and stored
+        for serder in (applyExn, offerExn, agreeExn, grantExn):
+            assert hby.db.exns.get(keys=(serder.said,)) is not None
+
+        # Check recorder for correct route/message pairs
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/apply", "Please issue a credential"),
+            ("/exn/ipex/offer", "Here is the offered credential"),
+            ("/exn/ipex/agree", "I agree to the offer"),
+            ("/exn/ipex/grant", "Here is the granted credential"),
+        ]
+
+
+def test_ipex_v2_rejects_unsupported_nested_frame():
+    """Reject a carried artifact that starts with an unsupported CESR frame."""
+    with openHby(name="ipex-v2-bad-frame",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        bad = Counter.enclose(qb64=b'',
+                              code=Codens.AttachmentGroup,
+                              version=Vrsn_2_0)
+
+        with pytest.raises(ValueError, match="unsupported leading frame"):
+            ipexOffer(hab=hab,
+                      message="Here is the offered credential",
+                      acdc=bad)


### PR DESCRIPTION
- Summary:
  - implement V2-native IPEX builders: `apply`, `offer`, `agree`, `grant`, `admit`, `spurn`
  - add a basic linear `IpexHandler` dispatcher and `loadHandlers` route registration
  - replace V1-style embedding with V2 `exchange` messages plus nested substream framing

- Changes:
  - build all outer IPEX messages as signed V2 `exn` streams
  - carry `acdc`, `iss`, and `anc` as nested substreams instead of `specialExchange`/embedded payloads
  - add nested-stream normalization so bare artifacts and already-nested artifacts both parse correctly
  - support both transferable and non-transferable signing paths for the outer exchange
  - export the new V2 IPEX API from `keri.acdc`

- Dispatcher behavior:
  - enforce the current linear flow rules for `apply -> offer -> agree -> grant -> admit`
  - allow `spurn` for supported prior verbs
  - reject out-of-order replies and duplicate responses to the same prior

- Tests:
  - add V2-focused `tests/acdc/test_ipexing.py`
  - cover builder parseability, nested artifact handling, linear dispatch, spurn flow, non-transferable signing, and wrong-prior rejection