### PR TITLE
Fix xdist flake in ogling tests from leaked global logger state (#1521)

### DIFF
--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -9,9 +9,32 @@ import os
 import platform
 import logging
 
+import pytest
+
 from hio.help import ogling
 
 from keri import help
+
+
+@pytest.fixture
+def keri_ogler():
+    """Pin help.ogler to a known syslogged=True default so handler-count
+    assertions don't depend on sibling scheduling order (xdist-safe, #1521).
+
+    The process-global help.ogler is created in keri.help with syslogged=False
+    (console only = 1 handler), but these tests assert the syslogged=True
+    default (console + syslog = 2 handlers, +file = 3 when opened). Serially
+    that precondition happens to be met by a preceding sibling test that resets
+    help.ogler via initOgler(prefix='keri'); under pytest-xdist load-scheduling
+    it is not guaranteed. Establish it here instead, and restore the real
+    global on teardown so nothing leaks to later tests.
+    """
+    saved = help.ogler
+    help.ogler = ogling.initOgler(prefix='keri')  # syslogged=True -> 2 handlers unopened
+    try:
+        yield help.ogler
+    finally:
+        help.ogler = saved
 
 
 def test_openogler():
@@ -246,7 +269,7 @@ def test_ogler():
     """End Test"""
 
 
-def test_init_ogler():
+def test_init_ogler(keri_ogler):
     """
     Test initOgler function for ogler global
     """
@@ -344,7 +367,7 @@ def test_init_ogler():
     """End Test"""
 
 
-def test_reset_levels():
+def test_reset_levels(keri_ogler):
     """
     Test resetLevel on preexisting loggers
     """


### PR DESCRIPTION
## Summary

Fixes #1521 — a latent `pytest-xdist` flake in `tests/help/test_ogling.py`. `test_init_ogler` and `test_reset_levels` fail with `AssertionError: assert 1 == 2` (logger **handler count**) when xdist schedules them into a worker without a preceding sibling from the same module.

## Root cause

Both tests read the **process-global** `help.ogler` and assert an **absolute** handler count. `getLogger()` produces `consoled(1) + syslogged(1) + (filed && opened)(1)` handlers, so the count is entirely determined by the global ogler's flags.

keripy's real default global is created in `keri/help/__init__.py` with `syslogged=False` (console only → **1** handler). But these two tests assert `2` (unopened) / `3` (opened), i.e. they assume `syslogged=True`. That precondition is only met because an **earlier sibling in the same module** (`test_ogler`, `test_init_ogler`) ends with `help.ogler = ogling.initOgler(prefix='keri')`, which defaults `syslogged=True` and leaks a 2-handler global into the next test.

Under xdist load-scheduling, tests from one module are **not guaranteed** to run in the same worker in definition order, so the leaked precondition can be absent and the assertions see `1 != 2`. Serial runs pass only by luck of load order.

Confirmed deterministically by running just the two tests in isolation (no sibling): `2 failed` with the exact `assert 1 == 2`.

## Fix

Add a function-scoped `keri_ogler` fixture (test file only, **no product code change**) that snapshots `help.ogler`, pins it to a known `syslogged=True` default, and restores the real global on teardown; apply it to the two affected tests. They now establish their own precondition instead of inheriting it, making them independent of sibling scheduling order. Teardown also stops the pre-existing leak of a `syslogged=True` global to later tests.

This mirrors the per-worker store isolation added in #1496 during the same de-flaking pass, which explicitly left this logging flake out of scope.

## Verification

- Two tests in isolation: `2 failed` → **`2 passed`**
- `pytest tests/help -n auto` (issue's deterministic reproduction): was `2 failed, 11 passed` → **`13 passed`**
- `pytest tests/help/test_ogling.py` serial: **`4 passed`** (no regression)

---

_Root-caused and implemented with assistance from Claude (Claude Code)._
