### PR TITLE
test: guard essrs suber deserializes as Texter (regression for #1538 typo)

### DIFF
--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -63,6 +63,11 @@ def test_baser():
     assert isinstance(baser.pses, IoDupSuber)
     assert isinstance(baser.dels, OnIoDupSuber)
     assert isinstance(baser.ldes, OnIoDupSuber)
+    # essrs deserializes ESSR payloads as Texter. Guards against a `klass=`
+    # misspelling of the `klas=` kwarg silently falling back to coring.Matter
+    # (the v1.3.5 bug fixed in PR #1538).
+    assert isinstance(baser.essrs, CesrIoSetSuber)
+    assert baser.essrs.klas is Texter
 
     baser.close(clear=True)
     assert not os.path.exists(baser.path)


### PR DESCRIPTION
## What

Adds a regression test asserting that `Baser.essrs` deserializes ESSR
payloads as `coring.Texter`:

```python
assert isinstance(baser.essrs, CesrIoSetSuber)
assert baser.essrs.klas is Texter
```

## Why

While reviewing #1538 I traced why the `klass=` -> `klas=` typo it fixes
could sit undetected on the `v1.3.5` branch. `CesrSuberBase.__init__` takes
a keyword-only `klas=` argument; the misspelled `klass=` fell into `**kwa`
and was silently swallowed by `SuberBase.__init__`, so `klas` defaulted to
`coring.Matter`. ESSR values are written as `Texter` instances
(`exchanging.py`) and read back via `essrs.get(...)`, but the existing
round-trip test (`test_essrs`) only touches the returned object's `.raw`
property — which both `Matter` and `Texter` expose — so it never noticed
the class was wrong.

`main` already carries the correct `klas=coring.Texter`, so this test is a
standalone regression guard (green on `main` today). I verified it fails
with the expected `assert <class 'keri.core.coring.Matter'> is Texter`
against the pre-fix typo state, then passes once the fix is present.

Scope is one file, `tests/db/test_basing.py`; no product code changes.

---
Test authored with assistance from Claude Code (analysis + drafting);
reviewed and verified by me.
