### PR TITLE
Fix NameError that has main red again: #1529's aggregate tests use KWA/CUE_KWA deleted by #1547

### DIFF
--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -686,7 +686,7 @@ def _aggregate_far_node(ian, ianiss, ianreg, issueeAid):
     # anchor a TEL issuance event for the aggregate SAID so it is "issued".
     iss = ianiss.issue(said=agg.said)
     rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-    ian.interact(data=[rseal], framed=True, **CUE_KWA)
+    ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
     ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
                      seqner=Seqner(sn=ian.kever.sn),
                      saider=Diger(qb64=ian.kever.serder.said))
@@ -704,13 +704,13 @@ def test_verifier_saves_aggregate_credential(seeder):
     subject-indexed at all. It must instead resolve the issuee via ``.iseaid``,
     identically to an attributive credential.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -745,13 +745,13 @@ def test_verifier_aggregate_far_node_chain(seeder):
     verifier must resolve targeted-ness and the issuee via ``.iseaid`` so an edge
     to an aggregate far node behaves identically to an attributive one.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))
@@ -810,13 +810,13 @@ def test_verifier_e1e_aggregate_far_node(seeder):
     based; this locks in that it works for an aggregate far node through the real
     verifier, not just a bespoke example verifier.
     """
-    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', **KWA) as (ianHby, ian), \
-            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', **KWA) \
+    with openHab(name="ian", temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) as (ianHby, ian), \
+            openHab(name="han", transferable=True, temp=True, salt=b'0123456789abcdef', version=Vrsn_1_0, kind=Kinds.json) \
             as (hanHby, han):
         ianreg = Regery(hby=ianHby, name="ian", temp=True)
-        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", **KWA)
+        ianiss = ianreg.makeRegistry(prefix=ian.pre, name="ian", version=Vrsn_1_0, kind=Kinds.json)
         rseal = SealEvent(ianiss.regk, "0", ianiss.regd)._asdict()
-        ian.interact(data=[rseal], framed=True, **CUE_KWA)
+        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
         ianiss.anchorMsg(pre=ianiss.regk, regd=ianiss.regd,
                          seqner=Seqner(sn=ian.kever.sn),
                          saider=Diger(qb64=ian.kever.serder.said))


### PR DESCRIPTION
`tests/vdr/test_verifying.py` fails at `main` (`8e67f2e6a`) with `NameError: name 'KWA' is not defined` in three tests:

```
FAILED tests/vdr/test_verifying.py::test_verifier_saves_aggregate_credential
FAILED tests/vdr/test_verifying.py::test_verifier_aggregate_far_node_chain
FAILED tests/vdr/test_verifying.py::test_verifier_e1e_aggregate_far_node
3 failed, 5 passed
```

## Same semantic merge conflict as #1551, one PR later

This is the second occurrence of the failure #1551 fixed, in a different set of tests:

- `5b8b1cd92` (#1547) deleted `tests/common.py` and inlined every `version=`/`kind=`/`gvrsn=` argument, removing the `KWA`/`CUE_KWA` constants and their import.
- `8e67f2e6a` (#1529) added `test_verifier_saves_aggregate_credential`, `test_verifier_aggregate_far_node_chain`, `test_verifier_e1e_aggregate_far_node` and the `_aggregate_far_node` helper — all of which use `**KWA` and `**CUE_KWA`. It was authored 2026-07-29, before #1547 landed.

The merge touched disjoint regions of the file, so git resolved it cleanly and left the new tests referencing names that no longer exist. Neither PR's CI would have caught it in isolation — this class of break is only visible after the merge.

## The fix

Inline the arguments the way #1547 did everywhere else, and #1551 did for the E1E test:

```
**KWA     -> version=Vrsn_1_0, kind=Kinds.json
**CUE_KWA -> version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0
```

Those are exactly the values the deleted `tests/common.py` defined:

```python
KWA = dict(version=Vrsn_1_0, kind=Kinds.json)
CUE_KWA = dict(**KWA, gvrsn=Vrsn_1_0)
```

so this preserves the tests' intent exactly. It is a pure substitution in test arguments — no source change, no behavior change, 13 call sites.

## Verification

`tests/vdr/test_verifying.py`: **8 passed** (was 3 failed, 5 passed).

Full suite at this commit: **656 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
