### PR TITLE
fix test_ogling error surfaced by xdist

### DIFF
--- a/tests/help/test_ogling.py
+++ b/tests/help/test_ogling.py
@@ -242,7 +242,7 @@ def test_ogler():
     assert not os.path.exists(path)
     assert ogler.opened == False
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -258,18 +258,12 @@ def test_init_ogler():
     assert help.ogler.dirPath == None
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 1
 
     # nothing should log to file because .path not created and level critical
     # # nothing should log to console because level critical
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 1
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -277,10 +271,7 @@ def test_init_ogler():
     help.ogler.level = logging.DEBUG
     # nothing should log because .path not created despite loggin level debug
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 1
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -293,10 +284,7 @@ def test_init_ogler():
     assert help.ogler.dirPath.endswith("_temp")
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    assert len(logger.handlers) == 2
     logger.debug("Test logger at debug level")
     logger.info("Test logger at info level")
     logger.error("Test logger at error level")
@@ -340,7 +328,7 @@ def test_init_ogler():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 
@@ -355,10 +343,7 @@ def test_reset_levels():
     assert help.ogler.level == logging.CRITICAL  # default
     assert help.ogler.path == None
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 1
-    else:
-        assert len(logger.handlers) == 2
+    assert len(logger.handlers) == 1
 
     # logger console: nothing should log  because level CRITICAL
     # logger file: nothing should log because .path not created
@@ -384,10 +369,7 @@ def test_reset_levels():
     assert help.ogler.path.endswith(os.path.join(os.path.sep, "main.log"))
     # recreate loggers to pick up file handler
     logger = help.ogler.getLogger()
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    assert len(logger.handlers) == 2
 
     # logger console: All should log  because level DEBUG
     # logger file: All should log because .path created
@@ -410,11 +392,8 @@ def test_reset_levels():
     assert ogler.path.startswith(os.path.join(tempDirPath, "keri", "logs", "test_"))
     assert ogler.dirPath.endswith("_temp")
     assert ogler.path.endswith(os.path.join(os.path.sep, "test.log"))
-    # Still have 3 handlers
-    if platform.system() == "Windows":
-        assert len(logger.handlers) == 2
-    else:
-        assert len(logger.handlers) == 3
+    # Still have the handlers from the previous ogler
+    assert len(logger.handlers) == 2
 
     with open(ogler.path, 'r') as logfile:
         contents = logfile.read()
@@ -453,7 +432,7 @@ def test_reset_levels():
     ogler.close(clear=True)
     assert not os.path.exists(path)
 
-    help.ogler = ogling.initOgler(prefix='keri')  # reset help.ogler to defaults
+    help.ogler = ogling.initOgler(prefix='keri', syslogged=False)  # reset help.ogler to defaults
     """End Test"""
 
 


### PR DESCRIPTION
In this PR:
- Restore ogler to the help.ogler default, which changed in help.\_\_init\_\_ sometime after this test was written
- Remove the test-order dependency exposed by pytest-xdist on Ubuntu, where isolated tests received one handler but expected two from a previous test’s default