### PR TITLE
Fix NameError that has main red: E1E test uses KWA/CUE_KWA deleted by #1547

### DIFF
--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -564,15 +564,15 @@ def test_verifier_e1e_identity_edge(seeder):
     """
     optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         seeder.seedSchema(db=ianHby.db)
 
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -590,7 +590,7 @@ def test_verifier_e1e_identity_edge(seeder):
                 pass  # expected: the TEL issuance event is anchored just below
             iss = ianiss.issue(said=creder.said)
             rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-            ian.interact(data=[rseal], framed=True, **CUE_KWA)
+            ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
             ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
                              seqner=Seqner(sn=ian.kever.sn),
                              saider=Diger(qb64=ian.kever.serder.said))
@@ -601,7 +601,7 @@ def test_verifier_e1e_identity_edge(seeder):
         coreSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="core identity")
         _, cd = Saider.saidify(sad=coreSubject, code=MtrDex.Blake3_256, label=Saids.d)
         core = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=cd,
-                          status=ianiss.regk, source={}, rules={}, **KWA)
+                          status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0, kind=Kinds.json)
         assert core.israid == ian.pre        # issuer
         assert core.iseaid == han.pre        # issuee (a.i)
         issueAndSave(core)
@@ -613,7 +613,7 @@ def test_verifier_e1e_identity_edge(seeder):
         entSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="over 21")
         _, ed = Saider.saidify(sad=entSubject, code=MtrDex.Blake3_256, label=Saids.d)
         ent = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=ed,
-                         status=ianiss.regk, source=chain, rules={}, **KWA)
+                         status=ianiss.regk, source=chain, rules={}, version=Vrsn_1_0, kind=Kinds.json)
         assert ent.israid == ian.pre         # issuer is ian ...
         assert ent.iseaid == han.pre         # ... but issuee is han: issuer != issuee
         assert ent.israid != ent.iseaid
@@ -634,7 +634,7 @@ def test_verifier_e1e_identity_edge(seeder):
         badSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="wrong subject")
         _, bd = Saider.saidify(sad=badSubject, code=MtrDex.Blake3_256, label=Saids.d)
         bad = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=bd,
-                         status=ianiss.regk, source=chain, rules={}, **KWA)
+                         status=ianiss.regk, source=chain, rules={}, version=Vrsn_1_0, kind=Kinds.json)
         assert bad.iseaid == ian.pre         # near issuee (ian) != far issuee (han)
         issueAndSave(bad)
         assert verfer.reger.saved.get(keys=bad.saidb) is None
@@ -646,7 +646,7 @@ def test_verifier_e1e_identity_edge(seeder):
         orphanSubject = dict(d="", dt=helping.nowIso8601(), claim="untargeted")  # no 'i'
         _, od = Saider.saidify(sad=orphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
         orphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=od,
-                            status=ianiss.regk, source={}, rules={}, **KWA)
+                            status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0, kind=Kinds.json)
         assert orphan.iseaid is None         # untargeted far node
         issueAndSave(orphan)
         assert verfer.reger.saved.get(keys=orphan.saidb) is not None
@@ -655,7 +655,7 @@ def test_verifier_e1e_identity_edge(seeder):
         toOrphanSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="to orphan")
         _, td = Saider.saidify(sad=toOrphanSubject, code=MtrDex.Blake3_256, label=Saids.d)
         toOrphan = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=td,
-                              status=ianiss.regk, source=ochain, rules={}, **KWA)
+                              status=ianiss.regk, source=ochain, rules={}, version=Vrsn_1_0, kind=Kinds.json)
         issueAndSave(toOrphan)
         assert verfer.reger.saved.get(keys=toOrphan.saidb) is None
 


### PR DESCRIPTION
## `main` is currently red

CI on `main` has been failing since 2026-07-28T17:43Z. Run [30383984308](https://github.com/WebOfTrust/keripy/actions/runs/30383984308) on `9161a7054` fails on **macos-latest** and **windows-latest** with:

```
>       with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
E       NameError: name 'KWA' is not defined
tests/vdr/test_verifying.py:567: NameError

FAILED tests/vdr/test_verifying.py::test_verifier_e1e_identity_edge
1 failed, 647 passed, 4 skipped
```

(Note that `9161a7054` also has a green **WASM Tests** run, so the commit shows a mix of check results — the main test job is the failing one.)

## Cause: a semantic merge conflict

Two PRs that never conflicted textually:

- **#1547** (`5b8b1cd92`, authored 2026-07-21) — "Clean up version-related args in tests" — deleted `tests/common.py`, removed `from tests.common import CUE_KWA, KWA`, and inlined every `version=` / `kind=` / `gvrsn=` argument across the suite.
- **#1527** (`4da606571`, authored 2026-07-28) — "Add E1E identity edge operator" — added `test_verifier_e1e_identity_edge`, which uses `**KWA` and `**CUE_KWA`.

The merge at `9161a7054` touched disjoint regions of `tests/vdr/test_verifying.py`, so git resolved it cleanly and shipped a test referencing names that no longer exist. Neither PR's CI would have caught this in isolation — each was green against its own base.

This is not environment-specific: it reproduces on a pristine checkout of `9161a7054` under Python 3.14.4, and `NameError` is version-independent by construction. `KWA` is used 8 times and `CUE_KWA` twice in that file with no definition and no import that could supply them.

## Fix

Inline the arguments in the E1E test exactly the way #1547 did everywhere else — no behavior change, no new dependency on the deleted module:

```
**KWA      ->  version=Vrsn_1_0, kind=Kinds.json
**CUE_KWA  ->  version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0
```

matching the original definitions from `tests/common.py`:

```python
KWA = dict(version=Vrsn_1_0, kind=Kinds.json)
CUE_KWA = dict(**KWA, gvrsn=Vrsn_1_0)
```

## Verification

`tests/vdr/test_verifying.py`: **5 passed** (was 1 failed, 4 passed).

Full suite locally on Python 3.14.4: **659 passed, 4 skipped**.

Scope is one file, 10 insertions / 10 deletions, test-only — no production code touched.

---

*This change was developed with AI assistance (Claude, Anthropic).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
