### PR TITLE
Use bounded ports for xdist tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Use this module to configure pytest
 https://docs.pytest.org/en/latest/pythonpath.html
 
 """
+import errno
 import os
 import shutil
 import socket
@@ -165,28 +166,19 @@ def isolate_keri_store_roots(tmp_path_factory):
             cls.AltHeadDirPath = alt
 
 
-def _unused_tcp_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
 @pytest.fixture(scope="session")
 def unused_tcp_port_factory(tmp_path_factory):
-    """Return a callable that allocates currently free localhost TCP ports."""
+    """Return a callable that allocates currently free TCP listener ports."""
 
-    produced = set()
+    # Keep test listeners below the macOS automatic port range (49152-65535).
+    candidates = iter(range(20000, 30000))
     base = tmp_path_factory.getbasetemp()
     root = base.parent if os.environ.get("PYTEST_XDIST_WORKER") else base
     reservationDir = root / "keripy-port-reservations"
     reservationDir.mkdir(parents=True, exist_ok=True)
 
     def make():
-        for _ in range(100):
-            port = _unused_tcp_port()
-            if port in produced:
-                continue
-
+        for port in candidates:
             try:
                 fd = os.open(reservationDir / f"{port}.lock",
                              os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -194,7 +186,17 @@ def unused_tcp_port_factory(tmp_path_factory):
                 continue
 
             os.close(fd)
-            produced.add(port)
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    sock.bind(("0.0.0.0", port))
+                    sock.listen()
+                except OSError as ex:
+                    if ex.errno == errno.EADDRINUSE:
+                        continue
+                    raise
+
             return port
 
         raise RuntimeError("unable to allocate an unused TCP port")


### PR DESCRIPTION
In this PR:
- Allocate test listener ports from 20000 through 29999 instead of the macOS automatic port range
- Keep atomic reservation files so xdist workers cannot claim the same port
- Probe candidates with the wildcard SO_REUSEADDR bind and listen behavior that HIO uses before returning them
- Skip candidates that another local process already uses
- Validate the five original failures and all three port-heavy modules with pytest 9.1.1, xdist 3.8.0, HIO 0.7.19, and three workers
