### PR TITLE
Adopt the settled `dp` disclosure-paths construct in the IPEX examples

### DIFF
--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -1004,9 +1004,16 @@ def test_disclosure_gating_and_revocation_JSON():
     # 1. apply (verifier -> holder): the challenge (schema/fields + governance).
     #
     # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
-    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
-    # with ACDC-relative paths -- see the same construct in tests/acdc/
-    # test_cp_disclosure.py, and WebOfTrust/keripy discussion #1549 for the rules.
+    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, prefix, [paths])
+    # triples -- see the same construct in tests/acdc/test_cp_disclosure.py, and
+    # WebOfTrust/keripy discussion #1549 for the rules.
+    #
+    # The middle element is a path prefix: the DAG-absolute route to the ACDC the
+    # entry's schema SAID names, either empty or a route that both begins and ends with
+    # '/'. It is EMPTY on both entries here, which makes the paths ACDC-relative and
+    # leaves the breadth-first POSITION of each triple to say which ACDC it is about
+    # (@SmithSamuelM, #1549). The effective path is prefix + entry, concatenated with
+    # nothing between them, so an entry never leads with '/'.
     #
     # Bulk issuance is exactly why the list form matters here. The verifier names a
     # SCHEMA SAID, which is shared by all M copies in the set and is therefore the one
@@ -1027,18 +1034,26 @@ def test_disclosure_gating_and_revocation_JSON():
     # requested from it -- the over-21 flag alone answers the challenge. Entries are
     # therefore a breadth-first-ordered SUBSET of the DAG, and each one still names its
     # own schema SAID, so a skipped node cannot shift the meaning of the entries below.
+    # A hole in that ordering is the case a non-empty prefix exists for. The prefix
+    # stays empty here because the two entries carry distinct schema SAIDs and the
+    # zeroth is still the origin, so the skip cannot be misread -- a DAG whose holes
+    # were ambiguous would have to spell the routes out instead.
     presSchemaSaid, _ = _saidify_schema(dict(PRESENT_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=verifier, receiver=ALICES[k], route="/ipex/apply",
-                     modifiers=dict(dp=[[presSchemaSaid, ["i", "a/i"]],
-                                        [ageCopies[k].sad['s']['$id'],
+                     modifiers=dict(dp=[[presSchemaSaid, "", ["i", "a/i"]],
+                                        [ageCopies[k].sad['s']['$id'], "",
                                          ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21.",
                                      g=GOVERNANCE_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply"
     dp = apply.sad['q']['dp']
-    assert dp == [[presSchemaSaid, ["i", "a/i"]],
-                  [ageCopies[k].sad['s']['$id'], ["A/i", "A/over21"]]]
+    assert dp == [[presSchemaSaid, "", ["i", "a/i"]],
+                  [ageCopies[k].sad['s']['$id'], "", ["A/i", "A/over21"]]]
+    # Empty prefix on both entries, so the paths are relative to the ACDC each entry's
+    # position names, and none of them leads with '/'.
+    assert [entry[1] for entry in dp] == ["", ""]
+    assert all(not p.startswith("/") for _, _, paths in dp for p in paths)
     assert presSchemaSaid == pres.sad['s']['$id']   # the origin the holder actually issues
     # The schema SAID is shared across the whole bulk set by design; the request names
     # it, never a copy SAID, so the apply itself introduces no cross-context correlator.

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -5,7 +5,7 @@ tests.acdc.test_bulk_issuance module
 Worked, working example of *bulk-issued private ACDCs* (ACDC spec section 15.4,
 "Bulk-Issued Private ACDCs") used to defeat cross-verifier correlation for SEDI
 (Utah's State-Endorsed Digital Identity, Utah Code 63A-20). It is a sibling to
-tests/acdc/test_clc_disclosure.py (contractually-protected disclosure) and
+tests/acdc/test_cp_disclosure.py (contractually-protected disclosure) and
 tests/acdc/test_guardianship_presentation.py (represented presentation), and it
 adds the one axis neither shows: IDENTIFIER-level cross-verifier unlinkability.
 
@@ -286,7 +286,7 @@ def test_bulk_derivation_primitive_JSON():
 # Phase 2: the bulk sedi-id set + its shared blindable registry (keyed on B).
 # ===========================================================================
 # Schema helpers, ported verbatim in intent from the sibling SEDI examples
-# (test_clc_disclosure.py / test_guardianship_presentation.py).
+# (test_cp_disclosure.py / test_guardianship_presentation.py).
 def _saidify_schema(mad, kind=Kinds.json):
     """Compute a JSON Schema's SAID and return (said, schema-with-$id). Mirrors the
     sibling examples: a Mapper self-addresses the '$id' field (which must be first)."""
@@ -1006,7 +1006,7 @@ def test_disclosure_gating_and_revocation_JSON():
     # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
     # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
     # with ACDC-relative paths -- see the same construct in tests/acdc/
-    # test_clc_disclosure.py, and WebOfTrust/keripy discussion #1549 for the rules.
+    # test_cp_disclosure.py, and WebOfTrust/keripy discussion #1549 for the rules.
     #
     # Bulk issuance is exactly why the list form matters here. The verifier names a
     # SCHEMA SAID, which is shared by all M copies in the set and is therefore the one

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -1030,17 +1030,24 @@ def test_disclosure_gating_and_revocation_JSON():
     # asks it only for issuer and issuee: who is presenting, and that the presentation
     # is addressed to this verifier rather than replayed from another context.
     #
-    # The identity copy is a node in this DAG but carries no entry, because nothing is
-    # requested from it -- the over-21 flag alone answers the challenge. Entries are
-    # therefore a breadth-first-ordered SUBSET of the DAG, and each one still names its
-    # own schema SAID, so a skipped node cannot shift the meaning of the entries below.
-    # A hole in that ordering is the case a non-empty prefix exists for. The prefix
-    # stays empty here because the two entries carry distinct schema SAIDs and the
-    # zeroth is still the origin, so the skip cannot be misread -- a DAG whose holes
-    # were ambiguous would have to spell the routes out instead.
+    # All THREE nodes of the DAG get an entry, in breadth-first order: the presentation,
+    # then sedi-id and sedi-age, which the presentation's edge block names in that order.
+    # With empty prefixes it is POSITION that says which ACDC an entry is about, so the
+    # list cannot skip a node -- an entry for sedi-age at index 1 would sit where sedi-id
+    # belongs, and its schema SAID would contradict its position.
+    #
+    # sedi-id is asked for its issuee alone, and that is not a courtesy: BOTH edge
+    # operators in this DAG are checked against it. I2I holds only when the presentation's
+    # issuer is the issuee of each source, and E1E holds only when sedi-age and sedi-id
+    # share an issuee (see _verify_presentation and _verify_identity_edge). The edge blocks
+    # carry the far node's SAID and schema, never its issuee, so a verifier that never sees
+    # sedi-id's 'a/i' has to take the whole identity relation on faith. It costs nothing in
+    # correlation: that issuee is ALICE_k, which the age credential's 'A/i' already
+    # discloses, and the two matching is exactly what the operators assert.
     presSchemaSaid, _ = _saidify_schema(dict(PRESENT_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=verifier, receiver=ALICES[k], route="/ipex/apply",
                      modifiers=dict(dp=[[presSchemaSaid, "", ["i", "a/i"]],
+                                        [idCopies[k].sad['s']['$id'], "", ["a/i"]],
                                         [ageCopies[k].sad['s']['$id'], "",
                                          ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21.",
@@ -1049,10 +1056,13 @@ def test_disclosure_gating_and_revocation_JSON():
     assert apply.sad['r'] == "/ipex/apply"
     dp = apply.sad['q']['dp']
     assert dp == [[presSchemaSaid, "", ["i", "a/i"]],
+                  [idCopies[k].sad['s']['$id'], "", ["a/i"]],
                   [ageCopies[k].sad['s']['$id'], "", ["A/i", "A/over21"]]]
-    # Empty prefix on both entries, so the paths are relative to the ACDC each entry's
+    # One entry per DAG node, breadth-first, so position and schema SAID agree.
+    assert len(dp) == 3
+    # Empty prefix on every entry, so the paths are relative to the ACDC each entry's
     # position names, and none of them leads with '/'.
-    assert [entry[1] for entry in dp] == ["", ""]
+    assert [entry[1] for entry in dp] == ["", "", ""]
     assert all(not p.startswith("/") for _, _, paths in dp for p in paths)
     assert presSchemaSaid == pres.sad['s']['$id']   # the origin the holder actually issues
     # The schema SAID is shared across the whole bulk set by design; the request names

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -1010,7 +1010,7 @@ def test_disclosure_gating_and_revocation_JSON():
     #
     # The middle element is a path prefix: the DAG-absolute route to the ACDC the
     # entry's schema SAID names, either empty or a route that both begins and ends with
-    # '/'. It is EMPTY on both entries here, which makes the paths ACDC-relative and
+    # '/'. It is EMPTY on all three entries here, which makes the paths ACDC-relative and
     # leaves the breadth-first POSITION of each triple to say which ACDC it is about
     # (@SmithSamuelM, #1549). The effective path is prefix + entry, concatenated with
     # nothing between them, so an entry never leads with '/'.

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -965,8 +965,14 @@ def _offer(kind, *, sender, receiver, prior, presentationSaid, governance):
     is built with a per-presentation salt, so it is an ephemeral, not a stable correlator)
     and a public governance ref. This is the 'correlation-budget doctrine' as
     policy-by-construction -- an EGF/implementation-guide requirement, not a schema change.
+
+    Its query block carries an EMPTY disclosure-paths list, `dp: []`. Because this offer
+    is SOLICITED -- `prior` binds the apply it answers -- an empty `dp` means "the same
+    paths the apply asked for" (#1549). Restating them would be redundant, and here it
+    would also be a second place for the two messages to drift.
     """
     return exchange(sender=sender, receiver=receiver, route="/ipex/offer", prior=prior,
+                    modifiers=dict(dp=[]),
                     attributes=dict(acdc=presentationSaid, governance=governance),
                     stamp=OFFER_STAMP, kind=kind)
 
@@ -996,13 +1002,31 @@ def test_disclosure_gating_and_revocation_JSON():
     pres = _presentation(kind, verifier, idCopies, ageCopies, presNonces)
 
     # 1. apply (verifier -> holder): the challenge (schema/fields + governance).
+    #
+    # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
+    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
+    # with ACDC-relative paths -- see the same construct in tests/acdc/
+    # test_clc_disclosure.py, and WebOfTrust/keripy discussion #1549 for the rules.
+    #
+    # Bulk issuance is exactly why the list form matters here. The verifier names a
+    # SCHEMA SAID, which is shared by all M copies in the set and is therefore the one
+    # identifier that is deliberately NOT partitioned across presentation contexts. Had
+    # `dp` stayed a dict keyed by schema SAID, a DAG carrying two copies drawn from the
+    # same bulk-issued set would collapse onto a single key -- the ordered list keeps
+    # each copy addressable while the copy SAIDs themselves stay per-context.
     apply = exchange(sender=verifier, receiver=ALICES[k], route="/ipex/apply",
+                     modifiers=dict(dp=[[ageCopies[k].sad['s']['$id'],
+                                         ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21.",
-                                     disclose={ageCopies[k].sad['s']['$id']:
-                                               ["/A/i", "/A/over21"]},
                                      g=GOVERNANCE_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply"
+    dp = apply.sad['q']['dp']
+    assert dp == [[ageCopies[k].sad['s']['$id'], ["A/i", "A/over21"]]]
+    # The schema SAID is shared across the whole bulk set by design; the request names
+    # it, never a copy SAID, so the apply itself introduces no cross-context correlator.
+    assert ageCopies[k].said.encode() not in apply.raw
+    assert idCopies[k].said.encode() not in apply.raw
 
     # 2. offer (holder -> verifier): via the leak-proof constructor. NO source SAIDs, NO v_k.
     offer = _offer(kind, sender=ALICES[k], receiver=verifier, prior=apply.said,

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -1014,15 +1014,32 @@ def test_disclosure_gating_and_revocation_JSON():
     # `dp` stayed a dict keyed by schema SAID, a DAG carrying two copies drawn from the
     # same bulk-issued set would collapse onto a single key -- the ordered list keeps
     # each copy addressable while the copy SAIDs themselves stay per-context.
+    #
+    # The zeroth entry is the DAG's origin node (#1549): the self-presentation ALICE_k
+    # issues to this verifier. Its schema is the one part of the presentation the
+    # verifier knows in advance, because the EGF fixes the shape of the presentation it
+    # will accept (@SmithSamuelM, #1542) -- and, unlike the copy SAIDs, a schema SAID is
+    # shared across contexts, so naming it costs nothing in correlation. The verifier
+    # asks it only for issuer and issuee: who is presenting, and that the presentation
+    # is addressed to this verifier rather than replayed from another context.
+    #
+    # The identity copy is a node in this DAG but carries no entry, because nothing is
+    # requested from it -- the over-21 flag alone answers the challenge. Entries are
+    # therefore a breadth-first-ordered SUBSET of the DAG, and each one still names its
+    # own schema SAID, so a skipped node cannot shift the meaning of the entries below.
+    presSchemaSaid, _ = _saidify_schema(dict(PRESENT_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=verifier, receiver=ALICES[k], route="/ipex/apply",
-                     modifiers=dict(dp=[[ageCopies[k].sad['s']['$id'],
+                     modifiers=dict(dp=[[presSchemaSaid, ["i", "a/i"]],
+                                        [ageCopies[k].sad['s']['$id'],
                                          ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21.",
                                      g=GOVERNANCE_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply"
     dp = apply.sad['q']['dp']
-    assert dp == [[ageCopies[k].sad['s']['$id'], ["A/i", "A/over21"]]]
+    assert dp == [[presSchemaSaid, ["i", "a/i"]],
+                  [ageCopies[k].sad['s']['$id'], ["A/i", "A/over21"]]]
+    assert presSchemaSaid == pres.sad['s']['$id']   # the origin the holder actually issues
     # The schema SAID is shared across the whole bulk set by design; the request names
     # it, never a copy SAID, so the apply itself introduces no cross-context correlator.
     assert ageCopies[k].said.encode() not in apply.raw

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -77,8 +77,9 @@ from jsonschema.exceptions import ValidationError
 from keri import Kinds, Ilks
 from keri.core import (Salter, Noncer, Aggor, Compactor, Mapper, Diger, Verfer,
                        exchange, messagize, incept, rotate)
-from keri.core.coring import MtrDex
+from keri.core.coring import MtrDex, Pather
 from keri.core.serdering import SerderACDC
+from keri.help.helping import Repath
 from keri.acdc import regcept, acdcmap, acdcagg
 
 
@@ -999,23 +1000,43 @@ def test_gated_ipex_exchange_JSON():
     # identically. Ordering is a breadth-first walk of the DAG from its origin node.
     # JSON has no tuple, so each pair serializes as a 2-element array.
     #
-    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. Under #1549 a leading '/'
-    # means DAG-absolute rooted at the ORIGIN node, so '/a/i' hung on a non-origin entry
-    # would name the ORIGIN's issuee rather than that credential's. A trailing '/' would
-    # request a whole subtree ("the hammer"); every path here is a leaf ("the scalpel"),
-    # closing over only what is needed to validate the SAIDs along its own branch.
+    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. A leading '/' means
+    # DAG-ABSOLUTE, rooted at the origin node, and an absolute path that reaches a
+    # non-origin ACDC must cross the edge that links it. That hop is written as the
+    # virtual path component '_', which stands for the jump from the near-side edge
+    # block to the top level of the far-side ACDC (@SmithSamuelM, #1549). The same
+    # request in absolute form reads:
+    #     origin: /i, /a/i, /r/
+    #     sedi:   /e/identity/_/a/i, /e/identity/_/a/photo
+    #     age:    /e/age/_/A/i, /e/age/_/A/over21
+    # Omitting the '_' does not merely misroot such a path, it makes it meaningless:
+    # '/e/identity/a/i' names an 'a' field inside the near-side EDGE block, which has
+    # no such field. Relative form is used here because this DAG has no optional edges
+    # -- the bespoke schema requires both 'identity' and 'age' -- so the breadth-first
+    # ordering of `dp` is gapless and each entry's ACDC is unambiguous without
+    # restating the route to it. Absolute form is required only when optional edges
+    # could leave holes in that ordering.
     #
-    # OPEN QUESTION (#1542, unanswered by @SmithSamuelM). #1549 says the zeroth tuple
-    # MUST represent the DAG's origin node -- here Alice's bespoke presentation ACDC.
-    # But this is a FIRST-CONTACT apply, and per #1512 the applicant "won't necessarily
-    # know the SAID of its schema in the application"; the offer is what supplies it. So
-    # the origin tuple is omitted and the list carries only the two source schemas the
-    # club can actually name. If #1549's ordering rule is meant to hold literally even
-    # here, this list grows a zeroth entry and every index below shifts by one.
+    # A TRAILING '/' means the whole node ("the hammer"): the origin's 'r/' asks for the
+    # rule section fully expanded, because the club must read the CLC terms it is being
+    # asked to agree to. Every other path is a leaf ("the scalpel"), closing over only
+    # what is needed to validate the SAIDs along its own branch.
+    #
+    # The ZEROTH entry is the DAG's origin node (#1549) -- Alice's bespoke presentation
+    # ACDC. The club can name its schema even though Alice issues it: the origin is
+    # presenter-issued, but its SHAPE is governance, not Alice's invention, and "in all
+    # of these applications the Applicant would know the schema of the origin node
+    # despite it being a presenter issued ACDC" (@SmithSamuelM, #1542). So the club asks
+    # the origin for its issuer, its issuee, and its rules -- who is disclosing, that the
+    # presentation is addressed to the club, and the terms the club must agree to before
+    # the grant. The rule section is what the offer at step 2 answers with; the issuer
+    # and issuee arrive with the presentation itself, in the grant.
+    bespokeSchemaSaid, _ = _saidify_schema(dict(BESPOKE_SCHEMA_MAD), kind=kind)
     sediSchemaSaid = sedi.sad['s']['$id']
     ageSchemaSaid = age.sad['s']['$id']
     apply = exchange(sender=CLUB, receiver=ALICE, route="/ipex/apply",
-                     modifiers=dict(dp=[[sediSchemaSaid, ["a/i", "a/photo"]],
+                     modifiers=dict(dp=[[bespokeSchemaSaid, ["i", "a/i", "r/"]],
+                                        [sediSchemaSaid, ["a/i", "a/photo"]],
                                         [ageSchemaSaid,  ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21 and show the state-endorsed photo.",
                                      g=GOV_PROVISION_SAID),
@@ -1027,22 +1048,28 @@ def test_gated_ipex_exchange_JSON():
     # flag from the aggregative cred, each under the schema SAID the club is asking for.
     dp = apply.sad['q']['dp']
     # Ordered, not keyed: the schema SAIDs are positions in a list, so a DAG with two
-    # same-schema credentials would carry two entries rather than losing one.
-    assert [entry[0] for entry in dp] == [sediSchemaSaid, ageSchemaSaid]
-    reqSedi = dp[0][1]
-    reqAge = dp[1][1]
+    # same-schema credentials would carry two entries rather than losing one. The order
+    # is a breadth-first walk from the origin, which for this DAG is the bespoke
+    # presentation and then its two edges in section order, 'identity' and 'age'.
+    assert [entry[0] for entry in dp] == [bespokeSchemaSaid, sediSchemaSaid, ageSchemaSaid]
+    reqOrigin = dp[0][1]
+    reqSedi = dp[1][1]
+    reqAge = dp[2][1]
+    assert reqOrigin == ["i", "a/i", "r/"]              # origin: discloser, disclosee, terms
     assert reqSedi == ["a/i", "a/photo"]                # attributive: issuee + photo
     assert reqAge == ["A/i", "A/over21"]                # aggregate: issuee + over-21 flag
     assert "a/i" in reqSedi and "A/i" in reqAge         # the joining issuee, from both
-    # ACDC-relative form throughout: no path leads with '/' (which would root it at the
-    # DAG origin), and none trails with '/' (which would demand a whole subtree).
-    assert all(not p.startswith("/") and not p.endswith("/")
-               for _, paths in dp for p in paths)
+    # ACDC-relative form throughout: no path leads with '/', which would root it at the
+    # DAG origin and, for a non-origin entry, would have to cross a '_' hop to get back
+    # to the credential the entry is already about.
+    assert all(not p.startswith("/") for _, paths in dp for p in paths)
+    # Node vs. leaf: only the origin's rule section is asked for whole.
+    assert [p for _, paths in dp for p in paths if p.endswith("/")] == ["r/"]
     # The request lives in the query block, not the attribute block; the attribute
     # block carries only the human message and the governance reference.
     assert 'dp' not in apply.sad['a'] and 'disclose' not in apply.sad['a']
     assert set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EFrjhS5l3ZyQZ0VDSn3oiq-cnlhR-dyuzzx-NQiNkpgw"
+    assert apply.said == "EPiL36dPzFMlL5K4ybK5MaxC2a3qIzntPjHvExkn0189"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Commits ONLY to Alice's own bespoke-presentation SAID, the CLC
@@ -1067,7 +1094,7 @@ def test_gated_ipex_exchange_JSON():
     assert offer.sad['p'] == apply.said                 # answers the apply
     assert offer.sad['q']['dp'] == []                   # solicited: "as per the apply"
     assert bespoke.said.encode() in offer.raw           # commits to Alice's own presentation
-    assert offer.said == "EEpcgVyXzfcZW8iuRoLwOjHSdrFVZY0HN7OahJlgj7sV"
+    assert offer.said == "ENW6Q9TtdEyHtah7Tgg7ClV3XuD9CmAwAs8oEIZAu-KO"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -1082,7 +1109,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "EAI_3tluMw2m8r2Aion9m_9WBHKp5MIqBSIJGTTuPVgX"
+    assert agree.said == "ELU6DF53tqV2Dd_2Tpyk1uBcP5JLUnJ0JJQlsw4H1EsC"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1137,7 +1164,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "ENaSnz6Mh4Tf5lkP7t_5HnEg6hQmfMQhOlWvEfCaeauP"
+    assert grant.said == "EKPweFTQmyr2ghr5tBDLxAZY-_AXkiztDWmwcl6h0XTS"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1169,7 +1196,65 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EPegh4Oqd2RTyZsuw2rKkoIRT_l3xIt9hFhuu2upOLJQ"
+    assert admit.said == "EG_v0NItF5AH5QeBBCRaaR1XffK1iivzW9DJgfyNoTZ_"
+
+
+def _pathable_labels(value):
+    """Every field label reachable by a disclosure path, from a SAD value.
+
+    Recurses field maps and arrays. The SCHEMA section is skipped: it is always
+    disclosed whole, so no path ever descends into it -- which is just as well, since
+    JSON Schema's own keys ('$id', '$schema') are not Base64 at all and could never be
+    a Pather part. See test_disclosure_path_label_conformance_JSON.
+    """
+    if isinstance(value, dict):
+        for label, sub in value.items():
+            yield label
+            if label != 's':
+                yield from _pathable_labels(sub)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _pathable_labels(item)
+
+
+def test_disclosure_path_label_conformance_JSON():
+    """Every field label in the worked example can be a disclosure-path component.
+
+    Two restrictions come with the `_` DAG-hop component settled in discussion #1549.
+    A label may not contain '-', because '-' is what the '/' delimiter becomes when a
+    path is CESR-serialized as compact Base64; and a label may not be exactly '_',
+    because a bare '_' is reserved for the hop from an edge to the far-side ACDC.
+
+    The '-' half is already keripy's behavior rather than a new rule: Pather's part
+    regex is PATHREX = rb'^[a-zA-Z0-9_]*$' (keri.help.helping), and a part that fails
+    it forces the whole path out of compact Base64 into the Bytes code -- or raises
+    outright when pathive. So this asserts against Repath itself instead of restating
+    the character class, and adds only the bare-'_' rule on top.
+
+    A guard, not a discovery: these labels are clean today. It exists so that adding a
+    hyphenated attribute to the example fails here, with the reason, rather than
+    silently making a path unrepresentable at the CESR layer.
+    """
+    kind = Kinds.json
+    sedi, age, _ = _source_credentials(kind)
+    bespoke = _bespoke_presentation(sedi, age, kind)
+    for acdc in (sedi, age, bespoke):
+        for label in _pathable_labels(acdc.sad):
+            assert Repath.match(label.encode()), \
+                f"label {label!r} cannot be a Pather path part"
+            assert label != '_', "'_' is reserved for the DAG-hop path component"
+    # The hop component round-trips through Pather today, compactly and with no code
+    # change, so adopting it costs the wire nothing. What it does NOT yet do is
+    # RESOLVE: no Pather method follows '_' across an edge into the far-side ACDC.
+    # That extension is the open work item on #1549.
+    hop = Pather(path="/e/identity/_/a/photo")
+    assert hop.parts == ['', 'e', 'identity', '_', 'a', 'photo']
+    # A StrB64 code (4A/5A/6A, by length mod 3), NOT a Bytes code (4B/5B/6B): the '_'
+    # part keeps the path in the compact Base64 domain. A '-' in any label is what
+    # would force it into Bytes, which is the whole reason for the restriction above.
+    assert hop.code in (MtrDex.StrB64_L0, MtrDex.StrB64_L1, MtrDex.StrB64_L2)
+    assert hop.qb64 == "6AAGAAA-e-identity-_-a-photo"
+    assert Pather(qb64=hop.qb64).path == "/e/identity/_/a/photo"
 
 
 def test_accountability_and_terms_follow_data_JSON():

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -976,34 +976,71 @@ def test_gated_ipex_exchange_JSON():
 
     # 1. apply (club -> Alice): the challenge. It narrows what the club will accept up
     # front: not merely which schemas, but which FIELDS must be disclosed from each --
-    # the photo and issuee from the attributive sedi-id (/a/photo, /a/i), and the over-21
-    # flag and issuee from the aggregative age credential (/A/over21, /A/i). The issuee
+    # the photo and issuee from the attributive sedi-id (a/photo, a/i), and the over-21
+    # flag and issuee from the aggregative age credential (A/over21, A/i). The issuee
     # is required from BOTH so the club can confirm the two creds name the same holder
-    # (the I2I binding). The request is keyed by schema SAID -- the applicant is not
-    # assumed to know the actual ACDC SAIDs -- with a list of attribute paths, following
-    # the graduated-disclosure path-list model. This is a static, one-shot narrowing of
-    # the request, NOT full back-and-forth negotiation; the exact placement (attribute
-    # vs. query block) and encoding are still being designed (WebOfTrust/keripy
-    # discussion #1512). No creds yet -- schemas, required paths, governance.
+    # (the I2I binding). The request names SCHEMA SAIDs, never ACDC SAIDs -- the
+    # applicant is not assumed to know which actual credentials it will be shown. This
+    # is a static, one-shot narrowing of the request, NOT full back-and-forth
+    # negotiation. No creds yet -- schemas, required paths, governance.
+    #
+    # The request rides the disclosure-paths `dp` field of the QUERY section, `q`
+    # (exchange(modifiers=...)), not the attribute section. An exn's query block is the
+    # http-query-string analogue and its attribute block is the body; a disclosure
+    # request is a query, so `dp` belongs in `q` (WebOfTrust/keripy discussion #1549).
+    #
+    # `dp` is an ORDERED LIST OF (schemaSAID, [paths]) PAIRS, not a dict keyed by schema
+    # SAID. A dict cannot express a DAG containing two credentials of the SAME schema --
+    # they collapse onto one key -- which is legitimate and common (presenting one's own
+    # identity alongside a spouse's, both under the same SEDI schema). The ordered list
+    # keeps them distinct, and it makes two equivalent requests serialize byte-for-byte
+    # identically. Ordering is a breadth-first walk of the DAG from its origin node.
+    # JSON has no tuple, so each pair serializes as a 2-element array.
+    #
+    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. Under #1549 a leading '/'
+    # means DAG-absolute rooted at the ORIGIN node, so '/a/i' hung on a non-origin entry
+    # would name the ORIGIN's issuee rather than that credential's. A trailing '/' would
+    # request a whole subtree ("the hammer"); every path here is a leaf ("the scalpel"),
+    # closing over only what is needed to validate the SAIDs along its own branch.
+    #
+    # OPEN QUESTION (#1542, unanswered by @SmithSamuelM). #1549 says the zeroth tuple
+    # MUST represent the DAG's origin node -- here Alice's bespoke presentation ACDC.
+    # But this is a FIRST-CONTACT apply, and per #1512 the applicant "won't necessarily
+    # know the SAID of its schema in the application"; the offer is what supplies it. So
+    # the origin tuple is omitted and the list carries only the two source schemas the
+    # club can actually name. If #1549's ordering rule is meant to hold literally even
+    # here, this list grows a zeroth entry and every index below shifts by one.
     sediSchemaSaid = sedi.sad['s']['$id']
     ageSchemaSaid = age.sad['s']['$id']
     apply = exchange(sender=CLUB, receiver=ALICE, route="/ipex/apply",
+                     modifiers=dict(dp=[[sediSchemaSaid, ["a/i", "a/photo"]],
+                                        [ageSchemaSaid,  ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21 and show the state-endorsed photo.",
-                                     disclose={sediSchemaSaid: ["/a/i", "/a/photo"],
-                                               ageSchemaSaid:  ["/A/i", "/A/over21"]},
                                      g=GOV_PROVISION_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['t'] == Ilks.exn
     assert apply.sad['r'] == "/ipex/apply"
     assert apply.sad['i'] == CLUB and apply.sad['ri'] == ALICE
     # The field-level request: issuee + photo from the attributive cred, issuee + over-21
-    # flag from the aggregative cred, keyed by the schema SAID the club is asking for.
-    reqSedi = apply.sad['a']['disclose'][sediSchemaSaid]
-    reqAge = apply.sad['a']['disclose'][ageSchemaSaid]
-    assert reqSedi == ["/a/i", "/a/photo"]              # attributive: issuee + photo
-    assert reqAge == ["/A/i", "/A/over21"]              # aggregate: issuee + over-21 flag
-    assert "/a/i" in reqSedi and "/A/i" in reqAge       # the joining issuee, from both
-    assert apply.said == "EK0cONSlv5IO4feJcynRSrfR09udKpfQf4Y29QMWRrdH"
+    # flag from the aggregative cred, each under the schema SAID the club is asking for.
+    dp = apply.sad['q']['dp']
+    # Ordered, not keyed: the schema SAIDs are positions in a list, so a DAG with two
+    # same-schema credentials would carry two entries rather than losing one.
+    assert [entry[0] for entry in dp] == [sediSchemaSaid, ageSchemaSaid]
+    reqSedi = dp[0][1]
+    reqAge = dp[1][1]
+    assert reqSedi == ["a/i", "a/photo"]                # attributive: issuee + photo
+    assert reqAge == ["A/i", "A/over21"]                # aggregate: issuee + over-21 flag
+    assert "a/i" in reqSedi and "A/i" in reqAge         # the joining issuee, from both
+    # ACDC-relative form throughout: no path leads with '/' (which would root it at the
+    # DAG origin), and none trails with '/' (which would demand a whole subtree).
+    assert all(not p.startswith("/") and not p.endswith("/")
+               for _, paths in dp for p in paths)
+    # The request lives in the query block, not the attribute block; the attribute
+    # block carries only the human message and the governance reference.
+    assert 'dp' not in apply.sad['a'] and 'disclose' not in apply.sad['a']
+    assert set(apply.sad['a']) == {'m', 'g'}
+    assert apply.said == "EFrjhS5l3ZyQZ0VDSn3oiq-cnlhR-dyuzzx-NQiNkpgw"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Commits ONLY to Alice's own bespoke-presentation SAID, the CLC
@@ -1013,15 +1050,22 @@ def test_gated_ipex_exchange_JSON():
     # agrees would let the club spurn and walk away with stable holder correlators,
     # defeating the metadata-ACDC decorrelation (panel review, PRV-F2). They arrive
     # only post-agree, in the grant, reachable by expanding the delivered presentation.
+    # Its query block carries `dp` too, as an EMPTY list. For a SOLICITED offer -- one
+    # that answers an apply -- an empty `dp` means "the same disclosure paths the apply
+    # asked for", so Alice restates nothing and the two messages cannot drift (#1549).
+    # An unsolicited offer, or one that counter-offers different paths, MUST spell the
+    # list out instead; empty is only meaningful because `p` binds the apply it answers.
     offer = exchange(sender=ALICE, receiver=CLUB, route="/ipex/offer",
                      prior=apply.said,
+                     modifiers=dict(dp=[]),
                      attributes=dict(acdc=bespoke.said,
                                      governance=GOV_PROVISION_SAID,
                                      terms=_rules_in_bespoke()),
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said                 # answers the apply
+    assert offer.sad['q']['dp'] == []                   # solicited: "as per the apply"
     assert bespoke.said.encode() in offer.raw           # commits to Alice's own presentation
-    assert offer.said == "EIUqoqpXiU52iIp5q9M2RH_g0N0dbJnLFW8MprL3QOQN"
+    assert offer.said == "EEpcgVyXzfcZW8iuRoLwOjHSdrFVZY0HN7OahJlgj7sV"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -1036,7 +1080,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "EI30cUq5JGGSd-3cBoXx1nCtE6CBXXRgKPkZodJm-8da"
+    assert agree.said == "EAI_3tluMw2m8r2Aion9m_9WBHKp5MIqBSIJGTTuPVgX"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1091,7 +1135,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "EEIdc4wcI-9zB0eSZE4meZLWXfM8WuXZHMDhyBfIJJaD"
+    assert grant.said == "ENaSnz6Mh4Tf5lkP7t_5HnEg6hQmfMQhOlWvEfCaeauP"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1123,7 +1167,7 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EDmW_7vE6Ivdwr3ldV-W9uLPOcJp97Sz9bqD5eNaKpks"
+    assert admit.said == "EPegh4Oqd2RTyZsuw2rKkoIRT_l3xIt9hFhuu2upOLJQ"
 
 
 def test_accountability_and_terms_follow_data_JSON():

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -77,8 +77,9 @@ from jsonschema.exceptions import ValidationError
 from keri import Kinds, Ilks
 from keri.core import (Salter, Noncer, Aggor, Compactor, Mapper, Diger, Verfer,
                        exchange, messagize, incept, rotate)
-from keri.core.coring import MtrDex
+from keri.core.coring import MtrDex, Pather
 from keri.core.serdering import SerderACDC
+from keri.help.helping import Repath
 from keri.acdc import regcept, acdcmap, acdcagg
 
 
@@ -997,23 +998,43 @@ def test_gated_ipex_exchange_JSON():
     # identically. Ordering is a breadth-first walk of the DAG from its origin node.
     # JSON has no tuple, so each pair serializes as a 2-element array.
     #
-    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. Under #1549 a leading '/'
-    # means DAG-absolute rooted at the ORIGIN node, so '/a/i' hung on a non-origin entry
-    # would name the ORIGIN's issuee rather than that credential's. A trailing '/' would
-    # request a whole subtree ("the hammer"); every path here is a leaf ("the scalpel"),
-    # closing over only what is needed to validate the SAIDs along its own branch.
+    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. A leading '/' means
+    # DAG-ABSOLUTE, rooted at the origin node, and an absolute path that reaches a
+    # non-origin ACDC must cross the edge that links it. That hop is written as the
+    # virtual path component '_', which stands for the jump from the near-side edge
+    # block to the top level of the far-side ACDC (@SmithSamuelM, #1549). The same
+    # request in absolute form reads:
+    #     origin: /i, /a/i, /r/
+    #     sedi:   /e/identity/_/a/i, /e/identity/_/a/photo
+    #     age:    /e/age/_/A/i, /e/age/_/A/over21
+    # Omitting the '_' does not merely misroot such a path, it makes it meaningless:
+    # '/e/identity/a/i' names an 'a' field inside the near-side EDGE block, which has
+    # no such field. Relative form is used here because this DAG has no optional edges
+    # -- the bespoke schema requires both 'identity' and 'age' -- so the breadth-first
+    # ordering of `dp` is gapless and each entry's ACDC is unambiguous without
+    # restating the route to it. Absolute form is required only when optional edges
+    # could leave holes in that ordering.
     #
-    # OPEN QUESTION (#1542, unanswered by @SmithSamuelM). #1549 says the zeroth tuple
-    # MUST represent the DAG's origin node -- here Alice's bespoke presentation ACDC.
-    # But this is a FIRST-CONTACT apply, and per #1512 the applicant "won't necessarily
-    # know the SAID of its schema in the application"; the offer is what supplies it. So
-    # the origin tuple is omitted and the list carries only the two source schemas the
-    # club can actually name. If #1549's ordering rule is meant to hold literally even
-    # here, this list grows a zeroth entry and every index below shifts by one.
+    # A TRAILING '/' means the whole node ("the hammer"): the origin's 'r/' asks for the
+    # rule section fully expanded, because the club must read the CLC terms it is being
+    # asked to agree to. Every other path is a leaf ("the scalpel"), closing over only
+    # what is needed to validate the SAIDs along its own branch.
+    #
+    # The ZEROTH entry is the DAG's origin node (#1549) -- Alice's bespoke presentation
+    # ACDC. The club can name its schema even though Alice issues it: the origin is
+    # presenter-issued, but its SHAPE is governance, not Alice's invention, and "in all
+    # of these applications the Applicant would know the schema of the origin node
+    # despite it being a presenter issued ACDC" (@SmithSamuelM, #1542). So the club asks
+    # the origin for its issuer, its issuee, and its rules -- who is disclosing, that the
+    # presentation is addressed to the club, and the terms the club must agree to before
+    # the grant. The rule section is what the offer at step 2 answers with; the issuer
+    # and issuee arrive with the presentation itself, in the grant.
+    bespokeSchemaSaid, _ = _saidify_schema(dict(BESPOKE_SCHEMA_MAD), kind=kind)
     sediSchemaSaid = sedi.sad['s']['$id']
     ageSchemaSaid = age.sad['s']['$id']
     apply = exchange(sender=CLUB, receiver=ALICE, route="/ipex/apply",
-                     modifiers=dict(dp=[[sediSchemaSaid, ["a/i", "a/photo"]],
+                     modifiers=dict(dp=[[bespokeSchemaSaid, ["i", "a/i", "r/"]],
+                                        [sediSchemaSaid, ["a/i", "a/photo"]],
                                         [ageSchemaSaid,  ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21 and show the state-endorsed photo.",
                                      g=GOV_PROVISION_SAID),
@@ -1025,22 +1046,28 @@ def test_gated_ipex_exchange_JSON():
     # flag from the aggregative cred, each under the schema SAID the club is asking for.
     dp = apply.sad['q']['dp']
     # Ordered, not keyed: the schema SAIDs are positions in a list, so a DAG with two
-    # same-schema credentials would carry two entries rather than losing one.
-    assert [entry[0] for entry in dp] == [sediSchemaSaid, ageSchemaSaid]
-    reqSedi = dp[0][1]
-    reqAge = dp[1][1]
+    # same-schema credentials would carry two entries rather than losing one. The order
+    # is a breadth-first walk from the origin, which for this DAG is the bespoke
+    # presentation and then its two edges in section order, 'identity' and 'age'.
+    assert [entry[0] for entry in dp] == [bespokeSchemaSaid, sediSchemaSaid, ageSchemaSaid]
+    reqOrigin = dp[0][1]
+    reqSedi = dp[1][1]
+    reqAge = dp[2][1]
+    assert reqOrigin == ["i", "a/i", "r/"]              # origin: discloser, disclosee, terms
     assert reqSedi == ["a/i", "a/photo"]                # attributive: issuee + photo
     assert reqAge == ["A/i", "A/over21"]                # aggregate: issuee + over-21 flag
     assert "a/i" in reqSedi and "A/i" in reqAge         # the joining issuee, from both
-    # ACDC-relative form throughout: no path leads with '/' (which would root it at the
-    # DAG origin), and none trails with '/' (which would demand a whole subtree).
-    assert all(not p.startswith("/") and not p.endswith("/")
-               for _, paths in dp for p in paths)
+    # ACDC-relative form throughout: no path leads with '/', which would root it at the
+    # DAG origin and, for a non-origin entry, would have to cross a '_' hop to get back
+    # to the credential the entry is already about.
+    assert all(not p.startswith("/") for _, paths in dp for p in paths)
+    # Node vs. leaf: only the origin's rule section is asked for whole.
+    assert [p for _, paths in dp for p in paths if p.endswith("/")] == ["r/"]
     # The request lives in the query block, not the attribute block; the attribute
     # block carries only the human message and the governance reference.
     assert 'dp' not in apply.sad['a'] and 'disclose' not in apply.sad['a']
     assert set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EFrjhS5l3ZyQZ0VDSn3oiq-cnlhR-dyuzzx-NQiNkpgw"
+    assert apply.said == "EPiL36dPzFMlL5K4ybK5MaxC2a3qIzntPjHvExkn0189"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Commits ONLY to Alice's own bespoke-presentation SAID, the CLC
@@ -1065,7 +1092,7 @@ def test_gated_ipex_exchange_JSON():
     assert offer.sad['p'] == apply.said                 # answers the apply
     assert offer.sad['q']['dp'] == []                   # solicited: "as per the apply"
     assert bespoke.said.encode() in offer.raw           # commits to Alice's own presentation
-    assert offer.said == "EEpcgVyXzfcZW8iuRoLwOjHSdrFVZY0HN7OahJlgj7sV"
+    assert offer.said == "ENW6Q9TtdEyHtah7Tgg7ClV3XuD9CmAwAs8oEIZAu-KO"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -1080,7 +1107,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "EAI_3tluMw2m8r2Aion9m_9WBHKp5MIqBSIJGTTuPVgX"
+    assert agree.said == "ELU6DF53tqV2Dd_2Tpyk1uBcP5JLUnJ0JJQlsw4H1EsC"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1135,7 +1162,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "ENaSnz6Mh4Tf5lkP7t_5HnEg6hQmfMQhOlWvEfCaeauP"
+    assert grant.said == "EKPweFTQmyr2ghr5tBDLxAZY-_AXkiztDWmwcl6h0XTS"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1167,7 +1194,65 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EPegh4Oqd2RTyZsuw2rKkoIRT_l3xIt9hFhuu2upOLJQ"
+    assert admit.said == "EG_v0NItF5AH5QeBBCRaaR1XffK1iivzW9DJgfyNoTZ_"
+
+
+def _pathable_labels(value):
+    """Every field label reachable by a disclosure path, from a SAD value.
+
+    Recurses field maps and arrays. The SCHEMA section is skipped: it is always
+    disclosed whole, so no path ever descends into it -- which is just as well, since
+    JSON Schema's own keys ('$id', '$schema') are not Base64 at all and could never be
+    a Pather part. See test_disclosure_path_label_conformance_JSON.
+    """
+    if isinstance(value, dict):
+        for label, sub in value.items():
+            yield label
+            if label != 's':
+                yield from _pathable_labels(sub)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _pathable_labels(item)
+
+
+def test_disclosure_path_label_conformance_JSON():
+    """Every field label in the worked example can be a disclosure-path component.
+
+    Two restrictions come with the `_` DAG-hop component settled in discussion #1549.
+    A label may not contain '-', because '-' is what the '/' delimiter becomes when a
+    path is CESR-serialized as compact Base64; and a label may not be exactly '_',
+    because a bare '_' is reserved for the hop from an edge to the far-side ACDC.
+
+    The '-' half is already keripy's behavior rather than a new rule: Pather's part
+    regex is PATHREX = rb'^[a-zA-Z0-9_]*$' (keri.help.helping), and a part that fails
+    it forces the whole path out of compact Base64 into the Bytes code -- or raises
+    outright when pathive. So this asserts against Repath itself instead of restating
+    the character class, and adds only the bare-'_' rule on top.
+
+    A guard, not a discovery: these labels are clean today. It exists so that adding a
+    hyphenated attribute to the example fails here, with the reason, rather than
+    silently making a path unrepresentable at the CESR layer.
+    """
+    kind = Kinds.json
+    sedi, age, _ = _source_credentials(kind)
+    bespoke = _bespoke_presentation(sedi, age, kind)
+    for acdc in (sedi, age, bespoke):
+        for label in _pathable_labels(acdc.sad):
+            assert Repath.match(label.encode()), \
+                f"label {label!r} cannot be a Pather path part"
+            assert label != '_', "'_' is reserved for the DAG-hop path component"
+    # The hop component round-trips through Pather today, compactly and with no code
+    # change, so adopting it costs the wire nothing. What it does NOT yet do is
+    # RESOLVE: no Pather method follows '_' across an edge into the far-side ACDC.
+    # That extension is the open work item on #1549.
+    hop = Pather(path="/e/identity/_/a/photo")
+    assert hop.parts == ['', 'e', 'identity', '_', 'a', 'photo']
+    # A StrB64 code (4A/5A/6A, by length mod 3), NOT a Bytes code (4B/5B/6B): the '_'
+    # part keeps the path in the compact Base64 domain. A '-' in any label is what
+    # would force it into Bytes, which is the whole reason for the restriction above.
+    assert hop.code in (MtrDex.StrB64_L0, MtrDex.StrB64_L1, MtrDex.StrB64_L2)
+    assert hop.qb64 == "6AAGAAA-e-identity-_-a-photo"
+    assert Pather(qb64=hop.qb64).path == "/e/identity/_/a/photo"
 
 
 def test_accountability_and_terms_follow_data_JSON():

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -978,34 +978,71 @@ def test_gated_ipex_exchange_JSON():
 
     # 1. apply (club -> Alice): the challenge. It narrows what the club will accept up
     # front: not merely which schemas, but which FIELDS must be disclosed from each --
-    # the photo and issuee from the attributive sedi-id (/a/photo, /a/i), and the over-21
-    # flag and issuee from the aggregative age credential (/A/over21, /A/i). The issuee
+    # the photo and issuee from the attributive sedi-id (a/photo, a/i), and the over-21
+    # flag and issuee from the aggregative age credential (A/over21, A/i). The issuee
     # is required from BOTH so the club can confirm the two creds name the same holder
-    # (the I2I binding). The request is keyed by schema SAID -- the applicant is not
-    # assumed to know the actual ACDC SAIDs -- with a list of attribute paths, following
-    # the graduated-disclosure path-list model. This is a static, one-shot narrowing of
-    # the request, NOT full back-and-forth negotiation; the exact placement (attribute
-    # vs. query block) and encoding are still being designed (WebOfTrust/keripy
-    # discussion #1512). No creds yet -- schemas, required paths, governance.
+    # (the I2I binding). The request names SCHEMA SAIDs, never ACDC SAIDs -- the
+    # applicant is not assumed to know which actual credentials it will be shown. This
+    # is a static, one-shot narrowing of the request, NOT full back-and-forth
+    # negotiation. No creds yet -- schemas, required paths, governance.
+    #
+    # The request rides the disclosure-paths `dp` field of the QUERY section, `q`
+    # (exchange(modifiers=...)), not the attribute section. An exn's query block is the
+    # http-query-string analogue and its attribute block is the body; a disclosure
+    # request is a query, so `dp` belongs in `q` (WebOfTrust/keripy discussion #1549).
+    #
+    # `dp` is an ORDERED LIST OF (schemaSAID, [paths]) PAIRS, not a dict keyed by schema
+    # SAID. A dict cannot express a DAG containing two credentials of the SAME schema --
+    # they collapse onto one key -- which is legitimate and common (presenting one's own
+    # identity alongside a spouse's, both under the same SEDI schema). The ordered list
+    # keeps them distinct, and it makes two equivalent requests serialize byte-for-byte
+    # identically. Ordering is a breadth-first walk of the DAG from its origin node.
+    # JSON has no tuple, so each pair serializes as a 2-element array.
+    #
+    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. Under #1549 a leading '/'
+    # means DAG-absolute rooted at the ORIGIN node, so '/a/i' hung on a non-origin entry
+    # would name the ORIGIN's issuee rather than that credential's. A trailing '/' would
+    # request a whole subtree ("the hammer"); every path here is a leaf ("the scalpel"),
+    # closing over only what is needed to validate the SAIDs along its own branch.
+    #
+    # OPEN QUESTION (#1542, unanswered by @SmithSamuelM). #1549 says the zeroth tuple
+    # MUST represent the DAG's origin node -- here Alice's bespoke presentation ACDC.
+    # But this is a FIRST-CONTACT apply, and per #1512 the applicant "won't necessarily
+    # know the SAID of its schema in the application"; the offer is what supplies it. So
+    # the origin tuple is omitted and the list carries only the two source schemas the
+    # club can actually name. If #1549's ordering rule is meant to hold literally even
+    # here, this list grows a zeroth entry and every index below shifts by one.
     sediSchemaSaid = sedi.sad['s']['$id']
     ageSchemaSaid = age.sad['s']['$id']
     apply = exchange(sender=CLUB, receiver=ALICE, route="/ipex/apply",
+                     modifiers=dict(dp=[[sediSchemaSaid, ["a/i", "a/photo"]],
+                                        [ageSchemaSaid,  ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21 and show the state-endorsed photo.",
-                                     disclose={sediSchemaSaid: ["/a/i", "/a/photo"],
-                                               ageSchemaSaid:  ["/A/i", "/A/over21"]},
                                      g=GOV_PROVISION_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['t'] == Ilks.exn
     assert apply.sad['r'] == "/ipex/apply"
     assert apply.sad['i'] == CLUB and apply.sad['ri'] == ALICE
     # The field-level request: issuee + photo from the attributive cred, issuee + over-21
-    # flag from the aggregative cred, keyed by the schema SAID the club is asking for.
-    reqSedi = apply.sad['a']['disclose'][sediSchemaSaid]
-    reqAge = apply.sad['a']['disclose'][ageSchemaSaid]
-    assert reqSedi == ["/a/i", "/a/photo"]              # attributive: issuee + photo
-    assert reqAge == ["/A/i", "/A/over21"]              # aggregate: issuee + over-21 flag
-    assert "/a/i" in reqSedi and "/A/i" in reqAge       # the joining issuee, from both
-    assert apply.said == "EK0cONSlv5IO4feJcynRSrfR09udKpfQf4Y29QMWRrdH"
+    # flag from the aggregative cred, each under the schema SAID the club is asking for.
+    dp = apply.sad['q']['dp']
+    # Ordered, not keyed: the schema SAIDs are positions in a list, so a DAG with two
+    # same-schema credentials would carry two entries rather than losing one.
+    assert [entry[0] for entry in dp] == [sediSchemaSaid, ageSchemaSaid]
+    reqSedi = dp[0][1]
+    reqAge = dp[1][1]
+    assert reqSedi == ["a/i", "a/photo"]                # attributive: issuee + photo
+    assert reqAge == ["A/i", "A/over21"]                # aggregate: issuee + over-21 flag
+    assert "a/i" in reqSedi and "A/i" in reqAge         # the joining issuee, from both
+    # ACDC-relative form throughout: no path leads with '/' (which would root it at the
+    # DAG origin), and none trails with '/' (which would demand a whole subtree).
+    assert all(not p.startswith("/") and not p.endswith("/")
+               for _, paths in dp for p in paths)
+    # The request lives in the query block, not the attribute block; the attribute
+    # block carries only the human message and the governance reference.
+    assert 'dp' not in apply.sad['a'] and 'disclose' not in apply.sad['a']
+    assert set(apply.sad['a']) == {'m', 'g'}
+    assert apply.said == "EFrjhS5l3ZyQZ0VDSn3oiq-cnlhR-dyuzzx-NQiNkpgw"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Commits ONLY to Alice's own bespoke-presentation SAID, the CLC
@@ -1015,15 +1052,22 @@ def test_gated_ipex_exchange_JSON():
     # agrees would let the club spurn and walk away with stable holder correlators,
     # defeating the metadata-ACDC decorrelation (panel review, PRV-F2). They arrive
     # only post-agree, in the grant, reachable by expanding the delivered presentation.
+    # Its query block carries `dp` too, as an EMPTY list. For a SOLICITED offer -- one
+    # that answers an apply -- an empty `dp` means "the same disclosure paths the apply
+    # asked for", so Alice restates nothing and the two messages cannot drift (#1549).
+    # An unsolicited offer, or one that counter-offers different paths, MUST spell the
+    # list out instead; empty is only meaningful because `p` binds the apply it answers.
     offer = exchange(sender=ALICE, receiver=CLUB, route="/ipex/offer",
                      prior=apply.said,
+                     modifiers=dict(dp=[]),
                      attributes=dict(acdc=bespoke.said,
                                      governance=GOV_PROVISION_SAID,
                                      terms=_rules_in_bespoke()),
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said                 # answers the apply
+    assert offer.sad['q']['dp'] == []                   # solicited: "as per the apply"
     assert bespoke.said.encode() in offer.raw           # commits to Alice's own presentation
-    assert offer.said == "EIUqoqpXiU52iIp5q9M2RH_g0N0dbJnLFW8MprL3QOQN"
+    assert offer.said == "EEpcgVyXzfcZW8iuRoLwOjHSdrFVZY0HN7OahJlgj7sV"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -1038,7 +1082,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "EI30cUq5JGGSd-3cBoXx1nCtE6CBXXRgKPkZodJm-8da"
+    assert agree.said == "EAI_3tluMw2m8r2Aion9m_9WBHKp5MIqBSIJGTTuPVgX"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1093,7 +1137,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "EEIdc4wcI-9zB0eSZE4meZLWXfM8WuXZHMDhyBfIJJaD"
+    assert grant.said == "ENaSnz6Mh4Tf5lkP7t_5HnEg6hQmfMQhOlWvEfCaeauP"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1125,7 +1169,7 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EDmW_7vE6Ivdwr3ldV-W9uLPOcJp97Sz9bqD5eNaKpks"
+    assert admit.said == "EPegh4Oqd2RTyZsuw2rKkoIRT_l3xIt9hFhuu2upOLJQ"
 
 
 def test_accountability_and_terms_follow_data_JSON():

--- a/tests/acdc/test_cp_disclosure.py
+++ b/tests/acdc/test_cp_disclosure.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-tests.acdc.test_clc_disclosure module
+tests.acdc.test_cp_disclosure module
 
 Worked, working example of *contractually-protected disclosure* -- Chain-Link
 Confidentiality (CLC) realized as a credential rather than an out-of-band
@@ -1344,7 +1344,7 @@ def test_accountability_and_terms_follow_data_JSON():
 
 
 @pytest.mark.parametrize("kind", [Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk])
-def test_clc_serialization_kinds(kind):
+def test_cpd_serialization_kinds(kind):
     """Phases 1-3 invariants hold across every serialization kind, not just JSON.
 
     The detailed phases above pin canonical JSON SAIDs for readability. This check
@@ -1434,12 +1434,12 @@ def test_age_identity_edge_E1E_JSON():
     # not read back from the far node -- that is what gives the s-constraint teeth.
     coreSchemaSaid, _ = _saidify_schema(dict(SEDI_SCHEMA_MAD), kind=kind)
     assert coreSchemaSaid == sedi.sad['s']['$id']
-    assert _verify_identity_edge(age, sedi, coreSchemaSaid)
     assert_acdc_schema_valid(age)
     with pytest.raises(AssertionError):                         # wrong subject (far = bespoke)
         _verify_identity_edge(age, _bespoke_presentation(sedi, age, kind), coreSchemaSaid)
     with pytest.raises(AssertionError):                         # right subject, wrong core schema
         _verify_identity_edge(age, sedi, "E" + "A" * 43)
+    assert _verify_identity_edge(age, sedi, coreSchemaSaid)
 
 
 if __name__ == "__main__":
@@ -1449,4 +1449,4 @@ if __name__ == "__main__":
     test_gated_ipex_exchange_JSON()
     test_accountability_and_terms_follow_data_JSON()
     for _kind in (Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk):
-        test_clc_serialization_kinds(_kind)
+        test_cpd_serialization_kinds(_kind)

--- a/tests/acdc/test_cp_disclosure.py
+++ b/tests/acdc/test_cp_disclosure.py
@@ -1789,14 +1789,17 @@ def test_job_application_entitlement_presentation_JSON():
     ]
 
     # Build apply: the employer asks for the origin presentation plus the linked
-    # SEDI subset and entitlement using the normalized dp field.
+    # SEDI subset and entitlement using the normalized dp field. `dp` rides the
+    # QUERY section, `q`, not the attribute section: an exn models a ReST request,
+    # and naming which parts of which ACDCs are wanted is a query, not a body
+    # (@SmithSamuelM, #1549).
     apply = exchange(
         sender=CLUB,
         receiver=ALICE,
         route="/ipex/apply",
+        modifiers=dict(dp=requestedDp),
         attributes=dict(
             m="Show the SEDI identity subset and the linked food-handler permit.",
-            dp=requestedDp,
         ),
         stamp="2026-08-04T15:00:00.000000+00:00",
         kind=kind,
@@ -1804,11 +1807,12 @@ def test_job_application_entitlement_presentation_JSON():
     # Assert the apply carries the expected dp triples in BFS order:
     # root presentation first, then SEDI, then the permit.
     assert apply.sad['r'] == "/ipex/apply"
-    assert apply.sad['a']['dp'] == requestedDp
-    assert apply.sad['a']['dp'][0][0] == presentation.sad['s']['$id']
-    assert apply.sad['a']['dp'][0][1] == "/"
-    assert apply.sad['a']['dp'][1][1] == "/e/identity/_/"
-    assert apply.sad['a']['dp'][2][1] == "/e/entitlement/_/"
+    assert apply.sad['q']['dp'] == requestedDp
+    assert apply.sad['q']['dp'][0][0] == presentation.sad['s']['$id']
+    assert apply.sad['q']['dp'][0][1] == "/"
+    assert apply.sad['q']['dp'][1][1] == "/e/identity/_/"
+    assert apply.sad['q']['dp'][2][1] == "/e/entitlement/_/"
+    assert 'dp' not in apply.sad['a']
 
     # Build offer: Alice commits to the one-time presentation. Because this
     # offer is solicited and does not narrow or widen the request, an empty dp
@@ -1818,13 +1822,15 @@ def test_job_application_entitlement_presentation_JSON():
         receiver=CLUB,
         route="/ipex/offer",
         prior=apply.said,
-        attributes=dict(acdc=presentation.said, dp=[]),
+        modifiers=dict(dp=[]),
+        attributes=dict(acdc=presentation.said),
         stamp="2026-08-04T15:01:00.000000+00:00",
         kind=kind,
     )
     # Assert the offer binds the apply and still carries no disclosed identity data.
     assert offer.sad['p'] == apply.said
-    assert offer.sad['a']['dp'] == []
+    assert offer.sad['q']['dp'] == []
+    assert 'dp' not in offer.sad['a']
     assert b"Alice Anders" not in offer.raw
     assert b"220 E 300 S" not in offer.raw
     assert b"+1-801-555-0100" not in offer.raw

--- a/tests/acdc/test_cp_disclosure.py
+++ b/tests/acdc/test_cp_disclosure.py
@@ -992,30 +992,39 @@ def test_gated_ipex_exchange_JSON():
     # http-query-string analogue and its attribute block is the body; a disclosure
     # request is a query, so `dp` belongs in `q` (WebOfTrust/keripy discussion #1549).
     #
-    # `dp` is an ORDERED LIST OF (schemaSAID, [paths]) PAIRS, not a dict keyed by schema
-    # SAID. A dict cannot express a DAG containing two credentials of the SAME schema --
-    # they collapse onto one key -- which is legitimate and common (presenting one's own
-    # identity alongside a spouse's, both under the same SEDI schema). The ordered list
-    # keeps them distinct, and it makes two equivalent requests serialize byte-for-byte
-    # identically. Ordering is a breadth-first walk of the DAG from its origin node.
-    # JSON has no tuple, so each pair serializes as a 2-element array.
+    # `dp` is an ORDERED LIST OF (schemaSAID, prefix, [paths]) TRIPLES, not a dict keyed
+    # by schema SAID. A dict cannot express a DAG containing two credentials of the SAME
+    # schema -- they collapse onto one key -- which is legitimate and common (presenting
+    # one's own identity alongside a spouse's, both under the same SEDI schema). The
+    # ordered list keeps them distinct, and it makes two equivalent requests serialize
+    # byte-for-byte identically. Ordering is a breadth-first walk of the DAG from its
+    # origin node. JSON has no tuple, so each triple serializes as a 3-element array.
     #
-    # Paths are ACDC-RELATIVE and so do NOT lead with '/'. A leading '/' means
-    # DAG-ABSOLUTE, rooted at the origin node, and an absolute path that reaches a
-    # non-origin ACDC must cross the edge that links it. That hop is written as the
-    # virtual path component '_', which stands for the jump from the near-side edge
-    # block to the top level of the far-side ACDC (@SmithSamuelM, #1549). The same
-    # request in absolute form reads:
-    #     origin: /i, /a/i, /r/
-    #     sedi:   /e/identity/_/a/i, /e/identity/_/a/photo
-    #     age:    /e/age/_/A/i, /e/age/_/A/over21
-    # Omitting the '_' does not merely misroot such a path, it makes it meaningless:
+    # The middle element is a PATH PREFIX: the DAG-absolute route to the ACDC that the
+    # entry's schema SAID names (@SmithSamuelM, #1549). It is either the empty string,
+    # or a path that both BEGINS and ENDS with '/', of which '/' alone is the origin
+    # node's. The effective path is prefix + entry with nothing inserted between them,
+    # which is why an entry in the path list never leads with '/'.
+    #
+    # Every prefix here is EMPTY. That is the ACDC-RELATIVE form: nothing precedes the
+    # entries, so what says which ACDC a triple is about is its POSITION in the
+    # breadth-first order. It reads cleanly for this DAG because the DAG has no optional
+    # edges -- the bespoke schema requires both 'identity' and 'age' -- so the ordering
+    # is gapless and no entry needs the route to its credential restated.
+    #
+    # A non-empty prefix is DAG-ABSOLUTE, rooted at the origin node, and a route that
+    # reaches a non-origin ACDC must cross the edge that links it. That hop is written
+    # as the virtual path component '_', which stands for the jump from the near-side
+    # edge block to the top level of the far-side ACDC (@SmithSamuelM, #1549). The same
+    # request with absolute prefixes reads:
+    #     origin: /              + i, a/i, r/
+    #     sedi:   /e/identity/_/ + a/i, a/photo
+    #     age:    /e/age/_/      + A/i, A/over21
+    # Omitting the '_' does not merely misroot such a route, it makes it meaningless:
     # '/e/identity/a/i' names an 'a' field inside the near-side EDGE block, which has
-    # no such field. Relative form is used here because this DAG has no optional edges
-    # -- the bespoke schema requires both 'identity' and 'age' -- so the breadth-first
-    # ordering of `dp` is gapless and each entry's ACDC is unambiguous without
-    # restating the route to it. Absolute form is required only when optional edges
-    # could leave holes in that ordering.
+    # no such field. Prefixes earn their keep when optional edges could leave holes in
+    # the breadth-first ordering. They do not excuse it: the ordering is REQUIRED even
+    # where a prefix would make it technically unnecessary (@SmithSamuelM, #1549).
     #
     # A TRAILING '/' means the whole node ("the hammer"): the origin's 'r/' asks for the
     # rule section fully expanded, because the club must read the CLC terms it is being
@@ -1035,9 +1044,9 @@ def test_gated_ipex_exchange_JSON():
     sediSchemaSaid = sedi.sad['s']['$id']
     ageSchemaSaid = age.sad['s']['$id']
     apply = exchange(sender=CLUB, receiver=ALICE, route="/ipex/apply",
-                     modifiers=dict(dp=[[bespokeSchemaSaid, ["i", "a/i", "r/"]],
-                                        [sediSchemaSaid, ["a/i", "a/photo"]],
-                                        [ageSchemaSaid,  ["A/i", "A/over21"]]]),
+                     modifiers=dict(dp=[[bespokeSchemaSaid, "", ["i", "a/i", "r/"]],
+                                        [sediSchemaSaid, "", ["a/i", "a/photo"]],
+                                        [ageSchemaSaid,  "", ["A/i", "A/over21"]]]),
                      attributes=dict(m="Prove over-21 and show the state-endorsed photo.",
                                      g=GOV_PROVISION_SAID),
                      stamp=APPLY_STAMP, kind=kind)
@@ -1052,24 +1061,30 @@ def test_gated_ipex_exchange_JSON():
     # is a breadth-first walk from the origin, which for this DAG is the bespoke
     # presentation and then its two edges in section order, 'identity' and 'age'.
     assert [entry[0] for entry in dp] == [bespokeSchemaSaid, sediSchemaSaid, ageSchemaSaid]
-    reqOrigin = dp[0][1]
-    reqSedi = dp[1][1]
-    reqAge = dp[2][1]
+    # Every entry is a triple, and every prefix is empty -- the relative form, where the
+    # position of an entry is what identifies its ACDC. A club that preferred to spell
+    # the routes out would put '/', '/e/identity/_/' and '/e/age/_/' here instead, and
+    # would still have to keep the entries in breadth-first order.
+    assert all(len(entry) == 3 for entry in dp)
+    assert [entry[1] for entry in dp] == ["", "", ""]
+    reqOrigin = dp[0][2]
+    reqSedi = dp[1][2]
+    reqAge = dp[2][2]
     assert reqOrigin == ["i", "a/i", "r/"]              # origin: discloser, disclosee, terms
     assert reqSedi == ["a/i", "a/photo"]                # attributive: issuee + photo
     assert reqAge == ["A/i", "A/over21"]                # aggregate: issuee + over-21 flag
     assert "a/i" in reqSedi and "A/i" in reqAge         # the joining issuee, from both
-    # ACDC-relative form throughout: no path leads with '/', which would root it at the
-    # DAG origin and, for a non-origin entry, would have to cross a '_' hop to get back
-    # to the credential the entry is already about.
-    assert all(not p.startswith("/") for _, paths in dp for p in paths)
+    # No entry leads with '/'. That holds under any prefix, since the effective path is
+    # prefix + entry with nothing inserted; here the empty prefix leaves each entry
+    # relative to the credential it is already about.
+    assert all(not p.startswith("/") for _, _, paths in dp for p in paths)
     # Node vs. leaf: only the origin's rule section is asked for whole.
-    assert [p for _, paths in dp for p in paths if p.endswith("/")] == ["r/"]
+    assert [p for _, _, paths in dp for p in paths if p.endswith("/")] == ["r/"]
     # The request lives in the query block, not the attribute block; the attribute
     # block carries only the human message and the governance reference.
     assert 'dp' not in apply.sad['a'] and 'disclose' not in apply.sad['a']
     assert set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EPiL36dPzFMlL5K4ybK5MaxC2a3qIzntPjHvExkn0189"
+    assert apply.said == "EKxV278jQmXGzz3gEy7S-czxn-Rpsads_gegfqXsYhcg"
 
     # 2. offer (Alice -> club): "I'll prove over-21 and show my photo if you accept
     # these terms." Commits ONLY to Alice's own bespoke-presentation SAID, the CLC
@@ -1094,7 +1109,7 @@ def test_gated_ipex_exchange_JSON():
     assert offer.sad['p'] == apply.said                 # answers the apply
     assert offer.sad['q']['dp'] == []                   # solicited: "as per the apply"
     assert bespoke.said.encode() in offer.raw           # commits to Alice's own presentation
-    assert offer.said == "ENW6Q9TtdEyHtah7Tgg7ClV3XuD9CmAwAs8oEIZAu-KO"
+    assert offer.said == "ECGik4N-PMofYwkU-y0Rwc1UA-ey3gZdR8c2UMCovftP"
     # (property 1) the offer leaks no PII: not Alice's name, photo, or birthdate.
     assert b"Alice Anders" not in offer.raw
     assert b"<state-endorsed-photo-bytes>" not in offer.raw
@@ -1109,7 +1124,7 @@ def test_gated_ipex_exchange_JSON():
     agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
                      prior=offer.said, stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said                 # binds the offer SAID
-    assert agree.said == "ELU6DF53tqV2Dd_2Tpyk1uBcP5JLUnJ0JJQlsw4H1EsC"
+    assert agree.said == "ELLb6trSGPXRJURUXsLdhIh4xKIsr1yDWOUfve3PJgOu"
     # The club signs the agree, and we assemble the signed wire message the blessed
     # way: messagize() frames the signature as a CESR attachment group (genus code
     # and all). New keripy code should never hand-roll attachment framing -- pass
@@ -1164,7 +1179,7 @@ def test_gated_ipex_exchange_JSON():
     grant = disclose(agree, clubSig, capturedKeyState)
     assert grant is not None
     assert grant.sad['p'] == agree.said                 # grant follows the agree
-    assert grant.said == "EKPweFTQmyr2ghr5tBDLxAZY-_AXkiztDWmwcl6h0XTS"
+    assert grant.said == "ELZZ2ZWspcAomsT6lHyezSUQ_BMMrVh3P50oADXtvvjx"
     # (property 4) PII crosses the wire only now, in the grant: the photo and the
     # over-21 flag.
     assert b"<state-endorsed-photo-bytes>" in grant.raw
@@ -1196,7 +1211,7 @@ def test_gated_ipex_exchange_JSON():
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
                      prior=grant.said, stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EG_v0NItF5AH5QeBBCRaaR1XffK1iivzW9DJgfyNoTZ_"
+    assert admit.said == "EO8FlFo9eB4nN9tyjY4ZmDlwBkFAvWlQQn_LWfEZ1340"
 
 
 def _pathable_labels(value):

--- a/tests/acdc/test_cp_disclosure.py
+++ b/tests/acdc/test_cp_disclosure.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-tests.acdc.test_clc_disclosure module
+tests.acdc.test_cp_disclosure module
 
 Worked, working example of *contractually-protected disclosure* -- Chain-Link
 Confidentiality (CLC) realized as a credential rather than an out-of-band
@@ -1346,7 +1346,7 @@ def test_accountability_and_terms_follow_data_JSON():
 
 
 @pytest.mark.parametrize("kind", [Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk])
-def test_clc_serialization_kinds(kind):
+def test_cpd_serialization_kinds(kind):
     """Phases 1-3 invariants hold across every serialization kind, not just JSON.
 
     The detailed phases above pin canonical JSON SAIDs for readability. This check
@@ -1436,12 +1436,12 @@ def test_age_identity_edge_E1E_JSON():
     # not read back from the far node -- that is what gives the s-constraint teeth.
     coreSchemaSaid, _ = _saidify_schema(dict(SEDI_SCHEMA_MAD), kind=kind)
     assert coreSchemaSaid == sedi.sad['s']['$id']
-    assert _verify_identity_edge(age, sedi, coreSchemaSaid)
     assert_acdc_schema_valid(age)
     with pytest.raises(AssertionError):                         # wrong subject (far = bespoke)
         _verify_identity_edge(age, _bespoke_presentation(sedi, age, kind), coreSchemaSaid)
     with pytest.raises(AssertionError):                         # right subject, wrong core schema
         _verify_identity_edge(age, sedi, "E" + "A" * 43)
+    assert _verify_identity_edge(age, sedi, coreSchemaSaid)
 
 
 JOB_SEDI_SCHEMA_MAD = {
@@ -1929,4 +1929,4 @@ if __name__ == "__main__":
     test_accountability_and_terms_follow_data_JSON()
     test_job_application_entitlement_presentation_JSON()
     for _kind in (Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk):
-        test_clc_serialization_kinds(_kind)
+        test_cpd_serialization_kinds(_kind)

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -292,7 +292,7 @@ def test_registry_issuance_lifecycle_JSON():
 def test_registry_issuance_lifecycle_IPEX_JSON():
     """Same lifecycle as the worked example, but transported through IPEX.
 
-    This stays distinct from test_clc_disclosure.py's gated exchange. The point
+    This stays distinct from test_cp_disclosure.py's gated exchange. The point
     here is not pre-disclosure negotiation; it is to carry the foundational
     registry artifacts inside the IPEX builders and route them through the real
     IPEX handlers we have today.


### PR DESCRIPTION
Converts the IPEX disclosure request in the two merged worked examples from the #1542 strawman shape to the construct @SmithSamuelM settled in discussion #1549. Also moves `dp` from the attributes section to the query section of the IPEX messages to align with guidance in kswg-acdc-specification [#203](https://github.com/trustoverip/kswg-acdc-specification/pull/203). This matches some suggestions from Sam about how to think about `dp`, but it is a tweak to @KeaxD's food handler example, and could be debated before it locks.

The code in this PR has a lot of comments. House style for production code is much cleaner, but since this is a worked example, I left the comment suggestions that my AI tooling produced, because I think they're instructive for someone trying to understand the design. But I'm happy to rip some or all of them out if maintainers prefer.

Before:

```python
apply = exchange(..., attributes=dict(m=..., g=...,
                     disclose={sediSchemaSaid: ["/a/i", "/a/photo"],
                               ageSchemaSaid:  ["/A/i", "/A/over21"]}))
```

After:

```python
apply = exchange(...,
    modifiers=dict(dp=[[bespokeSchemaSaid, "", ["i", "a/i", "r/"]],
            [sediSchemaSaid,    "", ["a/i", "a/photo"]],
            [ageSchemaSaid,     "", ["A/i", "A/over21"]]]),
        attributes=dict(m=..., g=...))
```

There are four notable changes:

| | before | latest #1549 decision |
|---|---|---|
| field label | `disclose` | **`dp`** — reserved labels are compact |
| section | attribute (`a`) | **query (`q`)** — `exchange(modifiers=...)` |
| value | dict keyed by schema SAID | **ordered list of `(schemaSAID, prefix, [paths])` triples**, breadth-first from the DAG origin |
| path form | `/a/i` | **`a/i`** — ACDC-relative |

- **Query block, not attribute block.** An exn's query block is the http-query-string analogue and the attribute block is the body. A disclosure request is a query. `exchange()` already exposes this as `modifiers=`, which serializes to `q`.
- **List, not dict.** … The ordered list keeps them distinct and makes two equivalent requests serialize byte-for-byte
  identically. JSON has no tuple, so each entry is a 3-element array.
- **The middle element is a path prefix.** It is the DAG-absolute route to the ACDC that entry's schema SAID names —either empty, or a route that both begins and ends with `/`. Every entry in these two examples leaves it empty, which makes the paths ACDC-relative and leaves the breadth-first *position* of each triple to say which ACDC it is about. The effective path is prefix + entry concatenated with nothing between them, so an entry never leads with `/`.
- **Relative paths.** Under #1549 a leading `/` means DAG-absolute *rooted at the origin node*, so `/a/i` hung on a non-origin entry would name the **origin's** issuee rather than that credential's — a silent mis-request. None of these paths trails with `/` either, so each is a leaf ("the scalpel") rather than a whole-subtree demand ("the hammer").

This PR also adopts the **solicited-offer rule**: an offer whose `p` binds the apply it answers carries `dp: []`, meaning "the same paths the apply asked for", instead of restating them and giving the two messages a second place to drift.

The bulk-issuance example is where the list form matters. A schema SAID is shared by all M copies of a bulk-issued set and is deliberately **not** partitioned across presentation contexts — so keying the request by it is the problem that #1549 removes. The example now also asserts that the apply names only the schema SAID and never a copy SAID, so the request introduces no cross-context correlator of its own.

This PR originally omitted the zeroth `dp` tuple and asked Sam whether #1549's "the zeroth element MUST represent the origin node" was meant to hold for a first-contact apply, where per #1512 the applicant "won't necessarily know the SAID of its schema in the application." Sam answered on #1542: the origin is presenter-issued, but its *shape* is governance rather than the presenter's invention, so the applicant would know the schema of the origin node.

The club now asks the origin for its issuer, its issuee, and its rule section whole — who is disclosing, that the presentation is addressed to the club, and the terms it must agree to before the grant. That last one, `r/`, is also the first time these examples exercise the **node** form rather than only leaves.

This is a test-only fix; no product code changes.

The apply and offer SAIDs had to be regenerated, and with them the agree/grant/admit SAIDs that chain off the offer through `p`.

The sibling guardianship example in #1530 shows the same construct on its own branch and has had the same two changes applied, so that PR already resembles this one.
