### PR TITLE
Make edge-operator dispatch spec-conformant and diagnosable

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -33,6 +33,19 @@ class Verifier:
     TimeoutMRI = 3600  # seconds to timeout missing issuer escrows
     TimeoutBCE = 3600  # seconds to timeout missing issuer escrows
 
+    # Unary edge operators this verifier recognizes. A token outside this set is not an
+    # operator to this verifier and is skipped when resolving a list-valued `o` (see
+    # .verifyChain). DI2I and NOT are recognized but unimplemented: they are listed so
+    # they fail closed diagnosably instead of being dropped and silently defaulting.
+    # E1E is a keripy extension not yet in the spec's normative operator table.
+    UnaryOps = ('I2I', 'NI2I', 'DI2I', 'E1E', 'NOT')
+
+    # The delegative subset of .UnaryOps: each constrains the near ACDC's issuer
+    # relative to the far node's issuee, so they are mutually exclusive and a list
+    # containing several is a conflict resolved latest-wins. Operators outside this
+    # subset constrain something else and compose with the winner instead.
+    DelegativeOps = ('I2I', 'NI2I', 'DI2I')
+
     def __init__(self, hby, reger=None, creds=None, cues=None, expiry=36000000000):
         """
         Initialize Verifier instance
@@ -161,7 +174,16 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
+                try:
+                    state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
+                except ValidationError as ex:
+                    # .verifyChain knows the far node but not the near credential that
+                    # carried the edge, and the escrow handler logs only the exception.
+                    # Re-raise with the near SAID and edge label so an operator triaging
+                    # a stream can tell which credential to fix, matching the shape of
+                    # the MissingChainError messages below.
+                    raise ValidationError(f"Failure to verify credential {creder.said} "
+                                          f"chain {label}({nodeSaid}): {ex}") from ex
                 if state is None:
                     self.escrowMCE(creder, prefixer, seqner, saider)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -320,16 +342,19 @@ class Verifier:
                 self.processCredential(creder, prefixer, seqner, saider)
 
             except etype as ex:
+                # Log the exception, not ex.args[0]: an exception raised with no
+                # arguments has an empty args tuple, so indexing it would raise
+                # IndexError from inside this handler and abort the whole pass.
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.trace("Verifier unescrow failed: %s\n", ex.args[0])
-                    logger.exception("Verifier unescrow failed: %s\n", ex.args[0])
+                    logger.trace("Verifier unescrow failed: %s\n", ex)
+                    logger.exception("Verifier unescrow failed: %s\n", ex)
             except Exception as ex:  # log diagnostics errors etc
                 # error other than missing sigs so remove from PA escrow
                 db.rem(said)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Verifier unescrowed: %s", ex.args[0])
+                    logger.exception("Verifier unescrowed: %s", ex)
                 else:
-                    logger.error("Verifier unescrowed: %s", ex.args[0])
+                    logger.error("Verifier unescrowed: %s", ex)
             else:
                 db.rem(said)
                 logger.info("Verifier: unescrow succeeded in valid group op: creder=%s", creder.said)
@@ -377,7 +402,10 @@ class Verifier:
 
         Parameters:
             nodeSaid: (str): qb64 SAID of node credential
-            op(str): edge operator
+            op (str|list|None): edge operator, or a list of unary operators, in which
+                case the latest recognized one takes precedence. None, an empty list,
+                or a value containing no recognized operator applies the default:
+                I2I for a targeted far node, NI2I for an untargeted one.
             issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
             issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
                 required by the identity operators (E1E). None when the near ACDC is
@@ -393,14 +421,37 @@ class Verifier:
 
         creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
-        if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
-            # A far node is targeted (I2I) iff it has an issuee, else untargeted
-            # (NI2I). Resolve via .iseaid so an aggregate ('acg') far node -- whose
-            # issuee is at .sad["A"][1]["i"] and whose .attrib is None -- coerces the
-            # same as an attributive one.
+        # `o` is either a single unary operator or a list of them. Latest-wins applies
+        # only "among the conflicting Operators" (ACDC spec-body.md L1186), so the list
+        # is resolved in two parts: the delegative operators constrain the same thing
+        # (the near issuer relative to the far issuee) and therefore conflict, so the
+        # latest of those wins; E1E constrains the near issuee instead, so it does not
+        # conflict with them and composes (AND) rather than overriding or being
+        # overridden. Tokens this verifier does not recognize are skipped.
+        ops = op if isinstance(op, (list, tuple)) else [op]
+        ops = [cand for cand in ops if cand in self.UnaryOps]
+        op = next((cand for cand in reversed(ops) if cand in self.DelegativeOps), None)
+
+        if not ops:  # absent, empty, or nothing recognized: apply the default rule
+            # A far node is targeted (I2I) iff it has an issuee, else untargeted (NI2I).
+            # Resolve via .iseaid so an aggregate ('acg') far node -- whose issuee is at
+            # .sad["A"][1]["i"] and whose .attrib is None -- coerces the same as an
+            # attributive one (#1529).
             op = 'I2I' if creder.iseaid is not None else 'NI2I'
 
-        if op == 'E1E':
+        # Recognized but unimplemented operators fail closed with a diagnosable error
+        # rather than being silently dropped from the effective list. Deliberately not
+        # a MissingChainError: the chain is present and retrying cannot help, so
+        # escrowing would promise a retry that can never succeed.
+        if 'NOT' in ops:
+            raise ValidationError(f"Unsupported edge operator NOT on edge to node "
+                                  f"{nodeSaid}; NOT validation is not implemented")
+
+        if op == 'DI2I':
+            raise ValidationError(f"Unsupported edge operator DI2I on edge to node "
+                                  f"{nodeSaid}; DI2I validation is not implemented")
+
+        if 'E1E' in ops:
             # Identity relation (discussion #1515): the issuee AID of the near ACDC
             # (the one carrying this edge) MUST equal the issuee AID of the far node.
             # Unlike the delegative I2I, this says nothing about the issuer, so the
@@ -410,7 +461,8 @@ class Verifier:
             farIssuee = creder.iseaid
             if farIssuee is None or issuee is None or issuee != farIssuee:
                 return None
-        elif op != 'NI2I':
+
+        if op is not None and op != 'NI2I':
             # Resolve the far node's issuee via .iseaid so an aggregate ('acg') far
             # node (issuee at .sad["A"][1]["i"]) resolves identically to an
             # attributive one (.attrib["i"]). None means an untargeted far node,
@@ -425,9 +477,6 @@ class Verifier:
 
             if op == 'I2I' and issuer != farIssuee:
                 return None
-
-            if op == "DI2I":
-                raise NotImplementedError()
 
         if creder.regid not in self.tevers:
             return None

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -9,7 +9,7 @@ import copy
 import pytest
 
 from keri import (MissingRegistryError, MissingEntryError,
-                  MissingChainError, RevokedChainError, Vrsn_1_0)
+                  MissingChainError, RevokedChainError, ValidationError, Vrsn_1_0)
 from keri.app import openHab
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
                        Diger, Parser, SealEvent,
@@ -1026,5 +1026,427 @@ def test_verifier_edge_schema_constraint(seeder):
         assert verifier.reger.mse.get(keys=deferredCreder.said) is None
         saved = [s.qb64 for s in regery.reger.schms.get(optionalIssueeSchema)]
         assert deferredCreder.said in saved
+
+    """End Test"""
+
+
+def setupOperatorFixture(ian, ianHby, ianreg, ianiss):
+    """Wire ian's registry into a Verifier and return (verfer, issueAndSave).
+
+    Shared by the operator-dispatch tests below, which all need the same shape:
+    one issuer (ian) with an anchored registry, and a way to run a credential
+    through the full issue -> anchor -> escrow -> save flow.
+    """
+    verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+    def issueAndSave(creder):
+        try:
+            verfer.processCredential(creder, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        except MissingRegistryError:
+            pass  # expected: the TEL issuance event is anchored just below
+        iss = ianiss.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        verfer.processEscrows()
+
+    return verfer, issueAndSave
+
+
+def test_verifier_list_valued_operator(seeder):
+    """A list-valued `o` is a spec-legal spelling and MUST NOT fall to the default.
+
+    ACDC spec-body.md L1186: "When more than one unary Operator is applied to a given
+    Edge, then the value of the Operator, `o`, field is a list of those unary
+    Operators. When multiple unary Operators appear in the list, and there is a
+    conflict between Operators, the latest Operator among the conflicting Operators
+    in the list takes precedence."
+
+    Previously ``op not in ['I2I','DI2I','NI2I','E1E']`` was tested against the list
+    itself, which never matches, so every list form silently fell through to the
+    default inference -- I2I for a targeted far node. A conforming producer writing
+    ``"o": ["NI2I"]`` therefore got I2I semantics, and the same bytes verified
+    differently on a conforming non-keripy validator: an interop split with no
+    wire-visible cause.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        # Far node: targeted, ian -> han. Every near credential below is issued by
+        # ian, so `near issuer (ian) != far issuee (han)` -- I2I rejects, NI2I allows.
+        # That asymmetry is what makes the effective operator observable.
+        farSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        assert far.iseaid == han.pre
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        def nearWithOp(op, claim):
+            """Issue a near credential whose single edge carries operator `op`."""
+            chainSad = dict(d='', node=dict(n=far.said, o=op))
+            _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Single-element list: ["NI2I"] must mean NI2I, not the I2I default.
+        # This is the red case -- before the fix the list fell through to I2I and
+        # the credential sat in missing-chain escrow.
+        near = nearWithOp(["NI2I"], "single element list")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # Latest-wins: ["I2I", "NI2I"] resolves to NI2I, so the edge is accepted
+        # even though the near issuer is not the far issuee.
+        near = nearWithOp(["I2I", "NI2I"], "latest wins to NI2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # Latest-wins in the other direction: ["NI2I", "I2I"] resolves to I2I, which
+        # rejects. Ordering must matter -- a set-membership implementation that just
+        # asked "is NI2I present?" would wrongly accept this one.
+        near = nearWithOp(["NI2I", "I2I"], "latest wins to I2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Unrecognized tokens are skipped, not treated as conflicting: the latest
+        # *recognized* operator wins.
+        near = nearWithOp(["NI2I", "BOGUS"], "unrecognized token skipped")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # A list with no recognized operator falls to the default rule, which for a
+        # targeted far node is I2I -- and so rejects.
+        near = nearWithOp(["BOGUS"], "no recognized operator")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # An empty list likewise falls to the default rule.
+        near = nearWithOp([], "empty list")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Scalar forms are unchanged: "NI2I" still means NI2I.
+        near = nearWithOp("NI2I", "scalar NI2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # A tuple is accepted as a sequence too, not just a list.
+        near = nearWithOp(("NI2I",), "tuple form")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # E1E alone imposes no issuer constraint, and reaching it via a list must not
+        # change that. Here the near issuer is ian and the far issuee is han, so I2I
+        # would reject; E1E's own check (near issuee han == far issuee han) passes, so
+        # the edge is accepted. Composition of E1E with a delegative operator is
+        # covered by test_verifier_nonconflicting_operators_compose.
+        near = nearWithOp(["E1E"], "E1E via list")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # The flagship interop case from the review: "o": ["DI2I"] previously resolved
+        # to I2I via the default rule, silently downgrading a delegated-issuer edge to
+        # a strict issuer==issuee one. It must now reach DI2I and fail closed.
+        chainSad = dict(d='', node=dict(n=far.said, o=["DI2I"]))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="di2i in list")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        listDi2i = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=listDi2i.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(listDi2i, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "DI2I" in str(excinfo.value)
+
+        # NOT is normative (spec L1195: the far node's validity is inverted) and
+        # unimplemented here. It must fail closed like DI2I rather than being skipped
+        # as an unrecognized token -- otherwise an edge asserting "this node must be
+        # INVALID" would be accepted as valid.
+        chainSad = dict(d='', node=dict(n=far.said, o=["NOT"]))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="not operator")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        notCred = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                             status=ianiss.regk, source=chain, rules={},
+                             version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=notCred.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(notCred, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "NOT" in str(excinfo.value)
+
+    """End Test"""
+
+
+def test_verifier_nonconflicting_operators_compose(seeder):
+    """A non-delegative operator composes with the delegative winner, not overridden.
+
+    ACDC spec-body.md L1186 scopes latest-wins to "the conflicting Operators". I2I,
+    NI2I and DI2I all constrain the near ACDC's *issuer* relative to the far node's
+    issuee, so they conflict with one another. E1E constrains the near *issuee*, so it
+    conflicts with none of them and must be conjoined (AND).
+
+    Collapsing the whole list to a single operator drops the constraint that loses,
+    which is a silent weakening: ``["E1E", "I2I"]`` from a producer requiring both
+    relations would enforce only I2I and accept a far node whose issuee differs from
+    the near ACDC's.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        # Far node issued by ian to ian, so the far issuee is ian. Every near
+        # credential below is issued by ian, so I2I (near issuer ian == far issuee ian)
+        # is always satisfied -- which isolates E1E as the only constraint that can
+        # decide the outcome.
+        farSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        assert far.iseaid == ian.pre
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        def nearWithOp(op, nearIssuee, claim):
+            chainSad = dict(d='', node=dict(n=far.said, o=op))
+            _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+            subject = dict(d="", i=nearIssuee, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Both satisfied: I2I (issuer ian == far issuee ian) and E1E (near issuee ian ==
+        # far issuee ian). Accepted.
+        near = nearWithOp(["E1E", "I2I"], ian.pre, "both hold")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # I2I still satisfied, E1E violated: the near issuee is han, the far issuee is
+        # ian. Must be REJECTED. This is the red case -- collapsing the list to the
+        # latest operator (I2I) would accept it and drop the E1E constraint entirely.
+        near = nearWithOp(["E1E", "I2I"], han.pre, "e1e violated, i2i holds")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Order must not matter for a non-conflicting pair -- E1E composes either way.
+        near = nearWithOp(["I2I", "E1E"], han.pre, "order reversed, still rejected")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # E1E composed with NI2I: NI2I wins the delegative conflict (no issuer
+        # constraint), but E1E still applies and still rejects a mismatched issuee.
+        near = nearWithOp(["E1E", "NI2I"], han.pre, "ni2i wins but e1e still applies")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Same pair with the issuee matching: NI2I drops the issuer constraint, E1E is
+        # satisfied, so the edge is accepted.
+        near = nearWithOp(["E1E", "NI2I"], ian.pre, "ni2i wins, e1e satisfied")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+    """End Test"""
+
+
+def test_verifier_di2i_rejects_diagnosably(seeder):
+    """An unimplemented DI2I edge must fail closed *diagnosably*, not vanish.
+
+    DI2I previously raised a bare ``NotImplementedError``, which is not a
+    ValidationError, so every caller mishandled it: ``Parser.allParsator``'s blanket
+    ``except (ValidationError, Exception)`` logged and discarded the ACDC, and
+    ``_processEscrow``'s generic arm unescrowed it. Neither produced a signal an
+    operator could act on.
+
+    DI2I is still unimplemented -- this test pins the *failure mode*, not the
+    operator semantics. A ValidationError names the cause and stops the retry loop,
+    which is correct here: unlike a missing chain, retrying cannot help.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    # Single party: every credential here is issued by ian to ian, so no second hab is
+    # needed to exercise the operator's failure mode.
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        farSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        chainSad = dict(d='', node=dict(n=far.said, o="DI2I"))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="di2i edge")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=chain, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+
+        # Anchor the TEL issuance so processCredential reaches the edge walk rather
+        # than bailing out earlier on a missing registry.
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+
+        # Diagnosable: the message names the operator, the far node the edge points to,
+        # and the near credential that carried the edge -- an operator triaging a stream
+        # needs the last of those to know which credential to fix.
+        assert "DI2I" in str(excinfo.value)
+        assert far.said in str(excinfo.value)
+        assert near.said in str(excinfo.value)
+        # Fails closed -- the credential is not saved on the strength of an edge the
+        # verifier cannot evaluate.
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+        # Not a MissingChainError: the chain is present, the operator is unsupported.
+        # Escrowing it would promise a retry that can never succeed.
+        assert not isinstance(excinfo.value, MissingChainError)
+
+    """End Test"""
+
+
+def test_verifier_escrow_pass_survives_argless_exception(seeder):
+    """One poisoned escrow entry must not abort the whole escrow pass.
+
+    ``_processEscrow``'s generic arm removed the entry and then evaluated
+    ``ex.args[0]`` to log it. For an exception raised with no arguments -- which is
+    exactly what ``raise NotImplementedError()`` produced -- that indexes an empty
+    tuple, so the IndexError escaped ``_processEscrow`` *and* ``processEscrows``,
+    skipping every remaining entry in the current table and both subsequent tables
+    (mce -> mse -> mre).
+
+    Pinned independently of DI2I: any argless exception from any credential reaches
+    the same handler, so fixing only the DI2I raise would leave the trap armed.
+    """
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+        saids = []
+        for n in range(2):
+            subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim=f"poison {n}")
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            creder = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                                status=ianiss.regk, source={}, rules={},
+                                version=Vrsn_1_0, kind=Kinds.json)
+            verfer.escrowMCE(creder, prefixer=ian.kever.prefixer,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            saids.append(creder.said)
+
+        assert len(saids) == 2
+        for said in saids:
+            assert verfer.reger.mce.get(keys=said) is not None
+
+        # Every entry raises an argless exception, the shape that used to detonate.
+        def poisoned(*args, **kwa):
+            raise NotImplementedError()
+
+        verfer.processCredential = poisoned
+
+        # Must not raise. Before the fix this propagated IndexError out of
+        # processEscrows on the first entry.
+        verfer.processEscrows()
+
+        # Both entries were reached and unescrowed -- proving the pass continued past
+        # the first poisoned entry rather than aborting on it.
+        for said in saids:
+            assert verfer.reger.mce.get(keys=said) is None
 
     """End Test"""


### PR DESCRIPTION
> Rebased on current `main` (`a420471f7`); the diff is a single commit. The `KWA`/`CUE_KWA` fix this branch used to carry as its first commit is gone — #1563 was closed as a duplicate of #1562, which landed the byte-identical change, so the rebase dropped it as already applied.
>
> Two PRs landed in this code while this one waited, and the branch carries the merged result of both:
>
> - **#1529** resolves the far node's issuee via `.iseaid`, so an aggregate (`acg`) node coerces the same as an attributive one. That touches the same lines of `verifyChain` as this PR's dispatch rewrite; the merged form is this PR's dispatch structure with #1529's `.iseaid` resolution in the default rule, the `E1E` branch and the targeted branch alike.
> - **#1533** enforces the edge's declared far-node schema (`s`) by satisfiability. Its final form does that in `processCredential`, *after* the `verifyChain` call, and leaves `verifyChain`'s signature untouched, so the two changes are disjoint. This PR's `try`/`except ValidationError` wraps the `verifyChain` call alone; #1533's `MissingSchemaError`/`MissingChainError` raises sit outside it, so neither intercepts the other.

## Summary

Three defects in `Verifier.verifyChain`'s edge-operator handling. Each one makes a *conformant* ACDC fail in a way no operator can diagnose.

### 1. A list-valued `o` was silently downgraded to the default

ACDC [spec-body.md L1186](https://trustoverip.github.io/kswg-acdc-specification/) permits `o` to be a list of unary operators. The membership test compared the whole value against the recognized set:

```python
if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
    op = 'I2I' if 'i' in creder.attrib else 'NI2I'
```

A list never matches, so every list form fell through to the default inference. `"o": ["NI2I"]` got I2I semantics, and `"o": ["DI2I"]` got I2I semantics — a conforming non-keripy validator applying L1186 accepts the same bytes keripy rejects, an interop split with nothing on the wire to explain it.

**Latest-wins is scoped by the spec to *conflicting* operators:** "when multiple unary Operators appear in the list, and there is a **conflict** between Operators, the latest Operator among the **conflicting** Operators in the list takes precedence." `I2I`, `NI2I` and `DI2I` all constrain the near ACDC's issuer relative to the far node's issuee, so they genuinely conflict. `E1E` constrains the near *issuee* and conflicts with none of them, so it must compose rather than be overridden — otherwise `["E1E","I2I"]` from a producer requiring both relations enforces only `I2I` and accepts a far node whose issuee differs from the near ACDC's.

Hence two class constants: `UnaryOps` (what this verifier recognizes) and `DelegativeOps` (the conflict subset). Latest delegative operator wins; non-delegative operators compose (AND); unrecognized tokens are skipped.

### 2. `DI2I` raised a bare `NotImplementedError`, destroying the credential

`NotImplementedError` is not a `ValidationError`, so no caller treated it as a validation outcome. `_processEscrow`'s generic arm unescrowed the entry — and because the raise was **argless**, the handler's `ex.args[0]` indexed an empty tuple. The resulting `IndexError` escaped `_processEscrow` *and* `processEscrows`, skipping every remaining entry in the current table and both subsequent tables (`mce` → `mse` → `mre`). **One such credential halted escrow processing for every other credential queued.**

### 3. `NOT` was fail-open

`NOT` is normative (spec L1195 — "The validity of the node this Edge points to is inverted") and unrecognized here, so it fell to the default rule and the edge validated normally. An edge asserting *"this node must be INVALID"* was accepted as valid.

## What changes

`DI2I` and `NOT` both remain **unimplemented** — only the failure mode changes. Both now raise a `ValidationError` naming the operator, the far node, and (re-raised in `processCredential`, which has context `verifyChain` lacks) the near credential and edge label, matching the adjacent `MissingChainError` message shape.

Deliberately **not** a `MissingChainError`: the chain is present and retrying cannot help, so escrowing would promise a retry that can never succeed.

⚠️ **Data-retention note for deployments:** any DI2I-bearing credential currently sitting in MCE escrow was retained across passes before this change and is unescrowed now. The credential body remains in `creds.`/`cancs.` via `logCred`; only the escrow entry goes.

## Deliberately out of scope

**The `ex.args[0]` trap repo-wide.** The same idiom appears in the `Kevery`, `Tevery` (`vdr/eventing.py`), `Broker` (`db/escrowing.py`), `Revery` (`core/routing.py`) and `Exchanger` (`peer/exchanging.py`) escrow handlers, where any argless exception can still abort a pass. Fixed here only because this commit's regression test depends on it; the remaining sites are filed as #1553.

## Spec divergences this surfaces

Naming the recognized set makes three pre-existing gaps explicit and greppable, none of which this PR resolves:

| | |
|---|---|
| `E1E` | recognized by keripy (since #1527) but **not in the spec's normative operator table** |
| `NOT` | normative but unimplemented — now fails closed rather than silently ignored |
| unknown-operator behavior | L1197 arguably mandates *defaulting* an unrecognized token; whether it should instead be a diagnosable rejection is a spec question |

## Tests

- List forms resolve to the named operator; **latest-wins pinned in both directions** (`["I2I","NI2I"]` accepts, `["NI2I","I2I"]` rejects) so ordering is tested rather than set membership.
- `E1E` composes with the delegative winner in **both orders**, and still rejects a mismatched issuee when `NI2I` wins the conflict.
- `["DI2I"]` and `["NOT"]` fail closed diagnosably.
- Unrecognized tokens skipped; empty and unrecognized lists fall to the default; scalar and tuple forms.
- A poisoned escrow entry raising an argless exception no longer aborts the pass — the `IndexError` was reproduced before the fix.

Every new test was confirmed red against the prior implementation before the fix.

**Full suite: 666 passed, 3 skipped** (Python 3.14.4), against 662 passed / 3 skipped on `main` at `a420471f7` — the delta is exactly the four tests added here. Four new test functions plus a shared fixture helper; no existing test modified or removed.

---

*This change was developed with AI assistance (Claude, Anthropic).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)



