### PR TITLE
Make vdr verifier aggregate-aware when resolving the issuee

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -161,7 +161,7 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.israid)
+                state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
                 if state is None:
                     self.escrowMCE(creder, prefixer, seqner, saider)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -333,13 +333,16 @@ class Verifier:
         hab = self.hby.habs[pre]
         return hab.endorse(serder, last=True, framed=False, gvrsn=serder.pvrsn)
 
-    def verifyChain(self, nodeSaid, op, issuer):
+    def verifyChain(self, nodeSaid, op, issuer, issuee=None):
         """ Verifies the node credential at the end of an edge
 
         Parameters:
             nodeSaid: (str): qb64 SAID of node credential
             op(str): edge operator
-            issuer (str) qb64 AID of issuer
+            issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
+            issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
+                required by the identity operators (E1E). None when the near ACDC is
+                untargeted.
 
         Returns:
             Serder: transaction event state notification message
@@ -349,12 +352,22 @@ class Verifier:
         if said is None:
             return None
 
-        creder = self.reger.creds.get(keys=nodeSaid)
+        creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
-        if op not in ['I2I', 'DI2I', 'NI2I']:
+        if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
             op = 'I2I' if 'i' in creder.attrib else 'NI2I'
 
-        if op != 'NI2I':
+        if op == 'E1E':
+            # Identity relation (discussion #1515): the issuee AID of the near ACDC
+            # (the one carrying this edge) MUST equal the issuee AID of the far node.
+            # Unlike the delegative I2I, this says nothing about the issuer, so the
+            # common SEDI case -- both credentials issued by a third party to the same
+            # subject, issuer != issuee -- is valid (and is exactly what I2I rejects).
+            # Resolve the far issuee via .iseaid so an aggregate node (A[1].i) works too.
+            farIssuee = creder.iseaid
+            if farIssuee is None or issuee is None or issuee != farIssuee:
+                return None
+        elif op != 'NI2I':
             if 'i' not in creder.attrib:
                 return None
 

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -320,8 +320,11 @@ class Verifier:
         self.reger.issus.add(keys=issuer, val=saider)
         self.reger.schms.add(keys=schema, val=saider)
 
-        if not isinstance(creder.attrib, str) and 'i' in creder.attrib:
-            subject = creder.attrib["i"].encode("utf-8")
+        # Resolve the issuee via .iseaid so aggregate ('acg') credentials index
+        # their subject too: for them .attrib is None and the issuee lives at
+        # .sad["A"][1]["i"]. For attributive creds .iseaid == .attrib["i"].
+        if creder.iseaid is not None:
+            subject = creder.iseaid.encode("utf-8")
             self.reger.subjs.add(keys=subject, val=saider)
 
     def query(self, pre, regk, vcid, *, dt=None, dta=None, dtb=None, **kwa):
@@ -355,7 +358,11 @@ class Verifier:
         creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
         if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
-            op = 'I2I' if 'i' in creder.attrib else 'NI2I'
+            # A far node is targeted (I2I) iff it has an issuee, else untargeted
+            # (NI2I). Resolve via .iseaid so an aggregate ('acg') far node -- whose
+            # issuee is at .sad["A"][1]["i"] and whose .attrib is None -- coerces the
+            # same as an attributive one.
+            op = 'I2I' if creder.iseaid is not None else 'NI2I'
 
         if op == 'E1E':
             # Identity relation (discussion #1515): the issuee AID of the near ACDC
@@ -368,14 +375,19 @@ class Verifier:
             if farIssuee is None or issuee is None or issuee != farIssuee:
                 return None
         elif op != 'NI2I':
-            if 'i' not in creder.attrib:
+            # Resolve the far node's issuee via .iseaid so an aggregate ('acg') far
+            # node (issuee at .sad["A"][1]["i"]) resolves identically to an
+            # attributive one (.attrib["i"]). None means an untargeted far node,
+            # which cannot satisfy a targeted (I2I/DI2I) edge.
+            farIssuee = creder.iseaid
+            if farIssuee is None:
                 return None
 
-            iss = self.reger.subjs.get(keys=creder.attrib['i'])
+            iss = self.reger.subjs.get(keys=farIssuee)
             if iss is None:
                 return None
 
-            if op == 'I2I' and issuer != creder.attrib['i']:
+            if op == 'I2I' and issuer != farIssuee:
                 return None
 
             if op == "DI2I":

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -11,10 +11,12 @@ from keri import (MissingRegistryError, MissingEntryError,
 from keri.app import openHab
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
                        Diger, Parser, SealEvent,
-                       MtrDex, Saids)
+                       MtrDex, Saids, Aggor, Noncer)
 from keri.kering import Ilks, Kinds, Vrsn_2_0
 from keri.help import helping
 from keri.vc import credential
+from keri.acdc import acdcagg
+from keri.acdc.messaging import acgSchemaDefault
 from keri.vdr import Verifier, Regery, Tevery
 from tests.common import CUE_KWA, KWA
 
@@ -658,5 +660,134 @@ def test_verifier_e1e_identity_edge(seeder):
                               status=ianiss.regk, source=ochain, rules={}, **KWA)
         issueAndSave(toOrphan)
         assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
+
+    """End Test"""
+
+
+def _aggregate_far_node(ian, ianiss, ianreg, issueeAid):
+    """Build an aggregative ('acg') far-node credential and issue its SAID into
+    ian's registry TEL so ``vcState`` resolves it to issued.
+
+    The credential is issued by ian to ``issueeAid``. For an aggregate ACDC the
+    issuee lives at ``.sad["A"][1]["i"]`` (not ``.sad["a"]["i"]``), so ``.attrib``
+    is None and ``.iseaid`` is the only way to resolve the issuee -- exactly the
+    case that the attributive-only paths in verifying.py mishandle.
+    """
+    raws = [b'2lb6aggverifchn' + b'%0x' % (i,) for i in range(3)]
+    nonces = [Noncer(raw=r).qb64 for r in raws]
+    # element 0 is the AGID placeholder; element 1 carries the issuee (i).
+    ael = ['', dict(d='', u=nonces[0], i=issueeAid),
+           dict(d='', u=nonces[1], over21=True)]
+    aggor = Aggor(ael=ael, makify=True, kind=Kinds.json)
+    sschema, _ = acgSchemaDefault(kind=Kinds.json)  # SAID string, not the block
+    agg = acdcagg(israid=ian.pre, uuid=nonces[2], regid=ianiss.regk,
+                  schema=sschema, aggregate=aggor.ael, kind=Kinds.json)
+
+    # anchor a TEL issuance event for the aggregate SAID so it is "issued".
+    iss = ianiss.issue(said=agg.said)
+    rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+    ian.interact(data=[rseal], framed=True, **CUE_KWA)
+    ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                     seqner=Seqner(sn=ian.kever.sn),
+                     saider=Diger(qb64=ian.kever.serder.said))
+    ianreg.processEscrows()
+    return agg
+
+
+def test_verifier_saves_aggregate_credential(seeder):
+    """saveCredential indexes an aggregate ('acg') credential's subject via .iseaid.
+
+    Regression for tick 2lb6: saveCredential guarded subject indexing on
+    ``'i' in creder.attrib``, but ``creder.attrib`` is None for an aggregate
+    credential (the issuee is at ``.sad["A"][1]["i"]``), so the membership test
+    raised ``TypeError`` and the aggregate credential could not be saved or
+    subject-indexed at all. It must instead resolve the issuee via ``.iseaid``,
+    identically to an attributive credential.
+    """
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+            as (hanHby, han):
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        agg = _aggregate_far_node(ian, ianiss, ianreg, han.pre)
+        assert agg.attrib is None            # aggregate: no 'a' section
+        assert agg.iseaid == han.pre         # issuee resolves from A[1].i
+        assert agg.israid == ian.pre
+
+        # Before the fix this raised TypeError on ``'i' in creder.attrib`` (None).
+        verfer.saveCredential(agg, prefixer=ian.kever.prefixer,
+                              seqner=Seqner(sn=ian.kever.sn),
+                              saider=Diger(qb64=ian.kever.serder.said))
+
+        assert verfer.reger.saved.get(keys=agg.saidb) is not None
+        # subject indexed under the aggregate issuee (han), via .iseaid.
+        saiders = verfer.reger.subjs.get(han.pre)
+        assert agg.said in [s.qb64 for s in saiders]
+
+    """End Test"""
+
+
+def test_verifier_aggregate_far_node_chain(seeder):
+    """verifyChain resolves an aggregate ('acg') far node's issuee via .iseaid.
+
+    Regression for tick 2lb6: verifyChain coerced the default/unknown operator via
+    ``'i' in creder.attrib`` and resolved the I2I issuee via ``creder.attrib['i']``.
+    Both raise ``TypeError`` for an aggregate far node (``.attrib`` is None). The
+    verifier must resolve targeted-ness and the issuee via ``.iseaid`` so an edge
+    to an aggregate far node behaves identically to an attributive one.
+    """
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+            as (hanHby, han):
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        agg = _aggregate_far_node(ian, ianiss, ianreg, han.pre)
+        assert agg.attrib is None
+        assert agg.iseaid == han.pre
+
+        # Populate the reger indices directly (isolate this from saveCredential):
+        # creds (SerderSuber -> SerderACDC), saved, and the subject index.
+        verfer.reger.logCred(agg, ian.kever.prefixer, Seqner(sn=ian.kever.sn),
+                             Diger(qb64=ian.kever.serder.said))
+        saider = Saider(qb64=agg.said)
+        verfer.reger.saved.pin(keys=saider.qb64b, val=saider)
+        verfer.reger.subjs.add(keys=agg.iseaidb, val=saider)
+
+        # Default operator (None): coerced to a targeted (I2I) edge because the far
+        # node has an issuee (.iseaid). Before the fix this raised TypeError on the
+        # ``'i' in creder.attrib`` coercion. The near issuer (han) equals the far
+        # issuee (han), so the I2I binding is accepted.
+        state = verfer.verifyChain(agg.said, None, han.pre)
+        assert state is not None
+
+        # Explicit I2I with the same binding is accepted.
+        state = verfer.verifyChain(agg.said, 'I2I', han.pre, issuee=han.pre)
+        assert state is not None
+
+        # I2I mismatch: the near issuer (ian) does not equal the far issuee (han),
+        # so the binding is rejected (returns None, no TypeError).
+        assert verfer.verifyChain(agg.said, 'I2I', ian.pre) is None
+
+        # NI2I is untargeted: accepted regardless of issuer/issuee.
+        state = verfer.verifyChain(agg.said, 'NI2I', ian.pre)
+        assert state is not None
 
     """End Test"""

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -548,3 +548,115 @@ def test_verifier_chained_credential(seeder):
             assert cred['revancatc'] is not None
 
     """End Test"""
+
+
+def test_verifier_e1e_identity_edge(seeder):
+    """E1E identity edge: near issuee must equal far issuee; issuer != issuee allowed.
+
+    Models the SEDI core-identity <-> entitlement relationship (discussion #1515):
+    two credentials issued by the same third party (ian) to the same subject (han),
+    linked by an edge whose operator is the identity relation E1E. The near
+    (entitlement) credential's issuer is ian and its issuee is han, so
+    ``issuer != issuee``. The delegative I2I operator would reject that binding
+    (I2I requires the near issuer to be the far issuee), which is exactly the case
+    the identity operator E1E exists to allow: it constrains the near *issuee* to
+    equal the far issuee and says nothing about the issuer.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+            as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        def issueAndSave(creder):
+            """Run creder through the full issue -> anchor -> escrow -> save flow."""
+            try:
+                verfer.processCredential(creder, prefixer=ian.kever.prefixer,
+                                         seqner=Seqner(sn=ian.kever.sn),
+                                         saider=Diger(qb64=ian.kever.serder.said))
+            except MissingRegistryError:
+                pass  # expected: the TEL issuance event is anchored just below
+            iss = ianiss.issue(said=creder.said)
+            rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+            ian.interact(data=[rseal], framed=True, **CUE_KWA)
+            ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            ianreg.processEscrows()
+            verfer.processEscrows()
+
+        # far ("core identity") credential: ian -> han, no edge.
+        coreSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="core identity")
+        _, cd = Saider.saidify(sad=coreSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        core = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=cd,
+                          status=ianiss.regk, source={}, rules={}, **KWA)
+        assert core.israid == ian.pre        # issuer
+        assert core.iseaid == han.pre        # issuee (a.i)
+        issueAndSave(core)
+        assert verfer.reger.saved.get(keys=core.saidb) is not None
+
+        # near ("entitlement") credential: ian -> han, E1E identity edge -> core.
+        chainSad = dict(d='', coreIdentity=dict(n=core.said, o="E1E"))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        entSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="over 21")
+        _, ed = Saider.saidify(sad=entSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        ent = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=ed,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert ent.israid == ian.pre         # issuer is ian ...
+        assert ent.iseaid == han.pre         # ... but issuee is han: issuer != issuee
+        assert ent.israid != ent.iseaid
+
+        issueAndSave(ent)
+
+        # The identity edge validates: near issuee (han) == far issuee (han), even
+        # though the near issuer (ian) is not the issuee. Under the old coercion to
+        # I2I this credential would be stuck in missing-chain escrow, not saved.
+        assert verfer.reger.saved.get(keys=ent.saidb) is not None
+        saider = ianreg.reger.subjs.get(han.pre)
+        assert ent.said in [s.qb64 for s in saider]
+
+        # Guardrail: an E1E edge whose near issuee does NOT equal the far issuee must
+        # be rejected. Here the near cred is issued by ian to ian (issuee == ian), so
+        # its issuee differs from the far node's issuee (han). Note this is the inverse
+        # of I2I: because issuer == issuee, an I2I edge would accept it -- E1E does not.
+        badSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="wrong subject")
+        _, bd = Saider.saidify(sad=badSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        bad = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=bd,
+                         status=ianiss.regk, source=chain, rules={}, **KWA)
+        assert bad.iseaid == ian.pre         # near issuee (ian) != far issuee (han)
+        issueAndSave(bad)
+        assert verfer.reger.saved.get(keys=bad.saidb) is None
+
+        # Guardrail: an E1E edge to an UNTARGETED far node (no issuee) must be rejected.
+        # Both the near and far issuee resolve, and "same subject" is undefined when the
+        # far node has none -- so the `farIssuee is None` guard rejects. (Without it, two
+        # untargeted creds would compare None == None and wrongly bind as one subject.)
+        orphanSubject = dict(d="", dt=helping.nowIso8601(), claim="untargeted")  # no 'i'
+        _, od = Saider.saidify(sad=orphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        orphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=od,
+                            status=ianiss.regk, source={}, rules={}, **KWA)
+        assert orphan.iseaid is None         # untargeted far node
+        issueAndSave(orphan)
+        assert verfer.reger.saved.get(keys=orphan.saidb) is not None
+        orphanChain = dict(d='', coreIdentity=dict(n=orphan.said, o="E1E"))
+        _, ochain = Saider.saidify(sad=orphanChain, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphanSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="to orphan")
+        _, td = Saider.saidify(sad=toOrphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        toOrphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=td,
+                              status=ianiss.regk, source=ochain, rules={}, **KWA)
+        issueAndSave(toOrphan)
+        assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
+
+    """End Test"""


### PR DESCRIPTION
## Summary

`keri.vdr.verifying` was only half aggregate-aware. `SerderACDC.iseaid` resolves the issuee AID for **both** credential forms — attributive (`.sad['a']['i']`) and aggregative `'acg'` (`.sad['A'][1]['i']`) — but the verifier still reached the issuee through `creder.attrib`, which is `None` for an aggregate credential. That left three attributive-only paths that crash or wrongly reject when an edge targets an aggregate far node:

- **`verifyChain` operator coercion:** `op = 'I2I' if 'i' in creder.attrib else 'NI2I'` raised `TypeError: argument of type 'NoneType' is not ...` when the far node was aggregate. Reachable whenever an edge points at an aggregate far node with a default/absent or unrecognized operator.
- **`verifyChain` I2I/DI2I branch:** resolved the issuee via `creder.attrib['i']` and `reger.subjs.get(keys=creder.attrib['i'])`, so an I2I edge to an aggregate far node crashed instead of resolving the issuee.
- **`saveCredential`:** guarded subject indexing on `'i' in creder.attrib`, so an aggregate credential could not even be saved or subject-indexed — meaning it could never be a valid I2I far node in the first place.

## Fix

Resolve the issuee and targeted-ness via `creder.iseaid` in all three places (`self.reger.creds` stores `SerderACDC` instances, which expose `.iseaid`):

- An ACDC is **targeted (I2I)** iff `creder.iseaid is not None`, else untargeted (NI2I).
- The I2I/DI2I branch compares `issuer` against `creder.iseaid` and looks up `reger.subjs.get(keys=creder.iseaid)`; `creder.iseaid is None` (untargeted far node) returns `None`.
- `saveCredential` indexes the subject via `creder.iseaid`, guarded on `creder.iseaid is not None`.

Behavior is **identical for attributive credentials**, for which `creder.iseaid == creder.attrib['i']`. The **E1E** branch already used `.iseaid` and is left untouched.

## Tests

Two new tests in `tests/vdr/test_verifying.py` build an aggregate (`'acg'`) far node via `acdcagg` + `keri.core.Aggor` (issuee at aggregate index 1), issued into a real registry TEL:

- `test_verifier_saves_aggregate_credential` — `saveCredential` indexes the aggregate subject via `.iseaid`.
- `test_verifier_aggregate_far_node_chain` — `verifyChain` operator coercion (default op) and I2I resolution: accepts when the near issuer equals the far issuee, rejects on mismatch, and never raises `TypeError`.

Both fail before the fix with the `None`-attrib `TypeError` and pass after. The existing `test_verifier_chained_credential` (I2I/NI2I) and `test_verifier_e1e_identity_edge` remain green. Full `tests/vdr/` suite passes (31 tests).

## Stacking

**This PR is stacked on #1523** ("Add E1E identity edge operator") — its branch includes that commit, so please merge #1523 first. Once #1523 lands, the diff here collapses to just the aggregate-awareness change.

---

*This change was developed with AI assistance (Claude, Anthropic).*
