### PR TITLE
V2 attachments default

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -55,7 +55,7 @@ class Receiptor(doing.DoDoer):
     def receipt(self, pre, sn=None, auths=None):
         """Returns a generator performing witness receipting of KEL events.
 
-        The returns a generator that will submit the designated event to witnesses for receipts using
+        This returns a generator that will submit the designated event to witnesses for receipts using
         the synchronous witness API, then propagate the receipts to each of the other witnesses.
         Delegates to .catchup to catch up any new witnesses to the current state of the KEL.
 
@@ -546,7 +546,7 @@ class WitnessInquisitor(doing.DoDoer):
 
             msg = hab.query(target, src=witer.wit, route=r, query=q, **kwa)  # Query for remote pre Event
 
-            kel = introduce(hab, witer.wit)
+            kel = introduce(hab, witer.wit, gvrsn=self.hby.version)
             if kel:
                 witer.msgs.append(bytearray(kel))
 

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -74,7 +74,9 @@ class Receiptor(doing.DoDoer):
         hab = self.hby.habs[pre]
         sn = sn if sn is not None else hab.kever.sner.num
 
-        msg = hab.msgOwnEvent(sn=sn, framed=True)
+        # Match attachment genus to the event body so v1-only witnesses can parse.
+        serder, _, _ = hab.getOwnEvent(sn=sn)
+        msg = hab.msgOwnEvent(sn=sn, framed=True, gvrsn=serder.pvrsn)
         ser = serdering.SerderKERI(raw=msg)
         wits = [wit.qb64 for wit in hab.kvy.fetchWitnessState(ser.pre, ser.sn)]
 
@@ -348,7 +350,9 @@ class WitnessReceiptor(doing.DoDoer):
                 if len(wits) == 0:
                     continue
 
-                msg = hab.msgOwnEvent(sn=sn, framed=True)
+                # Match attachment genus to the event body so v1-only witnesses can parse.
+                serder, _, _ = hab.getOwnEvent(sn=sn)
+                msg = hab.msgOwnEvent(sn=sn, framed=True, gvrsn=serder.pvrsn)
                 ser = serdering.SerderKERI(raw=msg)
 
                 witers = []

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -54,7 +54,7 @@ class Director(doing.Doer):
         """
         Utility to send own event at sequence number sn
         """
-        msg = self.hab.msgOwnEvent(sn=sn, framed=True)
+        msg = self.hab.msgOwnEvent(sn=sn, framed=True, gvrsn=self.version)
         # send to connected remote
         self.client.tx(msg)
         logger.info("%s: %s sent event:\n%s\n\n", self.hab.name, self.hab.pre, bytes(msg))

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -209,7 +209,7 @@ class Poster(doing.DoDoer):
         # Its not us, randomly select a mailbox and forward it on
         mbx, mailbox = random.choice(list(ends.items()))
         msg = bytearray()
-        msg.extend(introduce(hab, mbx))
+        msg.extend(introduce(hab, mbx, gvrsn=self.version))
         # create the forward message with payload embedded at `a` field
 
         evt = bytearray(serder.raw)
@@ -247,7 +247,7 @@ class Poster(doing.DoDoer):
         # Its not us, randomly select a mailbox and forward it on
         mbx, mailbox = random.choice(list(ends.items()))
         msg = bytearray()
-        msg.extend(introduce(hab, mbx))
+        msg.extend(introduce(hab, mbx, gvrsn=self.version))
         # create the forward message with payload embedded at `a` field
 
         evt = bytearray(serder.raw)
@@ -472,7 +472,7 @@ class StreamPoster:
             msg = self._essrWrapper(hab, msg, mbx)
 
         ims = bytearray()
-        ims.extend(introduce(hab, mbx))
+        ims.extend(introduce(hab, mbx, gvrsn=self.version))
         ims.extend(msg)
 
         self.messagers.append(streamMessengerFrom(hab=hab, pre=mbx, urls=mailbox, msg=bytes(ims)))
@@ -555,7 +555,7 @@ class ForwardHandler:
         self.mbx.storeMsg(topic=resource, msg=pevt)
 
 
-def introduce(hab, wit):
+def introduce(hab, wit, gvrsn=None):
     """ Clone and return hab KEL if lastest event has not been receipted by wit
 
     Check to see if the target witness has already provided a receipt for the latest event
@@ -565,6 +565,10 @@ def introduce(hab, wit):
     Parameters:
         hab (Hab): local environment for the identifier to propagate
         wit (str): qb64 identifier prefix of the receiver of KEL if not already receipted
+        gvrsn (Versionage or None): CESR genus version for intro stream attachments.
+            None means use each clone/reply helper's library default (``Version``).
+            Callers talking to a peer that requires a different genus should pass
+            their configured Habery/Poster version (e.g. ``Vrsn_1_0``).
 
     Returns:
         bytearray: cloned KEL of hab
@@ -605,12 +609,12 @@ def introduce(hab, wit):
 
     if not found:  # no receipt from remote so pre-send own inception
         # no vrcs or rct of own icp from remote so send own inception.
-        # Match attachment genus to this hab's event version so v1-only
-        # witnesses can parse the introduction stream.
-        gvrsn = hab.kever.serder.pvrsn
-        for msg in hab.db.clonePreIter(pre=hab.pre, gvrsn=gvrsn):
+        # Attachment genus follows caller config when provided; otherwise each
+        # helper uses its library default.
+        kwa = dict(gvrsn=gvrsn) if gvrsn is not None else {}
+        for msg in hab.db.clonePreIter(pre=hab.pre, **kwa):
             msgs.extend(msg)
-        for msg in hab.db.cloneDelegation(hab.kever, gvrsn=gvrsn):
+        for msg in hab.db.cloneDelegation(hab.kever, **kwa):
             msgs.extend(msg)
-        msgs.extend(hab.replyEndRole(cid=hab.pre, gvrsn=gvrsn))
+        msgs.extend(hab.replyEndRole(cid=hab.pre, **kwa))
     return msgs

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -604,10 +604,13 @@ def introduce(hab, wit):
                 break
 
     if not found:  # no receipt from remote so pre-send own inception
-        # no vrcs or rct of own icp from remote so send own inception
-        for msg in hab.db.clonePreIter(pre=hab.pre, version=hab.kever.serder.pvrsn):
+        # no vrcs or rct of own icp from remote so send own inception.
+        # Match attachment genus to this hab's event version so v1-only
+        # witnesses can parse the introduction stream.
+        gvrsn = hab.kever.serder.pvrsn
+        for msg in hab.db.clonePreIter(pre=hab.pre, gvrsn=gvrsn):
             msgs.extend(msg)
-        for msg in hab.db.cloneDelegation(hab.kever):
+        for msg in hab.db.cloneDelegation(hab.kever, gvrsn=gvrsn):
             msgs.extend(msg)
-        msgs.extend(hab.replyEndRole(cid=hab.pre))
+        msgs.extend(hab.replyEndRole(cid=hab.pre, gvrsn=gvrsn))
     return msgs

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -10,10 +10,10 @@ from hio.base import doing
 from hio.help import ogler
 
 from ..kering import ValidationError, Version, Vrsn_1_0, Kinds, Ilks
-from ..core import (Counter, Number, Diger, Saider,
+from ..core import (Number, Diger, Saider,
                     Prefixer, Kevery, Router,
                     Revery, Parser, SerderKERI,
-                    Serder, Codens, NumDex)
+                    Serder, NumDex, SealSource, messagize)
 from ..peer import Exchanger, specialExchange, cloneMessage
 
 from .delegating import Anchorer
@@ -593,20 +593,13 @@ def getEscrowedEvent(db, pre, sn):
     sigers = db.sigs.get(keys=(pre, dig))
     duple = db.aess.get(keys=(pre, dig))
 
-    msg = bytearray()
-    msg.extend(serder.raw)
-    msg.extend(Counter(Codens.ControllerIdxSigs,
-                            count=len(sigers), version=Vrsn_1_0).qb64b)  # attach cnt
-    for siger in sigers:
-        msg.extend(siger.qb64b)  # attach siger
-
+    seal = None
     if duple is not None:
         number, diger = duple
-        msg.extend(Counter(Codens.SealSourceCouples,
-                                count=1, version=Vrsn_1_0).qb64b)
-        msg.extend(number.qb64b + diger.qb64b)
+        seal = SealSource(s=number.snh, d=diger.qb64)
 
-    return msg
+    return messagize(serder, sigers=sigers, bonds=seal, framed=True,
+                     gvrsn=serder.pvrsn)
 
 
 class Multiplexor:

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -599,7 +599,7 @@ def getEscrowedEvent(db, pre, sn):
         seal = SealSource(s=number.snh, d=diger.qb64)
 
     return messagize(serder, sigers=sigers, bonds=seal, framed=True,
-                     gvrsn=serder.pvrsn)
+                     gvrsn=Version)
 
 
 class Multiplexor:

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -76,7 +76,8 @@ class Counselor(doing.DoDoer):
 
         """
         # used just for the log message
-        evt = ghab.msgOwnEvent(sn=number.sn, allowPartiallySigned=True, framed=True)
+        evt = ghab.msgOwnEvent(sn=number.sn, allowPartiallySigned=True, framed=True,
+                               gvrsn=self.version if self.version is not None else Version)
         serder = SerderKERI(raw=evt)  # used just for the log message
         logger.info("Waiting for other signatures on %s for %s:%s...",
                     serder.ilk, prefixer.qb64, number.sn)

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1907,7 +1907,9 @@ class BaseHab:
             pre (str or None): qb64 str or bytes of identifier prefix.
                 Default is own ``.pre``.
             fn (int): first-seen ordering number to start from.
-            gvrsn (Versionage): CESR genus version for attachments
+            gvrsn (Versionage): CESR genus version for attachments. When the
+                default sentinel ``Version`` is used and ``pre`` is in
+                ``.kevers``, the target kever's ``serder.pvrsn`` is substituted.
             version (Versionage): legacy alias for gvrsn
 
         Returns:
@@ -1918,6 +1920,8 @@ class BaseHab:
 
         if version is not None:
             gvrsn = version
+        if gvrsn is Version and pre in self.kevers:
+            gvrsn = self.kevers[pre].serder.pvrsn
         msgs = bytearray()
         kever = self.kevers[pre]
         for msg in self.db.cloneDelegation(kever=kever, gvrsn=gvrsn):
@@ -2516,9 +2520,7 @@ class BaseHab:
             return msgs
 
         gvrsn = kwa.get("gvrsn")
-        msgs.extend(self.replay(
-            cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
-        ))
+        msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
 
         kever = self.kevers[cid]
         witness = self.pre in kever.wits  # see if we are cid's witness
@@ -3585,9 +3587,7 @@ class SignifyHab(BaseHab):
         gvrsn = kwa.get("gvrsn")
 
         # introduce yourself, please
-        msgs.extend(self.replay(
-            cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
-        ))
+        msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
 
         if role == Roles.witness:
             if kever := self.kevers[cid] if cid in self.kevers else None:
@@ -3601,15 +3601,11 @@ class SignifyHab(BaseHab):
                         if not witness:  # we are not witness, send auth records
                             msgs.extend(self.makeEndRole(eid=eid, role=role, **kwa))
                 if witness:  # we are witness, set KEL as authz
-                    msgs.extend(self.replay(
-                        cid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
-                    ))
+                    msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
 
         for (_, erole, eid), end in self.db.ends.getTopItemIter(keys=(cid,)):
             if (end.enabled or end.allowed) and (not role or role == erole) and (not eids or eid in eids):
-                msgs.extend(self.replay(
-                    eid, gvrsn=gvrsn if gvrsn is not None else Vrsn_1_0
-                ))
+                msgs.extend(self.replay(eid, gvrsn=kwa.get("gvrsn", Version)))
                 msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
                                                gvrsn=gvrsn))
                 msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole,

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1609,12 +1609,16 @@ class BaseHab:
             attributes (dict): attributes field map (payload body)
             stamp (str):  date-time-stamp RFC-3339 profile of ISO-8601 datetime of
                           creation of message or data, default is now.
-            version (Versionage): KERI protocol default version if psvrsn is None
-            pvrsn (Versionage): KERI protocol version
-            gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code (useful when serder.gvrsn < 2)
-                            gvrsn = max(svrsn, gvrsn) where svrsn = serder.gvrsn
-                                if serder.gvrsn else serder.pvrsn
+            version (Versionage): KERI protocol default version if pvrsn is None
+            pvrsn (Versionage): KERI protocol version for the exchange body
+            gvrsn (Versionage): CESR genus version for attachment framing.
+                            Also forwarded into exchange body ``versify`` when
+                            not None. When None: for ``specialExchange`` embeds
+                            (``version`` is ``Vrsn_1_0``) defaults to ``version``
+                            so body and attachments match; otherwise defaults to
+                            ``Version`` after message creation, independent of
+                            body pvrsn. Pass ``Vrsn_1_0`` only when the peer
+                            requires that attachment genus.
             kind (str): serialization for key event message
                         one of Kinds ("json","cbor","mgpk","cesr")
             framed (bool): True means may assume each message plus its attachments
@@ -1628,7 +1632,6 @@ class BaseHab:
                                 in non-native group code
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
-
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -1656,6 +1659,11 @@ class BaseHab:
 
         if embeds:
             if version is Vrsn_1_0:
+                # specialExchange is the v1 embeds path; match attachment genus
+                # to version when gvrsn was omitted so body and attachments agree.
+                if gvrsn is None:
+                    gvrsn = version
+                    kwa["gvrsn"] = gvrsn
                 serder, end = specialExchange(embeds=embeds, **kwa)
             elif version is Vrsn_2_0:
                 raise ValueError("Embeds not supported for v2 exchanges")
@@ -1908,8 +1916,9 @@ class BaseHab:
                 Default is own ``.pre``.
             fn (int): first-seen ordering number to start from.
             gvrsn (Versionage): CESR genus version for attachments. Default
-                ``Version`` means v2 attachment framing even when replaying
-                v1 key-event bodies. Pass ``Vrsn_1_0`` only for a v1-only peer.
+                ``Version`` means library-default attachment framing even when
+                replaying bodies with a different pvrsn. Pass ``Vrsn_1_0`` only
+                when the peer requires that attachment genus.
             version (Versionage): legacy alias for gvrsn
 
         Returns:
@@ -2195,9 +2204,9 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code. Default ``Version`` means v2
-                            attachment framing; pass ``Vrsn_1_0`` only for a
-                            v1-only peer. Independent of the reply body pvrsn.
+                            nesting group code. Default ``Version``. Independent
+                            of the reply body pvrsn. Pass ``Vrsn_1_0`` only when
+                            the peer requires that attachment genus.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2633,9 +2642,10 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code. Default ``Version`` means v2
-                            attachment framing even for v1 event bodies; pass
-                            ``Vrsn_1_0`` only for a v1-only peer.
+                            nesting group code. Default ``Version`` means
+                            library-default attachment framing, independent of
+                            the event body pvrsn. Pass ``Vrsn_1_0`` only when
+                            the peer requires that attachment genus.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2676,9 +2686,10 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code. Default ``Version`` means v2
-                            attachment framing even for v1 event bodies; pass
-                            ``Vrsn_1_0`` only for a v1-only peer.
+                            nesting group code. Default ``Version`` means
+                            library-default attachment framing, independent of
+                            the event body pvrsn. Pass ``Vrsn_1_0`` only when
+                            the peer requires that attachment genus.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2713,9 +2724,10 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code. Default ``Version`` means v2
-                            attachment framing even for v1 event bodies; pass
-                            ``Vrsn_1_0`` only for a v1-only peer.
+                            nesting group code. Default ``Version`` means
+                            library-default attachment framing, independent of
+                            the event body pvrsn. Pass ``Vrsn_1_0`` only when
+                            the peer requires that attachment genus.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -1570,7 +1570,7 @@ class BaseHab:
         query['i'] = pre
         query["src"] = src
         serder = eventing.query(pre=self.pre, query=query, **kwa)
-        gvrsn = kwa.get("gvrsn", serder.pvrsn)
+        gvrsn = kwa.get("gvrsn") or Version
         return self.endorse(serder, last=True, framed=False, gvrsn=gvrsn)
 
 
@@ -1663,7 +1663,7 @@ class BaseHab:
             end = bytearray()
 
         if gvrsn is None:
-            gvrsn = serder.pvrsn
+            gvrsn = Version
 
         if self.kever.prefixer.transferable:
             msg = self.endorse(serder=serder, framed=framed, nested=nested,
@@ -1671,7 +1671,6 @@ class BaseHab:
         else:
             cigars = self.sign(ser=serder.raw,
                                indexed=False)
-            gvrsn = gvrsn if gvrsn is not None else version
             msg = eventing.messagize(serder, cigars=cigars, framed=framed,
                                      nested=nested, gvrsn=gvrsn, genusify=genusify)
 
@@ -1907,9 +1906,9 @@ class BaseHab:
             pre (str or None): qb64 str or bytes of identifier prefix.
                 Default is own ``.pre``.
             fn (int): first-seen ordering number to start from.
-            gvrsn (Versionage): CESR genus version for attachments. When the
-                default sentinel ``Version`` is used and ``pre`` is in
-                ``.kevers``, the target kever's ``serder.pvrsn`` is substituted.
+            gvrsn (Versionage): CESR genus version for attachments. Default
+                ``Version`` means v2 attachment framing even when replaying
+                v1 key-event bodies. Pass ``Vrsn_1_0`` only for a v1-only peer.
             version (Versionage): legacy alias for gvrsn
 
         Returns:
@@ -1920,8 +1919,6 @@ class BaseHab:
 
         if version is not None:
             gvrsn = version
-        if gvrsn is Version and pre in self.kevers:
-            gvrsn = self.kevers[pre].serder.pvrsn
         msgs = bytearray()
         kever = self.kevers[pre]
         for msg in self.db.cloneDelegation(kever=kever, gvrsn=gvrsn):
@@ -2197,9 +2194,9 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code (useful when serder.gvrsn < 2)
-                            gvrsn = max(svrsn, gvrsn) where svrsn = serder.gvrsn
-                                if serder.gvrsn else serder.pvrsn
+                            nesting group code. Default ``Version`` means v2
+                            attachment framing; pass ``Vrsn_1_0`` only for a
+                            v1-only peer. Independent of the reply body pvrsn.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2222,8 +2219,6 @@ class BaseHab:
             kwa["kind"] = self.kever.serder.kind
 
         kwa["pre"] = self.pre
-        if gvrsn is Version:
-            gvrsn = pvrsn
         return self.endorse(eventing.reply(**kwa), framed=framed, nested=nested,
                             gvrsn=gvrsn, genusify=genusify)
 
@@ -2293,7 +2288,7 @@ class BaseHab:
         if end and (end.enabled or end.allowed):
             said = self.db.eans.get(keys=(cid, role, eid))
             serder = self.db.rpys.get(keys=(said.qb64,))
-            gvrsn = gvrsn if gvrsn is not None else serder.pvrsn
+            gvrsn = gvrsn if gvrsn is not None else Version
             cigars = self.db.scgs.get(keys=(said.qb64,))
             tsgs = fetchTsgs(db=self.db.tsgs, diger=said)
 
@@ -2432,7 +2427,7 @@ class BaseHab:
         keys = (eid, scheme) if scheme else (eid,)
         for (pre, _), said in self.db.lans.getTopItemIter(keys=keys):
             serder = self.db.rpys.get(keys=(said.qb64,))
-            egvrsn = gvrsn if gvrsn is not None else serder.pvrsn
+            egvrsn = gvrsn if gvrsn is not None else Version
             cigars = self.db.scgs.get(keys=(said.qb64,))
             tsgs = fetchTsgs(db=self.db.tsgs, diger=said)
 
@@ -2519,8 +2514,8 @@ class BaseHab:
         if cid not in self.kevers:
             return msgs
 
-        gvrsn = kwa.get("gvrsn")
-        msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
+        gvrsn = kwa.get("gvrsn") or Version
+        msgs.extend(self.replay(cid, gvrsn=gvrsn))
 
         kever = self.kevers[cid]
         witness = self.pre in kever.wits  # see if we are cid's witness
@@ -2637,9 +2632,9 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code (useful when serder.gvrsn < 2)
-                            gvrsn = max(svrsn, gvrsn) where svrsn = serder.gvrsn
-                                if serder.gvrsn else serder.pvrsn
+                            nesting group code. Default ``Version`` means v2
+                            attachment framing even for v1 event bodies; pass
+                            ``Vrsn_1_0`` only for a v1-only peer.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2650,9 +2645,6 @@ class BaseHab:
         """
         serder, sigers, duple = self.getOwnEvent(sn=sn,
                                     allowPartiallySigned=allowPartiallySigned)
-
-        if gvrsn is Version:
-            gvrsn = serder.pvrsn
 
         seal = None
         if duple is not None:
@@ -2683,9 +2675,9 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code (useful when serder.gvrsn < 2)
-                            gvrsn = max(svrsn, gvrsn) where svrsn = serder.gvrsn
-                                if serder.gvrsn else serder.pvrsn
+                            nesting group code. Default ``Version`` means v2
+                            attachment framing even for v1 event bodies; pass
+                            ``Vrsn_1_0`` only for a v1-only peer.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2720,9 +2712,9 @@ class BaseHab:
                            False means messagize for top level of stream.
                                 This allows bare non-native serialization of message
             gvrsn (Versionage): CESR Genus version for attachment group codes or
-                            nesting group code (useful when serder.gvrsn < 2)
-                            gvrsn = max(svrsn, gvrsn) where svrsn = serder.gvrsn
-                                if serder.gvrsn else serder.pvrsn
+                            nesting group code. Default ``Version`` means v2
+                            attachment framing even for v1 event bodies; pass
+                            ``Vrsn_1_0`` only for a v1-only peer.
             genusify (bool): True means prepend genus version code from gvrsn before
                             serder to override default stream genus version
                          False means do nothing
@@ -2744,8 +2736,6 @@ class BaseHab:
 
         serder = self.db.evts.get(keys=(pre, dig))
         sigers = [siger for siger in self.db.sigs.getIter(keys=(pre, dig))]
-        if gvrsn is Version:
-            gvrsn = serder.pvrsn
         return eventing.messagize(serder, sigers=sigers, framed=framed,
                                    nested=nested, gvrsn=gvrsn, genusify=genusify)
 
@@ -3094,8 +3084,10 @@ class Hab(BaseHab):
             raise ConfigurationError("Improper Habitat inception for "
                                             "pre={} {}".format(self.pre, ex))
 
-        # read in self.cf config file and process any oobis or endpoints
-        self.reconfigure(version=version, kind=kind)  # should we do this for new Habs not loaded from db
+        # read in self.cf config file and process any oobis or endpoints.
+        # Match attachment genus to the protocol version (and thus local
+        # parser) that will consume these locally generated replies.
+        self.reconfigure(version=version, kind=kind, gvrsn=version)
 
         self.inited = True
 
@@ -3584,10 +3576,10 @@ class SignifyHab(BaseHab):
         if eids is None:
             eids = []
 
-        gvrsn = kwa.get("gvrsn")
+        gvrsn = kwa.get("gvrsn") or Version
 
         # introduce yourself, please
-        msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
+        msgs.extend(self.replay(cid, gvrsn=gvrsn))
 
         if role == Roles.witness:
             if kever := self.kevers[cid] if cid in self.kevers else None:
@@ -3601,11 +3593,11 @@ class SignifyHab(BaseHab):
                         if not witness:  # we are not witness, send auth records
                             msgs.extend(self.makeEndRole(eid=eid, role=role, **kwa))
                 if witness:  # we are witness, set KEL as authz
-                    msgs.extend(self.replay(cid, gvrsn=kwa.get("gvrsn", Version)))
+                    msgs.extend(self.replay(cid, gvrsn=gvrsn))
 
         for (_, erole, eid), end in self.db.ends.getTopItemIter(keys=(cid,)):
             if (end.enabled or end.allowed) and (not role or role == erole) and (not eids or eid in eids):
-                msgs.extend(self.replay(eid, gvrsn=kwa.get("gvrsn", Version)))
+                msgs.extend(self.replay(eid, gvrsn=gvrsn))
                 msgs.extend(self.loadLocScheme(eid=eid, scheme=scheme,
                                                gvrsn=gvrsn))
                 msgs.extend(self.loadEndRole(cid=cid, eid=eid, role=erole,
@@ -4101,8 +4093,6 @@ class GroupHab(BaseHab):
         if gvrsn is not Version and "gvrsn" not in kwa:
             kwa["gvrsn"] = gvrsn
         serder = eventing.query(pre=self.mhab.pre, query=query, **kwa)
-        if gvrsn is Version:
-            gvrsn = kwa.get("gvrsn", serder.pvrsn)
 
         return self.mhab.endorse(serder, last=True, framed=framed, nested=nested,
                                  gvrsn=gvrsn, genusify=genusify)

--- a/src/keri/app/signing.py
+++ b/src/keri/app/signing.py
@@ -4,20 +4,14 @@ KERI
 keri.app.signing module
 
 """
-from .. import Vrsn_1_0
 from .habbing import GroupHab
-from ..core import Pather, Counter, Seqner, Diger, Codens
+from ..core import Pather, Seqner, Diger, SealEvent, messagize
 
 
 def serialize(creder, prefixer, seqner, saider):
-    craw = bytearray(creder.raw)
-    craw.extend(Counter(Codens.SealSourceTriples, count=1,
-                             version=Vrsn_1_0).qb64b)
-    craw.extend(prefixer.qb64b)
-    craw.extend(seqner.qb64b)
-    craw.extend(saider.qb64b)
-
-    return bytes(craw)
+    return bytes(messagize(creder,
+                           bonds=[SealEvent(i=prefixer, s=seqner, d=saider)],
+                           framed=True, gvrsn=creder.pvrsn))
 
 
 #def ratify(hab, serder, paths=None, pipelined=False):

--- a/src/keri/app/signing.py
+++ b/src/keri/app/signing.py
@@ -6,12 +6,13 @@ keri.app.signing module
 """
 from .habbing import GroupHab
 from ..core import Pather, Seqner, Diger, SealEvent, messagize
+from ..kering import Version
 
 
 def serialize(creder, prefixer, seqner, saider):
     return bytes(messagize(creder,
                            bonds=[SealEvent(i=prefixer, s=seqner, d=saider)],
-                           framed=True, gvrsn=creder.pvrsn))
+                           framed=True, gvrsn=Version))
 
 
 #def ratify(hab, serder, paths=None, pipelined=False):

--- a/src/keri/cli/commands/multisig/incept.py
+++ b/src/keri/cli/commands/multisig/incept.py
@@ -14,7 +14,7 @@ import sys
 from hio.base import doing
 from hio.help import ogler
 
-from ....kering import ConfigurationError, Kinds, Versionage
+from ....kering import ConfigurationError, Kinds, Versionage, Version
 from ....app import (Notifier, MailboxDirector, Multiplexor,
                      Counselor, HaberyDoer, Poster,
                      multisigInceptExn)
@@ -163,7 +163,8 @@ class GroupMultisigIncept(doing.DoDoer):
             ghab = self.hby.makeGroupHab(group=self.group, mhab=hab, smids=smids,
                                          rmids=rmids, **self.inits)
 
-            icp = ghab.msgOwnInception(allowPartiallySigned=True)
+            icp = ghab.msgOwnInception(allowPartiallySigned=True,
+                                       gvrsn=self.version if self.version is not None else Version)
 
             # Create a notification EXN message to send to the other agents
             exn, ims = multisigInceptExn(ghab.mhab,

--- a/src/keri/cli/commands/multisig/join.py
+++ b/src/keri/cli/commands/multisig/join.py
@@ -240,7 +240,8 @@ class JoinDoer(doing.DoDoer):
             except ValueError as e:
                 return False
 
-            icp = ghab.msgOwnInception(allowPartiallySigned=True)
+            icp = ghab.msgOwnInception(allowPartiallySigned=True,
+                                       gvrsn=self.version if self.version is not None else Version)
 
             exn, ims = multisigInceptExn(ghab.mhab,
                                          smids=ghab.smids,

--- a/src/keri/cli/commands/multisig/notice.py
+++ b/src/keri/cli/commands/multisig/notice.py
@@ -82,7 +82,8 @@ class NoticeDoer(doing.DoDoer):
         if hab.group:
             (smids, rmids) = hab.members()
             serder = hab.kever.serder
-            rot = hab.msgOwnEvent(sn=hab.kever.sn, framed=True)
+            rot = hab.msgOwnEvent(sn=hab.kever.sn, framed=True,
+                                  gvrsn=serder.pvrsn)
             eserder = SerderKERI(raw=rot)
             del rot[:eserder.size]
 

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1897,23 +1897,23 @@ class Baser(LMDBer):
         #return msg
 
 
-    def cloneDelegation(self, kever, gvrsn=None, *, version=None):
+    def cloneDelegation(self, kever, gvrsn=Version, *, version=None):
         """
         Recursively clone delegation chain from AID of Kever if one exists.
 
         Parameters:
             kever (Kever): Kever from which to clone the delegator's AID.
-            gvrsn (Versionage | None): CESR genus version for attachments.
-                None means derive from ``kever.serder.gvrsn`` or
-                ``kever.serder.pvrsn`` so V1 KELs are not rebuilt with the
-                global V2 default.
+            gvrsn (Versionage): CESR genus version for attachments. Default
+                ``Version`` means v2 attachment framing even when cloning
+                v1 key-event bodies. Pass ``Vrsn_1_0`` only for a v1-only peer.
+                Present-but-``None`` is treated as ``Version``.
             version (Versionage): legacy alias for gvrsn
 
         """
         if version is not None:
             gvrsn = version
         if gvrsn is None:
-            gvrsn = kever.serder.gvrsn or kever.serder.pvrsn
+            gvrsn = Version
         if kever.delegated and kever.delpre in self.kevers:
             dkever = self.kevers[kever.delpre]
             yield from self.cloneDelegation(dkever, gvrsn=gvrsn)

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1904,8 +1904,9 @@ class Baser(LMDBer):
         Parameters:
             kever (Kever): Kever from which to clone the delegator's AID.
             gvrsn (Versionage): CESR genus version for attachments. Default
-                ``Version`` means v2 attachment framing even when cloning
-                v1 key-event bodies. Pass ``Vrsn_1_0`` only for a v1-only peer.
+                ``Version`` means library-default attachment framing even when
+                cloning bodies with a different pvrsn. Pass ``Vrsn_1_0`` only
+                when the peer requires that attachment genus.
                 Present-but-``None`` is treated as ``Version``.
             version (Versionage): legacy alias for gvrsn
 

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -601,8 +601,8 @@ class OOBIEnd:
         if eid:
             eids.append(eid)
 
-        # Serve attachments at this node's configured CESR version (v1 demos
-        # pin --version 1.0; default Habery Version remains v2).
+        # Serve attachments at this node's configured CESR version (demos may
+        # pin --version 1.0; otherwise Habery uses Version).
         gvrsn = self.hby.version
         msgs = hab.replyToOobi(aid=aid, role=role, eids=eids, gvrsn=gvrsn)
         if not msgs and role is None:

--- a/src/keri/end/ending.py
+++ b/src/keri/end/ending.py
@@ -601,10 +601,13 @@ class OOBIEnd:
         if eid:
             eids.append(eid)
 
-        msgs = hab.replyToOobi(aid=aid, role=role, eids=eids)
+        # Serve attachments at this node's configured CESR version (v1 demos
+        # pin --version 1.0; default Habery Version remains v2).
+        gvrsn = self.hby.version
+        msgs = hab.replyToOobi(aid=aid, role=role, eids=eids, gvrsn=gvrsn)
         if not msgs and role is None:
-            msgs = hab.replyToOobi(aid=aid, role=Roles.witness, eids=eids)
-            msgs.extend(hab.replay(aid))
+            msgs = hab.replyToOobi(aid=aid, role=Roles.witness, eids=eids, gvrsn=gvrsn)
+            msgs.extend(hab.replay(aid, gvrsn=gvrsn))
 
         if msgs:
             rep.status = falcon.HTTP_200  # This is the default status

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -15,8 +15,8 @@ from ..kering import (Vrsn_1_0, Vrsn_2_0, Ilks,
 from ..core import (Counter, Pather, Dater, Diger,
                     Prefixer, Seqner, Saider,
                     Noncer, Sadder, Serder, SerderKERI,
-                    NonTransDex, Saids, Codens,
-                    verifySigs)
+                    Saids, Codens,
+                    verifySigs, messagize)
 from ..db import fetchTsgs
 from ..help import helping
 
@@ -636,56 +636,37 @@ def serializeMessage(hby, said, framed=False):
         msg (bytearray):  message by said with attachments
 
     """
-    atc = bytearray()
-
     exn = hby.db.exns.get(keys=(said,))
     if exn is None:
         return None, None
 
-    atc.extend(exn.raw)
-
     tsgs, cigars = verify(hby=hby, serder=exn)
 
-    if len(tsgs) > 0:
-        for (prefixer, seqner, saider, sigers) in tsgs:
-            atc.extend(Counter(Codens.TransIdxSigGroups, count=1,
-                                    version=Vrsn_1_0).qb64b)
-            atc.extend(prefixer.qb64b)
-            atc.extend(seqner.qb64b)
-            atc.extend(saider.qb64b)
+    aims = bytearray()
+    if tsgs or cigars:
+        # Authenticator attachments via messagize; framed=True so we can append
+        # pathed embeds after (pathed material is outside messagize support).
+        full = messagize(exn, tsgs=tsgs or None, cigars=cigars or None,
+                         framed=True, gvrsn=exn.pvrsn)
+        aims.extend(full[exn.size:])
 
-            atc.extend(Counter(Codens.ControllerIdxSigs, count=len(sigers),
-                                    version=Vrsn_1_0).qb64b)
-            for siger in sigers:
-                atc.extend(siger.qb64b)
-
-    if len(cigars) > 0:
-        atc.extend(Counter(Codens.NonTransReceiptCouples,
-                                count=len(cigars), version=Vrsn_1_0).qb64b)
-        for cigar in cigars:
-            if cigar.verfer.code not in NonTransDex:
-                raise ValueError("Attempt to use tranferable prefix={} for "
-                                 "receipt.".format(cigar.verfer.qb64))
-            atc.extend(cigar.verfer.qb64b)
-            atc.extend(cigar.qb64b)
-
-    # Smash the pathed components on the end
+    # Pathed embeds are outside current messagize support — deliberate special
+    # case until messagize gains path-material encoding.
     for p in hby.db.epath.get(keys=(exn.said,)):
-        atc.extend(Counter(Codens.PathedMaterialCouples,
-                                  count=(len(p) // 4), version=Vrsn_1_0).qb64b)
-        atc.extend(p.encode("utf-8"))
+        aims.extend(Counter(Codens.PathedMaterialCouples,
+                            count=(len(p) // 4), version=Vrsn_1_0).qb64b)
+        aims.extend(p.encode("utf-8"))
 
-    msg = bytearray()
+    msg = bytearray(exn.raw)
+    if aims:
+        if len(aims) % 4:
+            raise ValueError("Invalid attachments size={}, nonintegral"
+                             " quadlets.".format(len(aims)))
+        if not framed:
+            msg.extend(Counter(Codens.AttachmentGroup,
+                               count=(len(aims) // 4), version=exn.pvrsn).qb64b)
+        msg.extend(aims)
 
-    if len(atc) % 4:
-        raise ValueError("Invalid attachments size={}, nonintegral"
-                         " quadlets.".format(len(atc)))
-
-    if not framed:
-        msg.extend(Counter(Codens.AttachmentGroup,
-                                  count=(len(atc) // 4), version=Vrsn_1_0).qb64b)
-
-    msg.extend(atc)
     return msg
 
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -647,7 +647,7 @@ def serializeMessage(hby, said, framed=False):
         # Authenticator attachments via messagize; framed=True so we can append
         # pathed embeds after (pathed material is outside messagize support).
         full = messagize(exn, tsgs=tsgs or None, cigars=cigars or None,
-                         framed=True, gvrsn=exn.pvrsn)
+                         framed=True)
         aims.extend(full[exn.size:])
 
     # Pathed embeds are outside current messagize support — deliberate special
@@ -664,7 +664,7 @@ def serializeMessage(hby, said, framed=False):
                              " quadlets.".format(len(aims)))
         if not framed:
             msg.extend(Counter(Codens.AttachmentGroup,
-                               count=(len(aims) // 4), version=exn.pvrsn).qb64b)
+                               count=(len(aims) // 4), version=Version).qb64b)
         msg.extend(aims)
 
     return msg

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -647,7 +647,7 @@ def serializeMessage(hby, said, framed=False):
         # Authenticator attachments via messagize; framed=True so we can append
         # pathed embeds after (pathed material is outside messagize support).
         full = messagize(exn, tsgs=tsgs or None, cigars=cigars or None,
-                         framed=True)
+                         framed=True, gvrsn=Vrsn_1_0)
         aims.extend(full[exn.size:])
 
     # Pathed embeds are outside current messagize support — deliberate special
@@ -664,7 +664,7 @@ def serializeMessage(hby, said, framed=False):
                              " quadlets.".format(len(aims)))
         if not framed:
             msg.extend(Counter(Codens.AttachmentGroup,
-                               count=(len(aims) // 4), version=Version).qb64b)
+                               count=(len(aims) // 4), version=Vrsn_1_0).qb64b)
         msg.extend(aims)
 
     return msg

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -10,15 +10,15 @@ from typing import Optional
 from hio.base import doing
 from hio.help import decking, ogler
 
-from ..kering import (Vrsn_1_0, ClosedError,
+from ..kering import (ClosedError,
                       ConfigurationError, MissingAnchorError,
                       ValidationError, LikelyDuplicitousError,
                       MissingRegistryError)
 
 from ..core import (Parser, Schemer, SerderKERI, SerderACDC,
-                    Counter, Codens, MtrDex, NumDex,
+                    MtrDex, NumDex,
                     Number, Diger, TraitDex,
-                    Seqner, Saider, Prefixer)
+                    Seqner, Saider, Prefixer, SealEvent, messagize)
 from ..db import snKey, dgKey
 from ..vc import credential
 
@@ -1044,11 +1044,10 @@ def sendCredential(hby, hab, reger, postman, creder, recp):
         postman.send(serder=source, attachment=atc)
 
     serder, prefixer, seqner, saider = reger.cloneCred(creder.said)
-    atc = bytearray(Counter(Codens.SealSourceTriples,
-                                 count=1, version=Vrsn_1_0).qb64b)
-    atc.extend(prefixer.qb64b)
-    atc.extend(seqner.qb64b)
-    atc.extend(saider.qb64b)
+    msg = messagize(creder,
+                    bonds=[SealEvent(i=prefixer, s=seqner, d=saider)],
+                    framed=True, gvrsn=creder.pvrsn)
+    atc = bytes(msg[creder.size:])
     postman.send(serder=creder, attachment=atc)
 
 

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -13,7 +13,7 @@ from hio.help import decking, ogler
 from ..kering import (ClosedError,
                       ConfigurationError, MissingAnchorError,
                       ValidationError, LikelyDuplicitousError,
-                      MissingRegistryError)
+                      MissingRegistryError, Version)
 
 from ..core import (Parser, Schemer, SerderKERI, SerderACDC,
                     MtrDex, NumDex,
@@ -1046,7 +1046,7 @@ def sendCredential(hby, hab, reger, postman, creder, recp):
     serder, prefixer, seqner, saider = reger.cloneCred(creder.said)
     msg = messagize(creder,
                     bonds=[SealEvent(i=prefixer, s=seqner, d=saider)],
-                    framed=True, gvrsn=creder.pvrsn)
+                    framed=True, gvrsn=Version)
     atc = bytes(msg[creder.size:])
     postman.send(serder=creder, attachment=atc)
 

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -7,6 +7,7 @@ VC TEL  support
 """
 import logging
 from dataclasses import asdict
+from types import SimpleNamespace
 from ordered_set import OrderedSet as oset
 from math import ceil
 from  ordered_set import OrderedSet as oset
@@ -19,25 +20,23 @@ from ..kering import (Kinds, Ilks, versify,
                     ValidationError, OutOfOrderError,
                     LikelyDuplicitousError, MissingEntryError, MissingAnchorError,
                     UntrustedKeyStateSource,UnverifiedReplyError,
-                    OutOfOrderTxnStateError, MissingRegistryError)
+                    OutOfOrderTxnStateError, MissingRegistryError, smell)
 
-from ..core import (SerderKERI, Salter, Prefixer, Verfer,
-                    Number, Saider, Seqner,
-                    Diger, Dater, SealEvent,
+from ..core import (Salter, SealEvent, SealSource,
                     TraitDex, MtrDex, ample, verifySigs,
-                    query as queryCore)
+                    query as queryCore, messagize as coreMessagize)
 
 from ..db import (Baser, Broker, Komer, LMDBer,
                   Suber, OnSuber, CatCesrSuber, IoDupSuber,
                   CesrDupSuber, OnIoDupSuber, SerderSuber,
                   CesrIoSetSuber, CatCesrIoSetSuber, CesrSuber,
-                  openLMDB, dgKey, snKey, dgKey, snKey)
+                  openLMDB, dgKey, snKey)
 
 
 from ..core import (Counter, Number, Diger, Dater,
                     Prefixer, Verfer, Cigar, Saider,
                     Seqner, SerderACDC, SerderKERI,
-                    Siger, CtrDex_1_0, Codens)
+                    Siger, CtrDex_1_0)
 
 from ..help import helping
 
@@ -2625,40 +2624,33 @@ class Reger(LMDBer):
         return self.cloneTvt(pre, dig)
 
     def cloneTvt(self, pre, dig):
-        msg = bytearray()  # message
-        atc = bytearray()  # attachments
-        dgkey = dgKey(pre, dig)  # get message
-        if not (raw := self.tvts.get(keys=dgkey)):
+        if not (raw := self.tvts.get(keys=dgKey(pre, dig))):
             raise MissingEntryError("Missing event for dig={}.".format(dig))
-        msg.extend(raw.encode("utf-8"))
 
-        # add indexed backer signatures to attachments
-        if tibs := self.tibs.get(keys=(pre, dig)):
-            atc.extend(Counter(Codens.WitnessIdxSigs, count=len(tibs),
-                                    version=Vrsn_1_0).qb64b)
-            for tib in tibs:
-                atc.extend(tib.qb64b)
+        # Preserve exact stored body bytes. Do not Serder-parse: the version
+        # size field may not match (clone fixtures / legacy rows), and messagize
+        # only needs .raw / .pvrsn / .gvrsn / .pretty().
+        rawb = raw.encode("utf-8") if hasattr(raw, "encode") else bytes(raw)
+        tibs = self.tibs.get(keys=(pre, dig))
+        couple = self.ancs.get(keys=dgKey(pre, dig))
 
-        # add authorizer (delegator/issure) source seal event couple to attachments
-        couple = self.ancs.get(keys=dgkey)
+        if not tibs and couple is None:
+            return bytearray(rawb)
+
+        _, pvrsn, _, _, gvrsn = smell(rawb)
+        serder = SimpleNamespace(raw=rawb,
+                                 pvrsn=pvrsn,
+                                 gvrsn=gvrsn if gvrsn is not None else pvrsn,
+                                 pretty=lambda: rawb[:80].decode(
+                                     "utf-8", errors="replace"))
+
+        seal = None
         if couple is not None:
             number, diger = couple
-            seqner = Seqner(sn=number.sn)
-            saider = Saider(qb64=diger.qb64)
-            atc.extend(Counter(Codens.SealSourceCouples, count=1,
-                                    version=Vrsn_1_0).qb64b)
-            atc.extend(seqner.qb64b)
-            atc.extend(saider.qb64b)
+            seal = SealSource(s=number, d=diger)
 
-        # prepend pipelining counter to attachments
-        if len(atc) % 4:
-            raise ValueError("Invalid attachments size={}, nonintegral"
-                             " quadlets.".format(len(atc)))
-        pcnt = Counter(Codens.AttachmentGroup, count=(len(atc) // 4),
-                            version=Vrsn_1_0).qb64b
-        msg.extend(pcnt)
-        msg.extend(atc)
-        return msg
+        return coreMessagize(serder, wigers=tibs or None, bonds=seal,
+                             framed=False, gvrsn=pvrsn)
 
     def sources(self, db, creder):
         """ Returns raw bytes of any source ('e') credential that is in our database
@@ -2686,11 +2678,10 @@ class Reger(LMDBer):
         for said in saids:
             screder, prefixer, number, saider = self.cloneCred(said=said)
 
-            atc = bytearray(Counter(Codens.SealSourceTriples, count=1,
-                                         version=Vrsn_1_0).qb64b)
-            atc.extend(prefixer.qb64b)
-            atc.extend(number.qb64b)
-            atc.extend(saider.qb64b)
+            msg = coreMessagize(screder,
+                                bonds=[SealEvent(i=prefixer, s=number, d=saider)],
+                                framed=True, gvrsn=screder.pvrsn)
+            atc = bytearray(msg[screder.size:])
 
             sources.append((screder, atc))
             sources.extend(self.sources(db, screder))
@@ -2698,7 +2689,7 @@ class Reger(LMDBer):
         return sources
 
 
-def buildProof(prefixer, seqner, diger, sigers):
+def buildProof(prefixer, seqner, diger, sigers, creder, framed=True):
     """
     Create CESR proof attachment from the quadlet of seal plus signatures on the credential
 
@@ -2707,42 +2698,29 @@ def buildProof(prefixer, seqner, diger, sigers):
         seqner (Seqner) is the sequence number of the event used to sign the credential
         diger (Diger) is the digest of the event used to sign the credential
         sigers (list) are the cryptographic signatures on the credential
+        creder (SerderACDC): credential whose protocol version drives attachment encoding
+        framed (bool): True means bare attachments; False wraps AttachmentGroup
 
     """
-
-    prf = bytearray()
-    prf.extend(Counter(Codens.TransIdxSigGroups, count=1,
-                            version=Vrsn_1_0).qb64b)
-    prf.extend(prefixer.qb64b)
-    prf.extend(seqner.qb64b)
-    prf.extend(diger.qb64b)
-
-    prf.extend(Counter(Codens.ControllerIdxSigs, count=len(sigers),
-                            version=Vrsn_1_0).qb64b)
-    for siger in sigers:
-        prf.extend(siger.qb64b)
-
-    return prf
+    msg = coreMessagize(creder, tsgs=[(prefixer, seqner, diger, sigers)],
+                        framed=framed, gvrsn=creder.pvrsn)
+    return bytearray(msg[creder.size:])
 
 
-def messagize(creder, proof):
-    """ Create a CESR message format with proof attachment for credential
+def messagize(creder, prefixer, seqner, diger, sigers, framed=False):
+    """Create a CESR message with proof attachment for credential via core messagize.
 
-    Parameters
+    Parameters:
         creder (Creder): instance of credential
-        proof (str): CESR proof attachment
+        prefixer (Prefixer): identifier of the issuer of the credential
+        seqner (Seqner): sequence number of the event used to sign the credential
+        diger (Diger): digest of the event used to sign the credential
+        sigers (list): cryptographic signatures on the credential
+        framed (bool): True means bare attachments; False wraps AttachmentGroup
 
     Returns:
         bytearray: serialized credential with attached proof
 
     """
-
-    craw = bytearray(creder.raw)
-    if len(proof) % 4:
-        raise ValueError("Invalid attachments size={}, nonintegral"
-                         " quadlets.".format(len(proof)))
-    craw.extend(Counter(Codens.AttachmentGroup, count=(len(proof) // 4),
-                             version=Vrsn_1_0).qb64b)
-    craw.extend(proof)
-
-    return craw
+    return coreMessagize(creder, tsgs=[(prefixer, seqner, diger, sigers)],
+                         framed=framed, gvrsn=creder.pvrsn)

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -36,7 +36,7 @@ from ..db import (Baser, Broker, Komer, LMDBer,
 from ..core import (Counter, Number, Diger, Dater,
                     Prefixer, Verfer, Cigar, Saider,
                     Seqner, SerderACDC, SerderKERI,
-                    Siger, CtrDex_1_0)
+                    Siger, Codens)
 
 from ..help import helping
 
@@ -2468,18 +2468,22 @@ class Reger(LMDBer):
 
         return self.env
 
-    def cloneCreds(self, saids, db):
+    def cloneCreds(self, saids, db, gvrsn=Version, *, version=None):
         """ Returns fully expanded credential with chained credentials attached.
 
         Parameters:
            saids (list): of Saider objects:
            db (Baser): baser object to load schema
+           gvrsn (Versionage): CESR genus version for TEL attachments
+           version (Versionage): legacy alias for gvrsn
 
         Returns:
             list: fully hydrated credentials with full chains provided
 
         """
         from ..app import serialize
+        if version is not None:
+            gvrsn = version
         creds = []
         for saider in saids:
             key = saider.qb64
@@ -2491,12 +2495,12 @@ class Reger(LMDBer):
             status = self.tevers[regk].vcState(saider.qb64)
             schemer = db.schema.get(creder.schema)
 
-            iss = bytearray(self.cloneTvtAt(creder.said, sn=0))
+            iss = bytearray(self.cloneTvtAt(creder.said, sn=0, gvrsn=gvrsn))
             iserder = SerderKERI(raw=iss)
             issatc = bytes(iss[iserder.size:])
             del iss[0:iserder.size]
             if status.et in [Ilks.rev, Ilks.brv]:
-                rev = bytearray(self.cloneTvtAt(creder.said, sn=1))
+                rev = bytearray(self.cloneTvtAt(creder.said, sn=1, gvrsn=gvrsn))
                 rserder = SerderKERI(raw=rev)
                 revatc = bytes(rev[rserder.size:])
                 del rev[0:rserder.size]
@@ -2510,7 +2514,7 @@ class Reger(LMDBer):
                     continue
 
                 chainSaids.append(Saider(qb64=p["n"]))
-            chains = self.cloneCreds(chainSaids, db)
+            chains = self.cloneCreds(chainSaids, db, gvrsn=gvrsn)
 
             cred = dict(
                 sad=creder.sad,
@@ -2530,11 +2534,11 @@ class Reger(LMDBer):
                 )
             )
 
-            ctr = Counter(qb64b=iss, strip=True, version=Vrsn_1_0)
-            if ctr.code == CtrDex_1_0.AttachmentGroup:
-                ctr = Counter(qb64b=iss, strip=True, version=Vrsn_1_0)
+            ctr = Counter(qb64b=iss, strip=True, version=gvrsn)
+            if ctr.name == Codens.AttachmentGroup:
+                ctr = Counter(qb64b=iss, strip=True, version=gvrsn)
 
-            if ctr.code == CtrDex_1_0.SealSourceCouples:
+            if ctr.name == Codens.SealSourceCouples:
                 Number(qb64b=iss, strip=True)
                 saider = Saider(qb64b=iss)
 
@@ -2545,11 +2549,11 @@ class Reger(LMDBer):
                 cred['ancatc'] = ancatc.decode("utf-8"),
 
             if status.et in [Ilks.rev, Ilks.brv]:
-                ctr = Counter(qb64b=rev, strip=True, version=Vrsn_1_0)
-                if ctr.code == CtrDex_1_0.AttachmentGroup:
-                    ctr = Counter(qb64b=rev, strip=True, version=Vrsn_1_0)
+                ctr = Counter(qb64b=rev, strip=True, version=gvrsn)
+                if ctr.name == Codens.AttachmentGroup:
+                    ctr = Counter(qb64b=rev, strip=True, version=gvrsn)
 
-                if ctr.code == CtrDex_1_0.SealSourceCouples:
+                if ctr.name == Codens.SealSourceCouples:
                     Number(qb64b=rev, strip=True)
                     saider = Saider(qb64b=rev)
 
@@ -2596,7 +2600,7 @@ class Reger(LMDBer):
         prefixer, number, saider = self.cancs.get(keys=(said,))
         return creder, prefixer, number, saider
 
-    def clonePreIter(self, pre, fn=0):
+    def clonePreIter(self, pre, fn=0, gvrsn=Version, *, version=None):
         """ Iterator of first seen event messages
 
         Returns iterator of first seen event messages with attachments for the
@@ -2606,6 +2610,8 @@ class Reger(LMDBer):
         Parameters:
             pre (bytes): qb64 identifier prefix of registry state TEL
             fn (int): first seen ordinal
+            gvrsn (Versionage): CESR genus version for attachments
+            version (Versionage): legacy alias for gvrsn
 
         Returns:
             iterator: bytearray per serializeed event msg
@@ -2614,16 +2620,22 @@ class Reger(LMDBer):
         if hasattr(pre, 'encode'):
             pre = pre.encode("utf-8")
 
+        if version is not None:
+            gvrsn = version
         for _, fn, dig in self.tels.getAllItemIter(keys=pre, on=fn):
-            msg = self.cloneTvt(pre, dig)
+            msg = self.cloneTvt(pre, dig, gvrsn=gvrsn)
             yield msg
 
-    def cloneTvtAt(self, pre, sn=0):
+    def cloneTvtAt(self, pre, sn=0, gvrsn=Version, *, version=None):
+        if version is not None:
+            gvrsn = version
         snkey = snKey(pre, sn)
         dig = self.tels.get(keys=pre, on=sn)
-        return self.cloneTvt(pre, dig)
+        return self.cloneTvt(pre, dig, gvrsn=gvrsn)
 
-    def cloneTvt(self, pre, dig):
+    def cloneTvt(self, pre, dig, gvrsn=Version, *, version=None):
+        if version is not None:
+            gvrsn = version
         if not (raw := self.tvts.get(keys=dgKey(pre, dig))):
             raise MissingEntryError("Missing event for dig={}.".format(dig))
 
@@ -2637,10 +2649,10 @@ class Reger(LMDBer):
         if not tibs and couple is None:
             return bytearray(rawb)
 
-        _, pvrsn, _, _, gvrsn = smell(rawb)
+        _, pvrsn, _, _, body_gvrsn = smell(rawb)
         serder = SimpleNamespace(raw=rawb,
                                  pvrsn=pvrsn,
-                                 gvrsn=gvrsn if gvrsn is not None else pvrsn,
+                                 gvrsn=body_gvrsn if body_gvrsn is not None else pvrsn,
                                  pretty=lambda: rawb[:80].decode(
                                      "utf-8", errors="replace"))
 
@@ -2650,7 +2662,7 @@ class Reger(LMDBer):
             seal = SealSource(s=number, d=diger)
 
         return coreMessagize(serder, wigers=tibs or None, bonds=seal,
-                             framed=False, gvrsn=pvrsn)
+                             framed=False, gvrsn=gvrsn)
 
     def sources(self, db, creder):
         """ Returns raw bytes of any source ('e') credential that is in our database

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -440,7 +440,6 @@ def test_witness_inquisitor(mockHelpingNowUTC, seeder, witnessPorter):
         doist.exit()
 
 
-@pytest.mark.skip(reason="need to wait for DB changes")
 def test_witness_inquisitor_v2(mockHelpingNowUTC, seeder):
 
     KWA = dict(version=Vrsn_2_0, kind=Kinds.json)

--- a/tests/app/test_forwarding.py
+++ b/tests/app/test_forwarding.py
@@ -327,11 +327,13 @@ def test_essr_stream(seeder, unused_tcp_port):
         msgs = bytearray()
         msgs.extend(recpHab.makeEndRole(eid=recpHab.pre,
                                         role=Roles.controller,
-                                        stamp=help.nowIso8601(), **KWA))
+                                        stamp=help.nowIso8601(),
+                                        gvrsn=Vrsn_1_0, **KWA))
 
         msgs.extend(recpHab.makeLocScheme(url=f'http://127.0.0.1:{httpPort}',
                                           scheme=Schemes.http,
-                                          stamp=help.nowIso8601(), **KWA))
+                                          stamp=help.nowIso8601(),
+                                          gvrsn=Vrsn_1_0, **KWA))
         hab.psr.parse(ims=msgs)
 
         postman = StreamPoster(hby=hby, hab=hab, recp=recpHab.pre, essr=True)

--- a/tests/app/test_forwarding.py
+++ b/tests/app/test_forwarding.py
@@ -326,11 +326,13 @@ def test_essr_stream(seeder, unused_tcp_port):
         msgs = bytearray()
         msgs.extend(recpHab.makeEndRole(eid=recpHab.pre,
                                         role=Roles.controller,
-                                        stamp=help.nowIso8601(), version=Vrsn_1_0, kind=Kinds.json))
+                                        stamp=help.nowIso8601(), version=Vrsn_1_0,
+                                        kind=Kinds.json, gvrsn=Vrsn_1_0))
 
         msgs.extend(recpHab.makeLocScheme(url=f'http://127.0.0.1:{httpPort}',
                                           scheme=Schemes.http,
-                                          stamp=help.nowIso8601(), version=Vrsn_1_0, kind=Kinds.json))
+                                          stamp=help.nowIso8601(), version=Vrsn_1_0,
+                                          kind=Kinds.json, gvrsn=Vrsn_1_0))
         hab.psr.parse(ims=msgs)
 
         postman = StreamPoster(hby=hby, hab=hab, recp=recpHab.pre, essr=True)

--- a/tests/app/test_grouping.py
+++ b/tests/app/test_grouping.py
@@ -927,11 +927,11 @@ def test_multisig_incept_handler_parses_approved_v1_embed(mockHelpingNowUTC):
         ghab2 = hby2.makeGroupHab(group="approved-embed", mhab=hab2,
                                   smids=smids, rmids=None, **inits)
 
-        icp1 = ghab1.msgOwnInception(allowPartiallySigned=True)
+        icp1 = ghab1.msgOwnInception(allowPartiallySigned=True, gvrsn=TEST_VERSION)
         exn1, _ = multisigInceptExn(hab=ghab1.mhab, smids=ghab1.smids,
                                     rmids=ghab1.rmids, icp=icp1,
                                     version=TEST_VERSION, kind=Kinds.json)
-        icp2 = ghab2.msgOwnInception(allowPartiallySigned=True)
+        icp2 = ghab2.msgOwnInception(allowPartiallySigned=True, gvrsn=TEST_VERSION)
         exn2, atc2 = multisigInceptExn(hab=ghab2.mhab, smids=ghab2.smids,
                                        rmids=ghab2.rmids, icp=icp2,
                                        version=TEST_VERSION, kind=Kinds.json)

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -100,7 +100,8 @@ def test_create_cesr_request(mockHelpingNowUTC):
         assert headers["Content-Length"] == 254
         assert len(headers["CESR-ATTACHMENT"]) == 144
 
-        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0), version=Vrsn_1_0, kind=Kinds.json)
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0),
+                        version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         client = MockClient()
 
         createCESRRequest(msg, client, dest=wit, path="/qry/mbx")
@@ -240,7 +241,8 @@ def test_stream_cesr_request(mockHelpingNowUTC):
         assert headers["Content-Length"] == 254
         assert len(headers["CESR-ATTACHMENT"]) == 144
 
-        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0), version=Vrsn_1_0, kind=Kinds.json)
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0),
+                        version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         client = MockClient()
 
         streamCESRRequests(client, msg, dest=wit, path="/qry/mbx")
@@ -260,7 +262,8 @@ def test_stream_cesr_request(mockHelpingNowUTC):
                                               b'Z3al3V3z3VstRtHRPeOrotuqZZUgBl2yHzgpGyOjAXYGinVqWLAMhdmQ089FTSAz'
                                               b'qSTBmJzI8RvIezsJ')
 
-        msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0), version=Vrsn_1_0, kind=Kinds.json)
+        msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0),
+                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         msgs.extend(hab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_1_0))
 
         client = MockClient()

--- a/tests/app/test_httping.py
+++ b/tests/app/test_httping.py
@@ -101,7 +101,8 @@ def test_create_cesr_request(mockHelpingNowUTC):
         assert headers["Content-Length"] == 254
         assert len(headers["CESR-ATTACHMENT"]) == 144
 
-        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0), **KWA)
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0),
+                        gvrsn=Vrsn_1_0, **KWA)
         client = MockClient()
 
         createCESRRequest(msg, client, dest=wit, path="/qry/mbx")
@@ -241,7 +242,8 @@ def test_stream_cesr_request(mockHelpingNowUTC):
         assert headers["Content-Length"] == 254
         assert len(headers["CESR-ATTACHMENT"]) == 144
 
-        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0), **KWA)
+        msg = hab.query(pre=hab.pre, src=wit, route="mbx", query=dict(s=0),
+                        gvrsn=Vrsn_1_0, **KWA)
         client = MockClient()
 
         streamCESRRequests(client, msg, dest=wit, path="/qry/mbx")
@@ -261,7 +263,8 @@ def test_stream_cesr_request(mockHelpingNowUTC):
                                               b'Z3al3V3z3VstRtHRPeOrotuqZZUgBl2yHzgpGyOjAXYGinVqWLAMhdmQ089FTSAz'
                                               b'qSTBmJzI8RvIezsJ')
 
-        msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0), **KWA)
+        msgs = hab.query(pre=hab.pre, src=wit, route="logs", query=dict(s=0),
+                         gvrsn=Vrsn_1_0, **KWA)
         msgs.extend(hab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_1_0))
 
         client = MockClient()

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -455,7 +455,7 @@ def test_follow_on_events_honor_explicit_v1_kwargs():
 
 
 def test_end_role_reply_defaults_to_v2_attachments_for_v1_hab():
-    """Omitted gvrsn keeps v2 attachment framing on a v1 reply body."""
+    """Omitted gvrsn keeps default (``Version``) attachment framing on a v1 reply body."""
     with openHby(name="v1-end-role", version=Vrsn_1_0) as hby:
         hab = hby.makeHab(name="cam", version=Vrsn_1_0, kind=Kinds.json)
 
@@ -464,7 +464,7 @@ def test_end_role_reply_defaults_to_v2_attachments_for_v1_hab():
         assert serder.pvrsn == Vrsn_1_0
         assert serder.kind == Kinds.json
         atc = bytes(msg[serder.size:])
-        assert atc.startswith(b"-C")  # v2 attachment group framing
+        assert atc.startswith(b"-C")  # default AttachmentGroup framing
         assert not atc.startswith(b"-V")  # not v1 attachment group
 
         # Local v1-only parser needs explicit v1 attachments.

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -457,7 +457,8 @@ def test_follow_on_events_honor_explicit_v1_kwargs():
         assert iserder.kind == Kinds.json
 
 
-def test_end_role_reply_defaults_to_hab_version_for_v1_hab():
+def test_end_role_reply_defaults_to_v2_attachments_for_v1_hab():
+    """Omitted gvrsn keeps v2 attachment framing on a v1 reply body."""
     with openHby(name="v1-end-role", version=Vrsn_1_0) as hby:
         hab = hby.makeHab(name="cam", **KWA)
 
@@ -465,9 +466,15 @@ def test_end_role_reply_defaults_to_hab_version_for_v1_hab():
         serder = SerderKERI(raw=msg)
         assert serder.pvrsn == Vrsn_1_0
         assert serder.kind == Kinds.json
+        atc = bytes(msg[serder.size:])
+        assert atc.startswith(b"-C")  # v2 attachment group framing
+        assert not atc.startswith(b"-V")  # not v1 attachment group
 
-        hab.psr.parse(ims=bytearray(msg))
-        loaded = hab.loadEndRole(cid=hab.pre, eid=hab.pre, role=Roles.mailbox)
+        # Local v1-only parser needs explicit v1 attachments.
+        msg_v1 = hab.makeEndRole(eid=hab.pre, role=Roles.mailbox, gvrsn=Vrsn_1_0)
+        hab.psr.parse(ims=bytearray(msg_v1))
+        loaded = hab.loadEndRole(cid=hab.pre, eid=hab.pre, role=Roles.mailbox,
+                                 gvrsn=Vrsn_1_0)
         assert loaded
 
 

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -144,11 +144,13 @@ def test_oobiery(unused_tcp_port_factory):
         msgs = bytearray()
         msgs.extend(hab.makeEndRole(eid=hab.pre,
                                     role=Roles.controller,
-                                    stamp=helping.nowIso8601(), version=Vrsn_1_0, kind=Kinds.json))
+                                    stamp=helping.nowIso8601(), version=Vrsn_1_0,
+                                    kind=Kinds.json, gvrsn=Vrsn_1_0))
 
         msgs.extend(hab.makeLocScheme(url=f'http://127.0.0.1:{locPort}',
                                       scheme=Schemes.http,
-                                      stamp=helping.nowIso8601(), version=Vrsn_1_0, kind=Kinds.json))
+                                      stamp=helping.nowIso8601(), version=Vrsn_1_0,
+                                      kind=Kinds.json, gvrsn=Vrsn_1_0))
         hab.psr.parse(ims=msgs)
 
         oobiery = Oobiery(hby=hby)
@@ -226,20 +228,22 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
         msgs.extend(hab.makeEndRole(eid=hab.pre,
                                     role=Roles.controller,
                                     stamp=helping.nowIso8601(),
-                                    version=Vrsn_1_0, kind=Kinds.json))
+                                    version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
         msgs.extend(hab.makeLocScheme(url="http://127.0.0.1:5555",
                                       scheme=Schemes.http,
                                       stamp=helping.nowIso8601(),
-                                      version=Vrsn_1_0, kind=Kinds.json))
+                                      version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
         hab.psr.parse(ims=msgs)
 
         oobi = bytearray()
         oobi.extend(hab.replay(version=Vrsn_1_0))
         oobi.extend(hab.loadEndRole(cid=hab.pre,
                                     eid=hab.pre,
-                                    role=Roles.controller))
+                                    role=Roles.controller,
+                                    gvrsn=Vrsn_1_0))
         oobi.extend(hab.loadLocScheme(eid=hab.pre,
-                                      scheme=Schemes.http))
+                                      scheme=Schemes.http,
+                                      gvrsn=Vrsn_1_0))
 
         dst.psr.parse(ims=oobi)
 

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -266,7 +266,7 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
 
 
 def test_v2_reply_to_oobi_replay_without_explicit_gvrsn():
-    """replyToOobi with omitted gvrsn keeps library default (v2 attachments)."""
+    """replyToOobi with omitted gvrsn keeps library default (``Version``) attachments."""
     v2kwa = dict(version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
     with openHby(name="oobi-src-v2-replay", version=Vrsn_2_0) as src, \
             openHby(name="oobi-dst-v2-replay", version=Vrsn_2_0) as dst:
@@ -304,7 +304,7 @@ def test_v2_reply_to_oobi_replay_without_explicit_gvrsn():
 
 
 def test_v1_kel_replay_defaults_to_v2_attachments():
-    """v1 key-event bodies keep pvrsn; omitted gvrsn uses v2 attachment framing."""
+    """v1 key-event bodies keep pvrsn; omitted gvrsn uses ``Version`` attachment framing."""
     with openHby(name="v1-kel-v2-atc", version=Vrsn_1_0) as hby:
         hab = hby.makeHab(name="probe", version=Vrsn_1_0, kind=Kinds.json)
         msg = hab.replay()
@@ -313,8 +313,8 @@ def test_v1_kel_replay_defaults_to_v2_attachments():
         assert serder.ked["v"].startswith("KERI10")
 
         atc = bytes(msg[serder.size:])
-        assert atc.startswith(b"-CAi-KAW")  # v2 AttachmentGroup + ControllerIdxSigs
-        assert not atc.startswith(b"-VAi-AAB")  # not v1 AttachmentGroup + ControllerIdxSigs
+        assert atc.startswith(b"-CAi-KAW")  # Version AttachmentGroup + ControllerIdxSigs
+        assert not atc.startswith(b"-VAi-AAB")  # not Vrsn_1_0 AttachmentGroup + ControllerIdxSigs
 
         oobi = hab.replyToOobi(aid=hab.pre, role=Roles.controller, eids=[hab.pre])
         assert oobi
@@ -327,7 +327,7 @@ def test_v1_kel_replay_defaults_to_v2_attachments():
         rvy = Revery(db=hby.db, rtr=rtr)
         kvy = Kevery(db=hby.db, lax=False, local=False, rvy=rvy)
         kvy.registerReplyRoutes(router=rtr)
-        # v2 parser accepts v1 bodies with v2 attachments
+        # Version parser accepts v1 bodies with Version-framed attachments
         Parser(version=Vrsn_2_0, kvy=kvy, rvy=rvy).parse(ims=bytearray(msg))
 
 

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -261,6 +261,44 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
         assert locer.url == "http://127.0.0.1:5555"
 
 
+def test_v2_reply_to_oobi_replay_without_explicit_gvrsn():
+    """replyToOobi replay uses target kever pvrsn when gvrsn is omitted."""
+    v2kwa = dict(version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
+    with openHby(name="oobi-src-v2-replay", version=Vrsn_2_0) as src, \
+            openHby(name="oobi-dst-v2-replay", version=Vrsn_2_0) as dst:
+        hab = src.makeHab(name="wit", isith="1", icount=1,
+                          transferable=False, version=Vrsn_2_0, kind=Kinds.cesr)
+        msgs = bytearray()
+        msgs.extend(hab.makeEndRole(eid=hab.pre,
+                                    role=Roles.controller,
+                                    stamp=helping.nowIso8601(),
+                                    **v2kwa))
+        msgs.extend(hab.makeLocScheme(url="http://127.0.0.1:5555",
+                                      scheme=Schemes.http,
+                                      stamp=helping.nowIso8601(),
+                                      **v2kwa))
+        hab.psr.parse(ims=msgs)
+
+        oobi = hab.replyToOobi(aid=hab.pre,
+                               role=Roles.controller,
+                               eids=[hab.pre])
+        assert oobi
+
+        rtr = Router()
+        rvy = Revery(db=dst.db, rtr=rtr)
+        kvy = Kevery(db=dst.db, lax=False, local=False, rvy=rvy)
+        kvy.registerReplyRoutes(router=rtr)
+        Parser(version=Vrsn_2_0, kvy=kvy, rvy=rvy).parse(ims=bytearray(oobi))
+
+        assert hab.pre in kvy.kevers
+        ender = dst.db.ends.get(keys=(hab.pre, Roles.controller, hab.pre))
+        assert ender is not None
+        assert ender.allowed is True
+        locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
+        assert locer is not None
+        assert locer.url == "http://127.0.0.1:5555"
+
+
 def test_loaded_v2_oobi_endpoint_replies_bypass_kram(mockHelpingNowUTC):
     config = {
         "kram": {

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -226,20 +226,22 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
         msgs.extend(hab.makeEndRole(eid=hab.pre,
                                     role=Roles.controller,
                                     stamp=helping.nowIso8601(),
-                                    **KWA))
+                                    gvrsn=Vrsn_1_0, **KWA))
         msgs.extend(hab.makeLocScheme(url="http://127.0.0.1:5555",
                                       scheme=Schemes.http,
                                       stamp=helping.nowIso8601(),
-                                      **KWA))
+                                      gvrsn=Vrsn_1_0, **KWA))
         hab.psr.parse(ims=msgs)
 
         oobi = bytearray()
         oobi.extend(hab.replay(version=Vrsn_1_0))
         oobi.extend(hab.loadEndRole(cid=hab.pre,
                                     eid=hab.pre,
-                                    role=Roles.controller))
+                                    role=Roles.controller,
+                                    gvrsn=Vrsn_1_0))
         oobi.extend(hab.loadLocScheme(eid=hab.pre,
-                                      scheme=Schemes.http))
+                                      scheme=Schemes.http,
+                                      gvrsn=Vrsn_1_0))
 
         dst.psr.parse(ims=oobi)
 
@@ -262,7 +264,7 @@ def test_loaded_v1_endpoint_replies_use_stored_reply_framing():
 
 
 def test_v2_reply_to_oobi_replay_without_explicit_gvrsn():
-    """replyToOobi replay uses target kever pvrsn when gvrsn is omitted."""
+    """replyToOobi with omitted gvrsn keeps library default (v2 attachments)."""
     v2kwa = dict(version=Vrsn_2_0, kind=Kinds.cesr, gvrsn=Vrsn_2_0)
     with openHby(name="oobi-src-v2-replay", version=Vrsn_2_0) as src, \
             openHby(name="oobi-dst-v2-replay", version=Vrsn_2_0) as dst:
@@ -297,6 +299,34 @@ def test_v2_reply_to_oobi_replay_without_explicit_gvrsn():
         locer = dst.db.locs.get(keys=(hab.pre, Schemes.http))
         assert locer is not None
         assert locer.url == "http://127.0.0.1:5555"
+
+
+def test_v1_kel_replay_defaults_to_v2_attachments():
+    """v1 key-event bodies keep pvrsn; omitted gvrsn uses v2 attachment framing."""
+    with openHby(name="v1-kel-v2-atc", version=Vrsn_1_0) as hby:
+        hab = hby.makeHab(name="probe", version=Vrsn_1_0, kind=Kinds.json)
+        msg = hab.replay()
+        serder = SerderKERI(raw=msg)
+        assert serder.pvrsn == Vrsn_1_0
+        assert serder.ked["v"].startswith("KERI10")
+
+        atc = bytes(msg[serder.size:])
+        assert atc.startswith(b"-CAi-KAW")  # v2 AttachmentGroup + ControllerIdxSigs
+        assert not atc.startswith(b"-VAi-AAB")  # not v1 AttachmentGroup + ControllerIdxSigs
+
+        oobi = hab.replyToOobi(aid=hab.pre, role=Roles.controller, eids=[hab.pre])
+        assert oobi
+        oserder = SerderKERI(raw=oobi)
+        assert oserder.pvrsn == Vrsn_1_0
+        oatc = bytes(oobi[oserder.size:])
+        assert oatc.startswith(b"-CAi-KAW")
+
+        rtr = Router()
+        rvy = Revery(db=hby.db, rtr=rtr)
+        kvy = Kevery(db=hby.db, lax=False, local=False, rvy=rvy)
+        kvy.registerReplyRoutes(router=rtr)
+        # v2 parser accepts v1 bodies with v2 attachments
+        Parser(version=Vrsn_2_0, kvy=kvy, rvy=rvy).parse(ims=bytearray(msg))
 
 
 def test_loaded_v2_oobi_endpoint_replies_bypass_kram(mockHelpingNowUTC):

--- a/tests/core/test_reply.py
+++ b/tests/core/test_reply.py
@@ -1130,12 +1130,12 @@ def test_reply(mockHelpingNowUTC):
         assert rurls["witness"][wokHab.pre]['http'] == 'http://localhost:8080/witness/wok'
 
         msgs = bytearray()
-        msgs.extend(tamHab.makeEndRole(eid=wesHab.pre, role=Roles.witness, **KWA))
-        msgs.extend(tamHab.makeEndRole(eid=wokHab.pre, role=Roles.witness, **KWA))
-        msgs.extend(tamHab.makeEndRole(eid=wamHab.pre, role=Roles.witness, **KWA))
-        msgs.extend(wesHab.makeLocScheme(url='http://localhost:8080/witness/wes', **KWA))
-        msgs.extend(wokHab.makeLocScheme(url='http://localhost:8080/witness/wok', **KWA))
-        msgs.extend(wamHab.makeLocScheme(url='http://localhost:8080/witness/wam', **KWA))
+        msgs.extend(tamHab.makeEndRole(eid=wesHab.pre, role=Roles.witness, **CUE_KWA))
+        msgs.extend(tamHab.makeEndRole(eid=wokHab.pre, role=Roles.witness, **CUE_KWA))
+        msgs.extend(tamHab.makeEndRole(eid=wamHab.pre, role=Roles.witness, **CUE_KWA))
+        msgs.extend(wesHab.makeLocScheme(url='http://localhost:8080/witness/wes', **CUE_KWA))
+        msgs.extend(wokHab.makeLocScheme(url='http://localhost:8080/witness/wok', **CUE_KWA))
+        msgs.extend(wamHab.makeLocScheme(url='http://localhost:8080/witness/wam', **CUE_KWA))
 
         tamHab.psr.parse(bytearray(msgs))
         wesHab.psr.parse(bytearray(msgs))
@@ -1147,12 +1147,12 @@ def test_reply(mockHelpingNowUTC):
         welHab.psr.parse(bytearray(msgs))
 
         msgs = bytearray()
-        msgs.extend(nelHab.makeEndRole(eid=nelHab.pre, role=Roles.controller, **KWA))
-        msgs.extend(nelHab.makeEndRole(eid=watHab.pre, role=Roles.watcher, **KWA))
-        msgs.extend(nelHab.makeEndRole(eid=welHab.pre, role=Roles.watcher, **KWA))
-        msgs.extend(nelHab.makeLocScheme(url='http://localhost:8080/controller/nel', **KWA))
-        msgs.extend(watHab.makeLocScheme(url='http://localhost:8080/watcher/wat', **KWA))
-        msgs.extend(welHab.makeLocScheme(url='http://localhost:8080/watcher/wel', **KWA))
+        msgs.extend(nelHab.makeEndRole(eid=nelHab.pre, role=Roles.controller, **CUE_KWA))
+        msgs.extend(nelHab.makeEndRole(eid=watHab.pre, role=Roles.watcher, **CUE_KWA))
+        msgs.extend(nelHab.makeEndRole(eid=welHab.pre, role=Roles.watcher, **CUE_KWA))
+        msgs.extend(nelHab.makeLocScheme(url='http://localhost:8080/controller/nel', **CUE_KWA))
+        msgs.extend(watHab.makeLocScheme(url='http://localhost:8080/watcher/wat', **CUE_KWA))
+        msgs.extend(welHab.makeLocScheme(url='http://localhost:8080/watcher/wel', **CUE_KWA))
 
         tamHab.psr.parse(bytearray(msgs))
         wesHab.psr.parse(bytearray(msgs))

--- a/tests/core/test_reply.py
+++ b/tests/core/test_reply.py
@@ -1129,12 +1129,18 @@ def test_reply(mockHelpingNowUTC):
         assert rurls["witness"][wokHab.pre]['http'] == 'http://localhost:8080/witness/wok'
 
         msgs = bytearray()
-        msgs.extend(tamHab.makeEndRole(eid=wesHab.pre, role=Roles.witness, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(tamHab.makeEndRole(eid=wokHab.pre, role=Roles.witness, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(tamHab.makeEndRole(eid=wamHab.pre, role=Roles.witness, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(wesHab.makeLocScheme(url='http://localhost:8080/witness/wes', version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(wokHab.makeLocScheme(url='http://localhost:8080/witness/wok', version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(wamHab.makeLocScheme(url='http://localhost:8080/witness/wam', version=Vrsn_1_0, kind=Kinds.json))
+        msgs.extend(tamHab.makeEndRole(eid=wesHab.pre, role=Roles.witness,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(tamHab.makeEndRole(eid=wokHab.pre, role=Roles.witness,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(tamHab.makeEndRole(eid=wamHab.pre, role=Roles.witness,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(wesHab.makeLocScheme(url='http://localhost:8080/witness/wes',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(wokHab.makeLocScheme(url='http://localhost:8080/witness/wok',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(wamHab.makeLocScheme(url='http://localhost:8080/witness/wam',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
 
         tamHab.psr.parse(bytearray(msgs))
         wesHab.psr.parse(bytearray(msgs))
@@ -1146,12 +1152,18 @@ def test_reply(mockHelpingNowUTC):
         welHab.psr.parse(bytearray(msgs))
 
         msgs = bytearray()
-        msgs.extend(nelHab.makeEndRole(eid=nelHab.pre, role=Roles.controller, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(nelHab.makeEndRole(eid=watHab.pre, role=Roles.watcher, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(nelHab.makeEndRole(eid=welHab.pre, role=Roles.watcher, version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(nelHab.makeLocScheme(url='http://localhost:8080/controller/nel', version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(watHab.makeLocScheme(url='http://localhost:8080/watcher/wat', version=Vrsn_1_0, kind=Kinds.json))
-        msgs.extend(welHab.makeLocScheme(url='http://localhost:8080/watcher/wel', version=Vrsn_1_0, kind=Kinds.json))
+        msgs.extend(nelHab.makeEndRole(eid=nelHab.pre, role=Roles.controller,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(nelHab.makeEndRole(eid=watHab.pre, role=Roles.watcher,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(nelHab.makeEndRole(eid=welHab.pre, role=Roles.watcher,
+                                       version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(nelHab.makeLocScheme(url='http://localhost:8080/controller/nel',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(watHab.makeLocScheme(url='http://localhost:8080/watcher/wat',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
+        msgs.extend(welHab.makeLocScheme(url='http://localhost:8080/watcher/wel',
+                                         version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0))
 
         tamHab.psr.parse(bytearray(msgs))
         wesHab.psr.parse(bytearray(msgs))

--- a/tests/core/test_witness.py
+++ b/tests/core/test_witness.py
@@ -21,7 +21,7 @@ logger = ogler.getLogger()
 
 
 def _pin_hab_msgs_v1(hab):
-    """Force v1 on Hab message helpers when global defaults are v2."""
+    """Force v1 on Hab message helpers when global defaults use ``Version``."""
     kwa = dict(version=Vrsn_1_0, kind=Kinds.json)
     hab.receipt = partial(BaseHab.receipt, hab, gvrsn=Vrsn_1_0, **kwa)
     hab.reply = partial(BaseHab.reply, hab, gvrsn=Vrsn_1_0, **kwa)

--- a/tests/core/test_witness.py
+++ b/tests/core/test_witness.py
@@ -28,6 +28,11 @@ def _pin_hab_msgs_v1(hab):
     hab.query = partial(BaseHab.query, hab, gvrsn=Vrsn_1_0, **kwa)
     hab.witness = partial(BaseHab.witness, hab, gvrsn=Vrsn_1_0, **kwa)
     hab.msgOwnInception = partial(BaseHab.msgOwnInception, hab, gvrsn=Vrsn_1_0)
+    hab.msgOwnEvent = partial(BaseHab.msgOwnEvent, hab, gvrsn=Vrsn_1_0)
+    hab.processCues = partial(BaseHab.processCues, hab, gvrsn=Vrsn_1_0,
+                              version=Vrsn_1_0, kind=Kinds.json)
+    hab.processCuesIter = partial(BaseHab.processCuesIter, hab, gvrsn=Vrsn_1_0,
+                                  version=Vrsn_1_0, kind=Kinds.json)
 
 
 def test_indexed_witness_replay_v1():

--- a/tests/vdr/test_txn_state.py
+++ b/tests/vdr/test_txn_state.py
@@ -78,7 +78,7 @@ def test_tsn_message_out_of_order(mockHelpingNowUTC, mockCoringRandomNonce):
         assert saider[0].qb64b == b'ECZWYxq_Qgs0J0ls_imRWRYxrojzTKL2REjqe0rN8kWy'
 
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 
@@ -169,7 +169,7 @@ def test_tsn_message_missing_anchor(mockHelpingNowUTC, mockCoringRandomNonce):
         assert saider[0].qb64b == said
 
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 
@@ -227,7 +227,7 @@ def test_tsn_from_witness(mockHelpingNowUTC, mockCoringRandomNonce):
         assert bobHab.pre in wesHab.kevers
 
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 
@@ -351,7 +351,7 @@ def test_tsn_from_no_one(mockHelpingNowUTC, mockCoringRandomNonce):
         assert bobHab.pre in wesHab.kevers
 
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 
@@ -504,7 +504,7 @@ def test_credential_tsn_message(mockHelpingNowUTC, mockCoringRandomNonce, mockHe
         Parser(version=Vrsn_1_0).parse(ims=msgs, kvy=bamKvy, rvy=bamRvy)
 
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=issuer.regk, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 
@@ -523,7 +523,7 @@ def test_credential_tsn_message(mockHelpingNowUTC, mockCoringRandomNonce, mockHe
 
         vci = creder.said
         tmsgs = bytearray()
-        cloner = regery.reger.clonePreIter(pre=vci, fn=0)  # create iterator at 0
+        cloner = regery.reger.clonePreIter(pre=vci, fn=0, gvrsn=Vrsn_1_0)
         for msg in cloner:
             tmsgs.extend(msg)
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -348,9 +348,9 @@ def test_verifier_chained_credential(seeder):
         # Now process all the events that Ron's issuer has generated so far
         for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=iankvy, tvy=iantvy)
-        for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=iankvy, tvy=iantvy)
-        for msg in ronverfer.reger.clonePreIter(pre=creder.said):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=creder.said):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=iankvy, tvy=iantvy)
 
         ianverfer.processCredential(creder, prefixer=ron.kever.prefixer, seqner=seqner,
@@ -481,9 +481,9 @@ def test_verifier_chained_credential(seeder):
 
         for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ronverfer.reger.clonePreIter(pre=creder.said):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=creder.said):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
 
         vicverfer.processCredential(creder, prefixer=ian.kever.prefixer, seqner=seqner,
@@ -497,9 +497,9 @@ def test_verifier_chained_credential(seeder):
         # Get Ian's icp into Vic's db
         for msg in ian.db.clonePreIter(pre=ian.pre, version=ian.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ianverfer.reger.clonePreIter(pre=ianiss.regk):
+        for msg in ianverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=ianiss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ianverfer.reger.clonePreIter(pre=vLeiCreder.said):
+        for msg in ianverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=vLeiCreder.said):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
 
         # And now verify the credential:
@@ -527,9 +527,9 @@ def test_verifier_chained_credential(seeder):
 
         for msg in ron.db.clonePreIter(pre=ron.pre, version=ron.kever.serder.pvrsn):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ronverfer.reger.clonePreIter(pre=roniss.regk):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=roniss.regk):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
-        for msg in ronverfer.reger.clonePreIter(pre=creder.said):
+        for msg in ronverfer.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=creder.said):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=vickvy, tvy=victvy)
 
         with pytest.raises(RevokedChainError):

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -696,7 +696,8 @@ def _aggregate_far_node(ian, ianiss, ianreg, issueeAid):
     # anchor a TEL issuance event for the aggregate SAID so it is "issued".
     iss = ianiss.issue(said=agg.said)
     rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-    ian.interact(data=[rseal], framed=True, **CUE_KWA)
+    ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                 gvrsn=Vrsn_1_0)
     ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
                      seqner=Seqner(sn=ian.kever.sn),
                      saider=Diger(qb64=ian.kever.serder.said))
@@ -714,13 +715,17 @@ def test_verifier_saves_aggregate_credential(seeder):
     subject-indexed at all. It must instead resolve the issuee via ``.iseaid``,
     identically to an attributive credential.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian",
+                                     version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -755,13 +760,17 @@ def test_verifier_aggregate_far_node_chain(seeder):
     verifier must resolve targeted-ness and the issuee via ``.iseaid`` so an edge
     to an aggregate far node behaves identically to an attributive one.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian",
+                                     version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -820,13 +829,17 @@ def test_verifier_e1e_aggregate_far_node(seeder):
     based; this locks in that it works for an aggregate far node through the real
     verifier, not just a bespoke example verifier.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian",
+                                     version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -564,15 +564,19 @@ def test_verifier_e1e_identity_edge(seeder):
     """
     optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef',
+                 version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         seeder.seedSchema(db=ianHby.db)
 
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian",
+                                     version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -590,7 +594,8 @@ def test_verifier_e1e_identity_edge(seeder):
                 pass  # expected: the TEL issuance event is anchored just below
             iss = ianiss.issue(said=creder.said)
             rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-            ian.interact(data=[rseal], framed=True, **CUE_KWA)
+            ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                         gvrsn=Vrsn_1_0)
             ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
                              seqner=Seqner(sn=ian.kever.sn),
                              saider=Diger(qb64=ian.kever.serder.said))
@@ -601,7 +606,8 @@ def test_verifier_e1e_identity_edge(seeder):
         coreSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="core identity")
         _, cd = Saider.saidify(sad=coreSubject, code=MtrDex.Blake3_256, label=Saids.d)
         core = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=cd,
-                          status=ianiss.regk, source={}, rules={}, **KWA)
+                          status=ianiss.regk, source={}, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
         assert core.israid == ian.pre        # issuer
         assert core.iseaid == han.pre        # issuee (a.i)
         issueAndSave(core)
@@ -613,7 +619,8 @@ def test_verifier_e1e_identity_edge(seeder):
         entSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="over 21")
         _, ed = Saider.saidify(sad=entSubject, code=MtrDex.Blake3_256, label=Saids.d)
         ent = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=ed,
-                         status=ianiss.regk, source=chain, rules={}, **KWA)
+                         status=ianiss.regk, source=chain, rules={},
+                         version=Vrsn_1_0, kind=Kinds.json)
         assert ent.israid == ian.pre         # issuer is ian ...
         assert ent.iseaid == han.pre         # ... but issuee is han: issuer != issuee
         assert ent.israid != ent.iseaid
@@ -634,7 +641,8 @@ def test_verifier_e1e_identity_edge(seeder):
         badSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="wrong subject")
         _, bd = Saider.saidify(sad=badSubject, code=MtrDex.Blake3_256, label=Saids.d)
         bad = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=bd,
-                         status=ianiss.regk, source=chain, rules={}, **KWA)
+                         status=ianiss.regk, source=chain, rules={},
+                         version=Vrsn_1_0, kind=Kinds.json)
         assert bad.iseaid == ian.pre         # near issuee (ian) != far issuee (han)
         issueAndSave(bad)
         assert verfer.reger.saved.get(keys=bad.saidb) is None
@@ -646,7 +654,8 @@ def test_verifier_e1e_identity_edge(seeder):
         orphanSubject = dict(d="", dt=helping.nowIso8601(), claim="untargeted")  # no 'i'
         _, od = Saider.saidify(sad=orphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
         orphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=od,
-                            status=ianiss.regk, source={}, rules={}, **KWA)
+                            status=ianiss.regk, source={}, rules={},
+                            version=Vrsn_1_0, kind=Kinds.json)
         assert orphan.iseaid is None         # untargeted far node
         issueAndSave(orphan)
         assert verfer.reger.saved.get(keys=orphan.saidb) is not None
@@ -655,7 +664,8 @@ def test_verifier_e1e_identity_edge(seeder):
         toOrphanSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="to orphan")
         _, td = Saider.saidify(sad=toOrphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
         toOrphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=td,
-                              status=ianiss.regk, source=ochain, rules={}, **KWA)
+                              status=ianiss.regk, source=ochain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
         issueAndSave(toOrphan)
         assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
 

--- a/tests/vdr/test_viring.py
+++ b/tests/vdr/test_viring.py
@@ -13,7 +13,7 @@ import lmdb
 from keri import versify, Kinds, Vrsn_1_0
 
 from keri.core import (Siger, Diger, Number,
-                       Prefixer, Saider, Seqner)
+                       Prefixer, Saider)
 from keri.db import Suber, openLMDB, dgKey, snKey
 from keri.vdr import Reger
 
@@ -296,8 +296,7 @@ def test_clone():
     vdig = Diger(ser=vcpb)
     number01 = Number(num=0)
     diger01 = Diger(qb64=vdig.qb64)
-    anc01_couple = (Seqner(sn=number01.sn).qb64b +
-                    Saider(qb64=diger01.qb64).qb64b)
+    anc01_couple = number01.qb64b + diger01.qb64b
     # Valid Siger bytes (tibs must be Siger for CesrDupSuber)
     tib01 = (b'AAAUr5RHYiDH8RU0ig-2Dp5h7rVKx89StH5M3CL60-cWEbgG-XmtW31pZlFicYgSPduJZUnD838_'
              b'QLbASSQLAZcC')
@@ -313,8 +312,7 @@ def test_clone():
     r1dig = Diger(ser=rot1b)
     number02 = Number(num=1)
     diger02 = Diger(qb64=r1dig.qb64)
-    anc02_couple = (Seqner(sn=number02.sn).qb64b +
-                    Saider(qb64=diger02.qb64).qb64b)
+    anc02_couple = number02.qb64b + diger02.qb64b
 
     rot2 = dict(v=vs, i=regk.decode("utf-8"),
                 s="{:x}".format(sn + 2), br=[rarb.decode("utf-8")],
@@ -323,8 +321,7 @@ def test_clone():
     r2dig = Diger(ser=rot2b)
     number03 = Number(num=2)
     diger03 = Diger(qb64=r2dig.qb64)
-    anc03_couple = (Seqner(sn=number03.sn).qb64b +
-                    Saider(qb64=diger03.qb64).qb64b)
+    anc03_couple = number03.qb64b + diger03.qb64b
 
     with openLMDB(cls=Reger) as issuer:
         dgkey = dgKey(regk, vdig.qb64b)


### PR DESCRIPTION
- Default omitted/None/Version attachment genus to v2, even on v1 event bodies; use Vrsn_1_0 only when talking to v1-only peers
- Remove Hab Version → pvrsn caps (replay, reply, msgOwnEvent, msgOtherEvent, group query)
- Unify OOBI / end-role gvrsn resolution (kwa.get("gvrsn") or Version); drop v1 fallbacks in replyToOobi / replyEndRole
- Default cloneDelegation to Version (no derive-from-kever)
- Replace hand-rolled CESR attachment builders with messagize (exchange, signing, grouping, credentialing, Reger TEL clone)
- Thread gvrsn through Reger clonePreIter / cloneTvt / cloneCreds (default v2; parse counters via Codens)
- Tests: new policy regressions (v1 body + v2 attachments); pin remaining v1-peer paths with gvrsn=Vrsn_1_0