### PR TITLE
Add E1E identity edge operator to credential chain verification

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -161,7 +161,7 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.israid)
+                state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
                 if state is None:
                     self.escrowMCE(creder, prefixer, seqner, saider)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -333,13 +333,16 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True, framed=False, gvrsn=serder.pvrsn)
 
-    def verifyChain(self, nodeSaid, op, issuer):
+    def verifyChain(self, nodeSaid, op, issuer, issuee=None):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
             nodeSaid: (str): qb64 SAID of node credential
             op(str): edge operator
-            issuer (str) qb64 AID of issuer
+            issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
+            issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
+                required by the identity operators (E1E). None when the near ACDC is
+                untargeted.
 
         Returns:
             Serder: transaction event state notification message
@@ -349,12 +352,22 @@ class Verifier:
         if said is None:
             return None
 
-        creder = self.reger.creds.get(keys=nodeSaid)
+        creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
-        if op not in ['I2I', 'DI2I', 'NI2I']:
+        if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
             op = 'I2I' if 'i' in creder.attrib else 'NI2I'
 
-        if op != 'NI2I':
+        if op == 'E1E':
+            # Identity relation (discussion #1515): the issuee AID of the near ACDC
+            # (the one carrying this edge) MUST equal the issuee AID of the far node.
+            # Unlike the delegative I2I, this says nothing about the issuer, so the
+            # common SEDI case -- both credentials issued by a third party to the same
+            # subject, issuer != issuee -- is valid (and is exactly what I2I rejects).
+            # Resolve the far issuee via .iseaid so an aggregate node (A[1].i) works too.
+            farIssuee = creder.iseaid
+            if farIssuee is None or issuee is None or issuee != farIssuee:
+                return None
+        elif op != 'NI2I':
             if 'i' not in creder.attrib:
                 return None
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -548,3 +548,115 @@ def test_verifier_chained_credential(seeder):
             assert cred['revancatc'] is not None
 
     """End Test"""
+
+
+def test_verifier_e1e_identity_edge(seeder):
+    """E1E identity edge: near issuee must equal far issuee; issuer != issuee allowed.
+
+    Models the SEDI core-identity <-> entitlement relationship (discussion #1515):
+    two credentials issued by the same third party (ian) to the same subject (han),
+    linked by an edge whose operator is the identity relation E1E. The near
+    (entitlement) credential's issuer is ian and its issuee is han, so
+    ``issuer != issuee``. The delegative I2I operator would reject that binding
+    (I2I requires the near issuer to be the far issuee), which is exactly the case
+    the identity operator E1E exists to allow: it constrains the near *issuee* to
+    equal the far issuee and says nothing about the issuer.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+            as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        def issueAndSave(creder):
+            """Run creder through the full issue -> anchor -> escrow -> save flow."""
+            try:
+                verfer.processCredential(creder, prefixer=ian.kever.prefixer,
+                                         seqner=Seqner(sn=ian.kever.sn),
+                                         saider=Diger(qb64=ian.kever.serder.said))
+            except MissingRegistryError:
+                pass  # expected: the TEL issuance event is anchored just below
+            iss = ianiss.issue(said=creder.said)
+            rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+            ian.interact(data=[rseal], framed=True, **CUE_KWA)
+            ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            ianreg.processEscrows()
+            verfer.processEscrows()
+
+        # far ("core identity") credential: ian -> han, no edge.
+        coreSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="core identity")
+        _, cd = Saider.saidify(sad=coreSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        core = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=cd,
+                          status=ianiss.regk, source={}, rules={}, **KWA)
+        assert core.israid == ian.pre        # issuer
+        assert core.iseaid == han.pre        # issuee (a.i)
+        issueAndSave(core)
+        assert verfer.reger.saved.get(keys=core.saidb) is not None
+
+        # near ("entitlement") credential: ian -> han, E1E identity edge -> core.
+        chainSad = dict(d='', coreIdentity=dict(n=core.said, o="E1E"))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        entSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="over 21")
+        _, ed = Saider.saidify(sad=entSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        ent = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=ed,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert ent.israid == ian.pre         # issuer is ian ...
+        assert ent.iseaid == han.pre         # ... but issuee is han: issuer != issuee
+        assert ent.israid != ent.iseaid
+
+        issueAndSave(ent)
+
+        # The identity edge validates: near issuee (han) == far issuee (han), even
+        # though the near issuer (ian) is not the issuee. Under the old coercion to
+        # I2I this credential would be stuck in missing-chain escrow, not saved.
+        assert verfer.reger.saved.get(keys=ent.saidb) is not None
+        saider = ianreg.reger.subjs.get(han.pre)
+        assert ent.said in [s.qb64 for s in saider]
+
+        # Guardrail: an E1E edge whose near issuee does NOT equal the far issuee must
+        # be rejected. Here the near cred is issued by ian to ian (issuee == ian), so
+        # its issuee differs from the far node's issuee (han). Note this is the inverse
+        # of I2I: because issuer == issuee, an I2I edge would accept it -- E1E does not.
+        badSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="wrong subject")
+        _, bd = Saider.saidify(sad=badSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        bad = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=bd,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert bad.iseaid == ian.pre         # near issuee (ian) != far issuee (han)
+        issueAndSave(bad)
+        assert verfer.reger.saved.get(keys=bad.saidb) is None
+
+        # Guardrail: an E1E edge to an UNTARGETED far node (no issuee) must be rejected.
+        # Both the near and far issuee resolve, and "same subject" is undefined when the
+        # far node has none -- so the `farIssuee is None` guard rejects. (Without it, two
+        # untargeted creds would compare None == None and wrongly bind as one subject.)
+        orphanSubject = dict(d="", dt=helping.nowIso8601(), claim="untargeted")  # no 'i'
+        _, od = Saider.saidify(sad=orphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        orphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=od,
+                            status=ianiss.regk, source={}, rules={}, **KWA)
+        assert orphan.iseaid is None         # untargeted far node
+        issueAndSave(orphan)
+        assert verfer.reger.saved.get(keys=orphan.saidb) is not None
+        orphanChain = dict(d='', coreIdentity=dict(n=orphan.said, o="E1E"))
+        _, ochain = Saider.saidify(sad=orphanChain, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphanSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="to orphan")
+        _, td = Saider.saidify(sad=toOrphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=td,
+                              status=ianiss.regk, source=ochain, rules={}, **KWA)
+        issueAndSave(toOrphan)
+        assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
+
+    """End Test"""


### PR DESCRIPTION
## What this adds

A first-class **`E1E` identity edge operator** in credential chain verification (`keri.vdr.verifying.verifyChain`).

## Why

Every unary edge operator `verifyChain` understood so far — `I2I`, `DI2I`, `NI2I` — is **delegative**: it constrains the *issuer* of the near ACDC relative to the issuee of the far node. SEDI needs an **identity** relation instead. A core SEDI identity credential and its entitlement credentials are issued by third parties to the *same subject*, so the meaningful binding is **issuee-to-issuee, with `issuer != issuee`** (see discussion #1515).

Before this change, an `E1E` edge fell into the unknown-operator branch and was silently coerced to `I2I`, which rejected *exactly* the `issuer != issuee` case that `E1E` exists to allow.

## What it does

- Adds `E1E` as a recognized operator: the near ACDC's issuee AID MUST equal the far node's issuee AID, resolved via `SerderACDC.iseaid` so an **aggregate** node (`A[1].i`) works as well as an attributive one (`a.i`). The issuer is unconstrained.
- Threads the near-side issuee to `verifyChain` from its sole caller (`creder.iseaid`).
- Holds the rest of the proposed family (`I1I` / `I1E` / `E1I` / `I3I` / `E3E`) until a schema or named EGF needs them — this PR is the minimal adoption gate.

## Tests

- **`test_verifier_e1e_identity_edge`** — an `ian → han` entitlement carrying an `E1E` edge to an `ian → han` core credential verifies (`issuer = ian`, `issuee = han`, so `issuer != issuee`), where the old coercion to `I2I` left it in missing-chain escrow.
- **Guardrail** — a mismatched near issuee is rejected. It's the inverse of `I2I`: that same `issuer == issuee` credential *would* pass `I2I`, so the case proves `E1E` does real work.

Full `tests/vdr/` suite: **29 passed**, including the pre-existing `I2I` / `NI2I` chained-credential test (no regression).

## Relationship to the SEDI worked example

This is the **base of a stacked pair**. A follow-up PR corrects the merged CLC/SEDI worked example (`tests/acdc/test_clc_disclosure.py`, #1505) to express the core-identity ↔ age-entitlement relationship with an `E1E` edge instead of a misapplied `I2I`, and exercises the aggregate-far-node `.iseaid` path end to end.

---

*This change was developed with AI assistance (Claude, Anthropic).*
