### PR TITLE
fix: stop witness start double-opening the reg LMDB env

### DIFF
--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -1204,9 +1204,7 @@ class QueryEnd:
 
     def __init__(self, hab, reger=None):
         self.hab = hab
-        # Reuse the witness's shared Reger rather than opening a SECOND LMDB env on the same
-        # reg path — two env handles for one path in a process raise LMDB's "already open in
-        # this process" and abort witness start (setupWitness now passes its reger in).
+        # Reuse the shared reger if given; opening a second env on the same reg path aborts witness start.
         self.reger = reger if reger is not None else viring.Reger(name=hab.name, db=hab.db, temp=False)
 
     def on_get(self, req, rep):

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -93,7 +93,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     app.add_route("/", httpEnd)
     receiptEnd = ReceiptEnd(hab=hab, inbound=cues, aids=aids)
     app.add_route("/receipts", receiptEnd)
-    queryEnd = QueryEnd(hab=hab)
+    queryEnd = QueryEnd(hab=hab, reger=reger)
     app.add_route("/query", queryEnd)
     metricsEnd = EscrowEnd(hby=hby, reger=reger)
     app.add_route("/metrics", metricsEnd)
@@ -1202,9 +1202,12 @@ class QueryEnd:
 
      """
 
-    def __init__(self, hab):
+    def __init__(self, hab, reger=None):
         self.hab = hab
-        self.reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
+        # Reuse the witness's shared Reger rather than opening a SECOND LMDB env on the same
+        # reg path — two env handles for one path in a process raise LMDB's "already open in
+        # this process" and abort witness start (setupWitness now passes its reger in).
+        self.reger = reger if reger is not None else viring.Reger(name=hab.name, db=hab.db, temp=False)
 
     def on_get(self, req, rep):
         """ Handles GET requests to query KEL or TEL events of a pre from a witness.

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -416,11 +416,7 @@ class LMDBer(filing.Filer):
         if readonly is not None:
             self.readonly = readonly
 
-        # close self.env if already open so reopen() is idempotent: LMDB raises
-        # "The environment '<path>' is already open in this process" if the same
-        # path is opened twice in one process. The witness start path can reopen
-        # the reg env via its BaserDoer, so without this close-first the witness
-        # aborts at "Starting witness...".
+        # Close any open env first so reopen() is idempotent; LMDB forbids opening the same path twice in a process.
         if self.env:
             try:
                 self.env.close()

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -416,6 +416,18 @@ class LMDBer(filing.Filer):
         if readonly is not None:
             self.readonly = readonly
 
+        # close self.env if already open so reopen() is idempotent: LMDB raises
+        # "The environment '<path>' is already open in this process" if the same
+        # path is opened twice in one process. The witness start path can reopen
+        # the reg env via its BaserDoer, so without this close-first the witness
+        # aborts at "Starting witness...".
+        if self.env:
+            try:
+                self.env.close()
+            except:  # noqa: E722 - best-effort close before reopen
+                pass
+
+        self.env = None
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
         self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.MapSize,


### PR DESCRIPTION
## Problem

On the `v1.3.5` line, `kli witness start` aborts at **"Starting witness..."** with:

```
lmdb.Error: The environment '/home/witness/.keri/reg/witness' is already open in this process.
```

Two independent code paths open the **same** `reg` (credential registry) LMDB path in one process, which LMDB does not permit:

1. **`QueryEnd.__init__` opened its own `Reger(name=hab.name, …)`** on the same reg path as `setupWitness`'s shared `reger` — a second env handle for the same path.
2. **`LMDBer.reopen()` called `lmdb.open()` without first closing an already-open env**, so reopening the reg via its `BaserDoer` opened a second handle on the same path.

## Fix

1. Thread the shared reger into `QueryEnd` — `QueryEnd(hab, reger)` reuses it instead of opening a second env (`setupWitness` now passes `reger=reger`; the arg defaults to `None` so existing callers are unaffected).
2. Make `LMDBer.reopen()` idempotent — close `self.env` (best-effort) and null it before re-opening.

18 lines across two files; no behavior change for a healthy start beyond not double-opening.

## Validation

Built a witness image from the 1.3.5 line carrying this exact fix and ran it:

- **Before:** the container aborts at `Starting witness...` with the `lmdb.Error` above and never becomes ready.
- **After:** it boots cleanly — `Witness witness : BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9` — and `GET /oobi/<AID>/controller` returns **200**. Verified end-to-end through a black-box witness acceptance harness (identity, receipting, key events, pool, and key-state-query checks all pass).

Found while evaluating the keri 1.3 line as a deployable witness closure; this double-open was the only thing blocking it.