### PR TITLE
Fix worked-example schema discrepancies (#1520) + add spec drift guard

### DIFF
--- a/.github/workflows/spec-examples-drift.yml
+++ b/.github/workflows/spec-examples-drift.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          pip install pytest pytest-shell pytest-xdist  # needed to emit the worked-examples manifest
 
       - name: Emit keripy's canonical worked-examples manifest
         env:

--- a/.github/workflows/spec-examples-drift.yml
+++ b/.github/workflows/spec-examples-drift.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install keripy
         run: |

--- a/.github/workflows/spec-examples-drift.yml
+++ b/.github/workflows/spec-examples-drift.yml
@@ -1,0 +1,104 @@
+# Spec Worked-Examples Drift Guard
+#
+# keripy's tests are the single source of truth for the ACDC specification's
+# "Working ACDC Examples". This workflow regenerates keripy's canonical
+# worked-example manifest and compares it, value-for-value, against the JSON
+# example blocks embedded in the ACDC spec (trustoverip/kswg-acdc-specification,
+# spec/spec-body.md). If they disagree, the spec and keripy have DRIFTED and
+# this job fails.
+#
+# How the spec side is matched: each governed JSON block in spec-body.md is
+# tagged with an HTML comment marker immediately before its fenced code block:
+#     <!-- example: <blockName> -->
+#     ```json
+#     { ... }
+#     ```
+# The checker (tools/check_spec_examples.py) pairs each marker with the
+# same-named block in keripy's emitted manifest.
+#
+# SEQUENCING CAVEAT: this guard REQUIRES the sibling spec PR -- the one that
+# adds the `<!-- example: -->` markers and the synced JSON blocks to
+# spec-body.md -- to have LANDED in the pinned spec ref. Until then every run
+# reports "MISSING IN SPEC" and fails. Keep this workflow non-required (or add
+# it) only after that spec PR merges to the ref checked out below.
+
+name: Spec Worked-Examples Drift Guard
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec_ref:
+        description: "Git ref (branch/tag/SHA) of trustoverip/kswg-acdc-specification to check against"
+        required: false
+        default: "main"
+  pull_request:
+    # Drift can only be introduced by changing the canonical examples, the
+    # checker, or this workflow -- so only run then, not on every PR.
+    paths:
+      - "tests/spec/acdc/test_acdc_examples.py"
+      - "tools/check_spec_examples.py"
+      - ".github/workflows/spec-examples-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      # Resolve the spec ref once: workflow_dispatch supplies inputs.spec_ref;
+      # on pull_request that expression is empty, so fall back to 'main'.
+      SPEC_REF: ${{ github.event.inputs.spec_ref || 'main' }}
+    steps:
+      - name: Check out keripy
+        uses: actions/checkout@v6
+
+      - name: Check out ACDC specification
+        uses: actions/checkout@v6
+        with:
+          repository: trustoverip/kswg-acdc-specification
+          ref: ${{ env.SPEC_REF }}
+          path: spec-repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install keripy
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Emit keripy's canonical worked-examples manifest
+        env:
+          KERI_EMIT_WORKED_EXAMPLES: /tmp/manifest.json
+        run: |
+          python -m pytest \
+            tests/spec/acdc/test_acdc_examples.py::test_acdc_examples_JSON -q
+
+      - name: Compare spec examples against the manifest (drift guard)
+        run: |
+          python tools/check_spec_examples.py \
+            --manifest /tmp/manifest.json \
+            --spec spec-repo/spec/spec-body.md
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          echo "::error::ACDC worked-example DRIFT: keripy's canonical examples"
+          echo "::error::and the ACDC spec's example blocks disagree."
+          echo ""
+          echo "keripy's tests are the source of truth for the spec's"
+          echo "'Working ACDC Examples'. A failure here means one of:"
+          echo "  1. keripy's examples changed and the spec's JSON blocks (with"
+          echo "     their <!-- example: NAME --> markers in spec/spec-body.md)"
+          echo "     were not re-synced -- open a spec PR against"
+          echo "     trustoverip/kswg-acdc-specification to update them; or"
+          echo "  2. the sibling spec PR that introduces the markers/blocks has"
+          echo "     not landed yet in the checked-out spec ref (see the"
+          echo "     SEQUENCING CAVEAT at the top of this workflow file)."
+          echo ""
+          echo "Fix by reconciling this workflow"
+          echo "(.github/workflows/spec-examples-drift.yml + tools/check_spec_examples.py)"
+          echo "with the spec PR so keripy and the spec examples agree."

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -2014,7 +2014,7 @@ def test_parser_v2_basic():
         state = ''
         blinder0 = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn)
         sn = 2
-        acdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob project report ACDC
+        acdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob project report ACDC
         state = 'issued'
         blinder1 = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn)
         # enclose and extend with quadlet counter,
@@ -2031,7 +2031,7 @@ def test_parser_v2_basic():
         blinder0 = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn,
                                  bound=True, bsn=bsn, bd=bd)
         sn = 2
-        acdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob project report ACDC
+        acdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob project report ACDC
         state = 'issued'
         bsn = 2
         bd = "EJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv"

--- a/tests/spec/acdc/test_acdc_examples.py
+++ b/tests/spec/acdc/test_acdc_examples.py
@@ -8,7 +8,6 @@ from base64 import urlsafe_b64decode as decodeB64
 
 import pytest
 from jsonschema import Draft202012Validator
-from jsonschema.exceptions import ValidationError
 
 from keri import Vrsn_2_0, Kinds, Protocols, Ilks
 from keri.core import (MtrDex, Salter, Labeler, Noncer, Mapper, Compactor, Aggor,
@@ -613,14 +612,14 @@ def test_blindable_state_tel_examples_JSON():
     prior = serder.said
 
     # Change state to issued
-    acdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob project report ACDC
+    acdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob project report ACDC
     state = 'issued'
     sn = 2
-    blid = 'EOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_t'
+    blid = 'EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8N'
     uuid = 'aLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzB'
-    qb64 = 'EOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_taLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0Missued'
-    eqb64 = '-aAjEOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_taLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0Missued'
-    dummied = '############################################aLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0Missued'
+    qb64 = 'EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8NaLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0Missued'
+    eqb64 = '-aAjEItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8NaLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0Missued'
+    dummied = '############################################aLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzBEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0Missued'
     assert len(dummied) == 140
     blinder = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn)
     assert blinder.qb64 == qb64
@@ -631,7 +630,7 @@ def test_blindable_state_tel_examples_JSON():
     assert Blinder.enclose([blinder]).decode() == eqb64
 
     stamp = '2020-08-02T12:00:20.000000+00:00'
-    said = 'EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW'
+    said = 'EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3'
 
     serder = blindate(regid=regid, prior=prior, blid=blid, stamp=stamp, sn=sn)
     assert serder.proto == Protocols.acdc
@@ -648,12 +647,12 @@ def test_blindable_state_tel_examples_JSON():
     {
         "v": "ACDCCAACAAJSONAAEi.",
         "t": "bup",
-        "d": "EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW",
+        "d": "EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
         "n": "2",
         "p": "EPNwyvHp2XJsz9pSpXtHtcCmzw6bKSFc-nhGKTbso0Yg",
         "dt": "2020-08-02T12:00:20.000000+00:00",
-        "b": "EOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_t"
+        "b": "EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8N"
     }
     prior = serder.said
 
@@ -661,7 +660,7 @@ def test_blindable_state_tel_examples_JSON():
     state = 'revoked'
     sn = 3
 
-    blid = 'EPj3sZj8OOWTkTgAN5vzVYdANeoj3zxgEn5APb8fCRRN'
+    blid = 'EJakqLgla7ip4dygsRxRX3p3oYfAugvR6pm7zQByL0XO'
     uuid = 'aGx7b16vGHVPT56tX30kYOEzTwiVY4aabc4k9AawYyZG'
 
     blinder = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn)
@@ -670,14 +669,14 @@ def test_blindable_state_tel_examples_JSON():
     assert blinder.acdc == acdc
     assert blinder.state == state
 
-    qb64 = 'EPj3sZj8OOWTkTgAN5vzVYdANeoj3zxgEn5APb8fCRRNaGx7b16vGHVPT56tX30kYOEzTwiVY4aabc4k9AawYyZGEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4MYrevoked'
+    qb64 = 'EJakqLgla7ip4dygsRxRX3p3oYfAugvR6pm7zQByL0XOaGx7b16vGHVPT56tX30kYOEzTwiVY4aabc4k9AawYyZGEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtvYrevoked'
     assert blinder.qb64 == qb64
 
-    eqb64 = '-aAjEPj3sZj8OOWTkTgAN5vzVYdANeoj3zxgEn5APb8fCRRNaGx7b16vGHVPT56tX30kYOEzTwiVY4aabc4k9AawYyZGEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4MYrevoked'
+    eqb64 = '-aAjEJakqLgla7ip4dygsRxRX3p3oYfAugvR6pm7zQByL0XOaGx7b16vGHVPT56tX30kYOEzTwiVY4aabc4k9AawYyZGEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtvYrevoked'
     assert Blinder.enclose([blinder]).decode() == eqb64
 
     stamp = '2020-08-03T12:00:20.000000+00:00'
-    said = 'EM8B1uDhWaJLfpIiEqgp-3EurGUcbfe7u2k5AarDl2XD'
+    said = 'EAvy-pCxwjnBuNpU-1MasIL9WreuzpocGZ30wRlxj7tw'
 
     serder = blindate(regid=regid, prior=prior, blid=blid, stamp=stamp, sn=sn)
     assert serder.said == said
@@ -693,17 +692,17 @@ def test_blindable_state_tel_examples_JSON():
     {
         "v": "ACDCCAACAAJSONAAEi.",
         "t": "bup",
-        "d": "EM8B1uDhWaJLfpIiEqgp-3EurGUcbfe7u2k5AarDl2XD",
+        "d": "EAvy-pCxwjnBuNpU-1MasIL9WreuzpocGZ30wRlxj7tw",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
         "n": "3",
-        "p": "EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW",
+        "p": "EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3",
         "dt": "2020-08-03T12:00:20.000000+00:00",
-        "b": "EPj3sZj8OOWTkTgAN5vzVYdANeoj3zxgEn5APb8fCRRN"
+        "b": "EJakqLgla7ip4dygsRxRX3p3oYfAugvR6pm7zQByL0XO"
     }
 
 
     # alternate unblindable update
-    said = 'ENR6tbkJCJXQTiu5TP-RBxkS2_ZSZBgbJmpjKucDe07h'
+    said = 'ELtIDRReKb2Evivi8Gean2uVHi6HxvvNKwlS2rcB22IX'
     serder = update(regid=regid, prior=prior, acdc=acdc, state=state, stamp=stamp, sn=sn)
     assert serder.proto == Protocols.acdc
     assert serder.pvrsn == Vrsn_2_0
@@ -718,12 +717,12 @@ def test_blindable_state_tel_examples_JSON():
     {
         "v": "ACDCCAACAAJSONAAEy.",
         "t": "upd",
-        "d": "ENR6tbkJCJXQTiu5TP-RBxkS2_ZSZBgbJmpjKucDe07h",
+        "d": "ELtIDRReKb2Evivi8Gean2uVHi6HxvvNKwlS2rcB22IX",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
         "n": "3",
-        "p": "EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW",
+        "p": "EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3",
         "dt": "2020-08-03T12:00:20.000000+00:00",
-        "td": "EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M",
+        "td": "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv",
         "ts": "revoked"
     }
 
@@ -799,13 +798,13 @@ def test_blindable_state_tel_examples_JSON():
     }
     prior = serder.said
 
-    acdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob project report ACDC
+    acdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob project report ACDC
     state = 'issued'
     sn = 2
     bsn = 1
     bd = 'EJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
 
-    blid = 'EJAeKLEtVtMtt28IdAKJShyZHodEIZTHJHzaP21A_ZU4'
+    blid = 'EOhIBudxqPL1KP3PmJidkTHXtkneortJX4ygMcoC3p57'
     uuid = 'aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkO'
 
     blinder = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn,
@@ -818,17 +817,17 @@ def test_blindable_state_tel_examples_JSON():
     assert blinder.bsn == bsn
     assert blinder.bd == bd
 
-    dummied = '############################################aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
+    dummied = '############################################aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
     assert len(dummied) == 188
 
-    qb64 = 'EJAeKLEtVtMtt28IdAKJShyZHodEIZTHJHzaP21A_ZU4aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
+    qb64 = 'EOhIBudxqPL1KP3PmJidkTHXtkneortJX4ygMcoC3p57aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
     assert blinder.qb64 == qb64
 
-    eqb64 = '-bAvEJAeKLEtVtMtt28IdAKJShyZHodEIZTHJHzaP21A_ZU4aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
+    eqb64 = '-bAvEOhIBudxqPL1KP3PmJidkTHXtkneortJX4ygMcoC3p57aKNPEY4_60x6vUx2g5_5kAoJTn0RDspR04Ql8ecNyTkOEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv0MissuedMAABEJOnAKXGaSyJ_43kit0V806NNeGWS07lfjybB1UcfWsv'
     assert Blinder.enclose([blinder]).decode() == eqb64
 
     stamp = '2020-08-02T12:00:20.000000+00:00'
-    said = 'EGu4B78s6G_GVrzaoBw2a1vkFpB5tVo-wZ1OGsC9D_pK'
+    said = 'EMVBaTa_rjBo6bbJ6eFppI-xnnC8nCuS174-RSc1CxLh'
 
     serder = blindate(regid=regid, prior=prior, blid=blid, stamp=stamp, sn=sn)
     assert serder.said == said
@@ -845,12 +844,12 @@ def test_blindable_state_tel_examples_JSON():
     {
         "v": "ACDCCAACAAJSONAAEi.",
         "t": "bup",
-        "d": "EGu4B78s6G_GVrzaoBw2a1vkFpB5tVo-wZ1OGsC9D_pK",
+        "d": "EMVBaTa_rjBo6bbJ6eFppI-xnnC8nCuS174-RSc1CxLh",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
         "n": "2",
         "p": "EOBVdcIL2rVEzBDpQvmBpsp3R52DsoKhTAAdvHqAz9yc",
         "dt": "2020-08-02T12:00:20.000000+00:00",
-        "b": "EJAeKLEtVtMtt28IdAKJShyZHodEIZTHJHzaP21A_ZU4"
+        "b": "EOhIBudxqPL1KP3PmJidkTHXtkneortJX4ygMcoC3p57"
     }
 
     state = 'revoked'
@@ -858,7 +857,7 @@ def test_blindable_state_tel_examples_JSON():
     bsn = 8
     bd = "EDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk"
 
-    blid = 'EIBNZ3t5rA_-PbBNmhtvtf0VgHBjVrE0fc-DO67f-wGv'
+    blid = 'EMCLq-2IOahj__yMPEDZ5Fu7Uyvft66GYD4WYuMW8ztG'
     uuid = 'aFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVD'
 
     blinder = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn,
@@ -870,18 +869,18 @@ def test_blindable_state_tel_examples_JSON():
     assert blinder.bsn == bsn
     assert blinder.bd == bd
 
-    dummied = '############################################aFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4MYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
+    dummied = '############################################aFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtvYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
     assert len(dummied) == 188
 
-    qb64 = 'EIBNZ3t5rA_-PbBNmhtvtf0VgHBjVrE0fc-DO67f-wGvaFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4MYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
+    qb64 = 'EMCLq-2IOahj__yMPEDZ5Fu7Uyvft66GYD4WYuMW8ztGaFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtvYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
     assert blinder.qb64 == qb64
 
-    eqb64 = '-bAvEIBNZ3t5rA_-PbBNmhtvtf0VgHBjVrE0fc-DO67f-wGvaFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4MYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
+    eqb64 = '-bAvEMCLq-2IOahj__yMPEDZ5Fu7Uyvft66GYD4WYuMW8ztGaFudXE-d0b2owzZNBjd78sx4kCTJx-RTP_Zd19HRUcVDEP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtvYrevokedMAAIEDeCPBTHAt75Acgi9PfEciHFnc1r2DKAno3s9_QIYrXk'
     assert Blinder.enclose([blinder]).decode() == eqb64
 
     prior = serder.said
     stamp = '2020-08-03T12:00:20.000000+00:00'
-    said = 'EDXGqM-V_sfj65Dk-lgMnpOZ9DYziqMaYkrju7NRKpFn'
+    said = 'EKks_zuYb8OU1pw7KeXn6w_13kavTbPCE9eXq1KYIHcI'
 
     serder = blindate(regid=regid, prior=prior, blid=blid, stamp=stamp, sn=sn)
     assert serder.said == said
@@ -898,12 +897,12 @@ def test_blindable_state_tel_examples_JSON():
     {
         "v": "ACDCCAACAAJSONAAEi.",
         "t": "bup",
-        "d": "EDXGqM-V_sfj65Dk-lgMnpOZ9DYziqMaYkrju7NRKpFn",
+        "d": "EKks_zuYb8OU1pw7KeXn6w_13kavTbPCE9eXq1KYIHcI",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
         "n": "3",
-        "p": "EGu4B78s6G_GVrzaoBw2a1vkFpB5tVo-wZ1OGsC9D_pK",
+        "p": "EMVBaTa_rjBo6bbJ6eFppI-xnnC8nCuS174-RSc1CxLh",
         "dt": "2020-08-03T12:00:20.000000+00:00",
-        "b": "EIBNZ3t5rA_-PbBNmhtvtf0VgHBjVrE0fc-DO67f-wGv"
+        "b": "EMCLq-2IOahj__yMPEDZ5Fu7Uyvft66GYD4WYuMW8ztG"
     }
 
 
@@ -926,23 +925,23 @@ def test_blindable_state_tel_examples_JSON():
     prior = serder.said
 
     regid = regDeb
-    acdc = 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5'  # deb research report
+    acdc = 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt'  # deb research report
     stamp = '2020-08-03T12:00:20.000000+00:00'
     state = 'issued'
     sn = 1
-    said = 'EJFxtbr9WioIkzTfVX4iC6Axxyg8jjKSX0ZrJgoNHiB-'
+    said = 'EH_7mAMBpQ21f3nHSy8B6yCD_jdMYiZ__Je1Hac-c-Kc'
     serder = update(regid=regid, prior=prior, acdc=acdc, state=state, stamp=stamp, sn=sn)
     assert serder.said == said
     assert serder.sad == \
     {
         "v": "ACDCCAACAAJSONAAEx.",
         "t": "upd",
-        "d": "EJFxtbr9WioIkzTfVX4iC6Axxyg8jjKSX0ZrJgoNHiB-",
+        "d": "EH_7mAMBpQ21f3nHSy8B6yCD_jdMYiZ__Je1Hac-c-Kc",
         "rd": "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU",
         "n": "1",
         "p": "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU",
         "dt": "2020-08-03T12:00:20.000000+00:00",
-        "td": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
+        "td": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
         "ts": "issued"
     }
     prior = serder.said
@@ -950,19 +949,19 @@ def test_blindable_state_tel_examples_JSON():
     stamp = '2020-08-04T12:00:20.000000+00:00'
     state = 'revoked'
     sn = 2
-    said = 'EJQ-ezS6h0Oa0BIN_w4KjstdapfOfrwmVluxn1DR5Gja'
+    said = 'ENwruIG38ayVNCQWRvQvmloSW4cK6k5eeHbI2cx23fz4'
     serder = update(regid=regid, prior=prior, acdc=acdc, state=state, stamp=stamp, sn=sn)
     assert serder.said == said
     assert serder.sad == \
     {
         "v": "ACDCCAACAAJSONAAEy.",
         "t": "upd",
-        "d": "EJQ-ezS6h0Oa0BIN_w4KjstdapfOfrwmVluxn1DR5Gja",
+        "d": "ENwruIG38ayVNCQWRvQvmloSW4cK6k5eeHbI2cx23fz4",
         "rd": "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU",
         "n": "2",
-        "p": "EJFxtbr9WioIkzTfVX4iC6Axxyg8jjKSX0ZrJgoNHiB-",
+        "p": "EH_7mAMBpQ21f3nHSy8B6yCD_jdMYiZ__Je1Hac-c-Kc",
         "dt": "2020-08-04T12:00:20.000000+00:00",
-        "td": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
+        "td": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
         "ts": "revoked"
     }
     prior = serder.said
@@ -2125,8 +2124,8 @@ def test_acdc_examples_JSON():
                   "d",
                   "u",
                   "i",
-                  "score",
-                  "name"
+                  "name",
+                  "level"
                 ],
                 "properties":
                 {
@@ -2183,13 +2182,8 @@ def test_acdc_examples_JSON():
     compactor = Compactor(mad=iAccrAttrMad, makify=True, compactify=True, kind=kind)
     assert compactor.said == accrAttrSaid
     assert compactor.mad ==accrAttrMad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): accrAttrSchema's 'required' lists
-    # 'score', but this accreditation instance carries 'level' instead (no 'score').
-    # The expanded form therefore does not validate against its own schema; this
-    # documents the gap (issue #1482 class) and will start failing -- prompting an
-    # update -- once the schema or the worked example is corrected.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(accrAttrMad, accrAttrSchema)
+    # accreditation attribute section validates against its own schema (#1520)
+    assert_schema_valid(accrAttrMad, accrAttrSchema)
 
     #accreditation acdc schema
     iAccredSMad = \
@@ -2246,10 +2240,10 @@ def test_acdc_examples_JSON():
         "additionalProperties": False
     }
 
-    accredSchemaSaid = 'EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG'
+    accredSchemaSaid = 'EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf'
     accredSchemaMad = \
     {
-        "$id": "EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG",
+        "$id": "EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Accreditation Schema",
         "description": "Accreditation JSON Schema for acm ACDC.",
@@ -2283,7 +2277,7 @@ def test_acdc_examples_JSON():
                     {
                         "description": "Attribute Section Detail",
                         "type": "object",
-                        "required": ["d", "u", "i", "score", "name"],
+                        "required": ["d", "u", "i", "name", "level"],
                         "properties":
                         {
                             "d": {"description": "Attribute Section SAID", "type": "string"},
@@ -2333,16 +2327,16 @@ def test_acdc_examples_JSON():
     assert mapper.said == accredSchemaSaid
     assert mapper.mad == accredSchemaMad
 
-    accredSaid = 'EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi'
+    accredSaid = 'EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4'
     accredSad = \
     {
         "v": "ACDCCAACAAJSONAAKX.",
         "t": "acm",
-        "d": "EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi",
+        "d": "EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdh",
         "i": "ECsGDKWAYtHBCkiDrzajkxs3Iw2g-dls3bLUsRP4yVdT",
         "rd": "EPtolmh_NE2vC02oFc7FOiWkPcEiKUPWm5uu_Gv1JZDw",
-        "s": "EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG",
+        "s": "EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf",
         "a":
         {
             "d": "EK799owRYyk8UPFWUmfsm5AJfJmU7jZGtZXJFbg2I0KL",
@@ -2362,21 +2356,18 @@ def test_acdc_examples_JSON():
                      attribute=accrAttrMad, iseaid=amy, rule=ruleMad)
     assert serder.said == accredSaid
     assert serder.sad == accredSad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): this full ACDC embeds the same
-    # accreditation attribute schema whose 'required' lists 'score', while the 'a'
-    # block carries 'level'. See the accrAttrSchema note above; self-alerting gap.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(accredSad, accredSchemaMad)
+    # full accreditation ACDC validates against its embedded schema (#1520)
+    assert_schema_valid(accredSad, accredSchemaMad)
 
     accredCSad = \
     {
         "v": "ACDCCAACAAJSONAAF3.",
         "t": "acm",
-        "d": "EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi",
+        "d": "EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdh",
         "i": "ECsGDKWAYtHBCkiDrzajkxs3Iw2g-dls3bLUsRP4yVdT",
         "rd": "EPtolmh_NE2vC02oFc7FOiWkPcEiKUPWm5uu_Gv1JZDw",
-        "s": "EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG",
+        "s": "EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf",
         "a": "EK799owRYyk8UPFWUmfsm5AJfJmU7jZGtZXJFbg2I0KL",
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
     }
@@ -2398,7 +2389,7 @@ def test_acdc_examples_JSON():
             {
                 "description": "Attribute Section Detail",
                 "type": "object",
-                "required": [ "d", "u", "i", "title", "author", "report"],
+                "required": [ "d", "u", "title", "author", "report"],
                 "properties":
                 {
                   "d": {"description": "Attribute Section SAID", "type": "string"},
@@ -2454,10 +2445,10 @@ def test_acdc_examples_JSON():
         "additionalProperties": False
     }
 
-    reportSchemaSaid = 'EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-'
+    reportSchemaSaid = 'EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg'
     reportSchemaMad = \
     {
-        "$id": "EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-",
+        "$id": "EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Report Schema",
         "description": "Report JSON Schema for acm ACDC.",
@@ -2491,7 +2482,7 @@ def test_acdc_examples_JSON():
                     {
                         "description": "Attribute Section Detail",
                         "type": "object",
-                        "required": [ "d", "u", "i", "title", "author", "report"],
+                        "required": [ "d", "u", "title", "author", "report"],
                         "properties":
                         {
                           "d": {"description": "Attribute Section SAID", "type": "string"},
@@ -2547,46 +2538,42 @@ def test_acdc_examples_JSON():
         "d": "",
         "u": uuids[8],
         "title": "Post Quantum Security",
-        "name": "Zoe Doe",
+        "author": "Zoe Doe",
         "report": "Imprementation should prioritize cryptographic agility over PQ.",
     }
 
-    rrptSaid = 'EFTqnoiGSf-D76W3geNxEudBI_wz81FIkIXjzsjFztI-'
+    rrptSaid = 'EPAZa0PO_Clywez4Qig0FtT40M6LI1H5Zn5lTG4u17FF'
     rrptMad = \
     {
-        'd': 'EFTqnoiGSf-D76W3geNxEudBI_wz81FIkIXjzsjFztI-',
+        'd': 'EPAZa0PO_Clywez4Qig0FtT40M6LI1H5Zn5lTG4u17FF',
         'u': '0ABhY2Rjc3BlY3dvcmtyYXc4',
         'title': 'Post Quantum Security',
-        'name': 'Zoe Doe',
+        'author': 'Zoe Doe',
         'report': 'Imprementation should prioritize cryptographic agility over PQ.'
     }
 
     compactor = Compactor(mad=iRrptMad, makify=True, compactify=True, kind=kind)
     assert compactor.said == rrptSaid
     assert compactor.mad == rrptMad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): reportAttrSchema's 'required' lists
-    # 'author' and 'i', but this report instance uses 'name' and omits 'i'. The
-    # expanded form does not validate; documented here (issue #1482 class) as a
-    # self-alerting gap that will fail once the schema or example is corrected.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(rrptMad, reportAttrSchema)
+    # research report attribute section validates against its own schema (#1520)
+    assert_schema_valid(rrptMad, reportAttrSchema)
 
-    rReportSaid = 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5'
+    rReportSaid = 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt'
     rReportSad = \
     {
-        "v": "ACDCCAACAAJSONAAK4.",
+        "v": "ACDCCAACAAJSONAAK6.",
         "t": "acm",
-        "d": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
+        "d": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdi",
         "i": "EEDGM_DvZ9qFEAPf_FX08J3HX49ycrVvYVXe9isaP5SW",
         "rd": "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU",
-        "s": "EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-",
+        "s": "EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg",
         "a":
         {
-            "d": "EFTqnoiGSf-D76W3geNxEudBI_wz81FIkIXjzsjFztI-",
+            "d": "EPAZa0PO_Clywez4Qig0FtT40M6LI1H5Zn5lTG4u17FF",
             "u": "0ABhY2Rjc3BlY3dvcmtyYXc4",
             "title": "Post Quantum Security",
-            "name": "Zoe Doe",
+            "author": "Zoe Doe",
             "report": "Imprementation should prioritize cryptographic agility over PQ."
         },
         "r":
@@ -2600,22 +2587,19 @@ def test_acdc_examples_JSON():
                      attribute=rrptMad, rule=ruleMad)
     assert serder.said == rReportSaid
     assert serder.sad == rReportSad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): full ACDC embedding the report
-    # attribute schema that requires 'author'/'i' while the 'a' block uses 'name'
-    # and omits 'i'. See the reportAttrSchema note above; self-alerting gap.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(rReportSad, reportSchemaMad)
+    # full research-report ACDC validates against its embedded schema (#1520)
+    assert_schema_valid(rReportSad, reportSchemaMad)
 
     rReportCSad = \
     {
         "v": "ACDCCAACAAJSONAAF3.",
         "t": "acm",
-        "d": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
+        "d": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdi",
         "i": "EEDGM_DvZ9qFEAPf_FX08J3HX49ycrVvYVXe9isaP5SW",
         "rd": "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU",
-        "s": "EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-",
-        "a": "EFTqnoiGSf-D76W3geNxEudBI_wz81FIkIXjzsjFztI-",
+        "s": "EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg",
+        "a": "EPAZa0PO_Clywez4Qig0FtT40M6LI1H5Zn5lTG4u17FF",
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
     }
 
@@ -2632,44 +2616,42 @@ def test_acdc_examples_JSON():
         "d": "",
         "u": uuids[9],
         "title": "PQ Proof of Concept",
-        "name": "Zoe Doe",
+        "author": "Zoe Doe",
         "report": "Demonstration of recovery from surprise quantum attack",
     }
 
-    prptSaid = 'EIg1zAS3FfMMbQtLqARSwS3uGMttVbAPhKB71bjIPTs_'
+    prptSaid = 'EGApJO-Sts4BhAfpG21HoqVhRJSDLts00bz0doDOrBSD'
     prptMad = \
     {
-        'd': 'EIg1zAS3FfMMbQtLqARSwS3uGMttVbAPhKB71bjIPTs_',
+        'd': 'EGApJO-Sts4BhAfpG21HoqVhRJSDLts00bz0doDOrBSD',
         'u': '0ABhY2Rjc3BlY3dvcmtyYXc5',
         'title': 'PQ Proof of Concept',
-        'name': 'Zoe Doe',
+        'author': 'Zoe Doe',
         'report': 'Demonstration of recovery from surprise quantum attack'
     }
 
     compactor = Compactor(mad=iPrptMad, makify=True, compactify=True, kind=kind)
     assert compactor.said == prptSaid
     assert compactor.mad == prptMad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): same reportAttrSchema 'author'/'i'
-    # vs 'name'/no-'i' mismatch as the research report above; self-alerting gap.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(prptMad, reportAttrSchema)
+    # project report attribute section validates against its own schema (#1520)
+    assert_schema_valid(prptMad, reportAttrSchema)
 
-    pReportSaid = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'
+    pReportSaid = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'
     pReportSad = \
     {
-        "v": "ACDCCAACAAJSONAAKt.",
+        "v": "ACDCCAACAAJSONAAKv.",
         "t": "acm",
-        "d": "EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M",
+        "d": "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdj",
         "i": "ECWJZFBtllh99fESUOrBvT3EtBujWtDKCmyzDAXWhYmf",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
-        "s": "EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-",
+        "s": "EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg",
         "a":
         {
-            "d": "EIg1zAS3FfMMbQtLqARSwS3uGMttVbAPhKB71bjIPTs_",
+            "d": "EGApJO-Sts4BhAfpG21HoqVhRJSDLts00bz0doDOrBSD",
             "u": "0ABhY2Rjc3BlY3dvcmtyYXc5",
             "title": "PQ Proof of Concept",
-            "name": "Zoe Doe",
+            "author": "Zoe Doe",
             "report": "Demonstration of recovery from surprise quantum attack"
         },
         "r":
@@ -2683,21 +2665,19 @@ def test_acdc_examples_JSON():
                      attribute=prptMad, rule=ruleMad)
     assert serder.said == pReportSaid
     assert serder.sad == pReportSad
-    # KNOWN SPEC DISCREPANCY (deferred to KSWG): full ACDC embedding the report
-    # attribute schema ('author'/'i' vs 'name'/no-'i'), same as above; self-alerting.
-    with pytest.raises(ValidationError):
-        assert_schema_valid(pReportSad, reportSchemaMad)
+    # full project-report ACDC validates against its embedded schema (#1520)
+    assert_schema_valid(pReportSad, reportSchemaMad)
 
     pReportCSad = \
     {
         "v": "ACDCCAACAAJSONAAF3.",
         "t": "acm",
-        "d": "EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M",
+        "d": "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdj",
         "i": "ECWJZFBtllh99fESUOrBvT3EtBujWtDKCmyzDAXWhYmf",
         "rd": "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ",
-        "s": "EKMXqyMQmOy0RuEj1VgOK9aD4GYR0D8Dcj0kssQtcY4-",
-        "a": "EIg1zAS3FfMMbQtLqARSwS3uGMttVbAPhKB71bjIPTs_",
+        "s": "EOumGkAf8Y28g9xBWmVJAisgkolBPaJ64nPlf8McWgvg",
+        "a": "EGApJO-Sts4BhAfpG21HoqVhRJSDLts00bz0doDOrBSD",
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
     }
 
@@ -2954,42 +2934,42 @@ def test_acdc_examples_JSON():
         }
     }
 
-    mainEdgeSaid = 'ECpmTyIIc1duvCeIceK19Sbd0uymklmwNTtwtmfjQnX0'
+    mainEdgeSaid = 'EKlVDgiwF_LvLcc2OojJNkT4i1k8GgO1ILQk2raIoUzr'
     mainEdgeCMad = \
     {
-        'd': 'ECpmTyIIc1duvCeIceK19Sbd0uymklmwNTtwtmfjQnX0',
+        'd': 'EKlVDgiwF_LvLcc2OojJNkT4i1k8GgO1ILQk2raIoUzr',
         'u': '0ABhY2Rjc3BlY3dvcmtyYXcy',
-        'accreditation': 'EAFj8JaNEC3mdFNJKrXW8E03_k9qqb_xM9NjAPVHw-xJ',
-        'reports': 'EOObmbCppe1S-7vtLuy766_4-RcfrC7p4ciFtBxdexuz'
+        'accreditation': 'EAdyOKjFvjDtZoh5CpuR2bQ9MZnLnjOENo4j4o4PVX-f',
+        'reports': 'EG56Nuf62I9r_K01jDudg7eIk96GUGr4Y3IfPlyVK0Lp'
     }
     mainEdgeMad = \
     {
-        'd': 'ECpmTyIIc1duvCeIceK19Sbd0uymklmwNTtwtmfjQnX0',
+        'd': 'EKlVDgiwF_LvLcc2OojJNkT4i1k8GgO1ILQk2raIoUzr',
         'u': '0ABhY2Rjc3BlY3dvcmtyYXcy',
         'accreditation':
         {
-            'd': 'EAFj8JaNEC3mdFNJKrXW8E03_k9qqb_xM9NjAPVHw-xJ',
+            'd': 'EAdyOKjFvjDtZoh5CpuR2bQ9MZnLnjOENo4j4o4PVX-f',
             'u': '0ABhY2Rjc3BlY3dvcmtyYXcz',
-            'n': 'EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi',
-            's': 'EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG'
+            'n': 'EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4',
+            's': 'EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf'
         },
         'reports':
         {
-            'd': 'EOObmbCppe1S-7vtLuy766_4-RcfrC7p4ciFtBxdexuz',
+            'd': 'EG56Nuf62I9r_K01jDudg7eIk96GUGr4Y3IfPlyVK0Lp',
             'u': '0ABhY2Rjc3BlY3dvcmtyYXc0',
             'o': 'OR',
             'research':
             {
-                'd': 'EN9ngstOcFHqsjqf75JZFKtCRmW76NkeRrUSxTLoqqkI',
+                'd': 'EHuAavMyMU7mTHqYpd5ZaATCaCuDVPQCswzXAdQYTIim',
                 'u': '0ABhY2Rjc3BlY3dvcmtyYXc2',
-                'n': 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5',
+                'n': 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt',
                 'o': 'NI2I'
             },
             'project':
             {
-                'd': 'EFwHz5qJ4_8c7IefP7_zugX2eIgtoyY8Up_WZ3osXwkI',
+                'd': 'EC6N1yUc_3Nqt3xyJHg_GMxYpWSusijz9JqsNuW2Ay3P',
                 'u': '0ABhY2Rjc3BlY3dvcmtyYXc1',
-                'n': 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M',
+                'n': 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv',
                 'o': 'NI2I'
             }
         }
@@ -3248,11 +3228,11 @@ def test_acdc_examples_JSON():
     assert mapper.said == mainSchemaSaid
     assert mapper.mad == mainSchemaMad
 
-    mainSaid = 'EFSzw0J4Qq15NafhAezvFHII-5TmDHbNzmIpT17-cHOa'
+    mainSaid = 'EAHU2Aby51UiUtAxthONvCXnYMwle2JxoOg9VUDWeYRq'
     mainSad = \
     {
         "v": "ACDCCAACAAJSONAAXG.",
-        "d": "EFSzw0J4Qq15NafhAezvFHII-5TmDHbNzmIpT17-cHOa",
+        "d": "EAHU2Aby51UiUtAxthONvCXnYMwle2JxoOg9VUDWeYRq",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdk",
         "i": "ECmiMVHTfZIjhA_rovnfx73T3G_FJzIQtzDn1meBVLAz",
         "rd": "EOMMCyztOvg970W0dZVJT2JIwlQ22DSeY7wtxNBBtpmX",
@@ -3275,32 +3255,32 @@ def test_acdc_examples_JSON():
         },
         "e":
         {
-            "d": "ECpmTyIIc1duvCeIceK19Sbd0uymklmwNTtwtmfjQnX0",
+            "d": "EKlVDgiwF_LvLcc2OojJNkT4i1k8GgO1ILQk2raIoUzr",
             "u": "0ABhY2Rjc3BlY3dvcmtyYXcy",
             "accreditation":
             {
-                "d": "EAFj8JaNEC3mdFNJKrXW8E03_k9qqb_xM9NjAPVHw-xJ",
+                "d": "EAdyOKjFvjDtZoh5CpuR2bQ9MZnLnjOENo4j4o4PVX-f",
                 "u": "0ABhY2Rjc3BlY3dvcmtyYXcz",
-                "n": "EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi",
-                "s": "EK_iGlfdc7Q-qIGL-kqbDSD2z4fesT4dAQLEHGgH4lLG"
+                "n": "EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4",
+                "s": "EOlgQaGgXI6Zqikg4I0KWaQeL9sRUGu7PUj78GekKnSf"
             },
             "reports":
             {
-                "d": "EOObmbCppe1S-7vtLuy766_4-RcfrC7p4ciFtBxdexuz",
+                "d": "EG56Nuf62I9r_K01jDudg7eIk96GUGr4Y3IfPlyVK0Lp",
                 "u": "0ABhY2Rjc3BlY3dvcmtyYXc0",
                 "o": "OR",
                 "research":
                 {
-                    "d": "EN9ngstOcFHqsjqf75JZFKtCRmW76NkeRrUSxTLoqqkI",
+                    "d": "EHuAavMyMU7mTHqYpd5ZaATCaCuDVPQCswzXAdQYTIim",
                     "u": "0ABhY2Rjc3BlY3dvcmtyYXc2",
-                    "n": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
+                    "n": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
                     "o": "NI2I"
                 },
                 "project":
                 {
-                    "d": "EFwHz5qJ4_8c7IefP7_zugX2eIgtoyY8Up_WZ3osXwkI",
+                    "d": "EC6N1yUc_3Nqt3xyJHg_GMxYpWSusijz9JqsNuW2Ay3P",
                     "u": "0ABhY2Rjc3BlY3dvcmtyYXc1",
-                    "n": "EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M",
+                    "n": "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv",
                     "o": "NI2I"
                 }
             }
@@ -3321,13 +3301,13 @@ def test_acdc_examples_JSON():
     mainCSad = \
     {
         "v": "ACDCCAACAAJSONAAGg.",
-        "d": "EFSzw0J4Qq15NafhAezvFHII-5TmDHbNzmIpT17-cHOa",
+        "d": "EAHU2Aby51UiUtAxthONvCXnYMwle2JxoOg9VUDWeYRq",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdk",
         "i": "ECmiMVHTfZIjhA_rovnfx73T3G_FJzIQtzDn1meBVLAz",
         "rd": "EOMMCyztOvg970W0dZVJT2JIwlQ22DSeY7wtxNBBtpmX",
         "s": "EMm9Gn9Qq9gkRQduJx9Vjtj3b3l1cVpe4Sv18EdAVRtb",
         "a": "ELI2TuO6mLF0cR_0iU57EjYK4dExHIHdHxlRcAdO6x-U",
-        "e": "ECpmTyIIc1duvCeIceK19Sbd0uymklmwNTtwtmfjQnX0",
+        "e": "EKlVDgiwF_LvLcc2OojJNkT4i1k8GgO1ILQk2raIoUzr",
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
     }
 
@@ -3564,17 +3544,17 @@ def test_acdc_examples_JSON():
         }
     }
 
-    simpleEdgeSaid = 'EEWx-E6Rexj3eORT-e2kLcAWVgviTqxwWvxS2LbNKuCh'
+    simpleEdgeSaid = 'ELhvGYtKnX58nUjvXRpAdgez7ukDVgHiNvbILvk39awY'
     simpleEdgeCMad = \
     {
-        'd': 'EEWx-E6Rexj3eORT-e2kLcAWVgviTqxwWvxS2LbNKuCh',
+        'd': 'ELhvGYtKnX58nUjvXRpAdgez7ukDVgHiNvbILvk39awY',
         'u': '0ABhY2Rjc3BlY3dvcmtyYXcy',
-        'accreditation': 'EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi',
+        'accreditation': 'EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4',
         'reports':
         {
             'o': 'OR',
-            'research': 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5',
-            'project': 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'
+            'research': 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt',
+            'project': 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'
         }
     }
 
@@ -3584,11 +3564,11 @@ def test_acdc_examples_JSON():
     assert_schema_valid(simpleEdgeCMad, simpleEdgeSchema)  # compact form
 
 
-    simpleMainSaid = 'EMR8CTHmJEwF2EF5Ylgyk6soUEXvGEB5KgJumJ86-nUX'
+    simpleMainSaid = 'EEpeIvCdedpcSm_X5YqP8QMp7WSdXu7uL2HUGBziH5UH'
     simpleMainSad = \
     {
         "v": "ACDCCAACAAJSONAAOD.",
-        "d": "EMR8CTHmJEwF2EF5Ylgyk6soUEXvGEB5KgJumJ86-nUX",
+        "d": "EEpeIvCdedpcSm_X5YqP8QMp7WSdXu7uL2HUGBziH5UH",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdl",
         "i": "ECmiMVHTfZIjhA_rovnfx73T3G_FJzIQtzDn1meBVLAz",
         "rd": "EOMMCyztOvg970W0dZVJT2JIwlQ22DSeY7wtxNBBtpmX",
@@ -3611,14 +3591,14 @@ def test_acdc_examples_JSON():
         },
         "e":
         {
-            "d": "EEWx-E6Rexj3eORT-e2kLcAWVgviTqxwWvxS2LbNKuCh",
+            "d": "ELhvGYtKnX58nUjvXRpAdgez7ukDVgHiNvbILvk39awY",
             "u": "0ABhY2Rjc3BlY3dvcmtyYXcy",
-            "accreditation": "EIF7egPvC8ITbGRdM9G0kd6aPELDg-azMkAqT-7cMuAi",
+            "accreditation": "EPXbQWnLaNJ5oSu5JAoZXU5a1c5sicbNWgepjls1flG4",
             "reports":
             {
                 "o": "OR",
-                "research": "EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5",
-                "project": "EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M"
+                "research": "ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt",
+                "project": "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv"
             }
         },
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
@@ -3634,13 +3614,13 @@ def test_acdc_examples_JSON():
     simpleMainCSad = \
     {
         "v": "ACDCCAACAAJSONAAGg.",
-        "d": "EMR8CTHmJEwF2EF5Ylgyk6soUEXvGEB5KgJumJ86-nUX",
+        "d": "EEpeIvCdedpcSm_X5YqP8QMp7WSdXu7uL2HUGBziH5UH",
         "u": "0ABhY2Rjc3BlY3dvcmtyYXdl",
         "i": "ECmiMVHTfZIjhA_rovnfx73T3G_FJzIQtzDn1meBVLAz",
         "rd": "EOMMCyztOvg970W0dZVJT2JIwlQ22DSeY7wtxNBBtpmX",
         "s": "EKq-KXY-8jd5OR9WEWjj6JRRRRrvtdzqBNkOh9Oj0afK",
         "a": "ELI2TuO6mLF0cR_0iU57EjYK4dExHIHdHxlRcAdO6x-U",
-        "e": "EEWx-E6Rexj3eORT-e2kLcAWVgviTqxwWvxS2LbNKuCh",
+        "e": "ELhvGYtKnX58nUjvXRpAdgez7ukDVgHiNvbILvk39awY",
         "r": "EMZf9m0XYwqo4L8tnIDMZuX7YCZnMswS7Ta9j0CuYfjU"
     }
 

--- a/tests/spec/acdc/test_acdc_examples.py
+++ b/tests/spec/acdc/test_acdc_examples.py
@@ -3,6 +3,8 @@
 tests.spec.acdc.test_acdc_examples module
 
 """
+import json
+import os
 from base64 import urlsafe_b64encode as encodeB64
 from base64 import urlsafe_b64decode as decodeB64
 
@@ -27,6 +29,30 @@ def assert_schema_valid(instance, schema):
     """
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(instance)
+
+
+def emit_worked_examples(examples):
+    """Emit the worked-example blocks as a JSON manifest for the spec generator.
+
+    keripy computes every worked-example SAID via makify, so these tests are the
+    single source of truth for the ACDC specification's "Working ACDC Examples".
+    When ``KERI_EMIT_WORKED_EXAMPLES`` names an output path, each test that builds
+    worked examples calls this to append its {name: mad} blocks, so the spec can be
+    regenerated (and a CI guard can diff the spec's blocks) instead of hand-copied.
+
+    ``examples`` is an ordered mapping of stable block name -> mad (dict). Blocks
+    accumulate across tests into one manifest keyed by name.
+    """
+    path = os.environ.get("KERI_EMIT_WORKED_EXAMPLES")
+    if not path:
+        return
+    manifest = {}
+    if os.path.exists(path):
+        with open(path) as f:
+            manifest = json.load(f)
+    manifest.update({name: mad for name, mad in examples.items()})
+    with open(path, "w") as f:
+        json.dump(manifest, f, indent=2)
 
 
 def test_acdc_examples_setup():
@@ -3630,6 +3656,25 @@ def test_acdc_examples_JSON():
     assert serder.said == simpleMainSaid
     assert serder.sad == simpleMainCSad
     assert_schema_valid(simpleMainCSad, simpleMainSchemaMad)  # compact form
+
+    # single source of truth for the spec's "Working ACDC Examples" (see
+    # emit_worked_examples); names are the stable ids the spec references.
+    emit_worked_examples({
+        "accreditationSchema": accredSchemaMad,
+        "accreditationExpanded": accredSad,
+        "accreditationCompact": accredCSad,
+        "reportSchema": reportSchemaMad,
+        "researchReportExpanded": rReportSad,
+        "researchReportCompact": rReportCSad,
+        "projectReportExpanded": pReportSad,
+        "projectReportCompact": pReportCSad,
+        "transcriptSchema": mainSchemaMad,
+        "transcriptExpanded": mainSad,
+        "transcriptCompact": mainCSad,
+        "simpleTranscriptSchema": simpleMainSchemaMad,
+        "simpleTranscriptExpanded": simpleMainSad,
+        "simpleTranscriptCompact": simpleMainCSad,
+    })
 
 
 def test_required_arrays_have_no_implicit_string_concatenation():

--- a/tests/spec/keri/test_keri_examples.py
+++ b/tests/spec/keri/test_keri_examples.py
@@ -38,15 +38,15 @@ def test_keri_examples_json():
     # from ACDC examples
     bobaid = "ECWJZFBtllh99fESUOrBvT3EtBujWtDKCmyzDAXWhYmf"   # bob's AID
     bobreg = "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ"  # bob's acdc registry
-    bobacdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob's project report ACDC
-    bobbup = "EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW" # issued blindable update said
-    bobblid = "EOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_t"  # issued blid said
+    bobacdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob's project report ACDC
+    bobbup = "EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3" # issued blindable update said
+    bobblid = "EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8N"  # issued blid said
     bobbupsn = '2' # sn of issuing bup
 
     debaid = "EEDGM_DvZ9qFEAPf_FX08J3HX49ycrVvYVXe9isaP5SW"   # deb's AID
     debreg = "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU"  # deb's Registry
-    debacdc = 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5'  # deb's research report ACDC
-    debupd = "EJFxtbr9WioIkzTfVX4iC6Axxyg8jjKSX0ZrJgoNHiB-"  # deb's update said
+    debacdc = 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt'  # deb's research report ACDC
+    debupd = "EH_7mAMBpQ21f3nHSy8B6yCD_jdMYiZ__Je1Hac-c-Kc"  # deb's update said
     debupdsn = '1' # sn of issuing upd
 
 
@@ -1170,15 +1170,15 @@ def test_keri_examples_cesr():
     # from ACDC examples
     bobaid = "ECWJZFBtllh99fESUOrBvT3EtBujWtDKCmyzDAXWhYmf"   # bob's AID
     bobreg = "ECOWJI9kAjpCFYJ7RenpJx2w66-GsGlhyKLO-Or3qOIQ"  # bob's acdc registry
-    bobacdc = 'EMLjZLIMlfUOoKox_sDwQaJO-0wdoGW0uNbmI28Wwc4M'  # bob's project report ACDC
-    bobbup = "EBdytzDC4dnatn-6mrCWLSGuM62LM0BgS31YnAg5NTeW" # issued blindable update said
-    bobblid = "EOtWw6X_aoOJlkzNaLj23IC6MXHl7ZSYSWVulFW_Hr_t"  # issued blid said
+    bobacdc = 'EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv'  # bob's project report ACDC
+    bobbup = "EHdCoOs5P-xwHWjXuJOe8SWgTKVj_Vx_YbbDSYxJ6fK3" # issued blindable update said
+    bobblid = "EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8N"  # issued blid said
     bobbupsn = '2' # sn of issuing bup
 
     debaid = "EEDGM_DvZ9qFEAPf_FX08J3HX49ycrVvYVXe9isaP5SW"   # deb's AID
     debreg = "EJl5EUxL23p_pqgN3IyM-pzru89Nb7NzOM8ijH644xSU"  # deb's Registry
-    debacdc = 'EAU5dUws4ffM9jZjWs0QfXTnhJ1qk2u3IUhBwFVbFnt5'  # deb's research report ACDC
-    debupd = "EJFxtbr9WioIkzTfVX4iC6Axxyg8jjKSX0ZrJgoNHiB-"  # deb's update said
+    debacdc = 'ELCZRc2VlaDv0mdooNQ_Y_MGiaBS0YQ2OaSpV97Y-wrt'  # deb's research report ACDC
+    debupd = "EH_7mAMBpQ21f3nHSy8B6yCD_jdMYiZ__Je1Hac-c-Kc"  # deb's update said
     debupdsn = '1' # sn of issuing upd
 
 

--- a/tools/check_spec_examples.py
+++ b/tools/check_spec_examples.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+check_spec_examples.py -- ACDC worked-examples drift guard.
+
+keripy's tests are the single source of truth for the ACDC specification's
+"Working ACDC Examples". The test suite emits a JSON manifest of every canonical
+worked-example block (see tests/spec/acdc/test_acdc_examples.py and the
+KERI_EMIT_WORKED_EXAMPLES env var). This checker compares that manifest against
+the JSON blocks embedded in the spec's spec-body.md and fails if they diverge.
+
+In spec-body.md each governed block is tagged with an HTML comment marker on the
+line(s) immediately before its fenced JSON code block, e.g.:
+
+    <!-- example: accreditationCompact -->
+    ```json
+    { ... }
+    ```
+
+Comparison is VALUE-EQUAL (parsed dict/list equality), so formatting, key order,
+and whitespace do not matter -- only the actual data.
+
+Usage:
+    check_spec_examples.py --manifest <manifest.json> --spec <spec-body.md>
+
+Exit code 0 and prints "OK: N blocks in sync" when everything matches.
+Exit code 1 (with a report) on any mismatch, or any block present on one side
+but missing on the other.
+
+Dependency-light: standard library only (json, re, argparse, sys).
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+
+
+# Matches:  <!-- example: NAME -->  (whitespace-tolerant), then, skipping any
+# blank lines, an opening ```json OR ```python fence, the body, and a closing
+# ``` fence. The spec embeds schema/instance blocks two ways: json fences
+# (canonical JSON) and python fences (Python-dict repr: single quotes, True /
+# False / None). Both are governed and parsed to a value for comparison.
+_BLOCK_RE = re.compile(
+    r"<!--\s*example:\s*(?P<name>[^\s>-][^>]*?)\s*-->"  # marker w/ block name
+    r"\s*"                                              # blank lines / ws
+    r"```[ \t]*(?P<lang>json|python)[ \t]*\r?\n"        # opening fence + lang
+    r"(?P<body>.*?)"                                    # block body (lazy)
+    r"\r?\n[ \t]*```",                                  # closing fence
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _load_block_body(lang, body):
+    """Parse a fenced block body into a Python value.
+
+    ``json`` fences are parsed with ``json.loads``; ``python`` fences (a Python
+    literal such as a dict repr with single quotes and True/False/None) are
+    parsed with ``ast.literal_eval``, which evaluates literals ONLY and runs no
+    code. Both yield native Python values, so a python-repr block and its JSON
+    counterpart compare value-equal (Python ``False`` == JSON ``false``, etc.).
+
+    Raises ``ValueError`` with a human-readable message on failure.
+    """
+    if lang.lower() == "json":
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as ex:
+            raise ValueError(f"spec JSON block does not parse: {ex}") from ex
+    # python fence -> ast literal parse (safe: literals only, no execution)
+    try:
+        return ast.literal_eval(body)
+    except (ValueError, SyntaxError) as ex:
+        raise ValueError(f"spec python block does not parse: {ex}") from ex
+
+
+def parse_spec_blocks(text):
+    """Return (blocks, errors).
+
+    blocks: dict name -> parsed value for every tagged json/python fence.
+    errors: list of human-readable strings for markers whose body failed to
+            parse or whose block name was duplicated.
+    """
+    blocks = {}
+    errors = []
+    for m in _BLOCK_RE.finditer(text):
+        name = m.group("name").strip()
+        lang = m.group("lang")
+        body = m.group("body")
+        try:
+            value = _load_block_body(lang, body)
+        except ValueError as ex:
+            errors.append(f"{name}: {ex}")
+            continue
+        if name in blocks:
+            errors.append(f"{name}: duplicate <!-- example: {name} --> marker "
+                          f"in spec")
+            continue
+        blocks[name] = value
+    return blocks, errors
+
+
+def _diff_paths(expected, actual, path=""):
+    """Yield concise 'path: detail' strings describing where two JSON values
+    differ. `expected` is the manifest (canonical); `actual` is the spec."""
+    if type(expected) is not type(actual) and not (
+        isinstance(expected, (int, float)) and isinstance(actual, (int, float))
+    ):
+        yield (f"{path or '(root)'}: type differs "
+               f"(manifest={type(expected).__name__}, "
+               f"spec={type(actual).__name__})")
+        return
+
+    if isinstance(expected, dict):
+        e_keys, a_keys = set(expected), set(actual)
+        for k in sorted(e_keys - a_keys):
+            yield f"{path}.{k}".lstrip(".") + ": missing in spec"
+        for k in sorted(a_keys - e_keys):
+            yield f"{path}.{k}".lstrip(".") + ": unexpected in spec"
+        for k in sorted(e_keys & a_keys):
+            child = f"{path}.{k}".lstrip(".")
+            yield from _diff_paths(expected[k], actual[k], child)
+        return
+
+    if isinstance(expected, list):
+        if len(expected) != len(actual):
+            yield (f"{path or '(root)'}: list length differs "
+                   f"(manifest={len(expected)}, spec={len(actual)})")
+        for i in range(min(len(expected), len(actual))):
+            yield from _diff_paths(expected[i], actual[i], f"{path}[{i}]")
+        return
+
+    if expected != actual:
+        yield (f"{path or '(root)'}: value differs "
+               f"(manifest={expected!r}, spec={actual!r})")
+
+
+def compare(manifest, spec_blocks):
+    """Return (ok, report_lines)."""
+    report = []
+    manifest_names = set(manifest)
+    spec_names = set(spec_blocks)
+
+    missing_in_spec = sorted(manifest_names - spec_names)
+    extra_in_spec = sorted(spec_names - manifest_names)
+
+    for name in missing_in_spec:
+        report.append(f"MISSING IN SPEC: manifest block '{name}' has no "
+                      f"<!-- example: {name} --> marker in spec-body.md")
+    for name in extra_in_spec:
+        report.append(f"EXTRA IN SPEC: spec block '{name}' has no matching "
+                      f"block in the keripy manifest")
+
+    mismatches = 0
+    for name in sorted(manifest_names & spec_names):
+        diffs = list(_diff_paths(manifest[name], spec_blocks[name]))
+        if diffs:
+            mismatches += 1
+            report.append(f"MISMATCH: '{name}' differs "
+                          f"({len(diffs)} path(s)):")
+            for d in diffs[:40]:
+                report.append(f"    - {d}")
+            if len(diffs) > 40:
+                report.append(f"    ... and {len(diffs) - 40} more")
+
+    ok = not (missing_in_spec or extra_in_spec or mismatches)
+    return ok, report
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Fail if the ACDC spec's worked-example JSON blocks drift "
+                    "from keripy's canonical emitted manifest.")
+    ap.add_argument("--manifest", required=True,
+                    help="Path to keripy's emitted worked-examples manifest "
+                         "(JSON: {blockName: acdcDict}).")
+    ap.add_argument("--spec", required=True,
+                    help="Path to the spec's spec-body.md.")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.manifest, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as ex:
+        print(f"ERROR: cannot read manifest {args.manifest!r}: {ex}",
+              file=sys.stderr)
+        return 2
+    if not isinstance(manifest, dict):
+        print(f"ERROR: manifest {args.manifest!r} is not a JSON object of "
+              f"{{blockName: acdcDict}}", file=sys.stderr)
+        return 2
+
+    try:
+        with open(args.spec, encoding="utf-8") as f:
+            spec_text = f.read()
+    except OSError as ex:
+        print(f"ERROR: cannot read spec {args.spec!r}: {ex}", file=sys.stderr)
+        return 2
+
+    spec_blocks, parse_errors = parse_spec_blocks(spec_text)
+
+    ok, report = compare(manifest, spec_blocks)
+
+    if parse_errors:
+        ok = False
+        report = [f"PARSE ERROR: {e}" for e in parse_errors] + report
+
+    if ok:
+        print(f"OK: {len(manifest)} blocks in sync")
+        return 0
+
+    print("SPEC EXAMPLES DRIFT DETECTED")
+    print("=" * 60)
+    for line in report:
+        print(line)
+    print("=" * 60)
+    print("The ACDC spec's worked-example blocks disagree with keripy's "
+          "canonical generated ones.")
+    print("keripy's tests are the source of truth; regenerate/sync the spec "
+          "blocks (or the manifest) so they match.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tag_spec_examples.py
+++ b/tools/tag_spec_examples.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""tag_spec_examples.py -- idempotent auto-tagger for the ACDC spec.
+
+Inserts `<!-- example: NAME -->` markers before every fenced code block in the
+spec's spec-body.md that parses (json OR python fence) to a dict value-equal to
+a block in keripy's emitted worked-examples manifest, and does not already
+carry a marker. Intended as a maintenance aid for check_spec_examples.py.
+
+Rules (safety):
+  * A fence is tagged only when its parsed value is value-equal to EXACTLY ONE
+    manifest block. Ambiguous matches (0 or >1) are skipped and reported.
+  * A fence already immediately preceded (skipping blank lines) by any
+    `<!-- example: ... -->` marker is left untouched -> idempotent, and the 4
+    already-tagged schema blocks are not retagged.
+  * Only dict-valued manifest blocks are used as tag targets.
+
+Usage:
+    tag_spec_examples.py --manifest <manifest.json> --spec <spec-body.md>
+                         [--dry-run]
+
+Prints the list of blocks it tagged (or would tag).
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+
+_OPEN_RE = re.compile(r"^[ \t]*```[ \t]*(json|python)[ \t]*$", re.IGNORECASE)
+_CLOSE_RE = re.compile(r"^[ \t]*```[ \t]*$")
+_MARKER_RE = re.compile(r"^\s*<!--\s*example:\s*[^>]*-->\s*$")
+
+
+def _parse_body(lang, body):
+    if lang.lower() == "json":
+        return json.loads(body)
+    return ast.literal_eval(body)  # literals only; no code execution
+
+
+def find_blocks(lines):
+    """Yield (open_idx, close_idx, lang, body_text) for each fenced block."""
+    i = 0
+    n = len(lines)
+    while i < n:
+        m = _OPEN_RE.match(lines[i])
+        if m:
+            lang = m.group(1)
+            j = i + 1
+            while j < n and not _CLOSE_RE.match(lines[j]):
+                j += 1
+            if j < n:  # found close
+                body = "\n".join(lines[i + 1:j])
+                yield (i, j, lang, body)
+                i = j + 1
+                continue
+        i += 1
+
+
+def already_tagged(lines, open_idx):
+    """True if the fence at open_idx already has an example marker above it
+    (skipping blank lines)."""
+    k = open_idx - 1
+    while k >= 0 and lines[k].strip() == "":
+        k -= 1
+    return k >= 0 and bool(_MARKER_RE.match(lines[k]))
+
+
+def tag(manifest, text):
+    """Return (new_text, tagged_names, warnings)."""
+    targets = [(name, val) for name, val in manifest.items()
+               if isinstance(val, dict)]
+    lines = text.split("\n")
+    blocks = list(find_blocks(lines))
+
+    inserts = []          # (open_idx, name)
+    tagged = []
+    warnings = []
+    used = set()
+
+    for open_idx, close_idx, lang, body in blocks:
+        try:
+            value = _parse_body(lang, body)
+        except (ValueError, SyntaxError, json.JSONDecodeError):
+            continue
+        if not isinstance(value, dict):
+            continue
+        matches = [name for name, val in targets if val == value]
+        if not matches:
+            continue
+        if len(matches) > 1:
+            warnings.append(f"line {open_idx + 1}: ambiguous -- value-equal to "
+                            f"multiple manifest blocks {matches}; skipped")
+            continue
+        name = matches[0]
+        if already_tagged(lines, open_idx):
+            continue
+        if name in used:
+            warnings.append(f"line {open_idx + 1}: manifest block '{name}' "
+                            f"already tagged on an earlier fence; skipped")
+            continue
+        used.add(name)
+        inserts.append((open_idx, name))
+        tagged.append(name)
+
+    # Apply insertions bottom-up so indices stay valid.
+    for open_idx, name in sorted(inserts, reverse=True):
+        lines.insert(open_idx, f"<!-- example: {name} -->")
+
+    return "\n".join(lines), tagged, warnings
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--spec", required=True)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be tagged; do not write.")
+    args = ap.parse_args(argv)
+
+    with open(args.manifest, encoding="utf-8") as f:
+        manifest = json.load(f)
+    with open(args.spec, encoding="utf-8") as f:
+        text = f.read()
+
+    new_text, tagged, warnings = tag(manifest, text)
+
+    for w in warnings:
+        print(f"WARN: {w}", file=sys.stderr)
+
+    if not tagged:
+        print("No untagged value-equal blocks found (nothing to do).")
+        return 0
+
+    print(f"{'Would tag' if args.dry_run else 'Tagged'} {len(tagged)} block(s):")
+    for name in tagged:
+        print(f"  + {name}")
+
+    if not args.dry_run:
+        with open(args.spec, "w", encoding="utf-8") as f:
+            f.write(new_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_spec_examples.py
+++ b/tools/test_check_spec_examples.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_spec_examples.py.
+
+Covers both fence kinds the spec uses: ```json (JSON) and ```python (a Python
+dict repr), each in a good (value-equal to manifest) and a bad (drifted) case.
+"""
+
+import importlib.util
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_spec_examples", os.path.join(_HERE, "check_spec_examples.py"))
+csx = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(csx)
+
+
+# Canonical manifest block: JSON semantics (false / null / 3).
+MANIFEST = {
+    "widget": {"d": "abc", "flag": False, "n": 3, "opt": None, "list": [1, 2]},
+}
+
+
+def _spec_text(marker_name, lang, body):
+    return f"prose\n\n<!-- example: {marker_name} -->\n```{lang}\n{body}\n```\n"
+
+
+# ---- json fence -------------------------------------------------------------
+
+def test_json_fence_good():
+    body = '{"d": "abc", "flag": false, "n": 3, "opt": null, "list": [1, 2]}'
+    blocks, errors = csx.parse_spec_blocks(_spec_text("widget", "json", body))
+    assert not errors
+    ok, report = csx.compare(MANIFEST, blocks)
+    assert ok, report
+
+
+def test_json_fence_bad():
+    body = '{"d": "abc", "flag": true, "n": 3, "opt": null, "list": [1, 2]}'
+    blocks, errors = csx.parse_spec_blocks(_spec_text("widget", "json", body))
+    assert not errors
+    ok, report = csx.compare(MANIFEST, blocks)
+    assert not ok
+    assert any("flag" in line for line in report)
+
+
+# ---- python fence -----------------------------------------------------------
+
+def test_python_fence_good():
+    # Python-dict repr: single quotes, True/False/None. Value-equal to MANIFEST.
+    body = "{'d': 'abc', 'flag': False, 'n': 3, 'opt': None, 'list': [1, 2]}"
+    blocks, errors = csx.parse_spec_blocks(_spec_text("widget", "python", body))
+    assert not errors
+    ok, report = csx.compare(MANIFEST, blocks)
+    assert ok, report
+
+
+def test_python_fence_bad():
+    body = "{'d': 'abc', 'flag': True, 'n': 3, 'opt': None, 'list': [1, 2]}"
+    blocks, errors = csx.parse_spec_blocks(_spec_text("widget", "python", body))
+    assert not errors
+    ok, report = csx.compare(MANIFEST, blocks)
+    assert not ok
+    assert any("flag" in line for line in report)
+
+
+def test_python_fence_unparseable_reports_error():
+    body = "{'d': 'abc', this-is-not-a-literal}"
+    blocks, errors = csx.parse_spec_blocks(_spec_text("widget", "python", body))
+    assert not blocks
+    assert errors and "python block does not parse" in errors[0]
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Fixes #1520

## Summary

Fixes the two worked-example schema/instance discrepancies in #1520, and adds infrastructure so the ACDC specification's "Working ACDC Examples" can never silently drift from this reference implementation again.

## The fix (#1520)

Two expanded worked examples in `tests/spec/acdc/test_acdc_examples.py` carried JSON Schemas whose `required` arrays disagreed with the instances they describe, so the expanded forms did not validate against their own schema:

- **Accreditation**: schema required `score` (a copy-paste leftover from the grades example) while the schema property and instance use `level` → `score` → `level`.
- **Report**: schema required `author` and `i` while the instances used `name` and omit `i` → drop `i` from `required`; rename the instance field `name` → `author` (the field the schema describes as "Author Full Name").

The self-alerting `pytest.raises(ValidationError)` known-gap guards are flipped to positive `assert_schema_valid()` checks, and the ~30 cascaded SAIDs (attribute → schema → ACDC → edges → downstream transcript → blindable TEL example) are regenerated. The report-ACDC SAID changes are propagated to the sibling worked examples in `tests/spec/keri/test_keri_examples.py` and `tests/core/test_parsing.py` so the corpus stays coherent. `tests/spec` and `tests/core` are green (254 passed).

## Preventing recurrence

- **Generator** (`emit_worked_examples`): keripy computes every worked-example SAID via makify, so these tests are the single source of truth. When `KERI_EMIT_WORKED_EXAMPLES` names a path, the worked test emits a JSON manifest of the canonical blocks.
- **Drift guard** (`.github/workflows/spec-examples-drift.yml` + `tools/check_spec_examples.py`): a CI job regenerates the manifest and compares it value-for-value against the spec's example blocks (tagged `<!-- example: NAME -->`), failing on divergence. Covers all 14 schema + ACDC-instance blocks (both `json` and `python` fences). node24-pinned actions; `paths:`-filtered so it only runs when the examples/checker/workflow change.

## Sibling spec PR

The ACDC spec (`trustoverip/kswg-acdc-specification`) carried the same two bugs, and its transcript example had already drifted to a stale transcript schema. Companion PR: **trustoverip/kswg-acdc-specification#198**. The two should land together; the drift guard passes once the spec PR merges (it is `paths:`-filtered and safe to keep non-required until then).

## Notes

- Registry `rip`/`bup` events are value-equal to keripy but each inception repeats across spec sections; guarding them needs many-to-one marker support (left as a follow-up).
- Raw-CESR blindable state blobs are out of scope for structured comparison (they are still corrected by the SAID re-sync in the spec PR).

---

🤖 Prepared with [Claude Code](https://claude.com/claude-code), directed and reviewed by the author.

