### PR TITLE
Fix small klass -> klas typo

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1165,7 +1165,7 @@ class Baser(dbing.LMDBer):
         # TODO: clean
         self.epath = subing.IoSetSuber(db=self, subkey=".epath")
 
-        self.essrs = subing.CesrIoSetSuber(db=self, subkey=".essrs", klass=coring.Texter)
+        self.essrs = subing.CesrIoSetSuber(db=self, subkey=".essrs", klas=coring.Texter)
 
         # accepted signed 12-word challenge response exn messages keys by prefix of signer
         # TODO: clean


### PR DESCRIPTION
Looks like there was an accidental 's' character included in the ESSR database when it was added.