### PR TITLE
Speed up Windows runner

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -46,102 +46,8 @@ jobs:
             job_name: "test (ubuntu-latest)"
             pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts -n auto"
           - os: windows-latest
-            job_name: "test (windows-latest, shard 1)"
-            pytest_command: >-
-              pytest
-              tests/core/test_kraming.py
-              tests/core/test_delegating.py
-              tests/vdr/test_eventing.py
-              tests/vdr/test_verifying.py
-              tests/core/test_eventing_messagize.py
-              tests/app/test_directing.py
-              tests/app/cli/test_kli_commands.py
-              tests/app/test_querying.py
-              tests/peer/test_exchanging.py
-              tests/app/test_signing.py
-              tests/core/test_partial_rotation.py
-              tests/app/test_watching.py
-              tests/core/test_coring.py
-              tests/spec/acdc/test_acdc_examples.py
-              tests/core/test_indexing.py
-              tests/cli/commands/vc/test_vc_schema_validation.py
-              tests/spec/keri/test_keri_examples.py
-              tests/wasm/test_webdbing_wasm.py
-          - os: windows-latest
-            job_name: "test (windows-latest, shard 2)"
-            pytest_command: >-
-              pytest
-              tests/app/test_grouping.py
-              tests/core/test_eventing_v1.py
-              tests/db/test_basing.py
-              tests/core/test_witness.py
-              tests/core/test_replay.py
-              tests/vdr/test_issuing.py
-              tests/app/test_indirecting.py
-              tests/app/cli/commands/exn/test_send.py
-              tests/app/test_keeping.py
-              tests/core/test_serdering.py
-              tests/core/test_signing.py
-              tests/core/test_parsing_pathed.py
-              tests/core/test_weighted_threshold.py
-              tests/db/test_dbing.py
-              tests/app/test_challenging.py
-              tests/core/test_counting.py
-              tests/core/test_crypto.py
-              tests/core/test_bare.py
-              tests/app/test_apping.py
-              tests/help/test_ogling.py
-              tests/spac/test_payloading.py
-          - os: windows-latest
-            job_name: "test (windows-latest, shard 3)"
-            pytest_command: >-
-              pytest
-              tests/app/test_habbing_v2.py
-              tests/app/test_habbing_v1.py
-              tests/app/test_forwarding.py
-              tests/vdr/test_txn_state.py
-              tests/app/cli/commands/contacts/test_contacts.py
-              tests/app/test_oobiing.py
-              tests/app/test_delegating.py
-              tests/app/test_organizing.py
-              tests/vc/test_protocoling.py
-              tests/app/test_signaling.py
-              tests/vc/test_proving.py
-              tests/comply/test_direct_mode.py
-              tests/vdr/test_viring.py
-              tests/core/test_structing.py
-              tests/app/test_storing.py
-              tests/db/test_koming.py
-              tests/db/test_webdbing.py
-              tests/core/test_annotating.py
-              tests/help/test_helping.py
-              tests/test_kering.py
-          - os: windows-latest
-            job_name: "test (windows-latest, shard 4)"
-            pytest_command: >-
-              pytest
-              tests/core/test_eventing_v2.py
-              tests/core/test_parsing.py
-              tests/app/test_agenting.py
-              tests/core/test_reply.py
-              tests/core/test_escrow.py
-              tests/core/test_keystate.py
-              tests/vdr/test_credentialing.py
-              tests/core/test_kevery.py
-              tests/end/test_ending.py
-              tests/db/test_escrowing.py
-              tests/db/test_subing.py
-              tests/app/test_httping.py
-              tests/app/test_signify.py
-              tests/vc/test_walleting.py
-              tests/app/test_notifying.py
-              tests/core/test_scheming.py
-              tests/acdc/test_messaging.py
-              tests/acdc/test_examples.py
-              tests/core/test_mapping.py
-              tests/app/test_configing.py
-              tests/app/cli/common/test_parsing.py
-              tests/spec/cesr/test_cesr_examples.py
+            job_name: "test (windows-latest)"
+            pytest_command: "pytest tests/ --ignore tests/demo/ --ignore test/scripts"
     name: ${{ matrix.job_name }}
 
     steps:
@@ -150,6 +56,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.14'
+
+      - name: Use runner temp drive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "TMPDIR=$env:RUNNER_TEMP" >> $env:GITHUB_ENV
+          "TEMP=$env:RUNNER_TEMP" >> $env:GITHUB_ENV
+          "TMP=$env:RUNNER_TEMP" >> $env:GITHUB_ENV
 
       - name: Install libsodium (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
In this PR:
- Set Windows temporary file variables to the GitHub runner temp directory
- Move temporary HIO and LMDB files to the faster runner temp drive
- Run the full Windows test suite in one sequential job, no longer sharded, still faster than sharding with this change

The tests create and remove many temporary HIO and LMDB directories. Windows placed these directories on the slower system drive by default. GitHub provides RUNNER_TEMP on a faster work drive. We set TMPDIR, TEMP, and TMP to this location before Python imports HIO or keripy. The Python tempfile module then directs the temporary database work to the faster drive.