### PR TITLE
regbaser and webregbaser db scaffold

### DIFF
--- a/src/keri/acdc/regbasing.py
+++ b/src/keri/acdc/regbasing.py
@@ -47,7 +47,7 @@ class RegBaser(LMDBer):
 
         .heads is named subDB instance of CesrSuber (klas=Saider) for the
             current accepted registry heads.
-            subkey 'heads.'
+            subkey 'heds.'
             Key: registry SAID.
             Value: SAID of the latest accepted registry event.
             Only one value per DB key is allowed.
@@ -110,7 +110,7 @@ class RegBaser(LMDBer):
         self.ancs = CatCesrSuber(db=self, subkey='ancs.',
                                 klas=(Number, Diger))
         self.tels = CesrOnSuber(db=self, subkey='tels.', klas=Saider)
-        self.heads = CesrSuber(db=self, subkey='heads.', klas=Saider)
+        self.heads = CesrSuber(db=self, subkey='heds.', klas=Saider)
         self.maes = B64OnIoSetSuber(db=self, subkey='maes.')
         self.ooes = B64OnIoSetSuber(db=self, subkey='ooes.')
 

--- a/src/keri/acdc/regbasing.py
+++ b/src/keri/acdc/regbasing.py
@@ -5,3 +5,113 @@ keri.acdc.regbasing module
 Support for RegBaser(LMDBer)
 
 """
+
+import os
+
+from ..core import Diger, Number, Saider, SerderACDC
+from ..db import (LMDBer, B64OnIoSetSuber, CatCesrSuber, CesrOnSuber,
+                  CesrSuber, SerderSuber)
+
+
+class RegBaser(LMDBer):
+    """
+    RegBaser sets up named sub databases for public ACDC registry TELs.
+
+    Attributes:
+        see superclass LMDBer for inherited attributes
+
+        .evts is named subDB instance of SerderSuber (klas=SerderACDC)
+            whose values are serialized ACDC registry events.
+            subkey 'evts.'
+            Key: registry event SAID.
+            Value: SerderACDC instance for a rip or bup event.
+            Only one value per DB key is allowed.
+            Contains both accepted and escrowed event bodies. Membership does
+            not indicate acceptance.
+
+        .ancs is named subDB instance of CatCesrSuber
+            (klas=(Number, Diger)) for KEL source seal couples.
+            subkey 'ancs.'
+            Key: registry event SAID.
+            Value: Number and Diger of the KEL event that anchors the registry
+            event.
+            Only one value per DB key is allowed.
+
+        .tels is named subDB instance of CesrOnSuber (klas=Saider) for the
+            accepted transaction event log.
+            subkey 'tels.'
+            onKey (registry SAID + registry event sequence number)
+            Value: SAID of the accepted registry event in .evts.
+            Only one value per DB key is allowed.
+            Membership is the acceptance commit marker.
+
+        .heads is named subDB instance of CesrSuber (klas=Saider) for the
+            current accepted registry heads.
+            subkey 'heads.'
+            Key: registry SAID.
+            Value: SAID of the latest accepted registry event.
+            Only one value per DB key is allowed.
+            This cache is rebuildable from .tels.
+
+        .maes is named subDB instance of B64OnIoSetSuber for registry events
+            escrowed because the KEL anchor is missing.
+            subkey 'maes.'
+            onKey (registry SAID + registry event sequence number)
+            Value: registry event SAID.
+            More than one value per effective DB key is allowed in insertion
+            order without dupsort.
+
+        .ooes is named subDB instance of B64OnIoSetSuber for out-of-order
+            registry event escrows.
+            subkey 'ooes.'
+            onKey (registry SAID + registry event sequence number)
+            Value: registry event SAID.
+            More than one value per effective DB key is allowed in insertion
+            order without dupsort.
+
+    """
+
+    TailDirPath = os.path.join("keri", "acdc", "reg")
+    AltTailDirPath = os.path.join(".keri", "acdc", "reg")
+    TempPrefix = "keri_acdc_reg_"
+
+    def __init__(self, headDirPath=None, reopen=True, **kwa):
+        """
+        Setup named sub databases.
+
+        Inherited Parameters:
+            name (str): directory path name differentiator for main database
+            temp (bool): True means use a temporary directory and clear on close
+            headDirPath (str | None): optional head directory path for database
+            mode (int): numeric permissions for database directory
+            reopen (bool): True means reopen database during initialization
+
+        """
+        super(RegBaser, self).__init__(headDirPath=headDirPath,
+                                      reopen=reopen, **kwa)
+
+    def reopen(self, **kwa):
+        """
+        Open database and setup named sub databases.
+
+        Parameters:
+            **kwa (dict): keyword arguments passed to LMDBer.reopen
+
+        Returns:
+            opened (bool): True when database is opened
+
+        """
+        super(RegBaser, self).reopen(**kwa)
+
+        # Create by opening first time named sub DBs within main DB instance
+        # Names end with "." as sub DB name must include a non Base64 character
+        # to avoid namespace collisions with Base64 identifier prefixes.
+        self.evts = SerderSuber(db=self, subkey='evts.', klas=SerderACDC)
+        self.ancs = CatCesrSuber(db=self, subkey='ancs.',
+                                klas=(Number, Diger))
+        self.tels = CesrOnSuber(db=self, subkey='tels.', klas=Saider)
+        self.heads = CesrSuber(db=self, subkey='heads.', klas=Saider)
+        self.maes = B64OnIoSetSuber(db=self, subkey='maes.')
+        self.ooes = B64OnIoSetSuber(db=self, subkey='ooes.')
+
+        return self.opened

--- a/src/keri/acdc/regbasing.py
+++ b/src/keri/acdc/regbasing.py
@@ -103,9 +103,6 @@ class RegBaser(LMDBer):
         """
         super(RegBaser, self).reopen(**kwa)
 
-        # Create by opening first time named sub DBs within main DB instance
-        # Names end with "." as sub DB name must include a non Base64 character
-        # to avoid namespace collisions with Base64 identifier prefixes.
         self.evts = SerderSuber(db=self, subkey='evts.', klas=SerderACDC)
         self.ancs = CatCesrSuber(db=self, subkey='ancs.',
                                 klas=(Number, Diger))

--- a/src/keri/acdc/webregbaser.py
+++ b/src/keri/acdc/webregbaser.py
@@ -1,8 +1,0 @@
-# -*- encoding: utf-8 -*-
-"""
-keri.acdc.webregbaser module
-
-Support for WebRegBaser(IndexedDB)
-
-"""
-

--- a/src/keri/acdc/webregbasing.py
+++ b/src/keri/acdc/webregbasing.py
@@ -122,6 +122,7 @@ class WebRegBaser(WebDBer):
             clear=clear or self.temp,
             storageOpener=opener,
         )
+        self._version = None
         self.env = self.db.env
 
         _before = set(self.__dict__)
@@ -138,6 +139,32 @@ class WebRegBaser(WebDBer):
         self._subdb_names = set(self.__dict__) - _before
 
         self.opened = True
+
+    def getVer(self):
+        """Read the version from the opened browser database.
+
+        Returns:
+            str | None: persisted database version, or None when the database
+                is not open or has no version
+        """
+        if self.db is None:
+            return None
+
+        return self.db.getVer()
+
+    def setVer(self, val):
+        """Write the version to the opened browser database.
+
+        Parameters:
+            val (str | bytes): database version
+
+        Raises:
+            RuntimeError: if the browser database is not open
+        """
+        if self.db is None:
+            raise RuntimeError("WebRegBaser is not open")
+
+        self.db.setVer(val)
 
     def close(self, *, clear=False):
         """

--- a/src/keri/acdc/webregbasing.py
+++ b/src/keri/acdc/webregbasing.py
@@ -1,8 +1,200 @@
 # -*- encoding: utf-8 -*-
 """
-keri.acdc.regbasing module
+keri.acdc.webregbasing module
 
-Support for WebRebBaser(IndexedDB)
+Support for WebRegBaser(WebDBer)
 
 
 """
+
+import asyncio
+
+from ..core import Diger, Number, Saider, SerderACDC
+from ..db import (WebDBer, B64OnIoSetSuber, CatCesrSuber, CesrOnSuber,
+                  CesrSuber, SerderSuber)
+
+
+class WebRegBaser(WebDBer):
+    """
+    WebRegBaser sets up browser sub databases for public ACDC registry TELs.
+
+    Attributes:
+        see superclass WebDBer for inherited attributes
+
+        .evts is named subDB instance of SerderSuber (klas=SerderACDC)
+            whose values are serialized ACDC registry events.
+            subkey 'evts.'
+            Key: registry event SAID.
+            Value: SerderACDC instance for a rip or bup event.
+            Only one value per DB key is allowed.
+            Contains both accepted and escrowed event bodies. Membership does
+            not indicate acceptance.
+
+        .ancs is named subDB instance of CatCesrSuber
+            (klas=(Number, Diger)) for KEL source seal couples.
+            subkey 'ancs.'
+            Key: registry event SAID.
+            Value: Number and Diger of the KEL event that anchors the registry
+            event.
+            Only one value per DB key is allowed.
+
+        .tels is named subDB instance of CesrOnSuber (klas=Saider) for the
+            accepted transaction event log.
+            subkey 'tels.'
+            onKey (registry SAID + registry event sequence number)
+            Value: SAID of the accepted registry event in .evts.
+            Only one value per DB key is allowed.
+            Membership is the acceptance commit marker.
+
+        .heads is named subDB instance of CesrSuber (klas=Saider) for the
+            current accepted registry heads.
+            subkey 'heads.'
+            Key: registry SAID.
+            Value: SAID of the latest accepted registry event.
+            Only one value per DB key is allowed.
+            This cache is rebuildable from .tels.
+
+        .maes is named subDB instance of B64OnIoSetSuber for registry events
+            escrowed because the KEL anchor is missing.
+            subkey 'maes.'
+            onKey (registry SAID + registry event sequence number)
+            Value: registry event SAID.
+            More than one value per effective DB key is allowed in insertion
+            order without dupsort.
+
+        .ooes is named subDB instance of B64OnIoSetSuber for out-of-order
+            registry event escrows.
+            subkey 'ooes.'
+            onKey (registry SAID + registry event sequence number)
+            Value: registry event SAID.
+            More than one value per effective DB key is allowed in insertion
+            order without dupsort.
+
+    """
+
+    StoragePrefix = "acdc-reg"
+
+    def __init__(self, name="main", reopen=False, temp=False, **kwa):
+        """
+        Setup names for browser sub databases.
+
+        Parameters:
+            name (str): registry database name
+            reopen (bool): retained for interface parity with LMDBer
+            temp (bool): True means clear database on close
+            **kwa (dict): retained for interface parity with LMDBer
+
+        """
+        SubDbNames = [
+            "evts.",
+            "ancs.",
+            "tels.",
+            "heads.",
+            "maes.",
+            "ooes.",
+        ]
+        self.SubDbNames = SubDbNames
+
+        self.name = name
+        self._version = None
+        self.opened = False
+        self.temp = temp
+        self.db = None
+        self.env = None
+
+    async def reopen(self, *, clear=False, storageOpener=None):
+        """
+        Open browser database and setup named sub databases.
+
+        Parameters:
+            clear (bool): True means clear persisted data before opening
+            storageOpener (callable | None): async browser storage opener
+
+        """
+        if storageOpener is not None:
+            self._storageOpener = storageOpener
+        opener = getattr(self, "_storageOpener", None)
+
+        adapterName = f"{self.StoragePrefix}:{self.name}"
+        self.db = await WebDBer.open(
+            name=adapterName,
+            stores=self.SubDbNames,
+            clear=clear or self.temp,
+            storageOpener=opener,
+        )
+        self.env = self.db.env
+
+        _before = set(self.__dict__)
+        # Create by opening first time named sub DBs within main DB instance
+        # Names end with "." as sub DB name must include a non Base64 character
+        # to avoid namespace collisions with Base64 identifier prefixes.
+        self.evts = SerderSuber(db=self, subkey='evts.', klas=SerderACDC)
+        self.ancs = CatCesrSuber(db=self, subkey='ancs.',
+                                klas=(Number, Diger))
+        self.tels = CesrOnSuber(db=self, subkey='tels.', klas=Saider)
+        self.heads = CesrSuber(db=self, subkey='heads.', klas=Saider)
+        self.maes = B64OnIoSetSuber(db=self, subkey='maes.')
+        self.ooes = B64OnIoSetSuber(db=self, subkey='ooes.')
+        self._subdb_names = set(self.__dict__) - _before
+
+        self.opened = True
+
+    def close(self, *, clear=False):
+        """
+        Close browser database and schedule pending writes for persistence.
+
+        Parameters:
+            clear (bool): True means clear persisted data before close
+
+        """
+        if not self.opened or self.db is None:
+            return
+
+        if clear or self.temp:
+            for subdb in self.db._stores.values():
+                subdb.items.clear()
+                subdb.dirty = True
+
+        db = self.db
+        self.db = None
+        self.env = None
+        self.opened = False
+
+        for name in getattr(self, "_subdb_names", ()):
+            try:
+                delattr(self, name)
+            except AttributeError:
+                pass
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(db.flush())
+        except RuntimeError:
+            pass
+
+    async def aclose(self, *, clear=False):
+        """
+        Flush pending writes and close browser database.
+
+        Parameters:
+            clear (bool): True means clear persisted data before close
+
+        """
+        if not self.opened or self.db is None:
+            return
+
+        if clear or self.temp:
+            for subdb in self.db._stores.values():
+                subdb.items.clear()
+                subdb.dirty = True
+
+        await self.db.flush()
+        self.db = None
+        self.env = None
+        self.opened = False
+
+        for name in getattr(self, "_subdb_names", ()):
+            try:
+                delattr(self, name)
+            except AttributeError:
+                pass

--- a/src/keri/acdc/webregbasing.py
+++ b/src/keri/acdc/webregbasing.py
@@ -48,7 +48,7 @@ class WebRegBaser(WebDBer):
 
         .heads is named subDB instance of CesrSuber (klas=Saider) for the
             current accepted registry heads.
-            subkey 'heads.'
+            subkey 'heds.'
             Key: registry SAID.
             Value: SAID of the latest accepted registry event.
             Only one value per DB key is allowed.
@@ -89,7 +89,7 @@ class WebRegBaser(WebDBer):
             "evts.",
             "ancs.",
             "tels.",
-            "heads.",
+            "heds.",
             "maes.",
             "ooes.",
         ]
@@ -132,7 +132,7 @@ class WebRegBaser(WebDBer):
         self.ancs = CatCesrSuber(db=self, subkey='ancs.',
                                 klas=(Number, Diger))
         self.tels = CesrOnSuber(db=self, subkey='tels.', klas=Saider)
-        self.heads = CesrSuber(db=self, subkey='heads.', klas=Saider)
+        self.heads = CesrSuber(db=self, subkey='heds.', klas=Saider)
         self.maes = B64OnIoSetSuber(db=self, subkey='maes.')
         self.ooes = B64OnIoSetSuber(db=self, subkey='ooes.')
         self._subdb_names = set(self.__dict__) - _before

--- a/src/keri/acdc/webregbasing.py
+++ b/src/keri/acdc/webregbasing.py
@@ -126,9 +126,7 @@ class WebRegBaser(WebDBer):
         self.env = self.db.env
 
         _before = set(self.__dict__)
-        # Create by opening first time named sub DBs within main DB instance
-        # Names end with "." as sub DB name must include a non Base64 character
-        # to avoid namespace collisions with Base64 identifier prefixes.
+        
         self.evts = SerderSuber(db=self, subkey='evts.', klas=SerderACDC)
         self.ancs = CatCesrSuber(db=self, subkey='ancs.',
                                 klas=(Number, Diger))

--- a/src/keri/acdc/webregbasing.py
+++ b/src/keri/acdc/webregbasing.py
@@ -7,8 +7,6 @@ Support for WebRegBaser(WebDBer)
 
 """
 
-import asyncio
-
 from ..core import Diger, Number, Saider, SerderACDC
 from ..db import (WebDBer, B64OnIoSetSuber, CatCesrSuber, CesrOnSuber,
                   CesrSuber, SerderSuber)
@@ -166,21 +164,25 @@ class WebRegBaser(WebDBer):
 
     def close(self, *, clear=False):
         """
-        Close browser database and schedule pending writes for persistence.
+        Close browser database when it has no pending writes.
 
         Parameters:
             clear (bool): True means clear persisted data before close
+
+        Raises:
+            RuntimeError: if pending writes or clear require async persistence
 
         """
         if not self.opened or self.db is None:
             return
 
-        if clear or self.temp:
-            for subdb in self.db._stores.values():
-                subdb.items.clear()
-                subdb.dirty = True
+        dirty = any(subdb.dirty for subdb in self.db._stores.values())
+        if clear or self.temp or dirty:
+            raise RuntimeError(
+                "WebRegBaser.close() cannot persist pending browser writes; "
+                "use await aclose()."
+            )
 
-        db = self.db
         self.db = None
         self.env = None
         self.opened = False
@@ -190,12 +192,6 @@ class WebRegBaser(WebDBer):
                 delattr(self, name)
             except AttributeError:
                 pass
-
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(db.flush())
-        except RuntimeError:
-            pass
 
     async def aclose(self, *, clear=False):
         """

--- a/tests/acdc/test_regbasing.py
+++ b/tests/acdc/test_regbasing.py
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.acdc.test_regbasing module
+
+"""
+
+import os
+
+from keri.acdc import messaging, regbasing
+from keri.core import coring, serdering
+from keri.db import openLMDB, subing
+
+
+def test_regbaser_store_contract():
+    """Test the native six-store registry database contract."""
+    with openLMDB(cls=regbasing.RegBaser,
+                  name="test-regbaser", temp=True) as baser:
+        assert isinstance(baser, regbasing.RegBaser)
+        assert baser.opened
+        assert baser.TailDirPath == os.path.join("keri", "acdc", "reg")
+        assert any(
+            part.startswith(baser.TempPrefix)
+            for part in baser.path.split(os.path.sep)
+        )
+
+        assert isinstance(baser.evts, subing.SerderSuber)
+        assert baser.evts.klas is serdering.SerderACDC
+        assert isinstance(baser.ancs, subing.CatCesrSuber)
+        assert baser.ancs.klas == (coring.Number, coring.Diger)
+        assert isinstance(baser.tels, subing.CesrOnSuber)
+        assert baser.tels.klas is coring.Saider
+        assert isinstance(baser.heads, subing.CesrSuber)
+        assert baser.heads.klas is coring.Saider
+        assert isinstance(baser.maes, subing.B64OnIoSetSuber)
+        assert isinstance(baser.ooes, subing.B64OnIoSetSuber)
+
+        for name in ("evts", "ancs", "tels", "heads", "maes", "ooes"):
+            assert getattr(baser, name).sdb.flags()["dupsort"] is False
+
+        issuer = "EA2X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ"
+        serder = messaging.regcept(
+            israid=issuer,
+            uuid="0AAxyHwW6htOZ_rANOaZb2N2",
+            stamp="2020-08-22T17:50:09.988921+00:00",
+        )
+        saider = coring.Saider(qb64=serder.said)
+        source = (coring.Number(num=3), coring.Diger(qb64=serder.said))
+
+        assert baser.evts.put(keys=serder.said, val=serder)
+        assert baser.ancs.put(keys=serder.said, val=source)
+        assert baser.tels.put(keys=serder.said, on=0, val=saider)
+        assert baser.heads.put(keys=serder.said, val=saider)
+        assert baser.maes.add(keys=serder.said, on=1, val=serder.said)
+        assert baser.ooes.add(keys=serder.said, on=1, val=serder.said)
+
+        assert baser.evts.get(keys=serder.said).raw == serder.raw
+        assert baser.ancs.get(keys=serder.said)[0].num == 3
+        assert baser.ancs.get(keys=serder.said)[1].qb64 == serder.said
+        assert baser.tels.get(keys=serder.said, on=0).qb64 == serder.said
+        assert baser.heads.get(keys=serder.said).qb64 == serder.said
+        assert baser.maes.get(keys=serder.said, on=1) == [(serder.said,)]
+        assert baser.ooes.get(keys=serder.said, on=1) == [(serder.said,)]
+
+    assert baser.opened is False

--- a/tests/acdc/test_webregbasing.py
+++ b/tests/acdc/test_webregbasing.py
@@ -56,7 +56,7 @@ def test_webregbaser_store_contract_and_persistence():
             "evts.",
             "ancs.",
             "tels.",
-            "heads.",
+            "heds.",
             "maes.",
             "ooes.",
         ]

--- a/tests/acdc/test_webregbasing.py
+++ b/tests/acdc/test_webregbasing.py
@@ -1,0 +1,129 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.acdc.test_webregbasing module
+
+"""
+
+import asyncio
+
+from keri.acdc import messaging, webregbasing
+from keri.core import coring, serdering
+from keri.db import subing
+
+
+class FakeStorageHandle:
+    """Storage handle with explicit async persistence."""
+
+    def __init__(self, backend, namespace):
+        self.backend = backend
+        self.namespace = namespace
+        self.local = dict(backend.persisted.get(namespace, {}))
+
+    def get(self, key, default=None):
+        return self.local.get(key, default)
+
+    def __setitem__(self, key, value):
+        self.local[key] = value
+
+    async def sync(self):
+        self.backend.persisted[self.namespace] = dict(self.local)
+
+
+class FakeStorageBackend:
+    """Storage opener that records namespace declaration order."""
+
+    def __init__(self):
+        self.persisted = {}
+        self.opened = []
+
+    async def open(self, namespace):
+        self.opened.append(namespace)
+        return FakeStorageHandle(self, namespace)
+
+
+def test_webregbaser_store_contract_and_persistence():
+    """Test browser store parity, namespace isolation, and persistence."""
+
+    async def run():
+        backend = FakeStorageBackend()
+        baser = webregbasing.WebRegBaser(name="observer")
+        await baser.reopen(
+            clear=True,
+            storageOpener=backend.open,
+        )
+
+        expectedSubDbNames = [
+            "evts.",
+            "ancs.",
+            "tels.",
+            "heads.",
+            "maes.",
+            "ooes.",
+        ]
+        expected = [
+            f"acdc-reg:observer:{name}"
+            for name in (*expectedSubDbNames, "__meta__")
+        ]
+        assert backend.opened == expected
+        assert baser.SubDbNames == expectedSubDbNames
+        assert isinstance(baser.evts, subing.SerderSuber)
+        assert baser.evts.klas is serdering.SerderACDC
+        assert isinstance(baser.ancs, subing.CatCesrSuber)
+        assert baser.ancs.klas == (coring.Number, coring.Diger)
+        assert isinstance(baser.tels, subing.CesrOnSuber)
+        assert baser.tels.klas is coring.Saider
+        assert isinstance(baser.heads, subing.CesrSuber)
+        assert baser.heads.klas is coring.Saider
+        assert isinstance(baser.maes, subing.B64OnIoSetSuber)
+        assert isinstance(baser.ooes, subing.B64OnIoSetSuber)
+
+        for name in ("evts", "ancs", "tels", "heads", "maes", "ooes"):
+            assert getattr(baser, name).sdb.flags()["dupsort"] is False
+
+        issuer = "EA2X8Lfrl9lZbCGz8cfKIvM_cqLyTYVLSFLhnttezlzQ"
+        serder = messaging.regcept(
+            israid=issuer,
+            uuid="0AAxyHwW6htOZ_rANOaZb2N2",
+            stamp="2020-08-22T17:50:09.988921+00:00",
+        )
+        saider = coring.Saider(qb64=serder.said)
+        source = (coring.Number(num=3), coring.Diger(qb64=serder.said))
+
+        assert baser.evts.put(keys=serder.said, val=serder)
+        assert baser.ancs.put(keys=serder.said, val=source)
+        assert baser.tels.put(keys=serder.said, on=0, val=saider)
+        assert baser.heads.put(keys=serder.said, val=saider)
+        assert baser.maes.add(keys=serder.said, on=1, val=serder.said)
+        assert baser.ooes.add(keys=serder.said, on=1, val=serder.said)
+
+        await baser.aclose()
+        assert baser.opened is False
+        assert baser.db is None
+        assert baser.env is None
+        for name in ("evts", "ancs", "tels", "heads", "maes", "ooes"):
+            assert not hasattr(baser, name)
+
+        reopened = webregbasing.WebRegBaser(name="observer")
+        await reopened.reopen(storageOpener=backend.open)
+        assert reopened.evts.get(keys=serder.said).raw == serder.raw
+        assert reopened.ancs.get(keys=serder.said)[0].num == 3
+        assert reopened.ancs.get(keys=serder.said)[1].qb64 == serder.said
+        assert reopened.tels.get(keys=serder.said, on=0).qb64 == serder.said
+        assert reopened.heads.get(keys=serder.said).qb64 == serder.said
+        assert reopened.maes.get(keys=serder.said, on=1) == [(serder.said,)]
+        assert reopened.ooes.get(keys=serder.said, on=1) == [(serder.said,)]
+
+        syncSaid = coring.Diger(ser=b"sync close candidate").qb64
+        assert reopened.ooes.add(keys=serder.said, on=2, val=syncSaid)
+        reopened.close()
+        assert reopened.opened is False
+        assert reopened.db is None
+        assert reopened.env is None
+        await asyncio.sleep(0)
+
+        closed = webregbasing.WebRegBaser(name="observer")
+        await closed.reopen(storageOpener=backend.open)
+        assert closed.ooes.get(keys=serder.said, on=2) == [(syncSaid,)]
+        await closed.aclose()
+
+    asyncio.run(run())

--- a/tests/acdc/test_webregbasing.py
+++ b/tests/acdc/test_webregbasing.py
@@ -6,6 +6,8 @@ tests.acdc.test_webregbasing module
 
 import asyncio
 
+import pytest
+
 from keri.acdc import messaging, webregbasing
 from keri.core import coring, serdering
 from keri.db import subing
@@ -113,17 +115,21 @@ def test_webregbaser_store_contract_and_persistence():
         assert reopened.maes.get(keys=serder.said, on=1) == [(serder.said,)]
         assert reopened.ooes.get(keys=serder.said, on=1) == [(serder.said,)]
 
-        syncSaid = coring.Diger(ser=b"sync close candidate").qb64
-        assert reopened.ooes.add(keys=serder.said, on=2, val=syncSaid)
-        reopened.close()
+        pendingSaid = coring.Diger(ser=b"pending close candidate").qb64
+        assert reopened.ooes.add(keys=serder.said, on=2, val=pendingSaid)
+        with pytest.raises(RuntimeError):
+            reopened.close()
+        assert reopened.opened is True
+        assert reopened.db is not None
+        assert reopened.env is not None
+        await reopened.aclose()
         assert reopened.opened is False
         assert reopened.db is None
         assert reopened.env is None
-        await asyncio.sleep(0)
 
         closed = webregbasing.WebRegBaser(name="observer")
         await closed.reopen(storageOpener=backend.open)
-        assert closed.ooes.get(keys=serder.said, on=2) == [(syncSaid,)]
+        assert closed.ooes.get(keys=serder.said, on=2) == [(pendingSaid,)]
         await closed.aclose()
 
     asyncio.run(run())


### PR DESCRIPTION
In this PR:
- Add RegBaser and WebRegBaser with the same six sub-databases for LMDB and IndexedDB
- Replace the V1 tvts, states, oots, and taes responsibilities with evts, heads, ooes, and maes
- Store complete registry events in evts, accepted sequence entries in tels, KEL anchor references in ancs, and rebuildable current heads in heads
- Keep tels as the accepted sequence index and ancs as the KEL anchor reference store
- Drop V1 backer, partial witness, timestamp, and unused signature stores that do not apply to blindable registries
- Keep credential and wallet data outside this database; TEL processing goes in registering.py, registrar workflow in registraring.py, and IPEX in ipexing.py
- Remove the duplicate webregbaser.py stub