### PR TITLE
Traverse nested edge-groups in ACDC edge validation (stacked on #1552)

### DIFF
--- a/src/keri/cli/commands/vc/export.py
+++ b/src/keri/cli/commands/vc/export.py
@@ -15,6 +15,7 @@ from ...common import Parsery, setupHby
 from ....app import serialize
 from ....core import SerderKERI
 from ....vdr import Regery
+from ....vdr.eventing import edgesOf
 
 
 logger = ogler.getLogger()
@@ -111,15 +112,7 @@ class ExportDoer(doing.DoDoer):
 
         if self.chains:
             chains = creder.edge if creder.edge is not None else {}
-            saids = []
-            for key, source in chains.items():
-                if key == 'd':
-                    continue
-
-                if not isinstance(source, dict):
-                    continue
-
-                saids.append(source['n'])
+            saids = [edge['n'] for _, edge in edgesOf(chains)]
 
             for said in saids:
                 self.outputCred(said)

--- a/src/keri/cli/commands/vc/export.py
+++ b/src/keri/cli/commands/vc/export.py
@@ -15,6 +15,7 @@ from ...common import Parsery, setupHby
 from ....app import serialize
 from ....core import SerderKERI
 from ....vdr import Regery
+from ....vdr.eventing import edgesOf
 
 
 logger = ogler.getLogger()
@@ -112,15 +113,7 @@ class ExportDoer(doing.DoDoer):
 
         if self.chains:
             chains = creder.edge if creder.edge is not None else {}
-            saids = []
-            for key, source in chains.items():
-                if key == 'd':
-                    continue
-
-                if not isinstance(source, dict):
-                    continue
-
-                saids.append(source['n'])
+            saids = [edge['n'] for _, edge in edgesOf(chains)]
 
             for said in saids:
                 self.outputCred(said)

--- a/src/keri/vdr/__init__.py
+++ b/src/keri/vdr/__init__.py
@@ -13,4 +13,6 @@ from .credentialing import (Regery, RegeryDoer, BaseRegistry,
                             sendCredential, sendArtifacts, sendRegistry)
 from .verifying import Verifier
 from .eventing import (incept, rotate, issue, revoke, backerIssue, backerRevoke,
-                       Tever, Tevery, Reger, openReger, buildProof, messagize)
+                       Tever, Tevery, Reger, openReger, buildProof, messagize,
+                       isEdgeGroup, walkEdgeSection, edgesOf,
+                       EdgeGroupLabels, MaxEdgeGroupDepth)

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -47,6 +47,122 @@ from .vdring import RegistryRecord, RegStateRecord, VcStateRecord
 logger = ogler.getLogger()
 
 
+# Reserved field labels within an ACDC Edge-group block, in their required order of
+# appearance (ACDC spec-body.md, "#### Edge-group"). Everything else in an Edge-group
+# is a locally-unique non-reserved label naming a nested Edge or Edge-group.
+EdgeGroupLabels = ('d', 'u', 'o', 'w')
+
+# Maximum Edge-group nesting depth this implementation will traverse. SAID-based
+# references make a cycle infeasible to construct, so this is not a cycle guard; it
+# bounds the recursion so a pathologically deep (or hand-crafted) Edge Section cannot
+# exhaust the stack. Matches the shape of the delegation depth bound.
+MaxEdgeGroupDepth = 8
+
+
+def isEdgeGroup(block):
+    """ True when an Edge Section block is an Edge-group rather than an Edge.
+
+    The ACDC spec makes the node, `n`, field the discriminator: "An Edge block MUST
+    have a node, `n`, field. This differentiates an Edge block from an Edge-group
+    block," and "An Edge-group MUST NOT have a node, `n`, field." Presence of `n` is
+    therefore the test, not the presence of nested blocks -- an Edge-group with a
+    single nested Edge and an Edge with no properties beyond `n` are both legal.
+
+    Parameters:
+        block (dict): an Edge or Edge-group block from an ACDC Edge Section
+
+    Returns:
+        bool: True means Edge-group, False means Edge
+
+    """
+    return 'n' not in block
+
+
+def walkEdgeSection(section, maxDepth=MaxEdgeGroupDepth, path=()):
+    """ Walk an ACDC Edge Section, yielding every nested Edge-group and Edge block.
+
+    The Edge Section, `e`, of an ACDC is itself an Edge-group and MAY nest further
+    Edge-groups to arbitrary depth (spec-body.md, "#### Block Types"). Callers that
+    only care about edges filter on the returned `group` flag; callers that enforce
+    m-ary Operator semantics need the Edge-group blocks too, which is why both are
+    yielded from one walk.
+
+    Nested blocks appear under non-reserved labels only; reserved labels carry
+    properties of the enclosing block and are skipped.
+
+    Parameters:
+        section (dict): the Edge Section, or a nested Edge-group block within it
+        maxDepth (int): maximum nesting depth to traverse, see .MaxEdgeGroupDepth
+        path (tuple): non-reserved labels walked so far, from the Edge Section down
+            to (and including) the yielded block. Empty for the Edge Section itself.
+
+    Yields:
+        tuple: (path, block, group) where path (tuple of str) locates the block
+            within the Edge Section, block (dict) is the Edge-group or Edge block,
+            and group (bool) is True for an Edge-group and False for an Edge.
+
+    Raises:
+        ValidationError: if nesting exceeds maxDepth. Deliberately not an escrowing
+            error: the section is fully in hand and retrying cannot make it shallower.
+
+    """
+    if not isinstance(section, dict):  # compact Edge Section: just its SAID
+        return
+
+    if len(path) > maxDepth:
+        raise ValidationError(f"Edge-group nesting deeper than {maxDepth} at "
+                              f"{'.'.join(path)}")
+
+    if not isEdgeGroup(section):
+        # Only reachable from a top-level call, since the recursion below classifies
+        # each nested block before descending. An Edge Section is an Edge-group and
+        # so MUST NOT have a node, `n`, field; a section that does is malformed and
+        # there is no safe reading of it. Previously such a section made
+        # .processCredential raise TypeError (indexing a str) while .sources
+        # returned no artifacts at all -- a crash on one path and a silent empty on
+        # the other, for the same bad input.
+        raise ValidationError(f"Edge Section is an Edge-group and MUST NOT have a "
+                              f"node, 'n', field; got {sorted(section)}")
+
+    yield path, section, True
+
+    for label, value in section.items():
+        if label in EdgeGroupLabels:  # property of this block, not a nested block
+            continue
+
+        if not isinstance(value, dict):
+            # Compact and simple-compact Edge forms, where the Edge's value is a
+            # string (its Edge block SAID) rather than a block. Resolving one means
+            # dereferencing the Edge block, which keripy does not store separately
+            # from the ACDC that carries it, so compact Edges are out of scope here
+            # and skipped -- the same behavior as before Edge-groups traversed.
+            continue
+
+        if isEdgeGroup(value):
+            yield from walkEdgeSection(value, maxDepth=maxDepth, path=path + (label,))
+        else:
+            yield path + (label,), value, False
+
+
+def edgesOf(section, maxDepth=MaxEdgeGroupDepth):
+    """ Yields (path, edge) for every Edge in an Edge Section, Edge-groups traversed.
+
+    Convenience wrapper on .walkEdgeSection for the callers that gather far-node
+    SAIDs and do not interpret m-ary Operators.
+
+    Parameters:
+        section (dict): the ACDC Edge Section
+        maxDepth (int): maximum nesting depth to traverse, see .MaxEdgeGroupDepth
+
+    Yields:
+        tuple: (path, edge) where path (tuple of str) locates the Edge within the
+            Edge Section and edge (dict) is the Edge block, guaranteed to have `n`.
+
+    """
+    for path, block, group in walkEdgeSection(section, maxDepth=maxDepth):
+        if not group:
+            yield path, block
+
 
 def incept(
         pre,
@@ -2502,15 +2618,8 @@ class Reger(LMDBer):
                 revatc = bytes(rev[rserder.size:])
                 del rev[0:rserder.size]
 
-            chainSaids = []
-            for k, p in (creder.edge.items() if creder.edge is not None else {}):
-                if k == "d":
-                    continue
-
-                if not isinstance(p, dict):
-                    continue
-
-                chainSaids.append(Saider(qb64=p["n"]))
+            chainSaids = [Saider(qb64=edge["n"]) for _, edge
+                          in edgesOf(creder.edge if creder.edge is not None else {})]
             chains = self.cloneCreds(chainSaids, db)
 
             cred = dict(
@@ -2672,15 +2781,7 @@ class Reger(LMDBer):
 
         """
         chains = creder.edge if creder.edge is not None else {}
-        saids = []
-        for key, source in chains.items():
-            if key == 'd':
-                continue
-
-            if not isinstance(source, dict):
-                continue
-
-            saids.append(source['n'])
+        saids = [edge['n'] for _, edge in edgesOf(chains)]
 
         sources = []
         for said in saids:

--- a/src/keri/vdr/eventing.py
+++ b/src/keri/vdr/eventing.py
@@ -46,6 +46,122 @@ from .vdring import RegistryRecord, RegStateRecord, VcStateRecord
 logger = ogler.getLogger()
 
 
+# Reserved field labels within an ACDC Edge-group block, in their required order of
+# appearance (ACDC spec-body.md, "#### Edge-group"). Everything else in an Edge-group
+# is a locally-unique non-reserved label naming a nested Edge or Edge-group.
+EdgeGroupLabels = ('d', 'u', 'o', 'w')
+
+# Maximum Edge-group nesting depth this implementation will traverse. SAID-based
+# references make a cycle infeasible to construct, so this is not a cycle guard; it
+# bounds the recursion so a pathologically deep (or hand-crafted) Edge Section cannot
+# exhaust the stack. Matches the shape of the delegation depth bound.
+MaxEdgeGroupDepth = 8
+
+
+def isEdgeGroup(block):
+    """ True when an Edge Section block is an Edge-group rather than an Edge.
+
+    The ACDC spec makes the node, `n`, field the discriminator: "An Edge block MUST
+    have a node, `n`, field. This differentiates an Edge block from an Edge-group
+    block," and "An Edge-group MUST NOT have a node, `n`, field." Presence of `n` is
+    therefore the test, not the presence of nested blocks -- an Edge-group with a
+    single nested Edge and an Edge with no properties beyond `n` are both legal.
+
+    Parameters:
+        block (dict): an Edge or Edge-group block from an ACDC Edge Section
+
+    Returns:
+        bool: True means Edge-group, False means Edge
+
+    """
+    return 'n' not in block
+
+
+def walkEdgeSection(section, maxDepth=MaxEdgeGroupDepth, path=()):
+    """ Walk an ACDC Edge Section, yielding every nested Edge-group and Edge block.
+
+    The Edge Section, `e`, of an ACDC is itself an Edge-group and MAY nest further
+    Edge-groups to arbitrary depth (spec-body.md, "#### Block Types"). Callers that
+    only care about edges filter on the returned `group` flag; callers that enforce
+    m-ary Operator semantics need the Edge-group blocks too, which is why both are
+    yielded from one walk.
+
+    Nested blocks appear under non-reserved labels only; reserved labels carry
+    properties of the enclosing block and are skipped.
+
+    Parameters:
+        section (dict): the Edge Section, or a nested Edge-group block within it
+        maxDepth (int): maximum nesting depth to traverse, see .MaxEdgeGroupDepth
+        path (tuple): non-reserved labels walked so far, from the Edge Section down
+            to (and including) the yielded block. Empty for the Edge Section itself.
+
+    Yields:
+        tuple: (path, block, group) where path (tuple of str) locates the block
+            within the Edge Section, block (dict) is the Edge-group or Edge block,
+            and group (bool) is True for an Edge-group and False for an Edge.
+
+    Raises:
+        ValidationError: if nesting exceeds maxDepth. Deliberately not an escrowing
+            error: the section is fully in hand and retrying cannot make it shallower.
+
+    """
+    if not isinstance(section, dict):  # compact Edge Section: just its SAID
+        return
+
+    if len(path) > maxDepth:
+        raise ValidationError(f"Edge-group nesting deeper than {maxDepth} at "
+                              f"{'.'.join(path)}")
+
+    if not isEdgeGroup(section):
+        # Only reachable from a top-level call, since the recursion below classifies
+        # each nested block before descending. An Edge Section is an Edge-group and
+        # so MUST NOT have a node, `n`, field; a section that does is malformed and
+        # there is no safe reading of it. Previously such a section made
+        # .processCredential raise TypeError (indexing a str) while .sources
+        # returned no artifacts at all -- a crash on one path and a silent empty on
+        # the other, for the same bad input.
+        raise ValidationError(f"Edge Section is an Edge-group and MUST NOT have a "
+                              f"node, 'n', field; got {sorted(section)}")
+
+    yield path, section, True
+
+    for label, value in section.items():
+        if label in EdgeGroupLabels:  # property of this block, not a nested block
+            continue
+
+        if not isinstance(value, dict):
+            # Compact and simple-compact Edge forms, where the Edge's value is a
+            # string (its Edge block SAID) rather than a block. Resolving one means
+            # dereferencing the Edge block, which keripy does not store separately
+            # from the ACDC that carries it, so compact Edges are out of scope here
+            # and skipped -- the same behavior as before Edge-groups traversed.
+            continue
+
+        if isEdgeGroup(value):
+            yield from walkEdgeSection(value, maxDepth=maxDepth, path=path + (label,))
+        else:
+            yield path + (label,), value, False
+
+
+def edgesOf(section, maxDepth=MaxEdgeGroupDepth):
+    """ Yields (path, edge) for every Edge in an Edge Section, Edge-groups traversed.
+
+    Convenience wrapper on .walkEdgeSection for the callers that gather far-node
+    SAIDs and do not interpret m-ary Operators.
+
+    Parameters:
+        section (dict): the ACDC Edge Section
+        maxDepth (int): maximum nesting depth to traverse, see .MaxEdgeGroupDepth
+
+    Yields:
+        tuple: (path, edge) where path (tuple of str) locates the Edge within the
+            Edge Section and edge (dict) is the Edge block, guaranteed to have `n`.
+
+    """
+    for path, block, group in walkEdgeSection(section, maxDepth=maxDepth):
+        if not group:
+            yield path, block
+
 
 def incept(
         pre,
@@ -2413,15 +2529,8 @@ class Reger(LMDBer):
                 revatc = bytes(rev[rserder.size:])
                 del rev[0:rserder.size]
 
-            chainSaids = []
-            for k, p in (creder.edge.items() if creder.edge is not None else {}):
-                if k == "d":
-                    continue
-
-                if not isinstance(p, dict):
-                    continue
-
-                chainSaids.append(Saider(qb64=p["n"]))
+            chainSaids = [Saider(qb64=edge["n"]) for _, edge
+                          in edgesOf(creder.edge if creder.edge is not None else {})]
             chains = self.cloneCreds(chainSaids, db, gvrsn=gvrsn)
 
             cred = dict(
@@ -2576,15 +2685,7 @@ class Reger(LMDBer):
         Returns:
             list: credential sources as resolved from `e` in creder.crd"""
         chains = creder.edge if creder.edge is not None else {}
-        saids = []
-        for key, source in chains.items():
-            if key == 'd':
-                continue
-
-            if not isinstance(source, dict):
-                continue
-
-            saids.append(source['n'])
+        saids = [edge['n'] for _, edge in edgesOf(chains)]
 
         sources = []
         for said in saids:

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -18,7 +18,7 @@ from ..kering import (Ilks, MissingChainError,
 from ..core import Dater, Saider, Parser, CacheResolver, Schemer
 from ..help import helping
 
-from .eventing import Tevery, Reger, query
+from .eventing import Tevery, Reger, query, walkEdgeSection
 
 logger = ogler.getLogger()
 
@@ -45,6 +45,26 @@ class Verifier:
     # containing several is a conflict resolved latest-wins. Operators outside this
     # subset constrain something else and compose with the winner instead.
     DelegativeOps = ('I2I', 'NI2I', 'DI2I')
+
+    # M-ary (aggregating) Operators from the ACDC spec's normative Edge-group table
+    # (spec-body.md, "##### Operator, `o` field" under "#### Edge-group"). These
+    # apply to an Edge-group's members, not to a single edge, and are therefore
+    # disjoint from .UnaryOps. A token outside this set is not an m-ary Operator to
+    # this verifier and fails closed -- see .verifyGroup.
+    MAryOps = ('AND', 'OR', 'NAND', 'NOR', 'AVG', 'WAVG')
+
+    # The subset of .MAryOps whose semantics this verifier implements. AND is the
+    # spec's default when an Edge-group's `o` field is absent, and its meaning --
+    # the group is valid only if every member is valid -- is exactly the aggregation
+    # .processCredential already performs over a flat edge section. The rest are
+    # recognized but unimplemented, so they fail closed rather than being silently
+    # treated as AND, which would apply a weaker rule than the Issuer specified.
+    MAryOpsImplemented = ('AND',)
+
+    # Operator applied to an Edge-group whose `o` field is absent: "When the
+    # Operator, `o`, field is missing in an Edge-group block, the default value for
+    # the Operator, `o`, field MUST be the `AND` Operator."
+    DefaultMAryOp = 'AND'
 
     def __init__(self, hby, reger=None, creds=None, cues=None, expiry=36000000000):
         """
@@ -169,9 +189,18 @@ class Verifier:
             raise ValidationError(f"invalid type for edges: {prov}")
 
         for edge in edges:
-            for label, node in edge.items():
-                if label in ('d', 'o'):  # SAID or Operator of this edge block
+            # An Edge Section is itself an Edge-group and MAY nest further
+            # Edge-groups, so walk it rather than assuming every non-reserved label
+            # at the top level is a flat edge. Every Edge-group encountered has its
+            # m-ary Operator checked; every Edge found, at any depth, is validated.
+            # This is the AND aggregation -- the spec default -- and .verifyGroup
+            # rejects any group asking for something else.
+            for path, node, group in walkEdgeSection(edge):
+                if group:
+                    self.verifyGroup(node, path, creder)
                     continue
+
+                label = '.'.join(path)  # dotted path so nested edges are locatable
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
                 try:
@@ -206,6 +235,48 @@ class Verifier:
 
         self.saveCredential(creder, prefixer, seqner, saider)
         self.cues.append(dict(kin="saved", creder=creder))
+
+    def verifyGroup(self, group, path, creder):
+        """ Verifies the m-ary Operator of an Edge-group is one this verifier honors
+
+        Carries none of the aggregation semantics of the operators themselves beyond
+        AND: the caller validates every Edge in the section and fails on the first
+        bad one, which is AND. This method's job is to confirm the Issuer actually
+        asked for AND, so a group asking for something else cannot be quietly
+        validated under the wrong rule.
+
+        Parameters:
+            group (dict): the Edge-group block, possibly the Edge Section itself
+            path (tuple): non-reserved labels locating the group within the Edge
+                Section; empty for the Edge Section, which is the top-level group
+            creder (Creder): the near (edge-bearing) credential, for diagnostics
+
+        Raises:
+            ValidationError: the group's `o` is not a recognized m-ary Operator, or
+                is recognized but unimplemented. Deliberately not a MissingChainError
+                in either case: the section is fully in hand and no amount of
+                retrying will make an unsupported operator supported, so escrowing
+                would promise a retry that can never succeed. This matches the
+                treatment .verifyChain gives NOT and DI2I.
+
+        """
+        # An absent `o` is not "no operator": the spec assigns it a value, and that
+        # value goes through the same checks as an explicit one so the default can
+        # never drift out of .MAryOpsImplemented unnoticed.
+        op = group['o'] if 'o' in group else self.DefaultMAryOp
+        where = f"edge group {'.'.join(path)}" if path else "the edge section"
+
+        # Unlike an Edge's unary `o`, an Edge-group's `o` is a single aggregating
+        # Operator over the group's members -- the spec defines no list form for it.
+        if not isinstance(op, str) or op not in self.MAryOps:
+            raise ValidationError(f"Unrecognized m-ary edge operator {op!r} on "
+                                  f"{where} of credential {creder.said}; expected "
+                                  f"one of {self.MAryOps}")
+
+        if op not in self.MAryOpsImplemented:
+            raise ValidationError(f"Unsupported m-ary edge operator {op} on {where} "
+                                  f"of credential {creder.said}; only "
+                                  f"{self.MAryOpsImplemented} is implemented")
 
     def processACDC(self, **kwa):
         """Alias of .processCredential with Parser compatible call signature

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -33,6 +33,19 @@ class Verifier:
     TimeoutMRI = 3600  # seconds to timeout missing issuer escrows
     TimeoutBCE = 3600  # seconds to timeout missing issuer escrows
 
+    # Unary edge operators this verifier recognizes. A token outside this set is not an
+    # operator to this verifier and is skipped when resolving a list-valued `o` (see
+    # .verifyChain). DI2I and NOT are recognized but unimplemented: they are listed so
+    # they fail closed diagnosably instead of being dropped and silently defaulting.
+    # E1E is a keripy extension not yet in the spec's normative operator table.
+    UnaryOps = ('I2I', 'NI2I', 'DI2I', 'E1E', 'NOT')
+
+    # The delegative subset of .UnaryOps: each constrains the near ACDC's issuer
+    # relative to the far node's issuee, so they are mutually exclusive and a list
+    # containing several is a conflict resolved latest-wins. Operators outside this
+    # subset constrain something else and compose with the winner instead.
+    DelegativeOps = ('I2I', 'NI2I', 'DI2I')
+
     def __init__(self, hby, reger=None, creds=None, cues=None, expiry=36000000000):
         """
         Initialize Verifier instance
@@ -161,7 +174,16 @@ class Verifier:
                     continue
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
-                state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
+                try:
+                    state = self.verifyChain(nodeSaid, op, creder.israid, creder.iseaid)
+                except ValidationError as ex:
+                    # .verifyChain knows the far node but not the near credential that
+                    # carried the edge, and the escrow handler logs only the exception.
+                    # Re-raise with the near SAID and edge label so an operator triaging
+                    # a stream can tell which credential to fix, matching the shape of
+                    # the MissingChainError messages below.
+                    raise ValidationError(f"Failure to verify credential {creder.said} "
+                                          f"chain {label}({nodeSaid}): {ex}") from ex
                 if state is None:
                     self.escrowMCE(creder, prefixer, seqner, saider)
                     self.cues.append(dict(kin="proof",  said=nodeSaid))
@@ -284,16 +306,19 @@ class Verifier:
                 self.processCredential(creder, prefixer, seqner, saider)
 
             except etype as ex:
+                # Log the exception, not ex.args[0]: an exception raised with no
+                # arguments has an empty args tuple, so indexing it would raise
+                # IndexError from inside this handler and abort the whole pass.
                 if logger.isEnabledFor(logging.TRACE):
-                    logger.trace("Verifier unescrow failed: %s\n", ex.args[0])
-                    logger.exception("Verifier unescrow failed: %s\n", ex.args[0])
+                    logger.trace("Verifier unescrow failed: %s\n", ex)
+                    logger.exception("Verifier unescrow failed: %s\n", ex)
             except Exception as ex:  # log diagnostics errors etc
                 # error other than missing sigs so remove from PA escrow
                 db.rem(said)
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.exception("Verifier unescrowed: %s", ex.args[0])
+                    logger.exception("Verifier unescrowed: %s", ex)
                 else:
-                    logger.error("Verifier unescrowed: %s", ex.args[0])
+                    logger.error("Verifier unescrowed: %s", ex)
             else:
                 db.rem(said)
                 logger.info("Verifier: unescrow succeeded in valid group op: creder=%s", creder.said)
@@ -341,7 +366,10 @@ class Verifier:
 
         Parameters:
             nodeSaid: (str): qb64 SAID of node credential
-            op(str): edge operator
+            op (str|list|None): edge operator, or a list of unary operators, in which
+                case the latest recognized one takes precedence. None, an empty list,
+                or a value containing no recognized operator applies the default:
+                I2I for a targeted far node, NI2I for an untargeted one.
             issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
             issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
                 required by the identity operators (E1E). None when the near ACDC is
@@ -357,14 +385,37 @@ class Verifier:
 
         creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
-        if op not in ['I2I', 'DI2I', 'NI2I', 'E1E']:
-            # A far node is targeted (I2I) iff it has an issuee, else untargeted
-            # (NI2I). Resolve via .iseaid so an aggregate ('acg') far node -- whose
-            # issuee is at .sad["A"][1]["i"] and whose .attrib is None -- coerces the
-            # same as an attributive one.
+        # `o` is either a single unary operator or a list of them. Latest-wins applies
+        # only "among the conflicting Operators" (ACDC spec-body.md L1186), so the list
+        # is resolved in two parts: the delegative operators constrain the same thing
+        # (the near issuer relative to the far issuee) and therefore conflict, so the
+        # latest of those wins; E1E constrains the near issuee instead, so it does not
+        # conflict with them and composes (AND) rather than overriding or being
+        # overridden. Tokens this verifier does not recognize are skipped.
+        ops = op if isinstance(op, (list, tuple)) else [op]
+        ops = [cand for cand in ops if cand in self.UnaryOps]
+        op = next((cand for cand in reversed(ops) if cand in self.DelegativeOps), None)
+
+        if not ops:  # absent, empty, or nothing recognized: apply the default rule
+            # A far node is targeted (I2I) iff it has an issuee, else untargeted (NI2I).
+            # Resolve via .iseaid so an aggregate ('acg') far node -- whose issuee is at
+            # .sad["A"][1]["i"] and whose .attrib is None -- coerces the same as an
+            # attributive one (#1529).
             op = 'I2I' if creder.iseaid is not None else 'NI2I'
 
-        if op == 'E1E':
+        # Recognized but unimplemented operators fail closed with a diagnosable error
+        # rather than being silently dropped from the effective list. Deliberately not
+        # a MissingChainError: the chain is present and retrying cannot help, so
+        # escrowing would promise a retry that can never succeed.
+        if 'NOT' in ops:
+            raise ValidationError(f"Unsupported edge operator NOT on edge to node "
+                                  f"{nodeSaid}; NOT validation is not implemented")
+
+        if op == 'DI2I':
+            raise ValidationError(f"Unsupported edge operator DI2I on edge to node "
+                                  f"{nodeSaid}; DI2I validation is not implemented")
+
+        if 'E1E' in ops:
             # Identity relation (discussion #1515): the issuee AID of the near ACDC
             # (the one carrying this edge) MUST equal the issuee AID of the far node.
             # Unlike the delegative I2I, this says nothing about the issuer, so the
@@ -374,7 +425,8 @@ class Verifier:
             farIssuee = creder.iseaid
             if farIssuee is None or issuee is None or issuee != farIssuee:
                 return None
-        elif op != 'NI2I':
+
+        if op is not None and op != 'NI2I':
             # Resolve the far node's issuee via .iseaid so an aggregate ('acg') far
             # node (issuee at .sad["A"][1]["i"]) resolves identically to an
             # attributive one (.attrib["i"]). None means an untargeted far node,
@@ -389,9 +441,6 @@ class Verifier:
 
             if op == 'I2I' and issuer != farIssuee:
                 return None
-
-            if op == "DI2I":
-                raise NotImplementedError()
 
         if creder.regid not in self.tevers:
             return None

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -18,7 +18,7 @@ from ..kering import (Ilks, MissingChainError,
 from ..core import Dater, Saider, Parser, CacheResolver, Schemer
 from ..help import helping
 
-from .eventing import Tevery, Reger, query
+from .eventing import Tevery, Reger, query, walkEdgeSection
 
 logger = ogler.getLogger()
 
@@ -45,6 +45,26 @@ class Verifier:
     # containing several is a conflict resolved latest-wins. Operators outside this
     # subset constrain something else and compose with the winner instead.
     DelegativeOps = ('I2I', 'NI2I', 'DI2I')
+
+    # M-ary (aggregating) Operators from the ACDC spec's normative Edge-group table
+    # (spec-body.md, "##### Operator, `o` field" under "#### Edge-group"). These
+    # apply to an Edge-group's members, not to a single edge, and are therefore
+    # disjoint from .UnaryOps. A token outside this set is not an m-ary Operator to
+    # this verifier and fails closed -- see .verifyGroup.
+    MAryOps = ('AND', 'OR', 'NAND', 'NOR', 'AVG', 'WAVG')
+
+    # The subset of .MAryOps whose semantics this verifier implements. AND is the
+    # spec's default when an Edge-group's `o` field is absent, and its meaning --
+    # the group is valid only if every member is valid -- is exactly the aggregation
+    # .processCredential already performs over a flat edge section. The rest are
+    # recognized but unimplemented, so they fail closed rather than being silently
+    # treated as AND, which would apply a weaker rule than the Issuer specified.
+    MAryOpsImplemented = ('AND',)
+
+    # Operator applied to an Edge-group whose `o` field is absent: "When the
+    # Operator, `o`, field is missing in an Edge-group block, the default value for
+    # the Operator, `o`, field MUST be the `AND` Operator."
+    DefaultMAryOp = 'AND'
 
     def __init__(self, hby, reger=None, creds=None, cues=None, expiry=36000000000):
         """
@@ -169,9 +189,18 @@ class Verifier:
             raise ValidationError(f"invalid type for edges: {prov}")
 
         for edge in edges:
-            for label, node in edge.items():
-                if label in ('d', 'o'):  # SAID or Operator of this edge block
+            # An Edge Section is itself an Edge-group and MAY nest further
+            # Edge-groups, so walk it rather than assuming every non-reserved label
+            # at the top level is a flat edge. Every Edge-group encountered has its
+            # m-ary Operator checked; every Edge found, at any depth, is validated.
+            # This is the AND aggregation -- the spec default -- and .verifyGroup
+            # rejects any group asking for something else.
+            for path, node, group in walkEdgeSection(edge):
+                if group:
+                    self.verifyGroup(node, path, creder)
                     continue
+
+                label = '.'.join(path)  # dotted path so nested edges are locatable
                 nodeSaid = node["n"]
                 op = node['o'] if 'o' in node else None
                 try:
@@ -242,6 +271,48 @@ class Verifier:
 
         self.saveCredential(creder, prefixer, seqner, saider)
         self.cues.append(dict(kin="saved", creder=creder))
+
+    def verifyGroup(self, group, path, creder):
+        """ Verifies the m-ary Operator of an Edge-group is one this verifier honors
+
+        Carries none of the aggregation semantics of the operators themselves beyond
+        AND: the caller validates every Edge in the section and fails on the first
+        bad one, which is AND. This method's job is to confirm the Issuer actually
+        asked for AND, so a group asking for something else cannot be quietly
+        validated under the wrong rule.
+
+        Parameters:
+            group (dict): the Edge-group block, possibly the Edge Section itself
+            path (tuple): non-reserved labels locating the group within the Edge
+                Section; empty for the Edge Section, which is the top-level group
+            creder (Creder): the near (edge-bearing) credential, for diagnostics
+
+        Raises:
+            ValidationError: the group's `o` is not a recognized m-ary Operator, or
+                is recognized but unimplemented. Deliberately not a MissingChainError
+                in either case: the section is fully in hand and no amount of
+                retrying will make an unsupported operator supported, so escrowing
+                would promise a retry that can never succeed. This matches the
+                treatment .verifyChain gives NOT and DI2I.
+
+        """
+        # An absent `o` is not "no operator": the spec assigns it a value, and that
+        # value goes through the same checks as an explicit one so the default can
+        # never drift out of .MAryOpsImplemented unnoticed.
+        op = group['o'] if 'o' in group else self.DefaultMAryOp
+        where = f"edge group {'.'.join(path)}" if path else "the edge section"
+
+        # Unlike an Edge's unary `o`, an Edge-group's `o` is a single aggregating
+        # Operator over the group's members -- the spec defines no list form for it.
+        if not isinstance(op, str) or op not in self.MAryOps:
+            raise ValidationError(f"Unrecognized m-ary edge operator {op!r} on "
+                                  f"{where} of credential {creder.said}; expected "
+                                  f"one of {self.MAryOps}")
+
+        if op not in self.MAryOpsImplemented:
+            raise ValidationError(f"Unsupported m-ary edge operator {op} on {where} "
+                                  f"of credential {creder.said}; only "
+                                  f"{self.MAryOpsImplemented} is implemented")
 
     def processACDC(self, **kwa):
         """Alias of .processCredential with Parser compatible call signature

--- a/tests/vdr/test_eventing.py
+++ b/tests/vdr/test_eventing.py
@@ -14,7 +14,8 @@ from keri import (Ilks, TraitDex, MissingAnchorError, ValidationError,
                   Vrsn_1_0, Kinds)
 from keri.vdr import (openReger, incept, rotate,
                       issue, revoke, backerIssue,
-                      backerRevoke, Tever, Tevery)
+                      backerRevoke, Tever, Tevery,
+                      isEdgeGroup, walkEdgeSection, edgesOf, MaxEdgeGroupDepth)
 
 from tests.vdr import buildHab
 
@@ -779,6 +780,105 @@ def test_tevery_process_escrow_anchorless_with_bigers(mockHelpingNowUTC, mockCor
         # If unescrow succeeded, bis is in TEL and reprocessing raises duplicitous
         with pytest.raises(LikelyDuplicitousError):
             tvy.processEvent(serder=bis, seqner=Seqner(sn=2), saider=Diger(qb64b=rotsaid2), wigers=[biger])
+
+
+def test_walk_edge_section():
+    """Structural traversal of an ACDC Edge Section, independent of any validator.
+
+    The Edge Section of an ACDC is an Edge-group and MAY nest further Edge-groups to
+    arbitrary depth. Edges and Edge-groups are told apart by one thing only: "An Edge
+    block MUST have a node, `n`, field. This differentiates an Edge block from an
+    Edge-group block," and "An Edge-group MUST NOT have a node, `n`, field"
+    (spec-body.md, "#### Block Types"). Reserved labels -- [d, u, o, w] in a group,
+    [d, u, n, s, o, w] in an edge -- carry properties of their own block; every other
+    label names a nested block.
+    """
+    said = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+    other = "EBv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    # `n` is the discriminator, not the presence of nested blocks. A group holding a
+    # single edge is still a group; an edge with no properties beyond `n` is still an
+    # edge.
+    assert isEdgeGroup(dict(d='', o="AND", one=dict(n=said)))
+    assert isEdgeGroup(dict(d=''))
+    assert not isEdgeGroup(dict(n=said))
+    assert not isEdgeGroup(dict(d='', u='0AB', n=said, s='', o="I2I", w='1'))
+
+    # Flat section: the section itself is yielded as a group, its edge as an edge.
+    flat = dict(d=said, one=dict(n=other, o="NI2I"))
+    assert list(walkEdgeSection(flat)) == [
+        ((), flat, True),
+        (('one',), dict(n=other, o="NI2I"), False),
+    ]
+
+    # Nested group. Paths locate each block from the section down; the section's own
+    # path is empty. Labels are only locally unique, so the path -- not the label --
+    # is what identifies an edge within a section.
+    inner = dict(d='', o="AND", work=dict(n=said), citizenship=dict(n=other))
+    section = dict(d='', endorsed=inner, direct=dict(n=said))
+    assert [(p, g) for p, _, g in walkEdgeSection(section)] == [
+        ((), True),
+        (('endorsed',), True),
+        (('endorsed', 'work'), False),
+        (('endorsed', 'citizenship'), False),
+        (('direct',), False),
+    ]
+    assert [p for p, _ in edgesOf(section)] == [
+        ('endorsed', 'work'), ('endorsed', 'citizenship'), ('direct',)]
+
+    # Reserved Edge-group labels are properties of the group, never nested blocks.
+    # `u` and `w` matter here: both are scalars today, but a walker that skipped only
+    # `d` and `o` and leaned on "not a dict" to drop the rest would misclassify any
+    # future block-valued reserved field instead of ignoring it.
+    reserved = dict(d='', u='0ABhY2Rjc3BlY3dvcmtyYXcw', o="AND", w='2',
+                    one=dict(n=said))
+    assert [p for p, _ in edgesOf(reserved)] == [('one',)]
+
+    # Compact and simple-compact Edge forms put the Edge block's SAID in place of the
+    # block. Resolving one needs the Edge block, which keripy does not store apart
+    # from its ACDC, so these are skipped -- deliberately, and documented as deferred
+    # rather than silently dropped.
+    assert [p for p, _ in edgesOf(dict(d='', compact=said, one=dict(n=other)))] == \
+           [('one',)]
+
+    # A compact Edge Section is just its SAID, with no blocks to walk at all, and an
+    # empty section has no edges. Neither is an error.
+    assert list(edgesOf(said)) == []
+    assert list(walkEdgeSection(said)) == []
+    assert list(edgesOf({})) == []
+
+    # The Edge Section is an Edge-group, so it MUST NOT carry a node, `n`, field --
+    # a section written as if it were a single bare Edge is malformed. It fails
+    # closed rather than being read as either one edge or no edges: before this
+    # change the same input crashed the verifier with a TypeError (indexing a str)
+    # while Reger.sources quietly returned no artifacts at all.
+    with pytest.raises(ValidationError):
+        list(edgesOf(dict(d='', n=said, o="I2I")))
+
+    # Nesting is bounded. SAID references make a cycle infeasible to build, so this
+    # is a stack guard, not a cycle guard: a hand-crafted section cannot recurse the
+    # verifier to death. It fails with a ValidationError naming where it gave up --
+    # not a MissingChainError, since retrying cannot make the section shallower.
+    deep = cur = dict(d='')
+    for i in range(MaxEdgeGroupDepth + 2):
+        nxt = dict(d='')
+        cur[f'g{i}'] = nxt
+        cur = nxt
+    cur['leaf'] = dict(n=said)
+    with pytest.raises(ValidationError) as excinfo:
+        list(edgesOf(deep))
+    assert str(MaxEdgeGroupDepth) in str(excinfo.value)
+
+    # A section exactly at the bound still traverses.
+    ok = cur = dict(d='')
+    for i in range(MaxEdgeGroupDepth - 1):
+        nxt = dict(d='')
+        cur[f'g{i}'] = nxt
+        cur = nxt
+    cur['leaf'] = dict(n=said)
+    assert len(list(edgesOf(ok))) == 1
+
+    """End Test"""
 
 
 if __name__ == "__main__":

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -686,7 +686,7 @@ def _aggregate_far_node(ian, ianiss, ianreg, issueeAid):
     # anchor a TEL issuance event for the aggregate SAID so it is "issued".
     iss = ianiss.issue(said=agg.said)
     rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-    ian.interact(data=[rseal], framed=True, **CUE_KWA)
+    ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
     ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
                      seqner=Seqner(sn=ian.kever.sn),
                      saider=Diger(qb64=ian.kever.serder.said))
@@ -704,13 +704,13 @@ def test_verifier_saves_aggregate_credential(seeder):
     subject-indexed at all. It must instead resolve the issuee via ``.iseaid``,
     identically to an attributive credential.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -745,13 +745,13 @@ def test_verifier_aggregate_far_node_chain(seeder):
     verifier must resolve targeted-ness and the issuee via ``.iseaid`` so an edge
     to an aggregate far node behaves identically to an attributive one.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -810,13 +810,13 @@ def test_verifier_e1e_aggregate_far_node(seeder):
     based; this locks in that it works for an aggregate far node through the real
     verifier, not just a bespoke example verifier.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1213,6 +1213,263 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
     """End Test"""
 
 
+def test_verifier_edge_group_traversal(seeder):
+    """A nested Edge-group must traverse, and its m-ary Operator must be honored.
+
+    The ACDC spec gives an Edge Section two block types: Edges, which MUST have a
+    node, `n`, field, and Edge-groups, which MUST NOT (spec-body.md, "#### Block
+    Types"). The Edge Section is itself an Edge-group and MAY nest further
+    Edge-groups to arbitrary depth.
+
+    Before this change the edge loop skipped only the labels `d` and `o` and then
+    indexed ``node["n"]`` on everything else, so any nested Edge-group raised
+    ``KeyError: 'n'`` -- a crash, not a rejection, and one that escapes as an
+    unhandled exception rather than an escrow or a ValidationError. That made every
+    grouped edge section unusable, which in turn blocks the m-ary group operators
+    under discussion in #1555 (`ME`) and #1556 (group-scoped unary defaults).
+
+    This test carries none of `ME`'s semantics. It pins three things: nested groups
+    traverse, their members are really validated (not merely walked past), and a
+    group whose Operator this verifier does not implement fails closed.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        def farNode(claim):
+            """Issue and save a targeted far node, ian -> han."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                             status=ianiss.regk, source={}, rules={},
+                             version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(far)
+            assert verfer.reger.saved.get(keys=far.saidb) is not None
+            return far
+
+        def saidify(block):
+            _, block = Saider.saidify(sad=block, code=MtrDex.Blake3_256, label=Saids.d)
+            return block
+
+        def nearWithSection(section, claim):
+            """Issue a near credential carrying `section` as its edge section."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=section, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Both far nodes are issued by ian to han. Every near credential below is
+        # also issued by ian, so `near issuer (ian) != far issuee (han)`: NI2I edges
+        # accept and I2I edges reject. That asymmetry is what makes it observable
+        # whether a nested edge was actually evaluated or merely walked past.
+        work = farNode("work credential")
+        citizenship = farNode("citizenship credential")
+
+        # A group nested one level down. No `o` on the group, so the spec default
+        # AND applies -- and both members are valid, so the near credential saves.
+        # Before this change this section raised KeyError: 'n'.
+        endorsed = saidify(dict(d='', work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        grouped = nearWithSection(section, "grouped, default AND, all members valid")
+        assert verfer.reger.saved.get(keys=grouped.saidb) is not None
+
+        # The other half of the defect: Reger.sources gathers the far-node artifacts
+        # to ship alongside an IPEX grant, and walked the edge section with the same
+        # flat assumption. Both grouped edges must be discovered, or the disclosee
+        # receives an ACDC whose chain it cannot resolve.
+        srcs = verfer.reger.sources(ianHby.db, grouped)
+        assert {src.said for src, _ in srcs} == {work.said, citizenship.said}
+
+        # The same shape with the group's Operator written out explicitly. `AND` is
+        # the default, so this MUST behave identically to the block above.
+        endorsed = saidify(dict(d='', o="AND", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "grouped, explicit AND")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # AND means every member must be valid, so one bad member sinks the group.
+        # `citizenship` here is I2I, which rejects because the near issuer (ian) is
+        # not the far issuee (han). This is the load-bearing assertion of the test:
+        # a traversal that reached the nested edges but did not validate them, or
+        # that validated only the first, would wrongly save this credential.
+        endorsed = saidify(dict(d='', work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="I2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "grouped, one member fails")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Groups nest arbitrarily deep, and a failure at depth still propagates.
+        inner = saidify(dict(d='', citizenship=dict(n=citizenship.said, o="NI2I")))
+        outer = saidify(dict(d='', work=dict(n=work.said, o="NI2I"), inner=inner))
+        section = saidify(dict(d='', outer=outer))
+        near = nearWithSection(section, "two levels of nesting, all valid")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        inner = saidify(dict(d='', citizenship=dict(n=citizenship.said, o="I2I")))
+        outer = saidify(dict(d='', work=dict(n=work.said, o="NI2I"), inner=inner))
+        section = saidify(dict(d='', outer=outer))
+        near = nearWithSection(section, "two levels of nesting, deep member fails")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # The reserved Edge-group labels are [d, u, o, w]; only non-reserved labels
+        # name nested blocks. A group carrying `u` and `w` alongside its members must
+        # still traverse -- neither is an edge. (`u` is a salty nonce and `w` a
+        # weight for WAVG; both are strings, so a walker that only skipped `d`/`o`
+        # would have tripped over them once they stopped being silently non-dict.)
+        endorsed = saidify(dict(d='', u='0ABhY2Rjc3BlY3dvcmtyYXcw', o="AND", w='2',
+                                work=dict(n=work.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "group with u and w reserved labels")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # The Edge Section is itself an Edge-group, so it may carry its own m-ary
+        # Operator directly.
+        section = saidify(dict(d='', o="AND", work=dict(n=work.said, o="NI2I")))
+        near = nearWithSection(section, "AND on the edge section itself")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        def expectRejected(section, claim):
+            """Run a near credential to the point of failure and return the error."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=section, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            iss = ianiss.issue(said=near.said)
+            rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+            ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                         gvrsn=Vrsn_1_0)
+            ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            ianreg.processEscrows()
+            with pytest.raises(ValidationError) as excinfo:
+                verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                         seqner=Seqner(sn=ian.kever.sn),
+                                         saider=Diger(qb64=ian.kever.serder.said))
+            assert verfer.reger.saved.get(keys=near.saidb) is None
+            return excinfo.value
+
+        # `ME` (Multiply Endorsed, discussion #1555) is a *proposed* m-ary Operator,
+        # not one in the spec's normative table. An issuer asking for it is asking
+        # for a rule this verifier cannot apply, so it must fail closed rather than
+        # fall back to AND -- falling back would validate the ACDC under a weaker
+        # rule than the issuer specified, with nothing on the wire to show for it.
+        endorsed = saidify(dict(d='', o="ME", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "unrecognized m-ary operator ME")
+        assert "ME" in str(ex)
+        assert "endorsed" in str(ex)  # names the offending group, not just the ACDC
+        # Not a MissingChainError: both far nodes are present and saved. Retrying
+        # cannot make an unrecognized operator recognized, so escrowing it would
+        # promise a retry that can never succeed -- the same reasoning NOT and DI2I
+        # already follow in .verifyChain.
+        assert not isinstance(ex, MissingChainError)
+
+        # `OR` is normative, and unimplemented here. It must fail closed too: under
+        # OR the group is valid if *one* member is valid, which is strictly weaker
+        # than the AND this verifier performs. Silently applying AND would reject
+        # ACDCs their issuer considers valid; silently applying OR would accept ones
+        # it cannot actually evaluate. Recognized-but-unimplemented is the honest
+        # answer, and it is distinguishable from the unrecognized case above.
+        endorsed = saidify(dict(d='', o="OR", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "recognized but unimplemented operator OR")
+        assert "OR" in str(ex)
+        # Distinguishable from the unrecognized case: "Unsupported" says the token is
+        # in the spec's table but this verifier does not implement it, which is a
+        # different thing for an issuer to act on than "that is not an operator".
+        assert "Unsupported m-ary" in str(ex)
+
+        # An m-ary Operator on the top-level Edge Section fails closed just the same.
+        section = saidify(dict(d='', o="NOR", work=dict(n=work.said, o="NI2I")))
+        ex = expectRejected(section, "unimplemented operator on the edge section")
+        assert "NOR" in str(ex)
+        assert "edge section" in str(ex)
+
+        # An Edge-group's `o` is a single aggregating Operator over its members; the
+        # spec defines the list form only for an Edge's unary `o`. A list here is not
+        # a spec-legal m-ary Operator, so it is rejected rather than coerced.
+        endorsed = saidify(dict(d='', o=["AND"], work=dict(n=work.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "list-valued m-ary operator")
+        assert "Unrecognized m-ary" in str(ex)
+
+        # Diagnosability: an edge nested in a group is reported by its dotted path
+        # from the Edge Section, so an operator triaging a stream can find it. A bare
+        # label would be ambiguous -- labels are only locally unique, so two groups
+        # may each hold a `work` edge.
+        unknown = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"  # not a saved ACDC
+        endorsed = saidify(dict(d='', work=dict(n=unknown, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="dotted path")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=section, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(MissingChainError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "endorsed.work" in str(excinfo.value)
+
+        # A flat edge section keeps its bare label -- the dotted path of a top-level
+        # edge is just its own label, so nothing about existing diagnostics changes.
+        section = saidify(dict(d='', work=dict(n=unknown, o="NI2I")))
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="flat path")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=section, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(MissingChainError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "chain work(" in str(excinfo.value)
+
+    """End Test"""
+
+
 def test_verifier_escrow_pass_survives_argless_exception(seeder):
     """One poisoned escrow entry must not abort the whole escrow pass.
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -7,7 +7,7 @@ tests.vdr.verifying module
 import pytest
 
 from keri import (MissingRegistryError, MissingEntryError,
-                  MissingChainError, RevokedChainError, Vrsn_1_0)
+                  MissingChainError, RevokedChainError, ValidationError, Vrsn_1_0)
 from keri.app import openHab
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
                        Diger, Parser, SealEvent,
@@ -852,5 +852,427 @@ def test_verifier_e1e_aggregate_far_node(seeder):
 
         # E1E rejects a missing near issuee (untargeted near ACDC carrying the edge).
         assert verfer.verifyChain(agg.said, 'E1E', ian.pre, issuee=None) is None
+
+    """End Test"""
+
+
+def setupOperatorFixture(ian, ianHby, ianreg, ianiss):
+    """Wire ian's registry into a Verifier and return (verfer, issueAndSave).
+
+    Shared by the operator-dispatch tests below, which all need the same shape:
+    one issuer (ian) with an anchored registry, and a way to run a credential
+    through the full issue -> anchor -> escrow -> save flow.
+    """
+    verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+    def issueAndSave(creder):
+        try:
+            verfer.processCredential(creder, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        except MissingRegistryError:
+            pass  # expected: the TEL issuance event is anchored just below
+        iss = ianiss.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        verfer.processEscrows()
+
+    return verfer, issueAndSave
+
+
+def test_verifier_list_valued_operator(seeder):
+    """A list-valued `o` is a spec-legal spelling and MUST NOT fall to the default.
+
+    ACDC spec-body.md L1186: "When more than one unary Operator is applied to a given
+    Edge, then the value of the Operator, `o`, field is a list of those unary
+    Operators. When multiple unary Operators appear in the list, and there is a
+    conflict between Operators, the latest Operator among the conflicting Operators
+    in the list takes precedence."
+
+    Previously ``op not in ['I2I','DI2I','NI2I','E1E']`` was tested against the list
+    itself, which never matches, so every list form silently fell through to the
+    default inference -- I2I for a targeted far node. A conforming producer writing
+    ``"o": ["NI2I"]`` therefore got I2I semantics, and the same bytes verified
+    differently on a conforming non-keripy validator: an interop split with no
+    wire-visible cause.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        # Far node: targeted, ian -> han. Every near credential below is issued by
+        # ian, so `near issuer (ian) != far issuee (han)` -- I2I rejects, NI2I allows.
+        # That asymmetry is what makes the effective operator observable.
+        farSubject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        assert far.iseaid == han.pre
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        def nearWithOp(op, claim):
+            """Issue a near credential whose single edge carries operator `op`."""
+            chainSad = dict(d='', node=dict(n=far.said, o=op))
+            _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Single-element list: ["NI2I"] must mean NI2I, not the I2I default.
+        # This is the red case -- before the fix the list fell through to I2I and
+        # the credential sat in missing-chain escrow.
+        near = nearWithOp(["NI2I"], "single element list")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # Latest-wins: ["I2I", "NI2I"] resolves to NI2I, so the edge is accepted
+        # even though the near issuer is not the far issuee.
+        near = nearWithOp(["I2I", "NI2I"], "latest wins to NI2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # Latest-wins in the other direction: ["NI2I", "I2I"] resolves to I2I, which
+        # rejects. Ordering must matter -- a set-membership implementation that just
+        # asked "is NI2I present?" would wrongly accept this one.
+        near = nearWithOp(["NI2I", "I2I"], "latest wins to I2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Unrecognized tokens are skipped, not treated as conflicting: the latest
+        # *recognized* operator wins.
+        near = nearWithOp(["NI2I", "BOGUS"], "unrecognized token skipped")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # A list with no recognized operator falls to the default rule, which for a
+        # targeted far node is I2I -- and so rejects.
+        near = nearWithOp(["BOGUS"], "no recognized operator")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # An empty list likewise falls to the default rule.
+        near = nearWithOp([], "empty list")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Scalar forms are unchanged: "NI2I" still means NI2I.
+        near = nearWithOp("NI2I", "scalar NI2I")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # A tuple is accepted as a sequence too, not just a list.
+        near = nearWithOp(("NI2I",), "tuple form")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # E1E alone imposes no issuer constraint, and reaching it via a list must not
+        # change that. Here the near issuer is ian and the far issuee is han, so I2I
+        # would reject; E1E's own check (near issuee han == far issuee han) passes, so
+        # the edge is accepted. Composition of E1E with a delegative operator is
+        # covered by test_verifier_nonconflicting_operators_compose.
+        near = nearWithOp(["E1E"], "E1E via list")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # The flagship interop case from the review: "o": ["DI2I"] previously resolved
+        # to I2I via the default rule, silently downgrading a delegated-issuer edge to
+        # a strict issuer==issuee one. It must now reach DI2I and fail closed.
+        chainSad = dict(d='', node=dict(n=far.said, o=["DI2I"]))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="di2i in list")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        listDi2i = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=listDi2i.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(listDi2i, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "DI2I" in str(excinfo.value)
+
+        # NOT is normative (spec L1195: the far node's validity is inverted) and
+        # unimplemented here. It must fail closed like DI2I rather than being skipped
+        # as an unrecognized token -- otherwise an edge asserting "this node must be
+        # INVALID" would be accepted as valid.
+        chainSad = dict(d='', node=dict(n=far.said, o=["NOT"]))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="not operator")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        notCred = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                             status=ianiss.regk, source=chain, rules={},
+                             version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=notCred.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(notCred, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "NOT" in str(excinfo.value)
+
+    """End Test"""
+
+
+def test_verifier_nonconflicting_operators_compose(seeder):
+    """A non-delegative operator composes with the delegative winner, not overridden.
+
+    ACDC spec-body.md L1186 scopes latest-wins to "the conflicting Operators". I2I,
+    NI2I and DI2I all constrain the near ACDC's *issuer* relative to the far node's
+    issuee, so they conflict with one another. E1E constrains the near *issuee*, so it
+    conflicts with none of them and must be conjoined (AND).
+
+    Collapsing the whole list to a single operator drops the constraint that loses,
+    which is a silent weakening: ``["E1E", "I2I"]`` from a producer requiring both
+    relations would enforce only I2I and accept a far node whose issuee differs from
+    the near ACDC's.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        # Far node issued by ian to ian, so the far issuee is ian. Every near
+        # credential below is issued by ian, so I2I (near issuer ian == far issuee ian)
+        # is always satisfied -- which isolates E1E as the only constraint that can
+        # decide the outcome.
+        farSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        assert far.iseaid == ian.pre
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        def nearWithOp(op, nearIssuee, claim):
+            chainSad = dict(d='', node=dict(n=far.said, o=op))
+            _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+            subject = dict(d="", i=nearIssuee, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=chain, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Both satisfied: I2I (issuer ian == far issuee ian) and E1E (near issuee ian ==
+        # far issuee ian). Accepted.
+        near = nearWithOp(["E1E", "I2I"], ian.pre, "both hold")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # I2I still satisfied, E1E violated: the near issuee is han, the far issuee is
+        # ian. Must be REJECTED. This is the red case -- collapsing the list to the
+        # latest operator (I2I) would accept it and drop the E1E constraint entirely.
+        near = nearWithOp(["E1E", "I2I"], han.pre, "e1e violated, i2i holds")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Order must not matter for a non-conflicting pair -- E1E composes either way.
+        near = nearWithOp(["I2I", "E1E"], han.pre, "order reversed, still rejected")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # E1E composed with NI2I: NI2I wins the delegative conflict (no issuer
+        # constraint), but E1E still applies and still rejects a mismatched issuee.
+        near = nearWithOp(["E1E", "NI2I"], han.pre, "ni2i wins but e1e still applies")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Same pair with the issuee matching: NI2I drops the issuer constraint, E1E is
+        # satisfied, so the edge is accepted.
+        near = nearWithOp(["E1E", "NI2I"], ian.pre, "ni2i wins, e1e satisfied")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+    """End Test"""
+
+
+def test_verifier_di2i_rejects_diagnosably(seeder):
+    """An unimplemented DI2I edge must fail closed *diagnosably*, not vanish.
+
+    DI2I previously raised a bare ``NotImplementedError``, which is not a
+    ValidationError, so every caller mishandled it: ``Parser.allParsator``'s blanket
+    ``except (ValidationError, Exception)`` logged and discarded the ACDC, and
+    ``_processEscrow``'s generic arm unescrowed it. Neither produced a signal an
+    operator could act on.
+
+    DI2I is still unimplemented -- this test pins the *failure mode*, not the
+    operator semantics. A ValidationError names the cause and stops the retry loop,
+    which is correct here: unlike a missing chain, retrying cannot help.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    # Single party: every credential here is issued by ian to ian, so no second hab is
+    # needed to exercise the operator's failure mode.
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        farSubject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="far node")
+        _, fd = Saider.saidify(sad=farSubject, code=MtrDex.Blake3_256, label=Saids.d)
+        far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=fd,
+                         status=ianiss.regk, source={}, rules={}, version=Vrsn_1_0,
+                         kind=Kinds.json)
+        issueAndSave(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        chainSad = dict(d='', node=dict(n=far.said, o="DI2I"))
+        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
+        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="di2i edge")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=chain, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+
+        # Anchor the TEL issuance so processCredential reaches the edge walk rather
+        # than bailing out earlier on a missing registry.
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        with pytest.raises(ValidationError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+
+        # Diagnosable: the message names the operator, the far node the edge points to,
+        # and the near credential that carried the edge -- an operator triaging a stream
+        # needs the last of those to know which credential to fix.
+        assert "DI2I" in str(excinfo.value)
+        assert far.said in str(excinfo.value)
+        assert near.said in str(excinfo.value)
+        # Fails closed -- the credential is not saved on the strength of an edge the
+        # verifier cannot evaluate.
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+        # Not a MissingChainError: the chain is present, the operator is unsupported.
+        # Escrowing it would promise a retry that can never succeed.
+        assert not isinstance(excinfo.value, MissingChainError)
+
+    """End Test"""
+
+
+def test_verifier_escrow_pass_survives_argless_exception(seeder):
+    """One poisoned escrow entry must not abort the whole escrow pass.
+
+    ``_processEscrow``'s generic arm removed the entry and then evaluated
+    ``ex.args[0]`` to log it. For an exception raised with no arguments -- which is
+    exactly what ``raise NotImplementedError()`` produced -- that indexes an empty
+    tuple, so the IndexError escaped ``_processEscrow`` *and* ``processEscrows``,
+    skipping every remaining entry in the current table and both subsequent tables
+    (mce -> mse -> mre).
+
+    Pinned independently of DI2I: any argless exception from any credential reaches
+    the same handler, so fixing only the DI2I raise would leave the trap armed.
+    """
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer = Verifier(hby=ianHby, reger=ianreg.reger)
+
+        optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+        saids = []
+        for n in range(2):
+            subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim=f"poison {n}")
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            creder = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                                status=ianiss.regk, source={}, rules={},
+                                version=Vrsn_1_0, kind=Kinds.json)
+            verfer.escrowMCE(creder, prefixer=ian.kever.prefixer,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            saids.append(creder.said)
+
+        assert len(saids) == 2
+        for said in saids:
+            assert verfer.reger.mce.get(keys=said) is not None
+
+        # Every entry raises an argless exception, the shape that used to detonate.
+        def poisoned(*args, **kwa):
+            raise NotImplementedError()
+
+        verfer.processCredential = poisoned
+
+        # Must not raise. Before the fix this propagated IndexError out of
+        # processEscrows on the first entry.
+        verfer.processEscrows()
+
+        # Both entries were reached and unescrowed -- proving the pass continued past
+        # the first poisoned entry rather than aborting on it.
+        for said in saids:
+            assert verfer.reger.mce.get(keys=said) is None
 
     """End Test"""

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1362,6 +1362,263 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
     """End Test"""
 
 
+def test_verifier_edge_group_traversal(seeder):
+    """A nested Edge-group must traverse, and its m-ary Operator must be honored.
+
+    The ACDC spec gives an Edge Section two block types: Edges, which MUST have a
+    node, `n`, field, and Edge-groups, which MUST NOT (spec-body.md, "#### Block
+    Types"). The Edge Section is itself an Edge-group and MAY nest further
+    Edge-groups to arbitrary depth.
+
+    Before this change the edge loop skipped only the labels `d` and `o` and then
+    indexed ``node["n"]`` on everything else, so any nested Edge-group raised
+    ``KeyError: 'n'`` -- a crash, not a rejection, and one that escapes as an
+    unhandled exception rather than an escrow or a ValidationError. That made every
+    grouped edge section unusable, which in turn blocks the m-ary group operators
+    under discussion in #1555 (`ME`) and #1556 (group-scoped unary defaults).
+
+    This test carries none of `ME`'s semantics. It pins three things: nested groups
+    traverse, their members are really validated (not merely walked past), and a
+    group whose Operator this verifier does not implement fails closed.
+    """
+    optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0,
+                 kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef',
+                    version=Vrsn_1_0, kind=Kinds.json) as (hanHby, han):
+        seeder.seedSchema(db=ianHby.db)
+
+        ianreg = Regery(hby=ianHby, name="ian", temp=True)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0,
+                                     kind=Kinds.json)
+        rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+
+        verfer, issueAndSave = setupOperatorFixture(ian, ianHby, ianreg, ianiss)
+
+        def farNode(claim):
+            """Issue and save a targeted far node, ian -> han."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            far = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                             status=ianiss.regk, source={}, rules={},
+                             version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(far)
+            assert verfer.reger.saved.get(keys=far.saidb) is not None
+            return far
+
+        def saidify(block):
+            _, block = Saider.saidify(sad=block, code=MtrDex.Blake3_256, label=Saids.d)
+            return block
+
+        def nearWithSection(section, claim):
+            """Issue a near credential carrying `section` as its edge section."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=section, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            issueAndSave(near)
+            return near
+
+        # Both far nodes are issued by ian to han. Every near credential below is
+        # also issued by ian, so `near issuer (ian) != far issuee (han)`: NI2I edges
+        # accept and I2I edges reject. That asymmetry is what makes it observable
+        # whether a nested edge was actually evaluated or merely walked past.
+        work = farNode("work credential")
+        citizenship = farNode("citizenship credential")
+
+        # A group nested one level down. No `o` on the group, so the spec default
+        # AND applies -- and both members are valid, so the near credential saves.
+        # Before this change this section raised KeyError: 'n'.
+        endorsed = saidify(dict(d='', work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        grouped = nearWithSection(section, "grouped, default AND, all members valid")
+        assert verfer.reger.saved.get(keys=grouped.saidb) is not None
+
+        # The other half of the defect: Reger.sources gathers the far-node artifacts
+        # to ship alongside an IPEX grant, and walked the edge section with the same
+        # flat assumption. Both grouped edges must be discovered, or the disclosee
+        # receives an ACDC whose chain it cannot resolve.
+        srcs = verfer.reger.sources(ianHby.db, grouped)
+        assert {src.said for src, _ in srcs} == {work.said, citizenship.said}
+
+        # The same shape with the group's Operator written out explicitly. `AND` is
+        # the default, so this MUST behave identically to the block above.
+        endorsed = saidify(dict(d='', o="AND", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "grouped, explicit AND")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # AND means every member must be valid, so one bad member sinks the group.
+        # `citizenship` here is I2I, which rejects because the near issuer (ian) is
+        # not the far issuee (han). This is the load-bearing assertion of the test:
+        # a traversal that reached the nested edges but did not validate them, or
+        # that validated only the first, would wrongly save this credential.
+        endorsed = saidify(dict(d='', work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="I2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "grouped, one member fails")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # Groups nest arbitrarily deep, and a failure at depth still propagates.
+        inner = saidify(dict(d='', citizenship=dict(n=citizenship.said, o="NI2I")))
+        outer = saidify(dict(d='', work=dict(n=work.said, o="NI2I"), inner=inner))
+        section = saidify(dict(d='', outer=outer))
+        near = nearWithSection(section, "two levels of nesting, all valid")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        inner = saidify(dict(d='', citizenship=dict(n=citizenship.said, o="I2I")))
+        outer = saidify(dict(d='', work=dict(n=work.said, o="NI2I"), inner=inner))
+        section = saidify(dict(d='', outer=outer))
+        near = nearWithSection(section, "two levels of nesting, deep member fails")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # The reserved Edge-group labels are [d, u, o, w]; only non-reserved labels
+        # name nested blocks. A group carrying `u` and `w` alongside its members must
+        # still traverse -- neither is an edge. (`u` is a salty nonce and `w` a
+        # weight for WAVG; both are strings, so a walker that only skipped `d`/`o`
+        # would have tripped over them once they stopped being silently non-dict.)
+        endorsed = saidify(dict(d='', u='0ABhY2Rjc3BlY3dvcmtyYXcw', o="AND", w='2',
+                                work=dict(n=work.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        near = nearWithSection(section, "group with u and w reserved labels")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        # The Edge Section is itself an Edge-group, so it may carry its own m-ary
+        # Operator directly.
+        section = saidify(dict(d='', o="AND", work=dict(n=work.said, o="NI2I")))
+        near = nearWithSection(section, "AND on the edge section itself")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+
+        def expectRejected(section, claim):
+            """Run a near credential to the point of failure and return the error."""
+            subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim=claim)
+            _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+            near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                              status=ianiss.regk, source=section, rules={},
+                              version=Vrsn_1_0, kind=Kinds.json)
+            iss = ianiss.issue(said=near.said)
+            rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+            ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                         gvrsn=Vrsn_1_0)
+            ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                             seqner=Seqner(sn=ian.kever.sn),
+                             saider=Diger(qb64=ian.kever.serder.said))
+            ianreg.processEscrows()
+            with pytest.raises(ValidationError) as excinfo:
+                verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                         seqner=Seqner(sn=ian.kever.sn),
+                                         saider=Diger(qb64=ian.kever.serder.said))
+            assert verfer.reger.saved.get(keys=near.saidb) is None
+            return excinfo.value
+
+        # `ME` (Multiply Endorsed, discussion #1555) is a *proposed* m-ary Operator,
+        # not one in the spec's normative table. An issuer asking for it is asking
+        # for a rule this verifier cannot apply, so it must fail closed rather than
+        # fall back to AND -- falling back would validate the ACDC under a weaker
+        # rule than the issuer specified, with nothing on the wire to show for it.
+        endorsed = saidify(dict(d='', o="ME", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "unrecognized m-ary operator ME")
+        assert "ME" in str(ex)
+        assert "endorsed" in str(ex)  # names the offending group, not just the ACDC
+        # Not a MissingChainError: both far nodes are present and saved. Retrying
+        # cannot make an unrecognized operator recognized, so escrowing it would
+        # promise a retry that can never succeed -- the same reasoning NOT and DI2I
+        # already follow in .verifyChain.
+        assert not isinstance(ex, MissingChainError)
+
+        # `OR` is normative, and unimplemented here. It must fail closed too: under
+        # OR the group is valid if *one* member is valid, which is strictly weaker
+        # than the AND this verifier performs. Silently applying AND would reject
+        # ACDCs their issuer considers valid; silently applying OR would accept ones
+        # it cannot actually evaluate. Recognized-but-unimplemented is the honest
+        # answer, and it is distinguishable from the unrecognized case above.
+        endorsed = saidify(dict(d='', o="OR", work=dict(n=work.said, o="NI2I"),
+                                citizenship=dict(n=citizenship.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "recognized but unimplemented operator OR")
+        assert "OR" in str(ex)
+        # Distinguishable from the unrecognized case: "Unsupported" says the token is
+        # in the spec's table but this verifier does not implement it, which is a
+        # different thing for an issuer to act on than "that is not an operator".
+        assert "Unsupported m-ary" in str(ex)
+
+        # An m-ary Operator on the top-level Edge Section fails closed just the same.
+        section = saidify(dict(d='', o="NOR", work=dict(n=work.said, o="NI2I")))
+        ex = expectRejected(section, "unimplemented operator on the edge section")
+        assert "NOR" in str(ex)
+        assert "edge section" in str(ex)
+
+        # An Edge-group's `o` is a single aggregating Operator over its members; the
+        # spec defines the list form only for an Edge's unary `o`. A list here is not
+        # a spec-legal m-ary Operator, so it is rejected rather than coerced.
+        endorsed = saidify(dict(d='', o=["AND"], work=dict(n=work.said, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        ex = expectRejected(section, "list-valued m-ary operator")
+        assert "Unrecognized m-ary" in str(ex)
+
+        # Diagnosability: an edge nested in a group is reported by its dotted path
+        # from the Edge Section, so an operator triaging a stream can find it. A bare
+        # label would be ambiguous -- labels are only locally unique, so two groups
+        # may each hold a `work` edge.
+        unknown = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"  # not a saved ACDC
+        endorsed = saidify(dict(d='', work=dict(n=unknown, o="NI2I")))
+        section = saidify(dict(d='', endorsed=endorsed))
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="dotted path")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=section, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(MissingChainError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "endorsed.work" in str(excinfo.value)
+
+        # A flat edge section keeps its bare label -- the dotted path of a top-level
+        # edge is just its own label, so nothing about existing diagnostics changes.
+        section = saidify(dict(d='', work=dict(n=unknown, o="NI2I")))
+        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="flat path")
+        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+        near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
+                          status=ianiss.regk, source=section, rules={},
+                          version=Vrsn_1_0, kind=Kinds.json)
+        iss = ianiss.issue(said=near.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
+                         seqner=Seqner(sn=ian.kever.sn),
+                         saider=Diger(qb64=ian.kever.serder.said))
+        ianreg.processEscrows()
+        with pytest.raises(MissingChainError) as excinfo:
+            verfer.processCredential(near, prefixer=ian.kever.prefixer,
+                                     seqner=Seqner(sn=ian.kever.sn),
+                                     saider=Diger(qb64=ian.kever.serder.said))
+        assert "chain work(" in str(excinfo.value)
+
+    """End Test"""
+
+
 def test_verifier_escrow_pass_survives_argless_exception(seeder):
     """One poisoned escrow entry must not abort the whole escrow pass.
 


### PR DESCRIPTION
> **Stacked on #1552, which is stacked on #1563.** This branch includes both commits. Review from the bottom: #1563 (a 13-line test fix that unbreaks a red `main`), then #1552 (operator dispatch, which touches the adjacent code in `verifyChain`), then this. Once those merge, the diff here collapses to the single edge-group commit. This is a prerequisite for #1555 and #1556 and carries none of their semantics.
>
> Rebased on current `main` (`8e67f2e6a`), which merged #1529.

## Summary

An ACDC Edge Section has two block types. An Edge MUST have a node, `n`, field; an Edge-group MUST NOT, and MAY nest further Edge-groups to arbitrary depth ([spec-body.md L1058](https://trustoverip.github.io/kswg-acdc-specification/)). The Edge Section is itself an Edge-group.

keripy assumed every non-reserved label in `e` was a flat edge and indexed `node["n"]` on it. Four call sites walk the edge section, and all four made that assumption:

- `Verifier.processCredential`, the edge validation loop
- `Reger.sources`, which gathers the far-node artifacts to ship with an IPEX grant
- `Reger.cloneCreds`, chained-credential export
- `kli vc export --chains`, the same loop a fourth time

Each raises `KeyError: 'n'` on a nested Edge-group. So this ACDC was unprocessable, and nothing proposed on top of edge groups could be built:

```json
"e": {
  "d": "E...",
  "endorsed": {
    "d": "E...", "o": "AND",
    "work":        { "n": "E..." },
    "citizenship": { "n": "E..." }
  }
}
```

`Reger.sources` walks the edge section before it touches the database, so the defect reproduces on an unmodified checkout with no keystore, TEL, registry, or signatures. `credential()` is a pure builder, and literal SAIDs are enough. I have a standalone harness that does this in a dozen lines; say the word and I'll add it to the PR or paste it in a comment.

## Change

One shared recursive walker, `keri.vdr.eventing.walkEdgeSection`, with all four call sites routed through it.

It discriminates on the spec's own signal, the absence of `n` ([L1149](https://trustoverip.github.io/kswg-acdc-specification/): "An Edge block MUST have a node, `n`, field. This differentiates an Edge block from an Edge-group block"), rather than on whether a block contains nested dicts. Structural guessing gets both boundary cases wrong: an Edge-group holding a single Edge, and an Edge with no properties beyond `n`, are each legal.

It skips the reserved Edge-group labels `[d, u, o, w]`. The old loop skipped `d` and `o` and relied on an `isinstance` check to drop the rest, which works only because every reserved field happens to be a scalar today.

Nesting is bounded at `MaxEdgeGroupDepth` (8). SAID references make a cycle infeasible to construct, so this is a stack guard rather than a cycle guard.

## M-ary operators

The spec's normative Edge-group operator table is now recognized on `Verifier` as `MAryOps` — `AND`, `OR`, `NAND`, `NOR`, `AVG`, `WAVG` — with `AND` applied when a group's `o` is absent, as [L1110](https://trustoverip.github.io/kswg-acdc-specification/) requires. The default is not special-cased; it flows through the same checks as an explicit operator, so it cannot drift out of the implemented set unnoticed.

Only `AND` is implemented. It means the group is valid only if every member is valid, which is exactly the aggregation `processCredential` already performed over a flat section, so implementing it costs nothing and changes no existing behavior.

Every other operator fails closed with a `ValidationError`, and unrecognized tokens stay distinguishable in the message from recognized-but-unimplemented ones. Falling back to `AND` for an operator this verifier does not understand would validate the ACDC under a weaker rule than its Issuer specified, with nothing on the wire to explain the difference — the same failure shape as the list-valued `o` in #1552.

Deliberately **not** a `MissingChainError` in either case: the section is fully in hand and retrying cannot make an unsupported operator supported, so escrowing would promise a retry that can never succeed. That matches how `verifyChain` already treats `NOT` and `DI2I`.

## Diagnostics

An edge nested in a group is now reported by its dotted path from the Edge Section — `chain endorsed.work(E...)`. Labels are only locally unique, so two groups may each hold a `work` edge and a bare label cannot locate the failure. A top-level edge's path is just its own label, so messages for flat sections are byte-identical to before.

## One rejection that is new

An Edge Section carrying `n` is malformed, since the section is an Edge-group, and it now raises `ValidationError`. Previously that same input made `processCredential` raise `TypeError` from indexing a `str`, while `Reger.sources` returned no artifacts at all — a crash on one path and a silent empty on the other, for one bad input, and the silent one would have shipped a grant with no chain. This is the only case here that rejects something which did not previously raise.

## Deliberately out of scope

- `ME` (#1555), `IAND`, and group-scoped unary defaults (#1556) are still under discussion. Each of them needs traversal to exist first, and this supplies that and nothing else.
- `OR`, `NAND`, `NOR`, `AVG` and `WAVG` are recognized but not implemented. Each changes what "valid" means for a group and deserves its own tests. `OR` in particular interacts with escrow, since a failing member must not escrow the near ACDC. I'll raise a follow-up for them if the shape here looks right.
- Compact and simple-compact Edge forms, where an edge's value is its Edge block SAID rather than a block, are still skipped. Resolving one requires dereferencing the Edge block, which keripy does not store apart from the ACDC that carries it. The skip is now a commented deferral instead of an invisible side effect of an `isinstance` check.
- `DI2I` remains unimplemented, in a separate workstream.
- Enforcing that the top-level Edge Section carries no `w` ([L1120](https://trustoverip.github.io/kswg-acdc-specification/)) is normative, but it belongs in schema validation rather than in traversal.

## Spec conformance

Every rule implemented here is already normative text, so no spec change accompanies this PR:

- `n` as the Edge/Edge-group discriminator — L1058, L1085, L1149
- Edge-group reserved labels `[d, u, o, w]` and their order — L1076–L1083
- The m-ary operator table and the `AND` default — L1099–L1110
- Non-reserved labels name nested blocks and follow all reserved fields — L1126

## Tests

`tests/vdr/test_verifying.py::test_verifier_edge_group_traversal` covers nested groups traversing, explicit and default `AND`, reserved `u` and `w` ignored, an operator on the section itself, `ME` and `OR` failing closed and distinguishably, a list-valued group `o` rejected rather than coerced, dotted-path diagnostics, and `Reger.sources` discovering both far nodes of a grouped section.

The load-bearing case is a group whose members are one `NI2I` edge, which accepts, and one `I2I` edge, which rejects because the near issuer is not the far issuee. A traversal that reached the nested edges but did not validate them, or validated only the first, would wrongly save that credential. The same case is repeated one level deeper to pin that failures propagate from depth.

`tests/vdr/test_eventing.py::test_walk_edge_section` covers the walker in isolation: discriminator, paths, reserved labels, compact-edge skip, depth bound at and past the limit, and a malformed section.

Both go red on the parent commit.

Full suite: 659 passed, 4 skipped, against a measured branch-point baseline of 657 passed, 4 skipped — exactly the two new tests, nothing else moved. `test_verifier_chained_credential` and `test_verifier_e1e_identity_edge` stay green.

---

*This change was developed with AI assistance (Claude, Anthropic).*

