### PR TITLE
Fix SEDI worked example: E1E identity edge for core-identity <-> age (stacked on #1523)

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -161,7 +161,7 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.israid)
+                state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
                 if state is None:
                     self.escrowMCE(creder, prefixer, seqner, saider)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -333,13 +333,16 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True, framed=False, gvrsn=serder.pvrsn)
 
-    def verifyChain(self, nodeSaid, op, issuer):
+    def verifyChain(self, nodeSaid, op, issuer, issuee=None):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
             nodeSaid: (str): qb64 SAID of node credential
             op(str): edge operator
-            issuer (str) qb64 AID of issuer
+            issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
+            issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
+                required by the identity operators (E1E). None when the near ACDC is
+                untargeted.
 
         Returns:
             Serder: transaction event state notification message
@@ -349,12 +352,22 @@ class Verifier:
         if said is None:
             return None
 
-        creder = self.reger.creds.get(keys=nodeSaid)
+        creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
-        if op not in ['I2I', 'DI2I', 'NI2I']:
+        if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
             op = 'I2I' if 'i' in creder.attrib else 'NI2I'
 
-        if op != 'NI2I':
+        if op == 'E1E':
+            # Identity relation (discussion #1515): the issuee AID of the near ACDC
+            # (the one carrying this edge) MUST equal the issuee AID of the far node.
+            # Unlike the delegative I2I, this says nothing about the issuer, so the
+            # common SEDI case -- both credentials issued by a third party to the same
+            # subject, issuer != issuee -- is valid (and is exactly what I2I rejects).
+            # Resolve the far issuee via .iseaid so an aggregate node (A[1].i) works too.
+            farIssuee = creder.iseaid
+            if farIssuee is None or issuee is None or issuee != farIssuee:
+                return None
+        elif op != 'NI2I':
             if 'i' not in creder.attrib:
                 return None
 

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -13,9 +13,12 @@ file does not yet show:
     blocks (reveal the photo, withhold the birthdate), and an AGGREGATIVE age
     credential -- an array of boolean age-threshold flags (reveal over-21, withhold
     whether she is over 55 or 65),
-  * edges carrying the I2I operator that bind a rich presentation to a single
-    holder, with the issuee resolved uniformly (SerderACDC.iseaid) whether the far
-    node is attributive (a.i) or aggregative (A[1].i),
+  * an E1E identity edge chaining the age entitlement back to the core SEDI identity
+    credential -- an IDENTITY relation (same subject / issuee, issuer != issuee), NOT
+    a delegation, so it is the operator I2I would misapply (keripy discussion #1515) --
+    alongside the presentation-time I2I edges that bind a rich presentation to a single
+    holder, with the issuee resolved uniformly (SerderACDC.iseaid) whether the far node
+    is attributive (a.i) or aggregative (A[1].i),
   * combined disclosure across two source credentials into one bespoke
     presentation ACDC (the spec's "rich presentation" pattern), and
   * a Rules section that negotiates CLC terms -- a Purpose clause, an
@@ -161,6 +164,26 @@ def _disclosable_block(attr, attr_schema, desc):
 # even when unused, so the schema must admit them.
 _EMPTY_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
 
+# One E1E identity edge, pinned by schema (const "E1E"). This is the SEDI core-identity
+# <-> entitlement relationship (keripy discussion #1515): the near ACDC's issuee is the
+# SAME subject as the far node's issuee. E1E is an IDENTITY relation, NOT a delegation --
+# unlike I2I ("issuer = far issuee") it says nothing about the issuer, so it holds even
+# though the State issues sedi-id and the endorser issues age (issuer != issuee in both).
+# Pinning the operator to const "E1E" makes the identity relation schema-enforced.
+_E1E_EDGE_SCHEMA = {
+    "oneOf": [
+        {"type": "string"},
+        {"type": "object", "required": ["d", "n", "o"],
+         "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                        "n": {"description": "Far node (sedi-id core cred) SAID",
+                              "type": "string"},
+                        "s": {"description": "Far node schema SAID",
+                              "type": "string"},
+                        "o": {"description": "Edge operator; E1E: this ACDC's issuee = "
+                                             "far node's issuee (identity relation, "
+                                             "issuer unconstrained)",
+                              "const": "E1E"}}}]}
+
 # sedi-id is an ATTRIBUTIVE ('acm') credential. Its identity attributes are a fixed set
 # of well-known, meaningfully-labeled fields, so an attribute section with individually
 # partially-disclosable nested blocks is the right model: labels give clean paths and
@@ -262,7 +285,18 @@ AGE_SCHEMA_MAD = {
                  ]}},
             ],
         },
-        "e": _EMPTY_OR_SECTION,
+        # The entitlement chains back to the core SEDI identity credential via one
+        # E1E identity edge (same subject). Schema-required, so the identity relation
+        # is enforced rather than incidental.
+        "e": {
+            "description": "Edge section: one E1E identity edge to the sedi-id core cred",
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object", "required": ["d", "identity"],
+                 "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                                "identity": _E1E_EDGE_SCHEMA},
+                 "additionalProperties": False}],
+        },
         "r": _EMPTY_OR_SECTION,
     },
     "additionalProperties": False,
@@ -422,6 +456,8 @@ N_AGE_ISSUEE, N_AGE_FLAG0, N_AGE_ACDC = 7, 8, 14
 # registries and bespoke (attribute uuid, acdc uuid, edge-section uuid, two edge uuids).
 N_REG_STATE, N_REG_ENDORSER = 15, 16
 N_BESP_A, N_BESP_ACDC, N_BESP_E, N_BESP_E_ID, N_BESP_E_AGE = 17, 18, 19, 20, 21
+# age -> sedi-id E1E identity edge: edge-section uuid + edge uuid.
+N_AGE_E, N_AGE_E_ID = 22, 23
 
 # Age aggregate ARRAY positions (A[0] = AGID; A[1] = issuee; A[2..] = the flags, one per
 # AGE_THRESHOLDS entry). SerderACDC.iseaid resolves the aggregate issuee from A[1].i.
@@ -472,9 +508,13 @@ def _source_credentials(kind):
     sedi-id is an ATTRIBUTIVE ('acm') identity credential whose attributes are
     individually partially-disclosable nested blocks (issuee at a.i); age is an
     AGGREGATIVE ('acg') credential carrying an array of boolean age-threshold flags
-    (issuee at A[1].i). Both are bound to real registries created here via regcept and
-    validate against their purpose-authored schemas. Returns (sedi, age, ageAggor) --
-    the Aggor is returned so callers can selectively disclose over the age aggregate.
+    (issuee at A[1].i). The age entitlement chains back to the core sedi-id credential
+    with one E1E identity edge -- the SEDI "entitlement chains to the core identity"
+    pattern (disc #1515), an identity relation (same issuee, issuer != issuee), verified
+    by _verify_identity_edge. Both are bound to real registries created here via regcept
+    and validate against their purpose-authored schemas (the age schema now REQUIRES the
+    E1E edge). Returns (sedi, age, ageAggor) -- the Aggor is returned so callers can
+    selectively disclose over the age aggregate.
     """
     # Real registries: the State and the endorser each stand up a registry (rip
     # event); the credential's 'rd' binds it to that registry.
@@ -491,12 +531,20 @@ def _source_credentials(kind):
     sedi = acdcmap(israid=STATE, uuid=NONCES[N_SEDI_ACDC], regid=regState.said,
                    schema=sediSchema, attribute=_sedi_attr(), iseaid=ALICE, kind=kind)
     # age: aggregative boolean-flag credential the endorser issues to Alice; its issuee
-    # is the index-1 aggregate block. It carries no edge to sedi-id and needs none --
-    # the two source creds are independent, joined only at presentation by the bespoke
-    # ACDC's I2I edges (Phase 2), where Alice is issuer and the issuee of both.
+    # is the index-1 aggregate block. It chains back to the core sedi-id credential with
+    # one E1E identity edge: both name the same subject (issuee), so this is an IDENTITY
+    # relation, not a delegation. E1E constrains only the issuee (near == far), which is
+    # why it holds even though the State issues sedi-id and the endorser issues age
+    # (issuer != issuee in both) -- the case the delegative I2I would wrongly reject.
+    # This is the SEDI "entitlement chains to the core identity" pattern (disc #1515);
+    # the bespoke presentation's own I2I edges (Phase 2) are a separate, presentation-
+    # time binding of Alice-as-discloser to her sources.
+    ageEdge = dict(d='', u=NONCES[N_AGE_E],
+                   identity=dict(d='', u=NONCES[N_AGE_E_ID], n=sedi.said,
+                                 s=sedi.sad['s']['$id'], o='E1E'))
     ageAggor = Aggor(ael=_age_ael(), makify=True, kind=kind)
     age = acdcagg(israid=ENDORSER, uuid=NONCES[N_AGE_ACDC], regid=regEndorser.said,
-                  schema=ageSchema, aggregate=ageAggor.ael, kind=kind)
+                  schema=ageSchema, aggregate=ageAggor.ael, edge=ageEdge, kind=kind)
     return sedi, age, ageAggor
 
 
@@ -561,6 +609,28 @@ def _rules_in_bespoke():
         Assimilation=dict(d='', l=ASSIMILATION_TEXT),
         SafeHarbor=dict(d='', l=SAFE_HARBOR_TEXT),
     )
+
+
+def _verify_identity_edge(near, far):
+    """The example's real verifier branch for an E1E identity edge.
+
+    E1E binds the two credentials to the SAME subject: the near ACDC's issuee AID MUST
+    equal the far node's issuee AID, both resolved via SerderACDC.iseaid (so an aggregate
+    node's A[1].i reads the same as an attributive a.i). Unlike the delegative I2I it puts
+    NO constraint on the issuer -- which is why it holds for two credentials issued by
+    different third parties to one subject (issuer != issuee), exactly the case a
+    coerce-to-I2I verifier (keri.vdr.verifying.verifyChain before PR #1523) rejects.
+
+    A real chain verifier would additionally confirm the far node's registry (TEL) state;
+    that live check is out of scope for this data-structure-level example (see
+    _club_accepts_grant and test_examples.py). Returns True or raises AssertionError.
+    """
+    edge = near.sad['e']['identity']
+    assert edge['o'] == 'E1E'                          # identity operator
+    assert edge['n'] == far.said                       # edge points at this far node
+    assert near.iseaid is not None                     # near must be targeted (has issuee)
+    assert near.iseaid == far.iseaid                   # same subject: the identity relation
+    return True
 
 
 def _bespoke_edges(sedi, age):
@@ -686,7 +756,7 @@ def test_source_credentials_and_graduated_disclosure_JSON():
     assert age.sad['A'][AGE_OVER21]['over21'] is True                          # over 21...
     over65Pos = AGE_FLAG0 + AGE_THRESHOLDS.index(65)
     assert age.sad['A'][over65Pos]['over65'] is False                          # ...not over 65
-    assert age.said == "EBh61oE3I_O3tg8NbCLaAazseE2lzRolGGI0H-V7kmXd"
+    assert age.said == "EMYibHkYzqAqJ8frlSDqSfJkODqf3XdCnAvws1Z9Dwqe"
     ageSchema = assert_acdc_schema_valid(age)
 
     # Schema teeth: a non-boolean threshold flag is rejected.
@@ -782,7 +852,7 @@ def test_bespoke_presentation_acdc_JSON():
     assert bespoke.sad['a']['place'].startswith("The Alcove Club")
     assert 'over21' not in bespoke.sad['a']    # age proof referenced via edge, not restated
     assert 'rd' not in bespoke.sad             # deliberately not registry-bound
-    assert bespoke.said == "EEh1Fmv_fN2AUV_mTuCdMB3XZptOuvhklPzAFxLeTsuY"
+    assert bespoke.said == "EPYRxEgv7rRZOLOhHIi05zEN_Q3cvcmkzqCZAolba76M"
 
     # (1) I2I same-holder binding. The v2 path does not enforce operators, so we
     # assert the constraint the I2I operator stands for: the bespoke ACDC's issuer
@@ -921,7 +991,7 @@ def test_gated_ipex_exchange_JSON():
     assert reqSedi == ["/a/i", "/a/photo"]              # attributive: issuee + photo
     assert reqAge == ["/A/i", "/A/over21"]              # aggregate: issuee + over-21 flag
     assert "/a/i" in reqSedi and "/A/i" in reqAge       # the joining issuee, from both
-    assert apply.said == "EMaBzmylNSY-nwwvknFohrV87K9MlLGnnMB6y4CrLCDp"
+    assert apply.said == "EK0cONSlv5IO4feJcynRSrfR09udKpfQf4Y29QMWRrdH"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Carries only the SAIDs of the bespoke ACDC and its sources plus
@@ -935,7 +1005,7 @@ def test_gated_ipex_exchange_JSON():
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said                 # answers the apply
     assert bespoke.said.encode() in offer.raw           # commits to the bespoke by SAID
-    assert offer.said == "EPqHYfquYatWtmKy9BRFHX9YZ6N9Zv_bdMjqlThoEOhy"
+    assert offer.said == "EL9gLhuY4EfJZrMC5i09b5yviXnMSGF7ozDYKQWSJmuU"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -946,7 +1016,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "EB_aO3htcjsYl0zxNIO1zhPFNaW-XSrA96VgEfVNVHSs"
+    assert agree.said == "EGCk7jsgTabGjss9NajgoDl6qOkKur2ggvkqj_15L14h"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1001,7 +1071,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "EMRqeruzBqBsMOPeUCHNSGzQmOS64BDd9qthWTG4My5s"
+    assert grant.said == "EN9fynQwxa65RvLh18yDjB5u_HEyTCDJjHcjUhW4JvTf"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1033,7 +1103,7 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EI0QUbDFqJzTuMWbSdGKMFeEt_cDyKF4O_Uge9BzAY9s"
+    assert admit.said == "EKhk3UKnGYUfdPpmENFQc03lvKgYLXFnU_w5lc992_5I"
 
 
 def test_accountability_and_terms_follow_data_JSON():
@@ -1182,8 +1252,44 @@ def test_clc_serialization_kinds(kind):
     assert _SIGNERS[3].verfer.verify(sig=clubSig.raw, ser=agree.raw)
 
 
+def test_age_identity_edge_E1E_JSON():
+    """The age entitlement carries an E1E identity edge to the sedi-id core credential.
+
+    Per keripy discussion #1515, the relationship between a SEDI core identity credential
+    and an entitlement credential is an IDENTITY relation, not a delegation: both name the
+    same subject (issuee), so the edge operator is E1E (near issuee == far issuee), NOT the
+    delegative I2I. E1E puts no constraint on the issuer, so the edge holds even though the
+    State issues sedi-id and the endorser issues age -- issuer != issuee in both. Routing
+    this edge through the V1 keri.vdr.verifying.verifyChain would coerce the unknown
+    operator to I2I and wrongly reject it (keripy PR #1523 adds a real E1E branch there);
+    this data-structure-level example verifies the edge directly (see _verify_identity_edge).
+    """
+    kind = Kinds.json
+    sedi, age, _ = _source_credentials(kind)
+
+    # The age credential's edge section carries one edge: E1E -> sedi-id.
+    edge = age.sad['e']['identity']
+    assert edge['o'] == 'E1E'                         # identity operator, not delegation
+    assert edge['n'] == sedi.said                     # points at the core identity cred
+    assert edge['s'] == sedi.sad['s']['$id']          # names the core cred's schema
+
+    # The identity relation: same subject (issuee), different issuers, issuer != issuee.
+    assert age.iseaid == sedi.iseaid == ALICE         # same holder
+    assert age.israid == ENDORSER and sedi.israid == STATE   # different issuers ...
+    assert age.israid != age.iseaid                   # ... and issuer != issuee (I2I rejects)
+
+    # The example's real E1E verifier branch accepts the edge, the age credential
+    # validates against its (E1E-emitting) schema, and a far node naming a DIFFERENT
+    # subject is rejected (the bespoke presentation's issuee is the club, not Alice).
+    assert _verify_identity_edge(age, sedi)
+    assert_acdc_schema_valid(age)
+    with pytest.raises(AssertionError):
+        _verify_identity_edge(age, _bespoke_presentation(sedi, age, kind))
+
+
 if __name__ == "__main__":
     test_source_credentials_and_graduated_disclosure_JSON()
+    test_age_identity_edge_E1E_JSON()
     test_bespoke_presentation_acdc_JSON()
     test_gated_ipex_exchange_JSON()
     test_accountability_and_terms_follow_data_JSON()

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -548,3 +548,115 @@ def test_verifier_chained_credential(seeder):
             assert cred['revancatc'] is not None
 
     """End Test"""
+
+
+def test_verifier_e1e_identity_edge(seeder):
+    """E1E identity edge: near issuee must equal far issuee; issuer != issuee allowed.
+
+    Models the SEDI core-identity <-> entitlement relationship (discussion #1515):
+    two credentials issued by the same third party (ian) to the same subject (han),
+    linked by an edge whose operator is the identity relation E1E. The near
+    (entitlement) credential's issuer is ian and its issuee is han, so
+    ``issuer != issuee``. The delegative I2I operator would reject that binding
+    (I2I requires the near issuer to be the far issuee), which is exactly the case
+    the identity operator E1E exists to allow: it constrains the near *issuee* to
+    equal the far issuee and says nothing about the issuer.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+            as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        def issueAndSave(creder):
+            """Run creder through the full issue -> anchor -> escrow -> save flow."""
+            try:
+                verfer.processCredential(creder, prefixer=ian.kever.prefixer,
+                                         seqner=Seqner(sn=ian.kever.sn),
+                                         saider=Diger(qb64=ian.kever.serder.said))
+            except MissingRegistryError:
+                pass  # expected: the TEL issuance event is anchored just below
+            iss = ianiss.issue(said=creder.said)
+            rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+            ian.interact(data=[rseal], framed=True, **CUE_KWA)
+            ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            ianreg.processEscrows()
+            verfer.processEscrows()
+
+        # far ("core identity") credential: ian -> han, no edge.
+        coreSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="core identity")
+        _, cd = Saider.saidify(sad=coreSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        core = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=cd,
+                          status=ianiss.regk, source={}, rules={}, **KWA)
+        assert core.israid == ian.pre        # issuer
+        assert core.iseaid == han.pre        # issuee (a.i)
+        issueAndSave(core)
+        assert verfer.reger.saved.get(keys=core.saidb) is not None
+
+        # near ("entitlement") credential: ian -> han, E1E identity edge -> core.
+        chainSad = dict(d='', coreIdentity=dict(n=core.said, o="E1E"))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        entSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="over 21")
+        _, ed = Saider.saidify(sad=entSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        ent = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=ed,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert ent.israid == ian.pre         # issuer is ian ...
+        assert ent.iseaid == han.pre         # ... but issuee is han: issuer != issuee
+        assert ent.israid != ent.iseaid
+
+        issueAndSave(ent)
+
+        # The identity edge validates: near issuee (han) == far issuee (han), even
+        # though the near issuer (ian) is not the issuee. Under the old coercion to
+        # I2I this credential would be stuck in missing-chain escrow, not saved.
+        assert verfer.reger.saved.get(keys=ent.saidb) is not None
+        saider = ianreg.reger.subjs.get(han.pre)
+        assert ent.said in [s.qb64 for s in saider]
+
+        # Guardrail: an E1E edge whose near issuee does NOT equal the far issuee must
+        # be rejected. Here the near cred is issued by ian to ian (issuee == ian), so
+        # its issuee differs from the far node's issuee (han). Note this is the inverse
+        # of I2I: because issuer == issuee, an I2I edge would accept it -- E1E does not.
+        badSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="wrong subject")
+        _, bd = Saider.saidify(sad=badSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        bad = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=bd,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert bad.iseaid == ian.pre         # near issuee (ian) != far issuee (han)
+        issueAndSave(bad)
+        assert verfer.reger.saved.get(keys=bad.saidb) is None
+
+        # Guardrail: an E1E edge to an UNTARGETED far node (no issuee) must be rejected.
+        # Both the near and far issuee resolve, and "same subject" is undefined when the
+        # far node has none -- so the `farIssuee is None` guard rejects. (Without it, two
+        # untargeted creds would compare None == None and wrongly bind as one subject.)
+        orphanSubject = dict(d="", dt=helping.nowIso8601(), claim="untargeted")  # no 'i'
+        _, od = Saider.saidify(sad=orphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        orphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=od,
+                            status=ianiss.regk, source={}, rules={}, **KWA)
+        assert orphan.iseaid is None         # untargeted far node
+        issueAndSave(orphan)
+        assert verfer.reger.saved.get(keys=orphan.saidb) is not None
+        orphanChain = dict(d='', coreIdentity=dict(n=orphan.said, o="E1E"))
+        _, ochain = Saider.saidify(sad=orphanChain, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphanSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="to orphan")
+        _, td = Saider.saidify(sad=toOrphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=td,
+                              status=ianiss.regk, source=ochain, rules={}, **KWA)
+        issueAndSave(toOrphan)
+        assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
+
+    """End Test"""


### PR DESCRIPTION
## What this fixes

The CLC/SEDI worked example (`tests/acdc/test_clc_disclosure.py`, #1505) expressed the relationship between the **core SEDI identity credential** and the **age entitlement** only indirectly — through the bespoke presentation's `I2I` edges. But that relationship is an **identity** relation, not a delegation: both credentials name the *same subject* (issuee), while the issuer is a third party (`issuer != issuee`). `I2I` is the wrong operator for it — it constrains the issuer, and the unknown-operator fallback would coerce a stand-in edge to `I2I` and reject exactly this case (keripy discussion [#1515](https://github.com/WebOfTrust/keripy/discussions/1515)).

## What it does

Models the SEDI **"entitlement chains to the core identity"** pattern directly:

- The age credential now carries **one `E1E` identity edge → sedi-id** (near issuee == far issuee).
- The operator is pinned in the age schema (`const "E1E"`) so the identity relation is **schema-enforced** — the emitting schema.
- A real verifier branch, `_verify_identity_edge`, resolves both issuees via `SerderACDC.iseaid` and checks equality — exercising the aggregate far-node path (`A[1].i`) end to end. It deliberately does **not** route through `keri.vdr.verifying.verifyChain`, whose pre-#1523 coercion to `I2I` would wrongly reject the `issuer != issuee` relation.

The bespoke presentation's own `I2I` edges are **unchanged**: those are a separate, presentation-time binding of Alice-as-discloser to her sources (`issuer == far issuee`), where `I2I` is correct.

## Tests

- Adds **`test_age_identity_edge_E1E_JSON`** (edge present, operator `E1E`, same-subject relation, real verifier accepts, mismatched far node rejected).
- Re-derives the SAIDs that ripple from the age credential's new edge: `age`, `bespoke`, and the `apply` / `offer` / `agree` / `grant` / `admit` chain (derived, not pasted).
- All flows green across **JSON / CESR / CBOR / MGPK**, under `pytest -n auto`, and as a standalone script.

Holds the rest of the operator family (`I1I` / `I1E` / `E1I` / `I3I` / `E3E`) until a schema or named EGF needs them.

## Stacking

**Stacked on #1523** ("Add E1E identity edge operator to credential chain verification"). This PR's branch includes that commit; until #1523 merges, this PR shows both commits. Once #1523 lands, this diff collapses to the worked-example change alone. Please merge #1523 first.

---

*This worked example was developed with AI assistance (Claude, Anthropic).*
