### PR TITLE
Implement the DI2I edge operator

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -35,8 +35,8 @@ class Verifier:
 
     # Unary edge operators this verifier recognizes. A token outside this set is not an
     # operator to this verifier and is skipped when resolving a list-valued `o` (see
-    # .verifyChain). DI2I and NOT are recognized but unimplemented: they are listed so
-    # they fail closed diagnosably instead of being dropped and silently defaulting.
+    # .verifyChain). NOT is recognized but unimplemented (#1554): it is listed so it fails
+    # closed diagnosably instead of being dropped and silently defaulting.
     # E1E is a keripy extension not yet in the spec's normative operator table.
     UnaryOps = ('I2I', 'NI2I', 'DI2I', 'E1E', 'NOT')
 
@@ -406,13 +406,17 @@ class Verifier:
                 case the latest recognized one takes precedence. None, an empty list,
                 or a value containing no recognized operator applies the default:
                 I2I for a targeted far node, NI2I for an untargeted one.
-            issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC
+            issuer (str) qb64 AID of the issuer of the near (edge-bearing) ACDC. The
+                delegative operators (I2I, DI2I) constrain this against the far node's
+                issuee.
             issuee (str|None): qb64 AID of the issuee of the near (edge-bearing) ACDC,
                 required by the identity operators (E1E). None when the near ACDC is
                 untargeted.
 
         Returns:
-            Serder: transaction event state notification message
+            Serder|None: transaction event state notification message for the far node,
+                or None if the edge does not verify. None is a validation outcome, not an
+                error: processCredential turns it into a missing-chain escrow and retry.
 
         """
         said = self.reger.saved.get(keys=nodeSaid)
@@ -447,10 +451,6 @@ class Verifier:
             raise ValidationError(f"Unsupported edge operator NOT on edge to node "
                                   f"{nodeSaid}; NOT validation is not implemented")
 
-        if op == 'DI2I':
-            raise ValidationError(f"Unsupported edge operator DI2I on edge to node "
-                                  f"{nodeSaid}; DI2I validation is not implemented")
-
         if 'E1E' in ops:
             # Identity relation (discussion #1515): the issuee AID of the near ACDC
             # (the one carrying this edge) MUST equal the issuee AID of the far node.
@@ -462,11 +462,37 @@ class Verifier:
             if farIssuee is None or issuee is None or issuee != farIssuee:
                 return None
 
-        if op is not None and op != 'NI2I':
+        if op == 'DI2I':
+            # Delegated-issuer relation (ACDC spec-body.md L1194): the near ACDC's issuer
+            # MUST be "either the Issuee AID or a delegated AID" of the far node's issuee.
+            # So DI2I is a superset of I2I -- issuer == farIssuee satisfies it outright --
+            # and the delegation arm admits only *direct* delegates.
+            #
+            # Direct-only is the requirement, not an approximation of a transitive walk.
+            # The motivating case (#1559) is a QVI that delegates to subgroup AIDs which
+            # perform routine issuance: "any number of children, zero grandchildren". A
+            # transitive reading would let a subgroup delegate onward and mint new issuers,
+            # defeating it. Hence no walk here -- and hence no depth bound, which would be
+            # a conformance seam letting two conforming validators disagree on identical
+            # bytes with no wire-visible cause.
+            #
+            # Resolved through .iseaid rather than .attrib['i'] so an aggregate ('A') far
+            # node works: .attrib is None there, so `'i' in creder.attrib` would raise
+            # TypeError. Deliberately not routed through the .reger.subjs lookup the I2I
+            # branch below uses either -- saveCredential only indexes subjects out of the
+            # attribute section, so that index is attributive-only by construction.
+            farIssuee = creder.iseaid
+            if farIssuee is None:  # untargeted far node: no issuee to be a delegate of
+                return None
+
+            if issuer != farIssuee and not self._isApprovedDelegate(issuer, farIssuee):
+                return None
+
+        elif op is not None and op != 'NI2I':
             # Resolve the far node's issuee via .iseaid so an aggregate ('acg') far
             # node (issuee at .sad["A"][1]["i"]) resolves identically to an
             # attributive one (.attrib["i"]). None means an untargeted far node,
-            # which cannot satisfy a targeted (I2I/DI2I) edge.
+            # which cannot satisfy a targeted (I2I) edge (#1529).
             farIssuee = creder.iseaid
             if farIssuee is None:
                 return None
@@ -488,3 +514,90 @@ class Verifier:
             return None
 
         return state
+
+    def _isApprovedDelegate(self, pre, delpre):
+        """Returns True if pre is a direct delegate of delpre, approved by delpre.
+
+        Direct only: the relation is not followed transitively, so a delegate of a
+        delegate of delpre returns False. See .verifyChain's DI2I branch for why that is
+        the requirement rather than a simplification.
+
+        Deliberately NOT implemented as ``kevers[pre].delpre == delpre``.
+        ``Kevery.validateDelegation`` returns early -- with no seal lookup whatsoever --
+        when the delegated event is locally owned, locally membered, or locally witnessed
+        (core/eventing.py:3287-3289), and the comment there is explicit that a witness
+        "accepts without waiting for delegation seal to be anchored in delegator's KEL".
+        Since setupWitness co-locates a credential Verifier in the same Habery, a
+        delpre-based check would accept a DI2I edge for any AID this Habery happens to
+        witness whose claimed delegator never anchored anything: issuance under authority
+        never granted. ``delpre`` records what the delegate asserted in its own `di` field;
+        only the delegator's anchored approval seal records what the delegator agreed to.
+
+        So the delegation is confirmed the way the KEL layer confirms it, by delegating to
+        Kever.fetchDelegatingEvent: consult the approval source-seal couple in .db.aess --
+        which logEvent writes only when validateDelegation actually found and verified the
+        seal, since the exemption returns (None, None) and that write is gated on those
+        being present -- and failing that, walk the delegator's KEL for the anchoring seal
+        directly. The walk is what keeps a Habery with no .aess entry (a witness, or the
+        delegate's own controller) from being permanently unable to validate an edge that
+        is in fact approved.
+
+        .aess is also pinned by flows in which this Habery participated in the delegation
+        itself (app/delegating.py:153, app/grouping.py:216,
+        app/cli/commands/delegate/confirm.py:109). Each pins it only after observing the
+        delegator's anchor, and such a Habery already trusts the delegation, so treating
+        the entry as authority-bearing is sound there too.
+
+        Called with original=False so that a missing seal returns None rather than raising,
+        and so an inconsistent .aess entry is left alone: a verifier reads key state, it
+        does not repair the delegate's escrow. The one write this can cause is
+        fetchDelegatingEvent pinning the couple it has just verified against the
+        delegator's trunk -- the same cache repair keripy performs during escrow
+        processing, gated on the delegated event already having been accepted. A
+        ValidationError from a genuinely inconsistent database is left to propagate rather
+        than being flattened into a silent False.
+
+        Superseding is handled as the KEL layer handles it, not more strictly. The .aess
+        fast path accepts a delegating event that was first seen (it checks .fons) even if
+        it has since been superseded -- fetchDelegatingEvent documents that as deliberate --
+        while the KEL walk looks only at the last event at each sn and so would not find
+        one. Inheriting that asymmetry is the right call rather than something to tighten
+        here: a validator that has accepted the delegate's KEL should not then refuse the
+        credentials that delegate issued, and DI2I asks the same question the KEL layer
+        already answered.
+
+        Retirement of a subgroup is deliberately not modelled at all. It is key-state
+        based: a retired delegate rotates to keys it cannot sign with, so it issues nothing
+        further while everything it issued while authorized stays valid, and the approval
+        seals are byte-identical before and after (#1559). A check here that tried to detect
+        retirement would both fail (nothing changes structurally) and be wrong (it would
+        invalidate credentials issued while the subgroup was legitimately authorized).
+
+        Parameters:
+            pre (str): qb64 AID whose delegation is in question, i.e. the issuer of the
+                near (edge-bearing) ACDC
+            delpre (str): qb64 AID that must be its delegator, i.e. the far node's issuee
+
+        Returns:
+            bool: True means pre is a direct delegate of delpre and delpre's approval of
+                pre's current key state is anchored in delpre's KEL.
+
+        """
+        if pre not in self.hby.kevers:  # no key state for the issuer, nothing to evaluate
+            return False
+
+        kever = self.hby.kevers[pre]
+        if kever.delpre is None or kever.delpre != delpre:
+            return False
+
+        # Approved as of *current* key state, not merely at inception: every establishment
+        # event of a delegated AID requires its own approval, so checking the latest one
+        # covers the dip and any subsequent delegated rotation. Keying on .lastEst rather
+        # than .serder.said matters -- logEvent excludes interaction events from .aess, so
+        # a delegate whose latest event is an ixn would otherwise look unapproved.
+        serder = self.hby.db.evts.get(keys=(pre, kever.lastEst.d))
+        if serder is None:  # last establishment event not retrievable
+            return False
+
+        return kever.fetchDelegatingEvent(delpre=delpre, serder=serder,
+                                          original=False, eager=True) is not None

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -590,13 +590,26 @@ class Verifier:
         if kever.delpre is None or kever.delpre != delpre:
             return False
 
-        # Approved as of *current* key state, not merely at inception: every establishment
-        # event of a delegated AID requires its own approval, so checking the latest one
-        # covers the dip and any subsequent delegated rotation. Keying on .lastEst rather
-        # than .serder.said matters -- logEvent excludes interaction events from .aess, so
-        # a delegate whose latest event is an ixn would otherwise look unapproved.
-        serder = self.hby.db.evts.get(keys=(pre, kever.lastEst.d))
-        if serder is None:  # last establishment event not retrievable
+        # The delegation is settled at inception and does not move afterwards. `di` appears
+        # in a `dip` and in no other event -- a `drt` has no such field -- so the delegator
+        # anchoring the `dip` is the whole of what makes `pre` a delegated AID of `delpre`,
+        # and no later event can change or renew it.
+        #
+        # An earlier version keyed on `kever.lastEst.d`, which asks whether the delegate's
+        # *current* establishment event is approved. That is a real question and it is the
+        # KEL layer's: `Kevery.validateDelegation` already refuses an unanchored `drt` for
+        # every validator outside its locallyOwned/locallyMembered/locallyWitnessed
+        # short-circuit. Asking it again here bought nothing and made a fixed edge unstable,
+        # because inside that exemption the rotation is accepted locally, `lastEst` advances,
+        # and credentials the delegate issued while approved began to be refused. A
+        # compromised delegate is answered by cooperative superseding recovery, not by an
+        # edge operator changing its verdict.
+        #
+        # A delegated AID's prefix is a digest of its own `dip` (enforced for `dip` and
+        # `drt` by the digestive-prefix requirement in serdering), so `i` equals `d` there
+        # and the `dip` is retrievable at (pre, pre).
+        serder = self.hby.db.evts.get(keys=(pre, pre))
+        if serder is None:  # delegated inception event not retrievable
             return False
 
         return kever.fetchDelegatingEvent(delpre=delpre, serder=serder,

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -466,15 +466,14 @@ class Verifier:
             # Delegated-issuer relation (ACDC spec-body.md L1194): the near ACDC's issuer
             # MUST be "either the Issuee AID or a delegated AID" of the far node's issuee.
             # So DI2I is a superset of I2I -- issuer == farIssuee satisfies it outright --
-            # and the delegation arm admits only *direct* delegates.
+            # and the delegation arm admits a delegated AID at any depth.
             #
-            # Direct-only is the requirement, not an approximation of a transitive walk.
-            # The motivating case (#1559) is a QVI that delegates to subgroup AIDs which
-            # perform routine issuance: "any number of children, zero grandchildren". A
-            # transitive reading would let a subgroup delegate onward and mint new issuers,
-            # defeating it. Hence no walk here -- and hence no depth bound, which would be
-            # a conformance seam letting two conforming validators disagree on identical
-            # bytes with no wire-visible cause.
+            # Depth is not the operator's business. A delegator bounds how far its own
+            # delegation reaches with the DND config trait, which Kevery.validateDelegation
+            # honors at core/eventing.py:3287 by refusing any dip whose delegator carries
+            # it: to permit children but not grandchildren, put DND in the children.
+            # Reading DI2I as direct-only would instead forbid a two-layer hierarchy
+            # outright and force a second operator for every other depth.
             #
             # Resolved through .iseaid rather than .attrib['i'] so an aggregate ('A') far
             # node works: .attrib is None there, so `'i' in creder.attrib` would raise
@@ -485,7 +484,7 @@ class Verifier:
             if farIssuee is None:  # untargeted far node: no issuee to be a delegate of
                 return None
 
-            if issuer != farIssuee and not self._isApprovedDelegate(issuer, farIssuee):
+            if issuer != farIssuee and not self._isDelegatedAID(issuer, farIssuee):
                 return None
 
         elif op is not None and op != 'NI2I':
@@ -515,17 +514,17 @@ class Verifier:
 
         return state
 
-    def _isApprovedDelegate(self, pre, delpre):
-        """Returns True if pre is a direct delegate of delpre, approved by delpre.
+    def _isDelegatedAID(self, pre, delpre):
+        """Returns True if pre is a delegated AID of delpre, at any depth.
 
-        Direct only: the relation is not followed transitively, so a delegate of a
-        delegate of delpre returns False. See .verifyChain's DI2I branch for why that is
-        the requirement rather than a simplification.
+        Climbs pre's delegation chain toward delpre and requires of every hop that the
+        delegator anchored the delegate's `dip` and was itself permitted to delegate.
+        Both are per-hop questions, so neither can be asked once at the top.
 
         Deliberately NOT implemented as ``kevers[pre].delpre == delpre``.
         ``Kevery.validateDelegation`` returns early -- with no seal lookup whatsoever --
         when the delegated event is locally owned, locally membered, or locally witnessed
-        (core/eventing.py:3287-3289), and the comment there is explicit that a witness
+        (core/eventing.py:3269-3271), and the comment there is explicit that a witness
         "accepts without waiting for delegation seal to be anchored in delegator's KEL".
         Since setupWitness co-locates a credential Verifier in the same Habery, a
         delpre-based check would accept a DI2I edge for any AID this Habery happens to
@@ -533,20 +532,32 @@ class Verifier:
         never granted. ``delpre`` records what the delegate asserted in its own `di` field;
         only the delegator's anchored approval seal records what the delegator agreed to.
 
-        So the delegation is confirmed the way the KEL layer confirms it, by delegating to
+        So each hop is confirmed the way the KEL layer confirms it, by delegating to
         Kever.fetchDelegatingEvent: consult the approval source-seal couple in .db.aess --
         which logEvent writes only when validateDelegation actually found and verified the
         seal, since the exemption returns (None, None) and that write is gated on those
         being present -- and failing that, walk the delegator's KEL for the anchoring seal
-        directly. The walk is what keeps a Habery with no .aess entry (a witness, or the
-        delegate's own controller) from being permanently unable to validate an edge that
-        is in fact approved.
+        directly. That KEL walk is what keeps a Habery with no .aess entry (a witness, or
+        the delegate's own controller) from being permanently unable to validate an edge
+        that is in fact approved. .aess is also pinned by flows in which this Habery
+        took part in the delegation itself (app/delegating.py:153, app/grouping.py:220,
+        cli/commands/delegate/confirm.py:109), each only after observing the anchor.
 
-        .aess is also pinned by flows in which this Habery participated in the delegation
-        itself (app/delegating.py:153, app/grouping.py:216,
-        app/cli/commands/delegate/confirm.py:109). Each pins it only after observing the
-        delegator's anchor, and such a Habery already trusts the delegation, so treating
-        the entry as authority-bearing is sound there too.
+        DND is re-checked here for the same reason delpre is not trusted: the exemption
+        above returns before validateDelegation reaches its doNotDelegate refusal at
+        core/eventing.py:3287, so an exempted Habery holds dips a disinterested validator
+        would never have accepted. Without this, a witness-hosted Verifier would honor a
+        chain that a watcher-fed one refuses -- identical bytes, opposite verdicts, which
+        is precisely what reading the anchor instead of `delpre` exists to prevent. The
+        trait is inception-only and Kever.config runs once, so a delegator's answer here
+        never moves.
+
+        The climb needs no depth bound and gets none: a delegated AID's prefix is a digest
+        of the `dip` that carries its `di`, so a cycle in the chain would require a hash
+        cycle. A bound would also be a conformance seam, letting two conforming validators
+        disagree on identical bytes with no wire-visible cause. Depth is the delegator's to
+        choose, via DND. The visited set below is a termination guarantee over a possibly
+        corrupt local database, not a policy.
 
         Called with original=False so that a missing seal returns None rather than raising,
         and so an inconsistent .aess entry is left alone: a verifier reads key state, it
@@ -566,51 +577,63 @@ class Verifier:
         credentials that delegate issued, and DI2I asks the same question the KEL layer
         already answered.
 
-        Retirement of a subgroup is deliberately not modelled at all. It is key-state
-        based: a retired delegate rotates to keys it cannot sign with, so it issues nothing
-        further while everything it issued while authorized stays valid, and the approval
-        seals are byte-identical before and after (#1559). A check here that tried to detect
-        retirement would both fail (nothing changes structurally) and be wrong (it would
-        invalidate credentials issued while the subgroup was legitimately authorized).
+        Retirement of a delegate is deliberately not modelled. It is key-state based: a
+        retired delegate rotates to keys it cannot sign with, so it issues nothing further
+        while everything it issued while authorized stays valid, and the approval seals are
+        byte-identical before and after. A check here that tried to detect retirement would
+        both fail (nothing changes structurally) and be wrong (it would invalidate
+        credentials issued while the delegate was legitimately authorized).
 
         Parameters:
             pre (str): qb64 AID whose delegation is in question, i.e. the issuer of the
                 near (edge-bearing) ACDC
-            delpre (str): qb64 AID that must be its delegator, i.e. the far node's issuee
+            delpre (str): qb64 AID that must be somewhere above it in the delegation
+                chain, i.e. the far node's issuee
 
         Returns:
-            bool: True means pre is a direct delegate of delpre and delpre's approval of
-                pre's current key state is anchored in delpre's KEL.
+            bool: True means every hop from pre up to delpre is a delegation its delegator
+                anchored and that DND permitted.
 
         """
-        if pre not in self.hby.kevers:  # no key state for the issuer, nothing to evaluate
-            return False
+        seen = set()
+        while pre not in seen:
+            seen.add(pre)
 
-        kever = self.hby.kevers[pre]
-        if kever.delpre is None or kever.delpre != delpre:
-            return False
+            if pre not in self.hby.kevers:  # no key state, nothing to evaluate
+                return False
 
-        # The delegation is settled at inception and does not move afterwards. `di` appears
-        # in a `dip` and in no other event -- a `drt` has no such field -- so the delegator
-        # anchoring the `dip` is the whole of what makes `pre` a delegated AID of `delpre`,
-        # and no later event can change or renew it.
-        #
-        # An earlier version keyed on `kever.lastEst.d`, which asks whether the delegate's
-        # *current* establishment event is approved. That is a real question and it is the
-        # KEL layer's: `Kevery.validateDelegation` already refuses an unanchored `drt` for
-        # every validator outside its locallyOwned/locallyMembered/locallyWitnessed
-        # short-circuit. Asking it again here bought nothing and made a fixed edge unstable,
-        # because inside that exemption the rotation is accepted locally, `lastEst` advances,
-        # and credentials the delegate issued while approved began to be refused. A
-        # compromised delegate is answered by cooperative superseding recovery, not by an
-        # edge operator changing its verdict.
-        #
-        # A delegated AID's prefix is a digest of its own `dip` (enforced for `dip` and
-        # `drt` by the digestive-prefix requirement in serdering), so `i` equals `d` there
-        # and the `dip` is retrievable at (pre, pre).
-        serder = self.hby.db.evts.get(keys=(pre, pre))
-        if serder is None:  # delegated inception event not retrievable
-            return False
+            kever = self.hby.kevers[pre]
+            if kever.delpre is None:  # top of the chain reached without meeting delpre
+                return False
 
-        return kever.fetchDelegatingEvent(delpre=delpre, serder=serder,
-                                          original=False, eager=True) is not None
+            if kever.delpre not in self.hby.kevers:  # delegator's KEL unknown
+                return False
+
+            if self.hby.kevers[kever.delpre].doNotDelegate:
+                return False
+
+            # The delegation is settled at inception and does not move afterwards. `di`
+            # appears in a `dip` and in no other event -- a `drt` has no such field -- so
+            # the delegator anchoring the `dip` is the whole of what makes this hop a
+            # delegation, and no later event can change or renew it. An earlier revision
+            # keyed on `kever.lastEst.d`, asking whether the delegate's *current*
+            # establishment event was approved; that is the KEL layer's question, and
+            # asking it again here made a fixed edge unstable inside the exemption above,
+            # where an unanchored rotation is accepted locally and `lastEst` advances.
+            #
+            # A delegated AID's prefix is a digest of its own `dip`, so `i` equals `d`
+            # there and the `dip` is retrievable at (pre, pre).
+            serder = self.hby.db.evts.get(keys=(pre, pre))
+            if serder is None:  # delegated inception event not retrievable
+                return False
+
+            if kever.fetchDelegatingEvent(delpre=kever.delpre, serder=serder,
+                                          original=False, eager=True) is None:
+                return False
+
+            if kever.delpre == delpre:
+                return True
+
+            pre = kever.delpre
+
+        return False  # cycle, reachable only from a corrupt database

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -478,8 +478,9 @@ class Verifier:
             # Resolved through .iseaid rather than .attrib['i'] so an aggregate ('A') far
             # node works: .attrib is None there, so `'i' in creder.attrib` would raise
             # TypeError. Deliberately not routed through the .reger.subjs lookup the I2I
-            # branch below uses either -- saveCredential only indexes subjects out of the
-            # attribute section, so that index is attributive-only by construction.
+            # branch below uses either: subjs is an index of credentials this validator
+            # happens to have saved, so gating on it would make the edge's meaning depend
+            # on the local store rather than on the delegation.
             farIssuee = creder.iseaid
             if farIssuee is None:  # untargeted far node: no issuee to be a delegate of
                 return None
@@ -549,8 +550,8 @@ class Verifier:
         would never have accepted. Without this, a witness-hosted Verifier would honor a
         chain that a watcher-fed one refuses -- identical bytes, opposite verdicts, which
         is precisely what reading the anchor instead of `delpre` exists to prevent. The
-        trait is inception-only and Kever.config runs once, so a delegator's answer here
-        never moves.
+        trait is read from the delegator's inception event and Kever.config runs once, so a
+        delegator's answer here never moves.
 
         The climb needs no depth bound and gets none: a delegated AID's prefix is a digest
         of the `dip` that carries its `di`, so a cycle in the chain would require a hash
@@ -576,6 +577,17 @@ class Verifier:
         here: a validator that has accepted the delegate's KEL should not then refuse the
         credentials that delegate issued, and DI2I asks the same question the KEL layer
         already answered.
+
+        That asymmetry has a consequence worth stating plainly, because it sits in tension
+        with the DND paragraph above. A validator that evaluated an edge before an
+        intermediate's anchoring event was superseded keeps a pinned .aess entry and goes
+        on accepting; one that first evaluates it afterwards walks the KEL, does not find
+        the superseded anchor, and refuses. Same bytes, verdicts that differ by when the
+        validator first looked. It is not introduced here -- it is fetchDelegatingEvent's
+        documented first-seen behavior, and it is identical at one hop -- but this is the
+        first caller to reach it from the credential layer, so it is no longer only the KEL
+        layer's to own. Answering it belongs with superseding recovery, not with an edge
+        operator second-guessing the KEL its own validator accepted.
 
         Retirement of a delegate is deliberately not modelled. It is key-state based: a
         retired delegate rotates to keys it cannot sign with, so it issues nothing further

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -10,9 +10,9 @@ import pytest
 
 from keri import (MissingRegistryError, MissingEntryError,
                   MissingChainError, RevokedChainError, ValidationError, Vrsn_1_0)
-from keri.app import openHab
+from keri.app import openHab, openHby
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
-                       Diger, Parser, SealEvent,
+                       Diger, Parser, SealEvent, Salter,
                        MtrDex, Saids, Aggor, Noncer, Schemer)
 from keri.kering import Ilks, Kinds, Vrsn_2_0, MissingSchemaError
 from keri.help import helping
@@ -1059,6 +1059,93 @@ def setupOperatorFixture(ian, ianHby, ianreg, ianiss):
     return verfer, issueAndSave
 
 
+# Salt for the multi-hab DI2I fixtures below, which need openHby (several habs in one
+# Habery, plus delegated habs in Haberies of their own) rather than openHab's single hab.
+DI2I_SALT = Salter(raw=b'0123456789abcdef').qb64
+OPTIONAL_ISSUEE_SCHEMA = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+
+def anchorApproval(delegator, delegate):
+    """Approve `delegate`'s latest establishment event by anchoring its seal.
+
+    A ``dip`` becomes *validated* delegation only once the delegator anchors an event
+    seal to it on its own trunk; ``app.delegating.Anchorer`` does this in production.
+    The delegate's own Habery accepts its ``dip`` before that happens -- the
+    ``locallyOwned`` arm of the three-way local-source exemption at
+    ``core/eventing.py:3287-3289`` returns from ``validateDelegation`` with no seal
+    lookup at all -- so a fixture that skips this call still yields a Kever with
+    ``delpre`` set. That state is exactly what a DI2I check must not mistake for
+    authority, and it is what the ``unapproved`` hab below is for.
+    """
+    kever = delegate.kever
+    seal = SealEvent(i=kever.prefixer.qb64, s=kever.serder.snh,
+                     d=kever.serder.said)._asdict()
+    delegator.interact(data=[seal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                       gvrsn=Vrsn_1_0)
+
+
+def setupRegistry(hab, regery, name):
+    """Create and anchor a credential registry for `hab` inside `regery`.
+
+    One Regery can hold registries for several habs (they are keyed by prefix), which is
+    what lets the DI2I tests give the root issuer, the QVI and its subgroups a registry
+    each behind a single Verifier.
+    """
+    reg = regery.makeRegistry(prefix=hab.pre, name=name, version=Vrsn_1_0,
+                              kind=Kinds.json)
+    rseal = SealEvent(reg.regk, "0", reg.regd)._asdict()
+    hab.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                 gvrsn=Vrsn_1_0)
+    reg.anchorMsg(pre=reg.regk, regd=reg.regd, seqner=Seqner(sn=hab.kever.sn),
+                  saider=Diger(qb64=hab.kever.serder.said))
+    regery.processEscrows()
+    return reg
+
+
+def makeIssueAndSave(verfer, regery, hab, reg):
+    """Return an issueAndSave closure for `hab` issuing out of registry `reg`.
+
+    Same flow as .setupOperatorFixture's closure, but parameterized by issuer so a test
+    can issue from more than one AID against a single Verifier.
+    """
+    def issueAndSave(creder):
+        try:
+            verfer.processCredential(creder, prefixer=hab.kever.prefixer,
+                                     seqner=Seqner(sn=hab.kever.sn),
+                                     saider=Diger(qb64=hab.kever.serder.said))
+        except MissingRegistryError:
+            pass  # expected: the TEL issuance event is anchored just below
+        iss = reg.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        hab.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        reg.anchorMsg(pre=iss.pre, regd=iss.said, seqner=Seqner(sn=hab.kever.sn),
+                      saider=Diger(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+        verfer.processEscrows()
+
+    return issueAndSave
+
+
+def makeCred(hab, reg, *, issuee=None, claim="", source=None):
+    """Build a credential issued by `hab` in registry `reg`, targeted at `issuee`."""
+    subject = dict(d="")
+    if issuee is not None:
+        subject["i"] = issuee
+    subject.update(dt=helping.nowIso8601(), claim=claim)
+    _, data = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+    return credential(issuer=hab.pre, schema=OPTIONAL_ISSUEE_SCHEMA, data=data,
+                      status=reg.regk, source=source if source is not None else {},
+                      rules={}, version=Vrsn_1_0, kind=Kinds.json)
+
+
+def di2iEdge(nodeSaid):
+    """Saidified edge block carrying a single DI2I edge to `nodeSaid`."""
+    _, chain = Saider.saidify(sad=dict(d='', node=dict(n=nodeSaid, o="DI2I")),
+                              code=MtrDex.Blake3_256, label=Saids.d)
+    return chain
+
+
 def test_verifier_list_valued_operator(seeder):
     """A list-valued `o` is a spec-legal spelling and MUST NOT fall to the default.
 
@@ -1167,29 +1254,25 @@ def test_verifier_list_valued_operator(seeder):
         near = nearWithOp(["E1E"], "E1E via list")
         assert verfer.reger.saved.get(keys=near.saidb) is not None
 
-        # The flagship interop case from the review: "o": ["DI2I"] previously resolved
-        # to I2I via the default rule, silently downgrading a delegated-issuer edge to
-        # a strict issuer==issuee one. It must now reach DI2I and fail closed.
-        chainSad = dict(d='', node=dict(n=far.said, o=["DI2I"]))
-        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
-        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="di2i in list")
-        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
-        listDi2i = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
-                              status=ianiss.regk, source=chain, rules={},
-                              version=Vrsn_1_0, kind=Kinds.json)
-        iss = ianiss.issue(said=listDi2i.said)
-        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-        ian.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
-                     gvrsn=Vrsn_1_0)
-        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
-                         seqner=Seqner(sn=ian.kever.sn),
-                         saider=Diger(qb64=ian.kever.serder.said))
-        ianreg.processEscrows()
-        with pytest.raises(ValidationError) as excinfo:
-            verfer.processCredential(listDi2i, prefixer=ian.kever.prefixer,
-                                     seqner=Seqner(sn=ian.kever.sn),
-                                     saider=Diger(qb64=ian.kever.serder.said))
-        assert "DI2I" in str(excinfo.value)
+        # The flagship interop case from the review: "o": ["DI2I"] previously resolved to
+        # I2I via the default rule, silently downgrading a delegated-issuer edge to a
+        # strict issuer==issuee one. DI2I now has real semantics
+        # (test_verifier_di2i_delegated_issuer_edge), so what this pins is that the list
+        # form reaches DI2I *as a member of the delegative conflict set*. Here the near
+        # issuer (ian) is neither the far issuee (han) nor a delegate of it, so DI2I
+        # rejects.
+        near = nearWithOp(["DI2I"], "di2i in list")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # This pair is the discriminating one. ["DI2I", "NI2I"] -> NI2I wins and accepts,
+        # which a verifier that skipped DI2I as an unrecognized token would also do. But
+        # ["NI2I", "DI2I"] -> DI2I wins and rejects, whereas skipping DI2I would leave
+        # NI2I as the latest recognized operator and wrongly accept. So only the second of
+        # these distinguishes "DI2I took part in latest-wins" from "DI2I was dropped".
+        near = nearWithOp(["DI2I", "NI2I"], "ni2i wins over di2i")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+        near = nearWithOp(["NI2I", "DI2I"], "di2i wins over ni2i")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
 
         # NOT is normative (spec L1195: the far node's validity is inverted) and
         # unimplemented here. It must fail closed like DI2I rather than being skipped
@@ -1305,18 +1388,22 @@ def test_verifier_nonconflicting_operators_compose(seeder):
     """End Test"""
 
 
-def test_verifier_di2i_rejects_diagnosably(seeder):
-    """An unimplemented DI2I edge must fail closed *diagnosably*, not vanish.
+def test_verifier_unimplemented_operator_rejects_diagnosably(seeder):
+    """An unimplemented operator must fail closed *diagnosably*, not vanish.
 
-    DI2I previously raised a bare ``NotImplementedError``, which is not a
-    ValidationError, so every caller mishandled it: ``Parser.allParsator``'s blanket
-    ``except (ValidationError, Exception)`` logged and discarded the ACDC, and
-    ``_processEscrow``'s generic arm unescrowed it. Neither produced a signal an
-    operator could act on.
+    Both normative-but-unimplemented operators previously raised a bare
+    ``NotImplementedError``, which is not a ValidationError, so every caller mishandled
+    it: ``Parser.allParsator``'s blanket ``except (ValidationError, Exception)`` logged
+    and discarded the ACDC, and ``_processEscrow``'s generic arm unescrowed it. Neither
+    produced a signal an operator could act on.
 
-    DI2I is still unimplemented -- this test pins the *failure mode*, not the
-    operator semantics. A ValidationError names the cause and stops the retry loop,
-    which is correct here: unlike a missing chain, retrying cannot help.
+    This test pins the *failure mode*, not any operator's semantics. A ValidationError
+    names the cause and stops the retry loop, which is correct here: unlike a missing
+    chain, retrying cannot help.
+
+    Carried on ``NOT`` (#1554), which is still unimplemented. It was originally written
+    against DI2I; DI2I now has real semantics (test_verifier_di2i_delegated_issuer_edge)
+    and no longer raises, so the failure mode moved to the operator that still has none.
     """
     optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
@@ -1347,9 +1434,9 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         issueAndSave(far)
         assert verfer.reger.saved.get(keys=far.saidb) is not None
 
-        chainSad = dict(d='', node=dict(n=far.said, o="DI2I"))
+        chainSad = dict(d='', node=dict(n=far.said, o="NOT"))
         _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
-        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="di2i edge")
+        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="not edge")
         _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
         near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
                           status=ianiss.regk, source=chain, rules={},
@@ -1374,7 +1461,7 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         # Diagnosable: the message names the operator, the far node the edge points to,
         # and the near credential that carried the edge -- an operator triaging a stream
         # needs the last of those to know which credential to fix.
-        assert "DI2I" in str(excinfo.value)
+        assert "NOT" in str(excinfo.value)
         assert far.said in str(excinfo.value)
         assert near.said in str(excinfo.value)
         # Fails closed -- the credential is not saved on the strength of an edge the
@@ -1383,6 +1470,293 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         # Not a MissingChainError: the chain is present, the operator is unsupported.
         # Escrowing it would promise a retry that can never succeed.
         assert not isinstance(excinfo.value, MissingChainError)
+
+    """End Test"""
+
+
+def test_verifier_di2i_delegated_issuer_edge(seeder):
+    """DI2I: the near issuer must BE the far issuee, or be a *direct* delegate of it.
+
+    ACDC spec-body.md L1194: the near ACDC's issuer must be "either the Issuee AID or a
+    delegated AID" of the far node's issuee -- singular. Direct delegates only, per #1559:
+    GLEIF issues the QVI credential once through an expensive multisig ceremony, and the
+    QVI then delegates to subgroup AIDs that perform routine issuance. The requirement is
+    "any number of children, zero grandchildren" -- a subgroup must not be able to
+    delegate onward and mint new issuers. A transitive reading would actively defeat that,
+    so there is no walk here and no depth bound to disagree about.
+
+    The rows below are the full matrix: satisfied by delegation, satisfied by identity
+    (DI2I is a superset of I2I), and the five ways it must fail.
+    """
+    with openHby(name="di2i", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as hby, \
+            openHby(name="stranger", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as strangerHby:
+        seeder.seedSchema(db=hby.db)
+
+        # gar issues the far node (GLEIF); qvi is the far node's issuee and the delegator.
+        gar = hby.makeHab(name="gar", version=Vrsn_1_0, kind=Kinds.json)
+        qvi = hby.makeHab(name="qvi", version=Vrsn_1_0, kind=Kinds.json)
+        le = hby.makeHab(name="le", version=Vrsn_1_0, kind=Kinds.json)  # near-node issuee
+
+        # sub: an approved direct delegate of qvi -- the issuing subgroup.
+        sub = hby.makeHab(name="sub", delpre=qvi.pre, version=Vrsn_1_0, kind=Kinds.json)
+        anchorApproval(qvi, sub)
+
+        # unapproved: claims qvi as delegator, but qvi never anchored the approval.
+        unapproved = hby.makeHab(name="unapproved", delpre=qvi.pre, version=Vrsn_1_0,
+                                 kind=Kinds.json)
+
+        # rogue: an approved delegate -- but of gar, not of the far node's issuee.
+        rogue = hby.makeHab(name="rogue", delpre=gar.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(gar, rogue)
+
+        # grand: an approved delegate of sub, i.e. qvi's grandchild.
+        grand = hby.makeHab(name="grand", delpre=sub.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(sub, grand)
+
+        stranger = strangerHby.makeHab(name="stranger", version=Vrsn_1_0, kind=Kinds.json)
+
+        assert gar.kever.delpre is None
+        assert sub.kever.delpre == qvi.pre
+        assert unapproved.kever.delpre == qvi.pre
+        assert rogue.kever.delpre == gar.pre
+        assert grand.kever.delpre == sub.pre
+        assert stranger.pre not in hby.kevers
+
+        # Every dip in this Habery was accepted through the locallyOwned arm of the
+        # three-way local-source exemption (core/eventing.py:3287-3289), which returns from
+        # validateDelegation before any seal lookup -- so none of them has an .aess entry,
+        # approved or not. `delpre` is set for all of them and .aess is empty for all of
+        # them: neither field distinguishes sub from unapproved. The only thing that does
+        # is whether the delegator anchored an approval seal on its own trunk, which is
+        # what the check has to go and look at.
+        for hab in (sub, unapproved, rogue, grand):
+            assert hby.db.aess.get(keys=(hab.pre, hab.kever.lastEst.d)) is None
+
+        regery = Regery(hby=hby, name="di2i", temp=True)
+        garreg = setupRegistry(gar, regery, "gar")
+        qvireg = setupRegistry(qvi, regery, "qvi")
+        subreg = setupRegistry(sub, regery, "sub")
+        grandreg = setupRegistry(grand, regery, "grand")
+
+        verfer = Verifier(hby=hby, reger=regery.reger)
+        garIssue = makeIssueAndSave(verfer, regery, gar, garreg)
+        qviIssue = makeIssueAndSave(verfer, regery, qvi, qvireg)
+        subIssue = makeIssueAndSave(verfer, regery, sub, subreg)
+        grandIssue = makeIssueAndSave(verfer, regery, grand, grandreg)
+
+        # Far node: the QVI credential, gar -> qvi. Its issuee is the AID whose delegates
+        # a DI2I edge to it authorizes.
+        far = makeCred(gar, garreg, issuee=qvi.pre, claim="qvi credential")
+        assert far.iseaid == qvi.pre
+        garIssue(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        # 1 -- headline. The near issuer is a direct, approved delegate of the far issuee.
+        # This is the case the operator exists for, and the one that was previously
+        # impossible: DI2I raised a ValidationError and the credential was never saved.
+        bySub = makeCred(sub, subreg, issuee=le.pre, claim="issued by subgroup",
+                         source=di2iEdge(far.said))
+        subIssue(bySub)
+        assert verfer.reger.saved.get(keys=bySub.saidb) is not None
+
+        # Having verified the approval seal on qvi's trunk, the check repaired sub's .aess
+        # entry -- the same benign cache repair Kever.fetchDelegatingEvent performs during
+        # escrow processing, guarded on the delegated event already being accepted.
+        assert hby.db.aess.get(keys=(sub.pre, sub.kever.lastEst.d)) is not None
+
+        # 2 -- DI2I is a superset of I2I: "either the Issuee AID or a delegated AID". Easy
+        # to miss by implementing only the delegation half.
+        byQvi = makeCred(qvi, qvireg, issuee=le.pre, claim="issued by qvi itself",
+                         source=di2iEdge(far.said))
+        qviIssue(byQvi)
+        assert verfer.reger.saved.get(keys=byQvi.saidb) is not None
+
+        # 5 -- the direct-only requirement, end to end. grand is an approved delegate of an
+        # approved delegate of the far issuee. If this credential is saved, the
+        # implementation is transitive and "zero grandchildren" is not enforced.
+        byGrand = makeCred(grand, grandreg, issuee=le.pre, claim="issued by grandchild",
+                           source=di2iEdge(far.said))
+        grandIssue(byGrand)
+        assert verfer.reger.saved.get(keys=byGrand.saidb) is None
+
+        # 6 -- an untargeted far node has no issuee, so "delegate of the issuee" is
+        # undefined and there is nothing for the operator to bind to. Resolved through
+        # .iseaid so an aggregate ('A') far node reaches the same guard instead of crashing
+        # on a None attribute section.
+        farUntargeted = makeCred(gar, garreg, claim="untargeted far node")
+        assert farUntargeted.iseaid is None
+        garIssue(farUntargeted)
+        assert verfer.reger.saved.get(keys=farUntargeted.saidb) is not None
+        toUntargeted = makeCred(sub, subreg, issuee=le.pre, claim="to untargeted",
+                                source=di2iEdge(farUntargeted.said))
+        subIssue(toUntargeted)
+        assert verfer.reger.saved.get(keys=toUntargeted.saidb) is None
+
+        # The remaining rows vary only the near ACDC's issuer, which is the single input
+        # DI2I constrains, so they call .verifyChain directly instead of minting a
+        # credential and a registry apiece. A None state is exactly what processCredential
+        # turns into "escrow, do not save" -- cases 5 and 6 above pin that wiring.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+        assert verfer.verifyChain(far.said, "DI2I", issuer=qvi.pre) is not None
+
+        # 3 -- not delegated at all: delpre is None.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=gar.pre) is None
+
+        # 4 -- delegated, but by someone other than the far issuee. An implementation that
+        # checked the truthy `Kever.delegated` flag, or merely that .aess had an entry,
+        # would accept this one.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=rogue.pre) is None
+
+        # 5 at unit level -- the grandchild again, isolated from the issuance flow.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=grand.pre) is None
+
+        # 7 -- the near issuer's KEL is absent from .kevers. Must return None rather than
+        # raise KeyError, which would escape _processEscrow's typed arm and abort the pass.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=stranger.pre) is None
+
+        # 8 -- THE trap. unapproved.delpre == qvi.pre right here in .kevers, so a check
+        # written as `kevers[issuer].delpre == farIssuee` accepts it. But qvi anchored
+        # nothing: the dip was accepted only because this Habery owns it. Nothing was ever
+        # delegated. See test_verifier_di2i_requires_anchored_delegation for why this
+        # matters off the happy path -- the same exemption fires for a witness.
+        assert hby.kevers[unapproved.pre].delpre == qvi.pre
+        assert verfer.verifyChain(far.said, "DI2I", issuer=unapproved.pre) is None
+        # ... and no repair happened, because there was no seal to find.
+        assert hby.db.aess.get(keys=(unapproved.pre, unapproved.kever.lastEst.d)) is None
+
+    """End Test"""
+
+
+def test_verifier_di2i_requires_anchored_delegation(seeder):
+    """A self-asserted `di` must not manufacture issuing authority.
+
+    ``Kevery.validateDelegation`` short-circuits with *no seal lookup whatsoever* when the
+    event is locally owned, locally membered, or locally witnessed
+    (``core/eventing.py:3287-3289``), and the comment above it says so outright: "Witness
+    accepts without waiting for delegation seal to be anchored in delegator's KEL."
+    ``setupWitness`` co-locates a credential ``Verifier`` in that same Habery. So a DI2I
+    check written as ``kevers[issuer].delpre == farIssuee`` would let an operator running a
+    witness pool accept a DI2I edge for *any AID it witnesses* whose claimed delegator
+    never anchored anything -- issuance under authority never granted.
+
+    This test builds precisely that Habery: a witness that has accepted the delegate's
+    ``dip`` through the locallyWitnessed exemption, and that holds the far node in its own
+    credential store so the operator is genuinely evaluated rather than short-circuiting on
+    a missing far node. The edge must be refused. It then delivers the delegator's
+    anchoring event -- and nothing else -- and the same edge must validate. The delta
+    between the two assertions is one interaction event on the delegator's trunk, which is
+    the only thing that ever conferred the authority.
+    """
+    with openHby(name="qvi", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as qviHby, \
+            openHby(name="sub", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as subHby, \
+            openHby(name="wit", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as witHby, \
+            openHby(name="val", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as valHby:
+        seeder.seedSchema(db=qviHby.db)
+        seeder.seedSchema(db=witHby.db)
+
+        qvi = qviHby.makeHab(name="qvi", version=Vrsn_1_0, kind=Kinds.json)
+        wit = witHby.makeHab(name="wit", transferable=False, version=Vrsn_1_0,
+                             kind=Kinds.json)
+
+        # The delegate lives in a Habery of its own and designates wit as a witness. Its
+        # dip is entirely self-asserted -- qvi has approved nothing at this point. What
+        # matters for the exemption is only that wit is *designated*: that is what makes
+        # locallyWitnessed fire in witHby.
+        sub = subHby.makeHab(name="sub", delpre=qvi.pre, wits=[wit.pre], toad=1,
+                             version=Vrsn_1_0, kind=Kinds.json)
+        assert sub.kever.delpre == qvi.pre
+
+        # qvi issues the far node to itself, then -- as its LAST event -- anchors the
+        # approval of sub's dip. Keeping the approval last is what lets the replay below
+        # withhold it while still delivering everything the far node needs.
+        qvireg = Regery(hby=qviHby, name="qvi", temp=True)
+        qviiss = setupRegistry(qvi, qvireg, "qvi")
+        qviverfer = Verifier(hby=qviHby, reger=qvireg.reger)
+        far = makeCred(qvi, qviiss, issuee=qvi.pre, claim="qvi credential")
+        makeIssueAndSave(qviverfer, qvireg, qvi, qviiss)(far)
+        assert qviverfer.reger.saved.get(keys=far.saidb) is not None
+        farSeqner = Seqner(sn=qvi.kever.sn)
+        farSaider = Diger(qb64=qvi.kever.serder.said)
+
+        anchorApproval(qvi, sub)
+        approvalSn = qvi.kever.sn
+        dipSaid = sub.kever.serder.said
+
+        # The witness accepts sub's dip as a local (protected) source, because it is a
+        # designated witness of it -- reached without any cooperation from qvi. A remote
+        # source would be refused as a misfit event precisely because the witness is local
+        # to it (core/eventing.py:2842-2851), so this is the only way in, and it is the way
+        # a real witness pool takes.
+        wit.psr.parse(ims=bytearray(sub.msgOwnInception(framed=True, gvrsn=Vrsn_1_0)))
+        assert sub.pre in witHby.kevers
+        assert witHby.kevers[sub.pre].delpre == qvi.pre   # delpre claims qvi delegated it
+        assert witHby.db.aess.get(keys=(sub.pre, dipSaid)) is None   # on nobody's word
+
+        # The witness receipt, so the disinterested validator at the end of this test sees
+        # a fully witnessed dip and its refusal cannot be blamed on a missing receipt.
+        subReceipt = wit.witness(serder=witHby.kevers[sub.pre].serder, framed=True,
+                                 version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
+
+        # Give the witness everything except qvi's approval: qvi's KEL up to but not
+        # including it, qvi's registry TEL, and the far node's TEL.
+        witreg = Regery(hby=witHby, name="wit", temp=True)
+        witkvy = Kevery(db=witHby.db, lax=False, local=False)
+        wittvy = Tevery(reger=witreg.reger, db=witHby.db, local=False)
+        qviMsgs = [bytearray(msg) for msg
+                   in qviHby.db.clonePreIter(pre=qvi.pre, version=Vrsn_1_0)]
+        assert len(qviMsgs) == approvalSn + 1  # the approval is the last event
+        for msg in qviMsgs[:-1]:               # ... and it is withheld here
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=qviiss.regk):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=far.said):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+
+        witverfer = Verifier(hby=witHby, reger=witreg.reger)
+        witverfer.processCredential(far, prefixer=qvi.kever.prefixer, seqner=farSeqner,
+                                    saider=farSaider)
+        # The far node really is saved here. Without this the assertion below would pass
+        # vacuously -- .verifyChain returns None for an unknown far node too.
+        assert witverfer.reger.saved.get(keys=far.saidb) is not None
+        assert witHby.kevers[qvi.pre].sn == approvalSn - 1
+
+        # REFUSED. Everything a delpre-based check would look at says "sub is qvi's
+        # delegate"; qvi's trunk says nothing at all.
+        assert witverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is None
+
+        # Now deliver the one withheld event -- qvi's approval -- and nothing else.
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(qviMsgs[-1]), kvy=witkvy, tvy=wittvy)
+        assert witHby.kevers[qvi.pre].sn == approvalSn
+
+        # ACCEPTED. Same Habery, same call, byte-identical ACDCs. The only change is the
+        # approval seal now on the delegator's trunk.
+        assert witverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+        assert witHby.db.aess.get(keys=(sub.pre, dipSaid)) is not None
+
+        # For contrast, the disinterested validator: neither controller nor witness of sub,
+        # so no exemption applies. With the approval withheld it never accepts the dip at
+        # all -- it sits in the delegation escrow and there is no Kever to read a delpre
+        # off, so the DI2I check is never even the thing that stops it. That is why the
+        # witness Habery above is the load-bearing case: there, the exemption gets the dip
+        # accepted anyway. Deliver the approval and the same validator accepts it and
+        # populates .aess by real validation -- no test fixture pinned it.
+        valkvy = Kevery(db=valHby.db, lax=False, local=False)
+        for msg in qviMsgs[:-1]:
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=valkvy)
+        for msg in subHby.db.clonePreIter(pre=sub.pre, version=Vrsn_1_0):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=valkvy)
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(subReceipt), kvy=valkvy)
+        valkvy.processEscrows()
+        assert sub.pre not in valHby.kevers
+        assert valHby.db.aess.get(keys=(sub.pre, dipSaid)) is None
+
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(qviMsgs[-1]), kvy=valkvy)
+        valkvy.processEscrows()
+        assert sub.pre in valHby.kevers
+        assert valHby.kevers[sub.pre].delpre == qvi.pre
+        assert valHby.db.aess.get(keys=(sub.pre, dipSaid)) is not None
 
     """End Test"""
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1058,7 +1058,7 @@ def anchorApproval(delegator, delegate):
     seal to it on its own trunk; ``app.delegating.Anchorer`` does this in production.
     The delegate's own Habery accepts its ``dip`` before that happens -- the
     ``locallyOwned`` arm of the three-way local-source exemption at
-    ``core/eventing.py:3287-3289`` returns from ``validateDelegation`` with no seal
+    ``core/eventing.py:3269-3271`` returns from ``validateDelegation`` with no seal
     lookup at all -- so a fixture that skips this call still yields a Kever with
     ``delpre`` set. That state is exactly what a DI2I check must not mistake for
     authority, and it is what the ``unapproved`` hab below is for.
@@ -1451,18 +1451,20 @@ def test_verifier_unimplemented_operator_rejects_diagnosably(seeder):
 
 
 def test_verifier_di2i_delegated_issuer_edge(seeder):
-    """DI2I: the near issuer must BE the far issuee, or be a *direct* delegate of it.
+    """DI2I: the near issuer must BE the far issuee, or be a delegated AID of it.
 
     ACDC spec-body.md L1194: the near ACDC's issuer must be "either the Issuee AID or a
-    delegated AID" of the far node's issuee -- singular. Direct delegates only, per #1559:
-    GLEIF issues the QVI credential once through an expensive multisig ceremony, and the
-    QVI then delegates to subgroup AIDs that perform routine issuance. The requirement is
-    "any number of children, zero grandchildren" -- a subgroup must not be able to
-    delegate onward and mint new issuers. A transitive reading would actively defeat that,
-    so there is no walk here and no depth bound to disagree about.
+    delegated AID" of the far node's issuee. A delegated AID is one at any depth, so the
+    chain is climbed rather than probed one hop deep. Reading it as direct-only would
+    forbid a controller from horizontally scaling through two layers of delegated AIDs,
+    and would force a second operator for every other depth.
 
-    The rows below are the full matrix: satisfied by delegation, satisfied by identity
-    (DI2I is a superset of I2I), and the five ways it must fail.
+    Depth belongs to the delegator, expressed with the DND config trait in the inception
+    event of the delegate it wants to be a leaf. The `bounded`/`beyond` pair below is that
+    mechanism: `bounded` may issue, and nothing under `bounded` may.
+
+    The rows are the full matrix -- satisfied at three depths and by identity (DI2I is a
+    superset of I2I), and the six ways it must fail.
     """
     with openHby(name="di2i", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as hby, \
             openHby(name="stranger", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as strangerHby:
@@ -1477,37 +1479,79 @@ def test_verifier_di2i_delegated_issuer_edge(seeder):
         sub = hby.makeHab(name="sub", delpre=qvi.pre, version=Vrsn_1_0, kind=Kinds.json)
         anchorApproval(qvi, sub)
 
+        # grand, great: approved delegates two and three hops below qvi.
+        grand = hby.makeHab(name="grand", delpre=sub.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(sub, grand)
+        great = hby.makeHab(name="great", delpre=grand.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(grand, great)
+
+        # bounded: an approved delegate of qvi that qvi made a leaf, by putting DND in the
+        # inception event it approved. beyond: what bounded delegates anyway. A delegating
+        # seal may be anchored in an interaction event, which needs no approval from
+        # anyone above, so bounded can mint beyond unilaterally -- DND is what makes the
+        # result worthless rather than what stops it being created.
+        bounded = hby.makeHab(name="bounded", delpre=qvi.pre, DnD=True,
+                              version=Vrsn_1_0, kind=Kinds.json)
+        anchorApproval(qvi, bounded)
+        beyond = hby.makeHab(name="beyond", delpre=bounded.pre, version=Vrsn_1_0,
+                             kind=Kinds.json)
+        anchorApproval(bounded, beyond)
+        # further: one hop under beyond, so the DND violation sits in the middle of a
+        # chain rather than at the hop the climb starts from.
+        further = hby.makeHab(name="further", delpre=beyond.pre, version=Vrsn_1_0,
+                              kind=Kinds.json)
+        anchorApproval(beyond, further)
+
         # unapproved: claims qvi as delegator, but qvi never anchored the approval.
+        # under: an approval-complete delegate of unapproved, so the only defect in its
+        # chain to qvi is the hop above it.
         unapproved = hby.makeHab(name="unapproved", delpre=qvi.pre, version=Vrsn_1_0,
                                  kind=Kinds.json)
+        under = hby.makeHab(name="under", delpre=unapproved.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(unapproved, under)
+
+        # mid, leaf: sub never anchored mid, and mid did anchor leaf. So leaf's chain to
+        # qvi is sound at the hop it starts from and at the hop it ends at, and broken in
+        # between.
+        mid = hby.makeHab(name="mid", delpre=sub.pre, version=Vrsn_1_0, kind=Kinds.json)
+        leaf = hby.makeHab(name="leaf", delpre=mid.pre, version=Vrsn_1_0, kind=Kinds.json)
+        anchorApproval(mid, leaf)
 
         # rogue: an approved delegate -- but of gar, not of the far node's issuee.
         rogue = hby.makeHab(name="rogue", delpre=gar.pre, version=Vrsn_1_0,
                             kind=Kinds.json)
         anchorApproval(gar, rogue)
 
-        # grand: an approved delegate of sub, i.e. qvi's grandchild.
-        grand = hby.makeHab(name="grand", delpre=sub.pre, version=Vrsn_1_0,
-                            kind=Kinds.json)
-        anchorApproval(sub, grand)
-
         stranger = strangerHby.makeHab(name="stranger", version=Vrsn_1_0, kind=Kinds.json)
 
         assert gar.kever.delpre is None
         assert sub.kever.delpre == qvi.pre
-        assert unapproved.kever.delpre == qvi.pre
-        assert rogue.kever.delpre == gar.pre
         assert grand.kever.delpre == sub.pre
+        assert great.kever.delpre == grand.pre
+        assert bounded.kever.delpre == qvi.pre
+        assert hby.kevers[bounded.pre].doNotDelegate
+        assert beyond.kever.delpre == bounded.pre
+        assert further.kever.delpre == beyond.pre
+        assert unapproved.kever.delpre == qvi.pre
+        assert under.kever.delpre == unapproved.pre
+        assert mid.kever.delpre == sub.pre
+        assert leaf.kever.delpre == mid.pre
+        assert rogue.kever.delpre == gar.pre
         assert stranger.pre not in hby.kevers
 
         # Every dip in this Habery was accepted through the locallyOwned arm of the
-        # three-way local-source exemption (core/eventing.py:3287-3289), which returns from
-        # validateDelegation before any seal lookup -- so none of them has an .aess entry,
-        # approved or not. `delpre` is set for all of them and .aess is empty for all of
-        # them: neither field distinguishes sub from unapproved. The only thing that does
-        # is whether the delegator anchored an approval seal on its own trunk, which is
-        # what the check has to go and look at.
-        for hab in (sub, unapproved, rogue, grand):
+        # three-way local-source exemption (core/eventing.py:3269-3271), which returns from
+        # validateDelegation before any seal lookup -- and therefore before its DND refusal
+        # at :3287 too. So none of them has an .aess entry, approved or not, and beyond is
+        # here at all only because of that exemption. `delpre` is set for all of them: it
+        # distinguishes neither sub from unapproved nor grand from beyond. The only things
+        # that do are the approval seals on the delegators' trunks and the DND trait, both
+        # of which the check has to go and look at.
+        for hab in (sub, grand, great, bounded, beyond, further, unapproved, under, mid,
+                    leaf, rogue):
             assert hby.db.aess.get(keys=(hab.pre, hab.kever.lastEst.d)) is None
 
         regery = Regery(hby=hby, name="di2i", temp=True)
@@ -1515,12 +1559,14 @@ def test_verifier_di2i_delegated_issuer_edge(seeder):
         qvireg = setupRegistry(qvi, regery, "qvi")
         subreg = setupRegistry(sub, regery, "sub")
         grandreg = setupRegistry(grand, regery, "grand")
+        beyondreg = setupRegistry(beyond, regery, "beyond")
 
         verfer = Verifier(hby=hby, reger=regery.reger)
         garIssue = makeIssueAndSave(verfer, regery, gar, garreg)
         qviIssue = makeIssueAndSave(verfer, regery, qvi, qvireg)
         subIssue = makeIssueAndSave(verfer, regery, sub, subreg)
         grandIssue = makeIssueAndSave(verfer, regery, grand, grandreg)
+        beyondIssue = makeIssueAndSave(verfer, regery, beyond, beyondreg)
 
         # Far node: the QVI credential, gar -> qvi. Its issuee is the AID whose delegates
         # a DI2I edge to it authorizes.
@@ -1549,15 +1595,25 @@ def test_verifier_di2i_delegated_issuer_edge(seeder):
         qviIssue(byQvi)
         assert verfer.reger.saved.get(keys=byQvi.saidb) is not None
 
-        # 5 -- the direct-only requirement, end to end. grand is an approved delegate of an
-        # approved delegate of the far issuee. If this credential is saved, the
-        # implementation is transitive and "zero grandchildren" is not enforced.
+        # 3 -- depth. grand is an approved delegate of an approved delegate of the far
+        # issuee, and qvi left it room by putting DND in neither. If this credential is not
+        # saved, the relation is direct-only and a two-layer hierarchy cannot issue.
         byGrand = makeCred(grand, grandreg, issuee=le.pre, claim="issued by grandchild",
                            source=di2iEdge(far.said))
         grandIssue(byGrand)
-        assert verfer.reger.saved.get(keys=byGrand.saidb) is None
+        assert verfer.reger.saved.get(keys=byGrand.saidb) is not None
 
-        # 6 -- an untargeted far node has no issuee, so "delegate of the issuee" is
+        # 4 -- the bound, end to end, and the reason the walk re-checks DND rather than
+        # inheriting the KEL layer's answer. beyond's whole chain to qvi is anchored; the
+        # single thing wrong with it is that qvi told bounded not to delegate. A
+        # disinterested validator never accepts beyond's dip at all, so without this check
+        # a witness-hosted Verifier would honour a chain a watcher-fed one refuses.
+        byBeyond = makeCred(beyond, beyondreg, issuee=le.pre, claim="issued past the bound",
+                            source=di2iEdge(far.said))
+        beyondIssue(byBeyond)
+        assert verfer.reger.saved.get(keys=byBeyond.saidb) is None
+
+        # 5 -- an untargeted far node has no issuee, so "delegate of the issuee" is
         # undefined and there is nothing for the operator to bind to. Resolved through
         # .iseaid so an aggregate ('A') far node reaches the same guard instead of crashing
         # on a None attribute section.
@@ -1573,26 +1629,28 @@ def test_verifier_di2i_delegated_issuer_edge(seeder):
         # The remaining rows vary only the near ACDC's issuer, which is the single input
         # DI2I constrains, so they call .verifyChain directly instead of minting a
         # credential and a registry apiece. A None state is exactly what processCredential
-        # turns into "escrow, do not save" -- cases 5 and 6 above pin that wiring.
+        # turns into "escrow, do not save" -- cases 4 and 5 above pin that wiring.
         assert verfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
         assert verfer.verifyChain(far.said, "DI2I", issuer=qvi.pre) is not None
+        assert verfer.verifyChain(far.said, "DI2I", issuer=grand.pre) is not None
 
-        # 3 -- not delegated at all: delpre is None.
+        # 6 -- three hops down, with every hop anchored and none of them bounded. Depth is
+        # the delegator's to choose and it chose not to cap this arm.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=great.pre) is not None
+
+        # 7 -- not delegated at all: delpre is None.
         assert verfer.verifyChain(far.said, "DI2I", issuer=gar.pre) is None
 
-        # 4 -- delegated, but by someone other than the far issuee. An implementation that
+        # 8 -- delegated, but by someone other than the far issuee. An implementation that
         # checked the truthy `Kever.delegated` flag, or merely that .aess had an entry,
-        # would accept this one.
+        # would accept this one. The climb ends at gar, which has no delegator.
         assert verfer.verifyChain(far.said, "DI2I", issuer=rogue.pre) is None
 
-        # 5 at unit level -- the grandchild again, isolated from the issuance flow.
-        assert verfer.verifyChain(far.said, "DI2I", issuer=grand.pre) is None
-
-        # 7 -- the near issuer's KEL is absent from .kevers. Must return None rather than
+        # 9 -- the near issuer's KEL is absent from .kevers. Must return None rather than
         # raise KeyError, which would escape _processEscrow's typed arm and abort the pass.
         assert verfer.verifyChain(far.said, "DI2I", issuer=stranger.pre) is None
 
-        # 8 -- THE trap. unapproved.delpre == qvi.pre right here in .kevers, so a check
+        # 10 -- THE trap. unapproved.delpre == qvi.pre right here in .kevers, so a check
         # written as `kevers[issuer].delpre == farIssuee` accepts it. But qvi anchored
         # nothing: the dip was accepted only because this Habery owns it. Nothing was ever
         # delegated. See test_verifier_di2i_requires_anchored_delegation for why this
@@ -1602,6 +1660,21 @@ def test_verifier_di2i_delegated_issuer_edge(seeder):
         # ... and no repair happened, because there was no seal to find.
         assert hby.db.aess.get(keys=(unapproved.pre, unapproved.kever.lastEst.d)) is None
 
+        # 11 -- and the defect is not laundered by another hop. under's own delegation is
+        # anchored, so a walk that confirmed only the hop it started at would accept it.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=under.pre) is None
+
+        # 12 -- nor by hops on both sides of it. leaf's chain is anchored at the bottom and
+        # at the top, and unanchored at the hop between; a walk that confirmed only its
+        # endpoints would accept it. Every hop has to answer.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=leaf.pre) is None
+
+        # 13 -- and DND likewise is asked of every hop's delegator, not just the first.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=further.pre) is None
+
+        # bounded itself is unaffected: DND bounds what it may delegate, not what it may do.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=bounded.pre) is not None
+
     """End Test"""
 
 
@@ -1610,7 +1683,7 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
 
     ``Kevery.validateDelegation`` short-circuits with *no seal lookup whatsoever* when the
     event is locally owned, locally membered, or locally witnessed
-    (``core/eventing.py:3287-3289``), and the comment above it says so outright: "Witness
+    (``core/eventing.py:3269-3271``), and the comment above it says so outright: "Witness
     accepts without waiting for delegation seal to be anchored in delegator's KEL."
     ``setupWitness`` co-locates a credential ``Verifier`` in that same Habery. So a DI2I
     check written as ``kevers[issuer].delpre == farIssuee`` would let an operator running a
@@ -1737,7 +1810,6 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
     """End Test"""
 
 
-
 def test_verifier_di2i_survives_an_unapproved_delegated_rotation(seeder):
     """The delegation relation is fixed at inception and does not move afterwards.
 
@@ -1746,7 +1818,7 @@ def test_verifier_di2i_survives_an_unapproved_delegated_rotation(seeder):
     near issuer a delegated AID of the far node's issuee -- is settled once, by the
     delegator anchoring the `dip`, and no later event can change or renew it.
 
-    An earlier version of ._isApprovedDelegate keyed on ``kever.lastEst.d`` instead,
+    An earlier version of ._isDelegatedAID keyed on ``kever.lastEst.d`` instead,
     which asked a different question: is the delegate's *current* establishment event
     approved. That is a real question, but it belongs to the KEL layer, which already
     refuses an unanchored `drt` for every validator that is not exempted by the
@@ -1809,6 +1881,9 @@ def test_verifier_di2i_survives_an_unapproved_delegated_rotation(seeder):
         # An interaction event on top changes nothing either.
         sub.interact()
         assert subverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+
+    """End Test"""
+
 
 def test_verifier_escrow_pass_survives_argless_exception(seeder):
     """One poisoned escrow entry must not abort the whole escrow pass.

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -10,9 +10,9 @@ import pytest
 
 from keri import (MissingRegistryError, MissingEntryError,
                   MissingChainError, RevokedChainError, ValidationError, Vrsn_1_0)
-from keri.app import openHab
+from keri.app import openHab, openHby
 from keri.core import (Saider, Kevery, SerderKERI, Seqner,
-                       Diger, Parser, SealEvent,
+                       Diger, Parser, SealEvent, Salter,
                        MtrDex, Saids, Aggor, Noncer, Schemer)
 from keri.kering import Ilks, Kinds, Vrsn_2_0, MissingSchemaError
 from keri.help import helping
@@ -1045,6 +1045,93 @@ def setupOperatorFixture(ian, ianHby, ianreg, ianiss):
     return verfer, issueAndSave
 
 
+# Salt for the multi-hab DI2I fixtures below, which need openHby (several habs in one
+# Habery, plus delegated habs in Haberies of their own) rather than openHab's single hab.
+DI2I_SALT = Salter(raw=b'0123456789abcdef').qb64
+OPTIONAL_ISSUEE_SCHEMA = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
+
+
+def anchorApproval(delegator, delegate):
+    """Approve `delegate`'s latest establishment event by anchoring its seal.
+
+    A ``dip`` becomes *validated* delegation only once the delegator anchors an event
+    seal to it on its own trunk; ``app.delegating.Anchorer`` does this in production.
+    The delegate's own Habery accepts its ``dip`` before that happens -- the
+    ``locallyOwned`` arm of the three-way local-source exemption at
+    ``core/eventing.py:3287-3289`` returns from ``validateDelegation`` with no seal
+    lookup at all -- so a fixture that skips this call still yields a Kever with
+    ``delpre`` set. That state is exactly what a DI2I check must not mistake for
+    authority, and it is what the ``unapproved`` hab below is for.
+    """
+    kever = delegate.kever
+    seal = SealEvent(i=kever.prefixer.qb64, s=kever.serder.snh,
+                     d=kever.serder.said)._asdict()
+    delegator.interact(data=[seal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                       gvrsn=Vrsn_1_0)
+
+
+def setupRegistry(hab, regery, name):
+    """Create and anchor a credential registry for `hab` inside `regery`.
+
+    One Regery can hold registries for several habs (they are keyed by prefix), which is
+    what lets the DI2I tests give the root issuer, the QVI and its subgroups a registry
+    each behind a single Verifier.
+    """
+    reg = regery.makeRegistry(prefix=hab.pre, name=name, version=Vrsn_1_0,
+                              kind=Kinds.json)
+    rseal = SealEvent(reg.regk, "0", reg.regd)._asdict()
+    hab.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                 gvrsn=Vrsn_1_0)
+    reg.anchorMsg(pre=reg.regk, regd=reg.regd, seqner=Seqner(sn=hab.kever.sn),
+                  saider=Diger(qb64=hab.kever.serder.said))
+    regery.processEscrows()
+    return reg
+
+
+def makeIssueAndSave(verfer, regery, hab, reg):
+    """Return an issueAndSave closure for `hab` issuing out of registry `reg`.
+
+    Same flow as .setupOperatorFixture's closure, but parameterized by issuer so a test
+    can issue from more than one AID against a single Verifier.
+    """
+    def issueAndSave(creder):
+        try:
+            verfer.processCredential(creder, prefixer=hab.kever.prefixer,
+                                     seqner=Seqner(sn=hab.kever.sn),
+                                     saider=Diger(qb64=hab.kever.serder.said))
+        except MissingRegistryError:
+            pass  # expected: the TEL issuance event is anchored just below
+        iss = reg.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        hab.interact(data=[rseal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
+                     gvrsn=Vrsn_1_0)
+        reg.anchorMsg(pre=iss.pre, regd=iss.said, seqner=Seqner(sn=hab.kever.sn),
+                      saider=Diger(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+        verfer.processEscrows()
+
+    return issueAndSave
+
+
+def makeCred(hab, reg, *, issuee=None, claim="", source=None):
+    """Build a credential issued by `hab` in registry `reg`, targeted at `issuee`."""
+    subject = dict(d="")
+    if issuee is not None:
+        subject["i"] = issuee
+    subject.update(dt=helping.nowIso8601(), claim=claim)
+    _, data = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
+    return credential(issuer=hab.pre, schema=OPTIONAL_ISSUEE_SCHEMA, data=data,
+                      status=reg.regk, source=source if source is not None else {},
+                      rules={}, version=Vrsn_1_0, kind=Kinds.json)
+
+
+def di2iEdge(nodeSaid):
+    """Saidified edge block carrying a single DI2I edge to `nodeSaid`."""
+    _, chain = Saider.saidify(sad=dict(d='', node=dict(n=nodeSaid, o="DI2I")),
+                              code=MtrDex.Blake3_256, label=Saids.d)
+    return chain
+
+
 def test_verifier_list_valued_operator(seeder):
     """A list-valued `o` is a spec-legal spelling and MUST NOT fall to the default.
 
@@ -1150,28 +1237,25 @@ def test_verifier_list_valued_operator(seeder):
         near = nearWithOp(["E1E"], "E1E via list")
         assert verfer.reger.saved.get(keys=near.saidb) is not None
 
-        # The flagship interop case from the review: "o": ["DI2I"] previously resolved
-        # to I2I via the default rule, silently downgrading a delegated-issuer edge to
-        # a strict issuer==issuee one. It must now reach DI2I and fail closed.
-        chainSad = dict(d='', node=dict(n=far.said, o=["DI2I"]))
-        _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
-        subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="di2i in list")
-        _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
-        listDi2i = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
-                              status=ianiss.regk, source=chain, rules={},
-                              version=Vrsn_1_0, kind=Kinds.json)
-        iss = ianiss.issue(said=listDi2i.said)
-        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
-        ian.interact(data=[rseal], framed=True)
-        ianiss.anchorMsg(pre=iss.pre, regd=iss.said,
-                         seqner=Seqner(sn=ian.kever.sn),
-                         saider=Diger(qb64=ian.kever.serder.said))
-        ianreg.processEscrows()
-        with pytest.raises(ValidationError) as excinfo:
-            verfer.processCredential(listDi2i, prefixer=ian.kever.prefixer,
-                                     seqner=Seqner(sn=ian.kever.sn),
-                                     saider=Diger(qb64=ian.kever.serder.said))
-        assert "DI2I" in str(excinfo.value)
+        # The flagship interop case from the review: "o": ["DI2I"] previously resolved to
+        # I2I via the default rule, silently downgrading a delegated-issuer edge to a
+        # strict issuer==issuee one. DI2I now has real semantics
+        # (test_verifier_di2i_delegated_issuer_edge), so what this pins is that the list
+        # form reaches DI2I *as a member of the delegative conflict set*. Here the near
+        # issuer (ian) is neither the far issuee (han) nor a delegate of it, so DI2I
+        # rejects.
+        near = nearWithOp(["DI2I"], "di2i in list")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
+
+        # This pair is the discriminating one. ["DI2I", "NI2I"] -> NI2I wins and accepts,
+        # which a verifier that skipped DI2I as an unrecognized token would also do. But
+        # ["NI2I", "DI2I"] -> DI2I wins and rejects, whereas skipping DI2I would leave
+        # NI2I as the latest recognized operator and wrongly accept. So only the second of
+        # these distinguishes "DI2I took part in latest-wins" from "DI2I was dropped".
+        near = nearWithOp(["DI2I", "NI2I"], "ni2i wins over di2i")
+        assert verfer.reger.saved.get(keys=near.saidb) is not None
+        near = nearWithOp(["NI2I", "DI2I"], "di2i wins over ni2i")
+        assert verfer.reger.saved.get(keys=near.saidb) is None
 
         # NOT is normative (spec L1195: the far node's validity is inverted) and
         # unimplemented here. It must fail closed like DI2I rather than being skipped
@@ -1283,18 +1367,22 @@ def test_verifier_nonconflicting_operators_compose(seeder):
     """End Test"""
 
 
-def test_verifier_di2i_rejects_diagnosably(seeder):
-    """An unimplemented DI2I edge must fail closed *diagnosably*, not vanish.
+def test_verifier_unimplemented_operator_rejects_diagnosably(seeder):
+    """An unimplemented operator must fail closed *diagnosably*, not vanish.
 
-    DI2I previously raised a bare ``NotImplementedError``, which is not a
-    ValidationError, so every caller mishandled it: ``Parser.allParsator``'s blanket
-    ``except (ValidationError, Exception)`` logged and discarded the ACDC, and
-    ``_processEscrow``'s generic arm unescrowed it. Neither produced a signal an
-    operator could act on.
+    Both normative-but-unimplemented operators previously raised a bare
+    ``NotImplementedError``, which is not a ValidationError, so every caller mishandled
+    it: ``Parser.allParsator``'s blanket ``except (ValidationError, Exception)`` logged
+    and discarded the ACDC, and ``_processEscrow``'s generic arm unescrowed it. Neither
+    produced a signal an operator could act on.
 
-    DI2I is still unimplemented -- this test pins the *failure mode*, not the
-    operator semantics. A ValidationError names the cause and stops the retry loop,
-    which is correct here: unlike a missing chain, retrying cannot help.
+    This test pins the *failure mode*, not any operator's semantics. A ValidationError
+    names the cause and stops the retry loop, which is correct here: unlike a missing
+    chain, retrying cannot help.
+
+    Carried on ``NOT`` (#1554), which is still unimplemented. It was originally written
+    against DI2I; DI2I now has real semantics (test_verifier_di2i_delegated_issuer_edge)
+    and no longer raises, so the failure mode moved to the operator that still has none.
     """
     optionalIssueeSchema = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
@@ -1323,9 +1411,9 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         issueAndSave(far)
         assert verfer.reger.saved.get(keys=far.saidb) is not None
 
-        chainSad = dict(d='', node=dict(n=far.said, o="DI2I"))
+        chainSad = dict(d='', node=dict(n=far.said, o="NOT"))
         _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
-        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="di2i edge")
+        subject = dict(d="", i=ian.pre, dt=helping.nowIso8601(), claim="not edge")
         _, sd = Saider.saidify(sad=subject, code=MtrDex.Blake3_256, label=Saids.d)
         near = credential(issuer=ian.pre, schema=optionalIssueeSchema, data=sd,
                           status=ianiss.regk, source=chain, rules={},
@@ -1349,7 +1437,7 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         # Diagnosable: the message names the operator, the far node the edge points to,
         # and the near credential that carried the edge -- an operator triaging a stream
         # needs the last of those to know which credential to fix.
-        assert "DI2I" in str(excinfo.value)
+        assert "NOT" in str(excinfo.value)
         assert far.said in str(excinfo.value)
         assert near.said in str(excinfo.value)
         # Fails closed -- the credential is not saved on the strength of an edge the
@@ -1358,6 +1446,293 @@ def test_verifier_di2i_rejects_diagnosably(seeder):
         # Not a MissingChainError: the chain is present, the operator is unsupported.
         # Escrowing it would promise a retry that can never succeed.
         assert not isinstance(excinfo.value, MissingChainError)
+
+    """End Test"""
+
+
+def test_verifier_di2i_delegated_issuer_edge(seeder):
+    """DI2I: the near issuer must BE the far issuee, or be a *direct* delegate of it.
+
+    ACDC spec-body.md L1194: the near ACDC's issuer must be "either the Issuee AID or a
+    delegated AID" of the far node's issuee -- singular. Direct delegates only, per #1559:
+    GLEIF issues the QVI credential once through an expensive multisig ceremony, and the
+    QVI then delegates to subgroup AIDs that perform routine issuance. The requirement is
+    "any number of children, zero grandchildren" -- a subgroup must not be able to
+    delegate onward and mint new issuers. A transitive reading would actively defeat that,
+    so there is no walk here and no depth bound to disagree about.
+
+    The rows below are the full matrix: satisfied by delegation, satisfied by identity
+    (DI2I is a superset of I2I), and the five ways it must fail.
+    """
+    with openHby(name="di2i", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as hby, \
+            openHby(name="stranger", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as strangerHby:
+        seeder.seedSchema(db=hby.db)
+
+        # gar issues the far node (GLEIF); qvi is the far node's issuee and the delegator.
+        gar = hby.makeHab(name="gar", version=Vrsn_1_0, kind=Kinds.json)
+        qvi = hby.makeHab(name="qvi", version=Vrsn_1_0, kind=Kinds.json)
+        le = hby.makeHab(name="le", version=Vrsn_1_0, kind=Kinds.json)  # near-node issuee
+
+        # sub: an approved direct delegate of qvi -- the issuing subgroup.
+        sub = hby.makeHab(name="sub", delpre=qvi.pre, version=Vrsn_1_0, kind=Kinds.json)
+        anchorApproval(qvi, sub)
+
+        # unapproved: claims qvi as delegator, but qvi never anchored the approval.
+        unapproved = hby.makeHab(name="unapproved", delpre=qvi.pre, version=Vrsn_1_0,
+                                 kind=Kinds.json)
+
+        # rogue: an approved delegate -- but of gar, not of the far node's issuee.
+        rogue = hby.makeHab(name="rogue", delpre=gar.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(gar, rogue)
+
+        # grand: an approved delegate of sub, i.e. qvi's grandchild.
+        grand = hby.makeHab(name="grand", delpre=sub.pre, version=Vrsn_1_0,
+                            kind=Kinds.json)
+        anchorApproval(sub, grand)
+
+        stranger = strangerHby.makeHab(name="stranger", version=Vrsn_1_0, kind=Kinds.json)
+
+        assert gar.kever.delpre is None
+        assert sub.kever.delpre == qvi.pre
+        assert unapproved.kever.delpre == qvi.pre
+        assert rogue.kever.delpre == gar.pre
+        assert grand.kever.delpre == sub.pre
+        assert stranger.pre not in hby.kevers
+
+        # Every dip in this Habery was accepted through the locallyOwned arm of the
+        # three-way local-source exemption (core/eventing.py:3287-3289), which returns from
+        # validateDelegation before any seal lookup -- so none of them has an .aess entry,
+        # approved or not. `delpre` is set for all of them and .aess is empty for all of
+        # them: neither field distinguishes sub from unapproved. The only thing that does
+        # is whether the delegator anchored an approval seal on its own trunk, which is
+        # what the check has to go and look at.
+        for hab in (sub, unapproved, rogue, grand):
+            assert hby.db.aess.get(keys=(hab.pre, hab.kever.lastEst.d)) is None
+
+        regery = Regery(hby=hby, name="di2i", temp=True)
+        garreg = setupRegistry(gar, regery, "gar")
+        qvireg = setupRegistry(qvi, regery, "qvi")
+        subreg = setupRegistry(sub, regery, "sub")
+        grandreg = setupRegistry(grand, regery, "grand")
+
+        verfer = Verifier(hby=hby, reger=regery.reger)
+        garIssue = makeIssueAndSave(verfer, regery, gar, garreg)
+        qviIssue = makeIssueAndSave(verfer, regery, qvi, qvireg)
+        subIssue = makeIssueAndSave(verfer, regery, sub, subreg)
+        grandIssue = makeIssueAndSave(verfer, regery, grand, grandreg)
+
+        # Far node: the QVI credential, gar -> qvi. Its issuee is the AID whose delegates
+        # a DI2I edge to it authorizes.
+        far = makeCred(gar, garreg, issuee=qvi.pre, claim="qvi credential")
+        assert far.iseaid == qvi.pre
+        garIssue(far)
+        assert verfer.reger.saved.get(keys=far.saidb) is not None
+
+        # 1 -- headline. The near issuer is a direct, approved delegate of the far issuee.
+        # This is the case the operator exists for, and the one that was previously
+        # impossible: DI2I raised a ValidationError and the credential was never saved.
+        bySub = makeCred(sub, subreg, issuee=le.pre, claim="issued by subgroup",
+                         source=di2iEdge(far.said))
+        subIssue(bySub)
+        assert verfer.reger.saved.get(keys=bySub.saidb) is not None
+
+        # Having verified the approval seal on qvi's trunk, the check repaired sub's .aess
+        # entry -- the same benign cache repair Kever.fetchDelegatingEvent performs during
+        # escrow processing, guarded on the delegated event already being accepted.
+        assert hby.db.aess.get(keys=(sub.pre, sub.kever.lastEst.d)) is not None
+
+        # 2 -- DI2I is a superset of I2I: "either the Issuee AID or a delegated AID". Easy
+        # to miss by implementing only the delegation half.
+        byQvi = makeCred(qvi, qvireg, issuee=le.pre, claim="issued by qvi itself",
+                         source=di2iEdge(far.said))
+        qviIssue(byQvi)
+        assert verfer.reger.saved.get(keys=byQvi.saidb) is not None
+
+        # 5 -- the direct-only requirement, end to end. grand is an approved delegate of an
+        # approved delegate of the far issuee. If this credential is saved, the
+        # implementation is transitive and "zero grandchildren" is not enforced.
+        byGrand = makeCred(grand, grandreg, issuee=le.pre, claim="issued by grandchild",
+                           source=di2iEdge(far.said))
+        grandIssue(byGrand)
+        assert verfer.reger.saved.get(keys=byGrand.saidb) is None
+
+        # 6 -- an untargeted far node has no issuee, so "delegate of the issuee" is
+        # undefined and there is nothing for the operator to bind to. Resolved through
+        # .iseaid so an aggregate ('A') far node reaches the same guard instead of crashing
+        # on a None attribute section.
+        farUntargeted = makeCred(gar, garreg, claim="untargeted far node")
+        assert farUntargeted.iseaid is None
+        garIssue(farUntargeted)
+        assert verfer.reger.saved.get(keys=farUntargeted.saidb) is not None
+        toUntargeted = makeCred(sub, subreg, issuee=le.pre, claim="to untargeted",
+                                source=di2iEdge(farUntargeted.said))
+        subIssue(toUntargeted)
+        assert verfer.reger.saved.get(keys=toUntargeted.saidb) is None
+
+        # The remaining rows vary only the near ACDC's issuer, which is the single input
+        # DI2I constrains, so they call .verifyChain directly instead of minting a
+        # credential and a registry apiece. A None state is exactly what processCredential
+        # turns into "escrow, do not save" -- cases 5 and 6 above pin that wiring.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+        assert verfer.verifyChain(far.said, "DI2I", issuer=qvi.pre) is not None
+
+        # 3 -- not delegated at all: delpre is None.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=gar.pre) is None
+
+        # 4 -- delegated, but by someone other than the far issuee. An implementation that
+        # checked the truthy `Kever.delegated` flag, or merely that .aess had an entry,
+        # would accept this one.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=rogue.pre) is None
+
+        # 5 at unit level -- the grandchild again, isolated from the issuance flow.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=grand.pre) is None
+
+        # 7 -- the near issuer's KEL is absent from .kevers. Must return None rather than
+        # raise KeyError, which would escape _processEscrow's typed arm and abort the pass.
+        assert verfer.verifyChain(far.said, "DI2I", issuer=stranger.pre) is None
+
+        # 8 -- THE trap. unapproved.delpre == qvi.pre right here in .kevers, so a check
+        # written as `kevers[issuer].delpre == farIssuee` accepts it. But qvi anchored
+        # nothing: the dip was accepted only because this Habery owns it. Nothing was ever
+        # delegated. See test_verifier_di2i_requires_anchored_delegation for why this
+        # matters off the happy path -- the same exemption fires for a witness.
+        assert hby.kevers[unapproved.pre].delpre == qvi.pre
+        assert verfer.verifyChain(far.said, "DI2I", issuer=unapproved.pre) is None
+        # ... and no repair happened, because there was no seal to find.
+        assert hby.db.aess.get(keys=(unapproved.pre, unapproved.kever.lastEst.d)) is None
+
+    """End Test"""
+
+
+def test_verifier_di2i_requires_anchored_delegation(seeder):
+    """A self-asserted `di` must not manufacture issuing authority.
+
+    ``Kevery.validateDelegation`` short-circuits with *no seal lookup whatsoever* when the
+    event is locally owned, locally membered, or locally witnessed
+    (``core/eventing.py:3287-3289``), and the comment above it says so outright: "Witness
+    accepts without waiting for delegation seal to be anchored in delegator's KEL."
+    ``setupWitness`` co-locates a credential ``Verifier`` in that same Habery. So a DI2I
+    check written as ``kevers[issuer].delpre == farIssuee`` would let an operator running a
+    witness pool accept a DI2I edge for *any AID it witnesses* whose claimed delegator
+    never anchored anything -- issuance under authority never granted.
+
+    This test builds precisely that Habery: a witness that has accepted the delegate's
+    ``dip`` through the locallyWitnessed exemption, and that holds the far node in its own
+    credential store so the operator is genuinely evaluated rather than short-circuiting on
+    a missing far node. The edge must be refused. It then delivers the delegator's
+    anchoring event -- and nothing else -- and the same edge must validate. The delta
+    between the two assertions is one interaction event on the delegator's trunk, which is
+    the only thing that ever conferred the authority.
+    """
+    with openHby(name="qvi", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as qviHby, \
+            openHby(name="sub", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as subHby, \
+            openHby(name="wit", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as witHby, \
+            openHby(name="val", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as valHby:
+        seeder.seedSchema(db=qviHby.db)
+        seeder.seedSchema(db=witHby.db)
+
+        qvi = qviHby.makeHab(name="qvi", version=Vrsn_1_0, kind=Kinds.json)
+        wit = witHby.makeHab(name="wit", transferable=False, version=Vrsn_1_0,
+                             kind=Kinds.json)
+
+        # The delegate lives in a Habery of its own and designates wit as a witness. Its
+        # dip is entirely self-asserted -- qvi has approved nothing at this point. What
+        # matters for the exemption is only that wit is *designated*: that is what makes
+        # locallyWitnessed fire in witHby.
+        sub = subHby.makeHab(name="sub", delpre=qvi.pre, wits=[wit.pre], toad=1,
+                             version=Vrsn_1_0, kind=Kinds.json)
+        assert sub.kever.delpre == qvi.pre
+
+        # qvi issues the far node to itself, then -- as its LAST event -- anchors the
+        # approval of sub's dip. Keeping the approval last is what lets the replay below
+        # withhold it while still delivering everything the far node needs.
+        qvireg = Regery(hby=qviHby, name="qvi", temp=True)
+        qviiss = setupRegistry(qvi, qvireg, "qvi")
+        qviverfer = Verifier(hby=qviHby, reger=qvireg.reger)
+        far = makeCred(qvi, qviiss, issuee=qvi.pre, claim="qvi credential")
+        makeIssueAndSave(qviverfer, qvireg, qvi, qviiss)(far)
+        assert qviverfer.reger.saved.get(keys=far.saidb) is not None
+        farSeqner = Seqner(sn=qvi.kever.sn)
+        farSaider = Diger(qb64=qvi.kever.serder.said)
+
+        anchorApproval(qvi, sub)
+        approvalSn = qvi.kever.sn
+        dipSaid = sub.kever.serder.said
+
+        # The witness accepts sub's dip as a local (protected) source, because it is a
+        # designated witness of it -- reached without any cooperation from qvi. A remote
+        # source would be refused as a misfit event precisely because the witness is local
+        # to it (core/eventing.py:2842-2851), so this is the only way in, and it is the way
+        # a real witness pool takes.
+        wit.psr.parse(ims=bytearray(sub.msgOwnInception(framed=True, gvrsn=Vrsn_1_0)))
+        assert sub.pre in witHby.kevers
+        assert witHby.kevers[sub.pre].delpre == qvi.pre   # delpre claims qvi delegated it
+        assert witHby.db.aess.get(keys=(sub.pre, dipSaid)) is None   # on nobody's word
+
+        # The witness receipt, so the disinterested validator at the end of this test sees
+        # a fully witnessed dip and its refusal cannot be blamed on a missing receipt.
+        subReceipt = wit.witness(serder=witHby.kevers[sub.pre].serder, framed=True,
+                                 version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
+
+        # Give the witness everything except qvi's approval: qvi's KEL up to but not
+        # including it, qvi's registry TEL, and the far node's TEL.
+        witreg = Regery(hby=witHby, name="wit", temp=True)
+        witkvy = Kevery(db=witHby.db, lax=False, local=False)
+        wittvy = Tevery(reger=witreg.reger, db=witHby.db, local=False)
+        qviMsgs = [bytearray(msg) for msg
+                   in qviHby.db.clonePreIter(pre=qvi.pre, version=Vrsn_1_0)]
+        assert len(qviMsgs) == approvalSn + 1  # the approval is the last event
+        for msg in qviMsgs[:-1]:               # ... and it is withheld here
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=qviiss.regk):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=far.said):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
+
+        witverfer = Verifier(hby=witHby, reger=witreg.reger)
+        witverfer.processCredential(far, prefixer=qvi.kever.prefixer, seqner=farSeqner,
+                                    saider=farSaider)
+        # The far node really is saved here. Without this the assertion below would pass
+        # vacuously -- .verifyChain returns None for an unknown far node too.
+        assert witverfer.reger.saved.get(keys=far.saidb) is not None
+        assert witHby.kevers[qvi.pre].sn == approvalSn - 1
+
+        # REFUSED. Everything a delpre-based check would look at says "sub is qvi's
+        # delegate"; qvi's trunk says nothing at all.
+        assert witverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is None
+
+        # Now deliver the one withheld event -- qvi's approval -- and nothing else.
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(qviMsgs[-1]), kvy=witkvy, tvy=wittvy)
+        assert witHby.kevers[qvi.pre].sn == approvalSn
+
+        # ACCEPTED. Same Habery, same call, byte-identical ACDCs. The only change is the
+        # approval seal now on the delegator's trunk.
+        assert witverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+        assert witHby.db.aess.get(keys=(sub.pre, dipSaid)) is not None
+
+        # For contrast, the disinterested validator: neither controller nor witness of sub,
+        # so no exemption applies. With the approval withheld it never accepts the dip at
+        # all -- it sits in the delegation escrow and there is no Kever to read a delpre
+        # off, so the DI2I check is never even the thing that stops it. That is why the
+        # witness Habery above is the load-bearing case: there, the exemption gets the dip
+        # accepted anyway. Deliver the approval and the same validator accepts it and
+        # populates .aess by real validation -- no test fixture pinned it.
+        valkvy = Kevery(db=valHby.db, lax=False, local=False)
+        for msg in qviMsgs[:-1]:
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=valkvy)
+        for msg in subHby.db.clonePreIter(pre=sub.pre, version=Vrsn_1_0):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=valkvy)
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(subReceipt), kvy=valkvy)
+        valkvy.processEscrows()
+        assert sub.pre not in valHby.kevers
+        assert valHby.db.aess.get(keys=(sub.pre, dipSaid)) is None
+
+        Parser(version=Vrsn_1_0).parse(ims=bytearray(qviMsgs[-1]), kvy=valkvy)
+        valkvy.processEscrows()
+        assert sub.pre in valHby.kevers
+        assert valHby.kevers[sub.pre].delpre == qvi.pre
+        assert valHby.db.aess.get(keys=(sub.pre, dipSaid)) is not None
 
     """End Test"""
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1051,7 +1051,7 @@ DI2I_SALT = Salter(raw=b'0123456789abcdef').qb64
 OPTIONAL_ISSUEE_SCHEMA = "EAv8omZ-o3Pk45h72_WnIpt6LTWNzc8hmLjeblpxB9vz"
 
 
-def anchorApproval(delegator, delegate):
+def anchorApproval(delegator, delegate, version=Vrsn_1_0, kind=Kinds.json):
     """Approve `delegate`'s latest establishment event by anchoring its seal.
 
     A ``dip`` becomes *validated* delegation only once the delegator anchors an event
@@ -1066,8 +1066,8 @@ def anchorApproval(delegator, delegate):
     kever = delegate.kever
     seal = SealEvent(i=kever.prefixer.qb64, s=kever.serder.snh,
                      d=kever.serder.said)._asdict()
-    delegator.interact(data=[seal], framed=True, version=Vrsn_1_0, kind=Kinds.json,
-                       gvrsn=Vrsn_1_0)
+    delegator.interact(data=[seal], framed=True, version=version, kind=kind,
+                       gvrsn=version)
 
 
 def setupRegistry(hab, regery, name):
@@ -1287,10 +1287,14 @@ def test_verifier_list_valued_operator(seeder):
 def test_verifier_nonconflicting_operators_compose(seeder):
     """A non-delegative operator composes with the delegative winner, not overridden.
 
-    ACDC spec-body.md L1186 scopes latest-wins to "the conflicting Operators". I2I,
-    NI2I and DI2I all constrain the near ACDC's *issuer* relative to the far node's
-    issuee, so they conflict with one another. E1E constrains the near *issuee*, so it
-    conflicts with none of them and must be conjoined (AND).
+    ACDC spec-body.md L1186 scopes latest-wins to "the conflicting Operators" and does
+    not define conflict, so what follows is keripy's reading of it rather than a rule the
+    spec states: I2I, NI2I and DI2I all constrain the near ACDC's *issuer* relative to the
+    far node's issuee, so they conflict with one another, while E1E constrains the near
+    *issuee* and is therefore conjoined (AND). A second implementation could read :1186
+    differently -- I2I and DI2I are simultaneously satisfiable, so a reader may judge them
+    non-conflicting and conjoin them too. Settling that is a spec question, tracked
+    separately from this operator's depth.
 
     Collapsing the whole list to a single operator drops the constraint that loses,
     which is a silent weakening: ``["E1E", "I2I"]`` from a producer requiring both
@@ -1735,9 +1739,9 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
 
         # The witness accepts sub's dip as a local (protected) source, because it is a
         # designated witness of it -- reached without any cooperation from qvi. A remote
-        # source would be refused as a misfit event precisely because the witness is local
-        # to it (core/eventing.py:2842-2851), so this is the only way in, and it is the way
-        # a real witness pool takes.
+        # source would be refused with MisfitEventSourceError precisely because the witness
+        # is local to it, so this is the only way in, and it is the way a real witness pool
+        # takes.
         wit.psr.parse(ims=bytearray(sub.msgOwnInception(framed=True, gvrsn=Vrsn_1_0)))
         assert sub.pre in witHby.kevers
         assert witHby.kevers[sub.pre].delpre == qvi.pre   # delpre claims qvi delegated it
@@ -1748,11 +1752,22 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
         subReceipt = wit.witness(serder=witHby.kevers[sub.pre].serder, framed=True,
                                  version=Vrsn_1_0, kind=Kinds.json, gvrsn=Vrsn_1_0)
 
-        # Give the witness everything except qvi's approval: qvi's KEL up to but not
-        # including it, qvi's registry TEL, and the far node's TEL.
         witreg = Regery(hby=witHby, name="wit", temp=True)
         witkvy = Kevery(db=witHby.db, lax=False, local=False)
         wittvy = Tevery(reger=witreg.reger, db=witHby.db, local=False)
+        witverfer = Verifier(hby=witHby, reger=witreg.reger)
+
+        # Right here the Habery is in the state the delegator-KEL guard exists for: it
+        # holds the delegate, because it witnesses it, and has never seen the delegator at
+        # all. That is a witness's ordinary condition, not a contrived one. The climb reads
+        # the delegator's Kever to check DND, so without its own guard this is a KeyError
+        # on hostile input rather than a refusal -- and KeyError is not a type
+        # processCredential's callers handle.
+        assert qvi.pre not in witHby.kevers
+        assert witverfer._isDelegatedAID(sub.pre, qvi.pre) is False
+
+        # Give the witness everything except qvi's approval: qvi's KEL up to but not
+        # including it, qvi's registry TEL, and the far node's TEL.
         qviMsgs = [bytearray(msg) for msg
                    in qviHby.db.clonePreIter(pre=qvi.pre, version=Vrsn_1_0)]
         assert len(qviMsgs) == approvalSn + 1  # the approval is the last event
@@ -1763,7 +1778,6 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
         for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=far.said):
             Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=witkvy, tvy=wittvy)
 
-        witverfer = Verifier(hby=witHby, reger=witreg.reger)
         witverfer.processCredential(far, prefixer=qvi.kever.prefixer, seqner=farSeqner,
                                     saider=farSaider)
         # The far node really is saved here. Without this the assertion below would pass
@@ -1881,6 +1895,56 @@ def test_verifier_di2i_survives_an_unapproved_delegated_rotation(seeder):
         # An interaction event on top changes nothing either.
         sub.interact()
         assert subverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+
+    """End Test"""
+
+
+def test_verifier_di2i_climbs_v2_and_native_cesr_kels(seeder):
+    """The delegation climb is serialization-independent, at v2 and in native CESR.
+
+    Everything the climb reads -- ``Kever.delpre``, ``Kever.doNotDelegate``, the ``dip``
+    at ``(pre, pre)``, and the delegator's anchoring seal -- is decoded state rather than
+    bytes, so the same verdicts must hold whatever the KEL is serialized as. Worth pinning
+    rather than assuming: the DI2I matrix above is v1 JSON throughout, which is the one
+    point in the variant space where a serialization-sensitive bug would be invisible.
+
+    Unit level on purpose. v2 registry management is stubbed (``keri/acdc/registering.py``
+    and siblings), and ``Regery.makeRegistry`` is v1-only -- ``vcp`` is a v1 ilk -- so a v2
+    far node cannot be issued and .verifyChain cannot be reached end to end at v2 yet.
+    Nothing in the climb touches a registry, so exercising ._isDelegatedAID directly loses
+    no coverage of what this branch changes.
+    """
+    for kind in (Kinds.json, Kinds.cesr):
+        with openHby(name="v2di2i", salt=DI2I_SALT, temp=True, version=Vrsn_2_0) as hby:
+            kwa = dict(version=Vrsn_2_0, kind=kind)
+            qvi = hby.makeHab(name="qvi", **kwa)
+            sub = hby.makeHab(name="sub", delpre=qvi.pre, **kwa)
+            anchorApproval(qvi, sub, version=Vrsn_2_0, kind=kind)
+            grand = hby.makeHab(name="grand", delpre=sub.pre, **kwa)
+            anchorApproval(sub, grand, version=Vrsn_2_0, kind=kind)
+
+            bounded = hby.makeHab(name="bounded", delpre=qvi.pre, DnD=True, **kwa)
+            anchorApproval(qvi, bounded, version=Vrsn_2_0, kind=kind)
+            beyond = hby.makeHab(name="beyond", delpre=bounded.pre, **kwa)
+            anchorApproval(bounded, beyond, version=Vrsn_2_0, kind=kind)
+
+            unapproved = hby.makeHab(name="unapproved", delpre=qvi.pre, **kwa)
+
+            # The v2 dip really is v2, and really is retrievable where the climb looks for
+            # it -- `i` equals `d` for a digest-prefixed inception, so (pre, pre) resolves.
+            dip = hby.db.evts.get(keys=(sub.pre, sub.pre))
+            assert dip is not None
+            assert dip.ilk == Ilks.dip
+            assert dip.pvrsn == Vrsn_2_0
+            assert dip.kind == kind
+
+            verfer = Verifier(hby=hby, reger=Regery(hby=hby, name="v2di2i", temp=True).reger)
+            assert verfer._isDelegatedAID(sub.pre, qvi.pre) is True
+            assert verfer._isDelegatedAID(grand.pre, qvi.pre) is True    # depth
+            assert verfer._isDelegatedAID(bounded.pre, qvi.pre) is True  # DND binds below
+            assert verfer._isDelegatedAID(beyond.pre, qvi.pre) is False  # ... and only below
+            assert verfer._isDelegatedAID(unapproved.pre, qvi.pre) is False
+            assert verfer._isDelegatedAID(qvi.pre, qvi.pre) is False     # no self-loop
 
     """End Test"""
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1737,6 +1737,79 @@ def test_verifier_di2i_requires_anchored_delegation(seeder):
     """End Test"""
 
 
+
+def test_verifier_di2i_survives_an_unapproved_delegated_rotation(seeder):
+    """The delegation relation is fixed at inception and does not move afterwards.
+
+    A `dip` carries `di`; a `drt` does not (core/serdering.py field domains, and KERI
+    spec-body.md's Delegated Rotation field order). So the question DI2I asks -- is the
+    near issuer a delegated AID of the far node's issuee -- is settled once, by the
+    delegator anchoring the `dip`, and no later event can change or renew it.
+
+    An earlier version of ._isApprovedDelegate keyed on ``kever.lastEst.d`` instead,
+    which asked a different question: is the delegate's *current* establishment event
+    approved. That is a real question, but it belongs to the KEL layer, which already
+    refuses an unanchored `drt` for every validator that is not exempted by the
+    locallyOwned/locallyMembered/locallyWitnessed short-circuit in
+    ``Kevery.validateDelegation``. Re-asking it here bought nothing and made a fixed edge
+    an unstable fact: at an exempted Habery the unapproved rotation is accepted locally,
+    ``lastEst`` advances, and every credential the delegate issued while approved flipped
+    to refused.
+
+    This pins the stability. The delegate's own Habery is the exemption used here because
+    ``locallyOwned`` is the one that admits the rotation outright; a witness escrows it
+    instead, so the divergence is not reachable that way.
+    """
+    with openHby(name="qvi", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as qviHby, \
+            openHby(name="sub", salt=DI2I_SALT, temp=True, version=Vrsn_1_0) as subHby:
+        seeder.seedSchema(db=qviHby.db)
+        seeder.seedSchema(db=subHby.db)
+
+        qvi = qviHby.makeHab(name="qvi", version=Vrsn_1_0, kind=Kinds.json)
+        sub = subHby.makeHab(name="sub", delpre=qvi.pre, version=Vrsn_1_0, kind=Kinds.json)
+
+        qvireg = Regery(hby=qviHby, name="qvi", temp=True)
+        qviiss = setupRegistry(qvi, qvireg, "qvi")
+        qviverfer = Verifier(hby=qviHby, reger=qvireg.reger)
+        far = makeCred(qvi, qviiss, issuee=qvi.pre, claim="qvi credential")
+        makeIssueAndSave(qviverfer, qvireg, qvi, qviiss)(far)
+        farSeqner = Seqner(sn=qvi.kever.sn)
+        farSaider = Diger(qb64=qvi.kever.serder.said)
+
+        anchorApproval(qvi, sub)  # qvi approves the dip, and never anchors anything else
+
+        subreg = Regery(hby=subHby, name="sub", temp=True)
+        subkvy = Kevery(db=subHby.db, lax=False, local=False)
+        subtvy = Tevery(reger=subreg.reger, db=subHby.db, local=False)
+        for msg in qviHby.db.clonePreIter(pre=qvi.pre, version=Vrsn_1_0):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=subkvy, tvy=subtvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=qviiss.regk):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=subkvy, tvy=subtvy)
+        for msg in qvireg.reger.clonePreIter(gvrsn=Vrsn_1_0, pre=far.said):
+            Parser(version=Vrsn_1_0).parse(ims=bytearray(msg), kvy=subkvy, tvy=subtvy)
+
+        subverfer = Verifier(hby=subHby, reger=subreg.reger)
+        subverfer.processCredential(far, prefixer=qvi.kever.prefixer, seqner=farSeqner,
+                                    saider=farSaider)
+        assert subverfer.reger.saved.get(keys=far.saidb) is not None
+
+        assert subverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+        estBefore = subHby.kevers[sub.pre].lastEst.s
+
+        # A delegated rotation qvi never anchors. locallyOwned admits it here, so the
+        # delegate's current key state is now one the delegator has not approved.
+        sub.rotate()
+        assert subHby.kevers[sub.pre].lastEst.s != estBefore
+        assert subHby.db.aess.get(keys=(sub.pre, sub.kever.serder.said)) is None
+
+        # Still accepted. The `dip` qvi anchored is what the edge asks about, and the
+        # rotation did not touch it.
+        assert subverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+
+        # An interaction event on top changes nothing either.
+        sub.interact()
+        assert subverfer.verifyChain(far.said, "DI2I", issuer=sub.pre) is not None
+
 def test_verifier_escrow_pass_survives_argless_exception(seeder):
     """One poisoned escrow entry must not abort the whole escrow pass.
 


### PR DESCRIPTION
Implements the ACDC `DI2I` edge operator in `Verifier.verifyChain`.

Per spec-body.md L1194, the near ACDC's issuer must be **either the Issuee AID or a delegated AID** of the far node's issuee. Both halves matter: `DI2I` is a superset of `I2I`, so `issuer == farIssuee` passes outright, which is easy to miss by implementing only the delegation half.

A delegated AID is one at **any depth**. `verifyChain` climbs the issuer's delegation chain looking for the far node's issuee, and stops when it finds it, when it reaches an AID with no delegator, or when a hop fails.

Depth is the delegator's, not the operator's.

An earlier revision of this branch read `DI2I` as direct-delegates-only. @SmithSamuelM corrected that [on 2026-08-02](https://github.com/WebOfTrust/keripy/pull/1564#issuecomment-5158683549), and the correction is what this branch now implements. Direct-only forbids a controller from horizontally scaling through two layers of delegated AIDs, and every other depth would have needed an operator token of its own — which he ruled out in the same comment. I missed this at first because I was not familiar enough with the DND config traits mechanism.

The bound lives at the AID layer instead. A delegator that wants children but not grandchildren puts `DND` in the children's inception events, which it is the one approving. That expresses the bound per AID rather than per edge, it is visible to a validator in the KEL, and it governs delegation that has no ACDC anywhere in sight.

The climb asks 2 things of each hop.

1. The delegator anchored the delegate's `dip`. Not `Kever.delpre`, which records only what the delegate asserted about itself in its own `di` field. `Kevery.validateDelegation` returns early with no seal lookup at all when the delegated event is locally owned, locally membered, or locally witnessed (`core/eventing.py:3269-3271`), and the comment there is explicit that a witness "accepts without waiting for delegation seal to be anchored in delegator's KEL." Since `setupWitness` co-locates a credential `Verifier` in the same Habery, a `delpre`-based check would accept a `DI2I` edge for any AID an operator's witness pool happens to witness whose claimed delegator anchored nothing.

That exemption felt counterintuitive to me, but I now feel its correctness, although my confidence isn't perfect yet. You pointed out on #1559 why, and I want to try to restate it to make sure I got it right. The circularity is what I was missing: if witnesses withheld receipts pending the anchor while delegators withheld the anchor pending full witnessing, neither side moves and the delegator loses the eclipse detection the pool exists to provide. The error was never the witness's. It was a `Verifier` doing a watcher's job against Kevers populated under witness rules. So each hop goes through `Kever.fetchDelegatingEvent(original=False, eager=True)`: the approval source-seal couple in `db.aess`, and failing that an eager walk of the delegator's KEL for the anchoring seal. The eager walk is desirable rather than a fallback — a witness, or the delegate's own controller, has no `aess` entry precisely because of the exemption.

The check keys on the `dip`. `di` appears in a `dip` and in no other event, so the relation is settled once and no later event can change or renew it.

2. The delegator was permitted to delegate at all. `validateDelegation` reaches its `DND` refusal at `core/eventing.py:3287` only after that same exemption has already returned, so an exempted Habery holds `dip`s a disinterested validator never accepted — including ones whose delegator carries `DND`. A delegating seal may ride in an interaction event, which needs nobody's approval, so a `DND`-bound delegate can create a further delegate unilaterally; `DND` is what makes the result worthless, not what stops it being created. Without this check a witness-hosted `Verifier` would honour a chain a watcher-fed one refuses.

This is the one judgment in the diff that I feel least confident about. It fails closed, and `DND` is read from the delegator's own inception event, so the answer never moves. That feels correct to me, but this is making my head hurt a bit, and I might still be misanalyzing.

There is no depth bound, and none is needed. A delegated AID's prefix is a digest of the `dip` that carries its `di`, so a cycle in the chain requires a hash cycle. A bound would also be a conformance seam, letting two conforming validators disagree on identical bytes with nothing on the wire to explain it. The visited set in the loop is a termination guarantee over a corrupt local database; it cannot change the verdict for any well-formed chain.

There's a companion spec change, trustoverip/kswg-acdc-specification#213. It is the qualification I think you asked for, that "a delegated AID" here means any layer of delegation, plus what confirms a hop and where `DND` is read. **This PR should not merge ahead of it**, since otherwise keripy ships a reading the published text does not compel and a second implementer reading L1194 alone would be conformant and would disagree with us.

Here are the tests in the PR:

`test_verifier_di2i_delegated_issuer_edge` is the matrix: thirteen rows over identity, three depths, `DND` at two positions, an unanchored hop at three positions in the chain, an untargeted far node, an issuer absent from `kevers`, and a delegator absent from `kevers`.

`test_verifier_di2i_requires_anchored_delegation` is the one that proves the security property. It builds a witness Habery that accepted the delegate's `dip` through the `locallyWitnessed` exemption and that holds the far node in its own credential store, so the operator is genuinely evaluated rather than short-circuiting on a missing far node. The edge is refused; then the delegator's anchoring event **alone** is delivered and the same call succeeds. The delta between the two assertions is one interaction event on the delegator's trunk.

`test_verifier_di2i_survives_an_unapproved_delegated_rotation` pins that the relation does not move after inception.

`test_verifier_di2i_climbs_v2_and_native_cesr_kels` runs the climb at v2 in both JSON and native CESR. Unit level, because `Regery.makeRegistry` is v1-only and v2 registry management is still stubbed, so a v2 far node cannot be issued yet.

Mutation-checked. Each of these fails at least one assertion: reverting to a `delpre`-only check; refusing to climb; checking the anchor only at the final hop; dropping the `DND` check; checking `DND` only at the final hop; reading `DND` off the delegate instead of the delegator; dropping the I2I-superset arm; deleting the delegator-in-`kevers` guard; keying on `serder.said` instead of the `dip`.

## Deliberately out of scope

- **Revocation and retirement.** Retirement is key-state based: a retired delegate rotates to keys it cannot sign with, so it issues nothing further while everything it issued while authorized stays valid, and the approval seals are byte-identical before and after. A check that tried to detect retirement would both fail and be wrong. Revoking the far node already takes the whole subtree down, at any depth.
- **`NOT` (#1554)** still fails closed with a diagnosable `ValidationError`.
- **The `DID` trait.** keripy reads it nowhere. #1570 settled that it belongs in the delegatee's inception event; the KERI spec correction is owed and is mine.
- **CLI reachability of `DND`.** `kli incept` has no flag for it and `kli delegate confirm` never shows the delegate's config traits, so a single-sig delegator anchors a `dip` without being shown whether `DND` is in it. `kli multisig incept -f` does pass it through, which is the path a vLEI QVI would take. Separate PR.
- **Aggregate far nodes are reasoned, not tested.** Every far node here is attributive. The branch resolves the far issuee via `.iseaid`, which reads `A[1].i` when `a` is absent, so an aggregate far node works by construction; the fixture belongs with #1529's aggregate work.

## Adoption

The deployed vLEI Legal Entity credential's `qvi` edge is `additionalProperties: false` with no `o`, so `"o": "DI2I"` fails schema validation before `verifyChain` is reached. Using the pattern in that ladder needs GLEIF to publish a revised LE edge schema, which cascades SAIDs into the ECR/OOR AUTH schemas that `const`-pin it. Nothing in the applied corpus pins `o` to `DI2I` today, so there is no back-compat constraint on the semantics chosen here — and no second implementation to disagree with them either, which is the argument for settling the spec text now rather than after one exists.

Fixes #1559, in its updated form. (In its original form, it specified the direct-only semantics that were wrong.)
