### PR TITLE
Add the ward-presents guardianship worked example (sibling to #1530)

### DIFF
--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -8,26 +8,38 @@ ward -- not the guardian -- shows it to the service that gates the act. It is th
 @SmithSamuelM drew in WebOfTrust/keripy discussion #1550, in the diagram "Ward with Single
 Guardian Issues Authorization: Ward to Access Social".
 
-TWO REGIMES, TWO MODULES. #1550 separates them by what the ward can physically do. Before a
-child can operate a device, "any use case where the child is required to present something
-or have something presented on their behalf it must be done by the parents", because the
-parent custodies her keys; the guardian presents ABOUT the ward, and the invariant is
-holder != subject, so a verifier can always tell that a guardian and not the ward is acting.
-That is the sibling, tests/acdc/test_guardianship_presentation.py (PR #1530), whose ward is
-a six-year-old. Once the child can act -- "Its only when the child becomes old enough to
-operate a computer by themselves ... In that case, the Parent would delegate to their child
-attenuated capabilities" -- she holds her own keys and acts as herself, bounded by the
-authorization she carries. That is THIS module, and #1550 assigns Utah's social-media case
-to it explicitly: "the parents' further ability to restrict social media access even for the
-ages 13-18 requires delegated authorization to the child from their parents(s) (guardians)".
-Bob Carver is the custodial parent in both modules -- his six-year-old Mia is the sibling's
-ward, his 14-year-old Cara is this one's.
+TWO REGIMES, TWO MODULES, and the split is statutory. Utah Code 63A-20-302(3)(a): "If an
+individual is unable to apply for a state-endorsed digital identity due to the individual's
+youth or incapacitation, the application may be made on behalf of that individual by the
+individual's digital guardian." A ward who cannot act -- an infant, or an adult who has lost
+capacity -- has a guardian who custodies her keys and presents ABOUT her, and there the
+invariant is holder != subject, so a verifier can always tell that a guardian and not the
+ward is acting. That is the sibling, tests/acdc/test_guardianship_presentation.py (PR
+#1530), whose ward is a seven-year-old. A ward who CAN act holds her own keys and acts as
+herself, bounded by what her guardian has authorized. That is THIS module, and the
+invariant here is attenuation rather than holder != subject. Bob Carver is the custodial
+parent in both -- his seven-year-old Mia is the sibling's ward, his 17-year-old Cara is
+this one's.
 
-Scenario. Utah's social-media law conditions a minor's use of a platform on verified
-parental authorization. Cara operates a phone and can sign, but cannot self-assert
-entitlement to a service her parent gates. So Bob, rather than logging in for her, issues
-her an ACDC saying which routes she may exercise and with which capabilities -- drawn from,
-and no larger than, the authority the State recognized in him -- and she presents it.
+Scenario, under Utah's Minor Protection in Social Media Act (Utah Code 13-71). Cara is 17,
+so she is a "minor" (13-71-101(8): under 18, unemancipated, unmarried), and a social media
+company must run an age assurance system that identifies her as one (13-71-201). Being a
+minor does NOT gate her account: it forces maximum-privacy defaults, limiting visibility,
+sharing and direct messaging to connected accounts (13-71-202). Two platform duties then
+turn on her parent's authority. She may not change those defaults without verifiable
+parental consent (13-71-204(1)), and the supervisory tools she may activate are configured
+by "an individual selected by the Utah minor account holder", who sets daily time limits
+and mandatory breaks (13-71-203). Both are authority Bob holds and Cara exercises, so he
+issues her an ACDC naming the routes, capabilities and daily window she may use -- drawn
+from, and no larger than, what the State recognized in him -- and SHE presents it.
+
+WHAT THIS EXAMPLE DOES NOT CLAIM. 13-71-101(18) defines "verifiable parental consent" as a
+notice ritual running toward the parent: the service gives the parent advance notice of its
+information practices, and receives confirmation that the parent received it. An AuthZ
+credential runs the other way -- a parent-issued, cryptographically verifiable grant the
+ward carries -- so it models the parental AUTHORITY that 13-71-204(1) and 13-71-203 make
+load-bearing, not the statutory consent ceremony. A deployment wanting both would pair
+them; nothing here substitutes for the notice.
 
 Four credentials, all v2 ACDCs, all registry-bound, each validated against a
 purpose-authored JSON Schema (Draft 2020-12):
@@ -67,22 +79,22 @@ RECORDED DIVERGENCE: where the ward AID lives. Sam's diagram puts it in the ATTR
 of (2); the sibling names the ward only by an EDGE. Both preserve holder != subject, so this
 is a DISCLOSURE choice, and the edge form is better on Sam's own argument from #1515 that an
 edge "can also be blinded, which means that disclosure of the edge itself can be held back
-until the verifier (disclosee) has agreed not to exploit its correlatability" -- where an
-attribute in a WHOLE-disclosed credential cannot be held back at all. This module models
-SAM's placement because it is his diagram, and the question is open on #1550; Phase 4 shows
-the argument arriving as an actual leak, since the guardianship's expiry is Cara's 18th
-birthday and cannot be withheld.
+until the verifier (disclosee) has agreed not to exploit its correlatability" -- where a
+whole-disclosed attribute cannot be held back at all. This module models SAM's placement
+because it is his diagram, and the question is open on #1550; Phase 4 shows the argument
+arriving as an actual leak, since the guardianship's expiry is Cara's 18th birthday.
 
 The AuthZ payload is ILLUSTRATIVE and its syntax UNSETTLED. Sam says only that the field
 "contains the specifics of the authorization. The syntax TBD", and points at EVAC (Edge
 Verifiable Agent Control), sketched at the end of #1550 as a resource-capabilities map 'rc'
-of the form {resourceRoute: [capability, ...]}. That is modeled here, plus a time window,
-and no assertion reaches into it (the seam is _authz_capabilities, so a later syntax change
-is one function rather than a rewrite). One constraint on that syntax is not a matter of
-taste, and this example measured it by serializing rather than by arguing: a route written
-as a map LABEL falls under CESR's strict field-label grammar, so "social/feed" cannot be
-serialized in native CESR at all. The measurement, and the recommendation it produces for
-#1550 -- carry the route as a VALUE -- are at AUTHZ_BLOCK_SCHEMA.
+of the form {resourceRoute: [capability, ...]}. That is modeled here, plus the time window
+13-71-203 makes relevant, and no assertion reaches into it (the seam is
+_authz_capabilities, so a syntax change is one function rather than a rewrite). One
+constraint on that syntax is not taste, and this example measured it by serializing rather
+than arguing: a route written as a map LABEL falls under CESR's strict field-label grammar,
+so "social/feed" cannot be serialized in native CESR at all. The measurement, and the
+recommendation it produces for #1550 -- carry the route as a VALUE -- are at
+AUTHZ_BLOCK_SCHEMA.
 
 The negative that earns its place: a guardian cannot delegate more than he holds, so (4)'s
 capability tokens must be a SUBSET of (2)'s 'powers'. Over-reach is a binding property
@@ -131,8 +143,9 @@ def _actor_aid(cur, nxt):
 
 
 # STATE = the Utah state agency that endorses citizens and recognizes guardianships;
-# BOB = the custodial parent (guardian); CARA = the 14-year-old ward; SOCIAL = the
-# social-media platform that must gate a minor's access on parental authorization.
+# BOB = the custodial parent (guardian); CARA = the 17-year-old ward, who holds her own
+# keys; SOCIAL = the social media company, which under 13-71 must identify her as a minor
+# and hold her account to maximum-privacy defaults she cannot change on her own.
 STATE, BOB, CARA, SOCIAL = (_actor_aid(_SIGNERS[i], _SIGNERS[i + 4]) for i in range(4))
 
 # Per-example blinding nonces, derived (not pasted) from a distinct raw prefix so this
@@ -581,11 +594,12 @@ N_WC_ACDC, N_WC_E, N_WC_E_GUARD = 16, 17, 18
 # (4) ward AuthZ social: attribute uuid, acdc uuid, edge-section uuid, two edge uuids.
 N_AZ_A, N_AZ_ACDC, N_AZ_E, N_AZ_E_AUTH, N_AZ_E_SUBJ = 19, 20, 21, 22, 23
 
-# Cara's age at presentation (DOB 2012-04-10, presentation 2026-08-03). The 13-to-18 band
-# is exactly the band Utah's social-media law regulates, and the band in which a ward
-# operates her own device -- which is why the ward presents here and the guardian presents
-# in the sibling, whose ward is six (tests/acdc/test_guardianship_presentation.py).
-CARA_AGE = 14
+# Cara's age at presentation (DOB 2009-04-10, presentation 2026-08-03). 13-71 grades no
+# finer than "minor" (under 18), so her exact age is legally immaterial; what matters is
+# that she operates her own device and holds her own keys, which is why the ward presents
+# here and the guardian presents in the sibling, whose ward is seven
+# (tests/acdc/test_guardianship_presentation.py).
+CARA_AGE = 17
 
 
 def _citizen_registry(kind):
@@ -632,7 +646,7 @@ def _ward_citizen_attr():
     attributes."""
     return dict(d='', u=NONCES[N_WC_A],
                 name=dict(d='', u=NONCES[N_WC_NAME], name="Cara Carver"),
-                dob=dict(d='', u=NONCES[N_WC_DOB], dob="2012-04-10"),
+                dob=dict(d='', u=NONCES[N_WC_DOB], dob="2009-04-10"),
                 residence=dict(d='', u=NONCES[N_WC_RES], residence="Provo UT"))
 
 
@@ -658,19 +672,19 @@ def _guardian_attr(powers=None):
                 # not the date the parental right arose. For a custodial parent the
                 # latter is the ward's birth date, and an authority credential that both
                 # models agree is disclosed WHOLE cannot withhold an attribute -- so an
-                # effectiveDate of 2012-04-10 would hand every verifier Cara's exact
+                # effectiveDate of 2009-04-10 would hand every verifier Cara's exact
                 # birthdate while her own citizen credential was carefully withholding
                 # it. That is the docstring's disclosure argument arriving as a concrete
                 # leak rather than a principle, and it is dodged here rather than
                 # asserted, since a real deployment records the recognition date anyway.
                 effectiveDate="2026-01-06",
                 # Majority: Cara's 18th birthday. This DOES leak her birth month and day
-                # (2030-04-10 minus 18 years), and is left in as an honest residual --
+                # (2027-04-10 minus 18 years), and is left in as an honest residual --
                 # a termination date is load-bearing for a verifier in a way an
                 # effective date is not, so the fix is a coarser expiry (a quarter, a
                 # year) rather than dropping the field, and that is a schema decision
                 # for a deployment rather than something this example should invent.
-                expiryDate="2030-04-10")
+                expiryDate="2027-04-10")
 
 
 def _authz_block():
@@ -750,8 +764,8 @@ def _ward_citizen(kind, guardian=None, reg=None):
     credential, operator NI2I: the near issuee is Cara and the far issuee is Bob, so the
     subjects differ and the edge is a plain reference. The edge is what makes the ward's
     OWN credential declare that it is encumbered -- a verifier reading only Cara's
-    credential learns a guardianship stands over her identity, which is exactly what a
-    service gating a minor needs to know before it looks for an authorization.
+    credential learns a guardianship stands over her identity, which is what tells a
+    platform to look for an authorization before it honors a settings change.
     """
     if guardian is None:
         guardian = _guardian_credential(kind)
@@ -1004,7 +1018,7 @@ def test_wardauthz_credentials_JSON():
     assert guardian.sad['r'] == GUARDIAN_RULES_SAID
     assert guardian.sad['e']['citizen']['n'] == guardianCitizen.said
     assert guardian.sad['e']['citizen']['o'] == 'E1E'
-    assert guardian.said == "ENEm2GEIE0XFi4GqMsHFmCtPracHA5xDn0IRrTXnWjr9"
+    assert guardian.said == "EEFqTgzTDdysCOKfIqRtIzTWYhKkHov16QKXmI0R0BbM"
     assert_acdc_schema_valid(guardian)
 
     # (3) Ward as Citizen Ward: State -> Cara, and its edge is what declares that this
@@ -1016,7 +1030,7 @@ def test_wardauthz_credentials_JSON():
     assert wardCitizen.sad['r'] == WARD_RULES_SAID
     assert wardCitizen.sad['e']['guardian']['n'] == guardian.said
     assert wardCitizen.sad['e']['guardian']['o'] == 'NI2I'
-    assert wardCitizen.said == "EExThcF5yAjSgBXb6QCxWFKsT8PUZliRX64vRRn-mD46"
+    assert wardCitizen.said == "EI8xD7zuclwId0GunRi2e9q92K1oXuGfSo-HwaXaQOAQ"
     assert_acdc_schema_valid(wardCitizen)
 
     # (4) Ward AuthZ Social: BOB -> Cara, in BOB's own registry, two edges.
@@ -1029,7 +1043,7 @@ def test_wardauthz_credentials_JSON():
     assert wardAuthz.sad['e']['authority']['o'] == 'I2I'
     assert wardAuthz.sad['e']['subject']['n'] == wardCitizen.said
     assert wardAuthz.sad['e']['subject']['o'] == 'E1E'
-    assert wardAuthz.said == "EBzcl80p5eNMjk4cg-L-XI-cOrm3oZibqd84bypZloTB"
+    assert wardAuthz.said == "EDccew0We_pDxhtHrEOQcP4DIIBeteqZhaokGb7kXtNi"
     authzSchema = assert_acdc_schema_valid(wardAuthz)
 
     # The payload rides in the attribute block, reached only through the seam so the
@@ -1298,8 +1312,8 @@ def test_wardauthz_presentation_JSON():
                                         [guardian.sad['s']['$id'], "",
                                          ["a/i", "a/ward", "a/powers"]],
                                         [wardCitizen.sad['s']['$id'], "", ["a/i"]]]),
-                     attributes=dict(m="Prove a guardian authorized this minor to use "
-                                       "this service, and show the scope.",
+                     attributes=dict(m="Prove a guardian authorized this minor account "
+                                       "holder's settings, and show the scope.",
                                      g=AUTHZ_RULES_SAID),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
@@ -1315,10 +1329,10 @@ def test_wardauthz_presentation_JSON():
                for _, _, paths in dp for p in paths)
     assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the origin Cara actually holds
     # The guardian's own citizen credential is a node in the DAG and is asked for
-    # nothing: the platform gating a minor has no business learning the parent's name.
+    # nothing: the platform has no business learning the parent's name or residence.
     assert guardianCitizen.sad['s']['$id'] not in [entry[0] for entry in dp]
     assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EOdPg07RtIzlFeSkwX8l5YAatqJLLInpRn-9Ww97Zihn"
+    assert apply.said == "EMeUXBWGbmhe5MvD0DTPD1ckI5MyscpSC92qVzcOJFxk"
 
     # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
     # offering and to the governance ref, and binds the apply. It deliberately does NOT
@@ -1335,9 +1349,9 @@ def test_wardauthz_presentation_JSON():
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
-    assert offer.said == "EL0_DqqsSGKW-t4pjerj-27YHOPnwzOjqmc_eLHsyzKR"
+    assert offer.said == "EHwBEyvCRbsccjyS_UFNHBYbT7tRq8Z_s4jKD9eSc3LQ"
     assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
-    assert b"Cara Carver" not in offer.raw and b"2012-04-10" not in offer.raw
+    assert b"Cara Carver" not in offer.raw and b"2009-04-10" not in offer.raw
     assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
     assert wardCitizen.said.encode() not in offer.raw
     assert guardianCitizen.said.encode() not in offer.raw
@@ -1347,7 +1361,7 @@ def test_wardauthz_presentation_JSON():
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said
-    assert agree.said == "EK2dHqxhGQ7apRiYBMgEDtSw9KtjVji2PMIFwOVXP5w0"
+    assert agree.said == "EIcfwLEL6zJ_4TegWOY30qOYAwq8jCYKlxhaLzXfH6Ea"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1382,7 +1396,7 @@ def test_wardauthz_presentation_JSON():
     # The valid agree unlocks the grant.
     grant = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "EAOQ4viuiQX3R5bQ_7oU-hdfWc8vpKpDVhjwUigWaq98"
+    assert grant.said == "ECPr0RSNH4H__JNu5Bex2TSaMH_bnlb2P3-4C_Pk41wd"
 
     # What the platform receives is exactly what it asked for and no more: the
     # authorization payload, the guardianship's scope, and a binding to Cara.
@@ -1394,14 +1408,14 @@ def test_wardauthz_presentation_JSON():
     assert isinstance(granted['subject']['name'], str)  # ...with every attribute withheld
     assert isinstance(granted['subject']['dob'], str)
     assert b"Cara Carver" not in grant.raw             # name never on the wire
-    assert b"2012-04-10" not in grant.raw              # birthdate never on the wire
+    assert b"2009-04-10" not in grant.raw              # birthdate never on the wire
     assert b"Bob Carver" not in grant.raw              # nor the parent's identity
     # Honest residual, asserted present rather than quietly avoided: the guardianship
     # credential is disclosed WHOLE, so its expiry -- Cara's 18th birthday -- crosses the
     # wire and hands the platform her birth month and day. An attribute in a
     # whole-disclosed authority credential cannot be withheld the way an edge can, which
     # is the disclosure argument of the module docstring showing up as an actual leak.
-    assert b"2030-04-10" in grant.raw
+    assert b"2027-04-10" in grant.raw
     # The withheld blocks still recompute to the section SAID the credential commits to,
     # so the platform can prove the disclosure belongs to Cara's citizen credential.
     check = Compactor(mad=dict(granted['subject'], d=''), makify=True, kind=kind)
@@ -1416,7 +1430,7 @@ def test_wardauthz_presentation_JSON():
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EC5styk29zfJWRUIg4Ku1vIY_8U2nVxIgpxPU7rAnah2"
+    assert admit.said == "EIHZtaug8QZLED1659uJMKchvzttEnE7UmarnwiUOo5y"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -59,10 +59,11 @@ syntax UNSETTLED ("The syntax TBD", #1550), modeled on EVAC's 'rc' map and insul
 _authz_capabilities; the constraint the build measured -- a route cannot be a map LABEL in
 native CESR -- is at AUTHZ_BLOCK_SCHEMA. Over-reach is relational rather than structural, so
 an AuthZ credential exceeding (2)'s 'powers' is schema-valid and only the binding refuses it
-(Phase 3); note 'powers' here is the delegable capability set, where the sibling's statutory
-scope enum is 'scope'. And the altitude is the siblings': the credential graph, edge
-bindings and registry binding at the data-structure level on real v2 primitives, with no
-Habery/keystore and no verifyChain, which needs a live Reger/Tevery.
+(Phase 3); 'powers' here is the DELEGABLE capability set, and it is a different field from
+'scope', the coarse statutory enum that this module and the sibling both carry under that
+one name. And the altitude is the siblings': the credential graph, edge bindings and
+registry binding at the data-structure level on real v2 primitives, with no Habery/keystore
+and no verifyChain, which needs a live Reger/Tevery.
 """
 
 import json
@@ -166,8 +167,8 @@ def _disclosable_block(attr, attr_schema, desc):
     }
 
 
-# acm is a fixed-field format: it always carries (possibly empty) e and r sections even
-# when unused, so the schema must admit them.
+# acm is a fixed-field format: it always carries (possibly empty) e and r sections
+# even when unused, so the schema must admit them.
 _EMPTY_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
 
 
@@ -1259,7 +1260,9 @@ def test_wardauthz_presentation_JSON():
     # nothing is requested from it: the platform has no business knowing Bob's name or
     # where he lives. Entries are therefore a breadth-first-ordered SUBSET of the DAG,
     # and each still names its own schema SAID, so a skipped node cannot shift the
-    # meaning of the entries below it.
+    # meaning of the entries below it. (The sibling's list asks something of every node
+    # its DAG reaches, so it is gapless -- one entry per node. Both are legal; a gap is
+    # only safe because the schema SAID travels with each entry.)
     authzSchemaSaid, _ = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply",
                      modifiers=dict(dp=[[authzSchemaSaid, "",
@@ -1295,6 +1298,16 @@ def test_wardauthz_presentation_JSON():
     # credential): those are stable correlators, and attaching them before the platform
     # agrees would let a platform spurn and walk away with a persistent handle on both
     # the ward and her parent. They arrive only post-agree, in the grant.
+    #
+    # WHAT WITHHOLDING THEM DOES NOT BUY, and the sibling is the contrast that shows it.
+    # The one SAID this offer must commit to is the AuthZ credential's, and that is a
+    # credential Bob issued and Cara keeps: it is identical on every presentation she
+    # ever makes, so a platform that spurns still walks away with a stable handle on her.
+    # The sibling's origin is an envelope its discloser mints for the exchange, so a spurn
+    # there yields a digest never seen again. Decorrelation of the origin is something the
+    # represented shape gets for free and the ward-presents shape would have to buy -- by
+    # minting a per-exchange presentation ACDC that edges to the durable authorization,
+    # rather than offering the durable authorization itself as this example does.
     # Its query block carries `dp` as an EMPTY list: the offer is SOLICITED (its `p`
     # binds the apply), and an empty `dp` means "the same paths the apply asked for"
     # (#1549), so Cara restates nothing and the two messages cannot drift.

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -26,7 +26,8 @@ use, and SHE presents it. NOT claimed: that the ACDC is statutory consent. 13-71
 defines that as a notice ritual running toward the parent, and this runs the other way, so
 it models the parental AUTHORITY those duties rely on rather than the ceremony.
 
-Four credentials, registry-bound, each validated against a purpose-authored JSON Schema:
+Four DURABLE credentials, registry-bound, each validated against a purpose-authored JSON
+Schema, plus a fifth that Cara mints for the exchange itself:
 
   1. Guardian as Citizen  -- State -> Bob.  His own SEDI identity credential.
   2. Guardian as Guardian -- State -> Bob.  The guardianship, carrying the WARD's AID in its
@@ -34,10 +35,15 @@ Four credentials, registry-bound, each validated against a purpose-authored JSON
   3. Ward as Citizen Ward -- State -> Cara. Her identity credential, DECLARING ITSELF
      ENCUMBERED by its edge to (2).
   4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry. Edges to (2) and (3).
+  5. Ward Presentation    -- Cara -> the platform. One-time, NOT registry-bound, minted per
+     exchange: the "bespoke on-the-fly origin" of #1627, with a single edge to (4). It is
+     the DAG's origin, and it is what lets the offer commit to a digest that is never seen
+     again. Phase 4 argues why the shape needs it.
 
-Four edges, four operators, each PINNED by a schema const so a mislabel fails wire
+Five edges, four operators, each PINNED by a schema const so a mislabel fails wire
 validation. Each is argued where it is built; in brief:
 
+  (5)->(4) authz      I2I   near issuer Cara == far issuee Cara: she presents her own.
   (4)->(2) authority  I2I   near issuer Bob == far issuee Bob: Bob held what he delegates.
   (4)->(3) subject    E1E   same subject, different issuers; I2I would demand Bob == Cara.
   (2)->(1) citizen    E1E   same subject again; I2I would demand State == Bob.
@@ -176,11 +182,12 @@ _EMPTY_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
 def _edge_schema(op_const, desc):
     """One edge schema whose operator is PINNED to a single value (const op_const).
 
-    Pinning the operator in the schema is what makes each of this example's four
-    relationships schema-enforced rather than conventional: the I2I authority edge, the
-    two E1E identity edges and the NI2I encumbrance edge cannot be silently swapped for
-    one another without failing wire validation. It also means E1E is never INFERRED --
-    an unlabeled identity edge would default to I2I, which is the wrong answer here.
+    Pinning the operator in the schema is what makes each of this example's five
+    relationships schema-enforced rather than conventional: the two I2I edges (the
+    presentation's and the authority's), the two E1E identity edges and the NI2I
+    encumbrance edge cannot be silently swapped for one another without failing wire
+    validation. It also means E1E is never INFERRED -- an unlabeled identity edge would
+    default to I2I, which is the wrong answer here.
     """
     return {
         "oneOf": [
@@ -513,6 +520,69 @@ AUTHZ_SCHEMA_MAD = {
     "additionalProperties": False,
 }
 
+# --- (5) Ward Presentation: the bespoke, one-time origin Cara mints per exchange. ---
+# Cara -> the platform. NOT registry-bound and deliberately so: a one-time presentation is
+# not a credential whose state anyone revokes, and giving it a registry would create a
+# durable, publicly-observable artifact for something meant to be forgotten. Its single
+# edge is I2I to (4) -- Cara issues it and Cara is the issuee of (4), so the same-holder
+# constraint holds and no new operator is needed (#1627: "each edge from the recipe ACDC
+# can use the I2I edge operator").
+#
+# Its attribute section is FLAT and tiny: the issuee (which platform this presentation is
+# addressed to) and what Cara says she is doing. Flat because there is nothing here worth
+# splitting -- both fields are read together or not at all -- and small because everything
+# a verifier actually binds on lives in the credentials this origin edges to.
+PRESENTATION_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Ward Presentation",
+    "description": "A one-time, bespoke presentation ACDC minted by the WARD for a "
+                   "single exchange and issued to the disclosee. Not registry-bound. "
+                   "Single I2I edge to the delegated authorization she holds; it is the "
+                   "origin node that turns her durable credential into a DAG whose "
+                   "origin digest is never reused.",
+    "credentialType": "WardPresentation",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "s", "a", "e", "r"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer = the WARD (she presents her own)",
+              "type": "string"},
+        "s": {"description": "Schema Section",
+              "oneOf": [{"type": "string"}, {"type": "object"}]},
+        "a": {"description": "What this presentation is (disclosed whole)",
+              "oneOf": [
+                  {"description": "Attribute Section SAID", "type": "string"},
+                  {"type": "object",
+                   "required": ["d", "u", "i", "purpose", "occurredAt"],
+                   "properties": {
+                       "d": {"description": "Section SAID", "type": "string"},
+                       "u": {"description": "Section UUID", "type": "string"},
+                       "i": {"description": "Issuee = the DISCLOSEE's AID: which "
+                                            "platform this presentation is addressed to",
+                             "type": "string"},
+                       "purpose": {"description": "Why the ward is presenting",
+                                   "type": "string"},
+                       "occurredAt": {"type": "string"}},
+                   "additionalProperties": False}]},
+        "e": {"description": "Edge section: I2I to the authorization she holds",
+              "oneOf": [
+                  {"type": "string"},
+                  {"type": "object", "required": ["d", "authz"],
+                   "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                                  "authz": _edge_schema(
+                                      "I2I", "the ward holds this authorization")},
+                   "additionalProperties": False}]},
+        "r": {"description": "SAID of the delegated-authorization governance framework",
+              "type": "string"},
+    },
+    "additionalProperties": False,
+}
+
 # Published governance frameworks, referenced BY SAID rather than authored here. Each is
 # a PLACEHOLDER digest of a description string, standing in for the SAID a real
 # deployment computes over the governance document.
@@ -532,6 +602,9 @@ REG_AUTHZ_STAMP = "2026-07-01T12:00:00.000000+00:00"
 # are reproducible).
 AUTHZ_STAMP = "2026-08-01T09:00:00.000000+00:00"
 APPLY_STAMP = "2026-08-03T18:00:00.000000+00:00"
+# The presentation ACDC is minted between the apply and the offer: Cara reads what was
+# asked for, then mints an origin for THIS exchange.
+PRESENT_STAMP = "2026-08-03T18:00:30.000000+00:00"
 OFFER_STAMP = "2026-08-03T18:01:00.000000+00:00"
 AGREE_STAMP = "2026-08-03T18:02:00.000000+00:00"
 GRANT_STAMP = "2026-08-03T18:03:00.000000+00:00"
@@ -550,6 +623,19 @@ N_WC_A, N_WC_NAME, N_WC_DOB, N_WC_RES = 12, 13, 14, 15
 N_WC_ACDC, N_WC_E, N_WC_E_GUARD = 16, 17, 18
 # (4) ward AuthZ social: attribute uuid, acdc uuid, edge-section uuid, two edge uuids.
 N_AZ_A, N_AZ_ACDC, N_AZ_E, N_AZ_E_AUTH, N_AZ_E_SUBJ = 19, 20, 21, 22, 23
+# (5) ward presentation: attribute uuid, acdc uuid, edge-section uuid, one edge uuid.
+N_PR_A, N_PR_ACDC, N_PR_E, N_PR_E_AUTHZ = 24, 25, 26, 27
+# The IPEX transaction id.
+N_XID = 28
+
+# The exchange's TRANSACTION ID, carried in the 'x' field of every message in the flow.
+# Merged main requires it: IpexHandler.verify (src/keri/acdc/ipexing.py) rejects an apply
+# whose 'x' is empty, and every later message must repeat the same value, which is what
+# binds five separately-signed messages into one exchange rather than five that merely
+# happen to chain by 'p'. The library mints it as the digest of a fresh random nonce
+# (Diger(ser=Noncer().qb64b)); this example pins the nonce so the SAIDs stay reproducible,
+# which is the only difference.
+XID = Diger(ser=NONCES[N_XID].encode()).qb64
 
 # Cara's age at presentation (DOB 2009-04-10, presentation 2026-08-03). 13-71 grades no
 # finer than "minor" (under 18), so her exact age is legally immaterial; what matters is
@@ -773,6 +859,49 @@ def _ward_authz(kind, guardian=None, wardCitizen=None, reg=None, authz=None,
                    kind=kind, compactify=compactify)
 
 
+def _presentation_attr():
+    """The presentation's attribute section (a fresh map each call).
+
+    Two fields and no more, plus the issuee that acdcmap inserts at the top from iseaid.
+    That issuee is the DISCLOSEE -- which platform this presentation is addressed to --
+    and it is the field that makes a captured presentation useless anywhere else.
+    'purpose' says what Cara is doing in her own words, and is written to carry NO part
+    of the answer: it names neither the routes nor the capabilities nor the window, all
+    of which live in (4) and cross only after the platform has agreed.
+    """
+    return dict(d='', u=NONCES[N_PR_A],
+                purpose="Exercise a guardian-authorized change to my own account "
+                        "settings.",
+                occurredAt=PRESENT_STAMP)
+
+
+def _ward_presentation(kind, wardAuthz=None, disclosee=SOCIAL, compactify=False):
+    """(5) Ward Presentation: the one-time origin Cara mints for a single exchange.
+
+    Issuer = CARA, issuee = the disclosee, no registry. One edge, to (4), operator I2I:
+    Cara issues this and Cara is the issuee of (4), so issuer(near) == issuee(far) and the
+    same-holder constraint holds. Sam's #1627 makes exactly this argument for a bespoke
+    origin -- it needs no new operator, no registry and no anchoring, only a signature,
+    because it is used once.
+
+    WHY THIS EXISTS AT ALL, which is the design content of Phase 4. Without it the origin
+    of the presented DAG is (4) itself: a durable credential Bob issued and Cara keeps,
+    identical on every presentation she ever makes. Committing to its SAID in the offer
+    hands a platform that then SPURNS a permanent handle on her. The bespoke origin costs
+    one signature and buys a digest that is never seen again, and the durable SAID moves
+    behind the origin's edge section, which the offer's metadata form withholds.
+    """
+    if wardAuthz is None:
+        wardAuthz = _ward_authz(kind)
+    _, schema = _saidify_schema(dict(PRESENTATION_SCHEMA_MAD), kind=kind)
+    edge = dict(d='', u=NONCES[N_PR_E],
+                authz=dict(d='', u=NONCES[N_PR_E_AUTHZ], n=wardAuthz.said,
+                           s=wardAuthz.sad['s']['$id'], o='I2I'))
+    return acdcmap(israid=CARA, uuid=NONCES[N_PR_ACDC], schema=schema,
+                   attribute=_presentation_attr(), iseaid=disclosee,
+                   edge=edge, rule=AUTHZ_RULES_SAID, kind=kind, compactify=compactify)
+
+
 def _credential_graph(kind, powers=None, authz=None):
     """Build all four credentials in dependency order and return them.
 
@@ -875,20 +1004,47 @@ def _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen,
     return True
 
 
+def _verify_presentation(presentation, wardAuthz, disclosee):
+    """The exchange-level binding on the bespoke origin. Returns True or raises.
+
+    Three checks, and they are about the EXCHANGE rather than about the authority, which
+    is why they live here and not in _verify_authz_chain -- Phases 3 and 5 verify the
+    durable graph with no presentation in sight, exactly as a verifier would when it
+    re-checks a stored disclosure later.
+
+      1. Authz (I2I): the origin's edge names the authorization, with the delegative
+         operator. Whatever else the origin says, the authority it reaches is fixed by a
+         digest its own issuer committed to.
+      2. Same holder: the origin's ISSUER is the authorization's ISSUEE. Cara presents
+         what was issued to Cara. This is the I2I constraint stated as a binding rather
+         than as a label, and it is what stops anyone who merely OBSERVED the
+         authorization from minting an origin over it.
+      3. Addressed to me: the origin's issuee is this disclosee. A presentation captured
+         by one platform cannot be replayed at another, because the origin names the
+         audience and its SAID -- which the whole DAG hangs from -- covers that name.
+    """
+    edge = presentation.sad['e']['authz']
+    assert edge['o'] == 'I2I'
+    assert edge['n'] == wardAuthz.said
+    assert presentation.sad['i'] == wardAuthz.iseaid      # she presents her own
+    assert presentation.iseaid == disclosee               # ...to this platform only
+    return True
+
+
 # ---------------------------------------------------------------------------
-# Phase 1: the four schemas and the helpers that saidify and validate them.
+# Phase 1: the five schemas and the helpers that saidify and validate them.
 # ---------------------------------------------------------------------------
 def test_wardauthz_schemas_JSON():
-    """Phase 1: four purpose-authored Draft 2020-12 schemas, each self-addressed.
+    """Phase 1: five purpose-authored Draft 2020-12 schemas, each self-addressed.
 
     Every ACDC in this example commits to a real schema in its own 's' section, so the
     schemas come first and are asserted here on their own terms: each is a well-formed
-    Draft 2020-12 document, each saidifies to a stable '$id', and the four SAIDs are
+    Draft 2020-12 document, each saidifies to a stable '$id', and the five SAIDs are
     distinct (the ward's citizen credential and the guardian's share an attribute shape
     but are NOT the same schema -- the ward's requires the encumbrance edge, which is
     what a verifier reads to tell them apart).
 
-    The schema is also where the four edge operators are pinned, so the pins are
+    The schema is also where the five edge operators are pinned, so the pins are
     asserted directly rather than only through the credentials that carry them.
     """
     kind = Kinds.json
@@ -896,28 +1052,37 @@ def test_wardauthz_schemas_JSON():
     ggSaid, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
     wcSaid, wcSchema = _saidify_schema(dict(WARD_CITIZEN_SCHEMA_MAD), kind=kind)
     azSaid, azSchema = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
+    prSaid, prSchema = _saidify_schema(dict(PRESENTATION_SCHEMA_MAD), kind=kind)
 
-    for said, schema in ((gcSaid, gcSchema), (ggSaid, ggSchema),
-                         (wcSaid, wcSchema), (azSaid, azSchema)):
+    for said, schema in ((gcSaid, gcSchema), (ggSaid, ggSchema), (wcSaid, wcSchema),
+                         (azSaid, azSchema), (prSaid, prSchema)):
         Draft202012Validator.check_schema(schema)
         assert schema['$id'] == said                # self-addressed, '$id' first
         assert said.startswith('E')                 # Blake3-256 SAID
-    assert len({gcSaid, ggSaid, wcSaid, azSaid}) == 4
+    assert len({gcSaid, ggSaid, wcSaid, azSaid, prSaid}) == 5
     assert gcSaid == "EJVQ1b7CfiAQiq3MB0ffqaM6W3UT_6UW182Hvs9os7dS"
     assert ggSaid == "ENv3zT7Ni1yl8WOE4dIby4thRGXCKrgHMLqG86K1voFd"
     assert wcSaid == "EGg6ihxJmig7CE0cFSuxdQF6Gl4ByVTQqP5qYK8R6bW6"
     assert azSaid == "EP_6kA4inOsIK6DjNEy_qEPUF-vTExbfda1R_NgcPBVo"
+    assert prSaid == "EIn0_3g87vZCRjiP3D19mY8XLddtblRysjcGrahk4jAN"
 
-    # The four operator pins, read straight off the schemas. Each edge property's 'o'
+    # The five operator pins, read straight off the schemas. Each edge property's 'o'
     # is a const, so the operator is part of the shape rather than a convention.
     def pinned(schema, edgeName):
         return schema['properties']['e']['oneOf'][1]['properties'][edgeName][
             'oneOf'][1]['properties']['o']['const']
 
+    assert pinned(prSchema, 'authz') == 'I2I'       # (5) -> (4), same-holder
     assert pinned(azSchema, 'authority') == 'I2I'   # (4) -> (2), same-holder
     assert pinned(azSchema, 'subject') == 'E1E'     # (4) -> (3), identity
     assert pinned(ggSchema, 'citizen') == 'E1E'     # (2) -> (1), identity
     assert pinned(wcSchema, 'guardian') == 'NI2I'   # (3) -> (2), reference
+
+    # The presentation is the one schema that does NOT require a registry: a one-time
+    # origin has no state anyone revokes, so binding it to a registry would publish a
+    # durable artifact for something meant to be used once and forgotten.
+    assert 'rd' in ggSchema['required'] and 'rd' in azSchema['required']
+    assert 'rd' not in prSchema['required']
 
     # The AuthZ payload is illustrative and its syntax unsettled, so the block is
     # deliberately OPEN: an unknown sibling of 'rc' validates, and a later syntax can
@@ -951,6 +1116,10 @@ def test_wardauthz_credentials_JSON():
     against its own schema; that the ward's citizen credential declares its encumbrance;
     and that the schema has teeth -- an unrecognized capability, an empty powers list
     and a missing encumbrance edge are each rejected.
+
+    The bespoke presentation (5) is built here too, so its shape sits next to the four it
+    depends on, but it is a Phase 4 object: Cara mints one per exchange, it binds to no
+    registry, and what it is FOR is argued where it is used.
     """
     kind = Kinds.json
     guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
@@ -1008,6 +1177,26 @@ def test_wardauthz_credentials_JSON():
     assert _authz_capabilities(wardAuthz.sad['a']['authz']) == {"read", "post",
                                                                 "message"}
 
+    # (5) Ward Presentation: CARA -> the platform, NO registry, one I2I edge to (4). It
+    # is built here so its shape is asserted alongside the durable four, but it belongs
+    # to Phase 4 -- it is minted per exchange and the argument for it lives there.
+    presentation = _ward_presentation(kind, wardAuthz=wardAuthz)
+    assert presentation.sad['i'] == CARA             # the ward issues her own origin...
+    assert presentation.iseaid == SOCIAL             # ...addressed to one platform
+    assert 'rd' not in presentation.sad              # one-time: no registry at all
+    assert presentation.sad['r'] == AUTHZ_RULES_SAID
+    assert presentation.sad['e']['authz']['n'] == wardAuthz.said
+    assert presentation.sad['e']['authz']['o'] == 'I2I'
+    assert _i2i_holds(presentation, wardAuthz)       # issuer Cara == issuee Cara
+    assert presentation.said == "ECUgc001shq7dIF86UNgJq4fLkYECmlHB6DcOrj22YP6"
+    assert_acdc_schema_valid(presentation)
+    assert _verify_presentation(presentation, wardAuthz, SOCIAL)
+    # It says nothing about the authorization it reaches: routes, capabilities and window
+    # are all behind the edge, in (4). That is what lets its metadata form ride on an
+    # offer without disclosing anything (Phase 4).
+    assert set(presentation.sad['a']) == {'d', 'u', 'i', 'purpose', 'occurredAt'}
+    assert "social_" not in json.dumps(presentation.sad['a'])
+
     # A private ACDC: the compact and expanded forms share one SAID, so a ward can hand
     # over the compact form and expand only what a verifier has agreed to receive.
     compact = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
@@ -1016,6 +1205,16 @@ def test_wardauthz_credentials_JSON():
     assert isinstance(wardAuthz.sad['e'], dict)      # sections inline...
     assert isinstance(compact.sad['e'], str)         # ...vs collapsed to a SAID
     assert_acdc_schema_valid(compact, schema=authzSchema)
+
+    # The presentation compacts the same way, and its compact form is what rides on the
+    # offer: same SAID, both sections collapsed to bare SAIDs. So an offer that commits
+    # to this origin discloses neither the purpose nor -- the point -- the SAID of the
+    # durable authorization its edge names.
+    compactPresentation = _ward_presentation(kind, wardAuthz=wardAuthz, compactify=True)
+    assert compactPresentation.said == presentation.said
+    assert isinstance(compactPresentation.sad['a'], str)
+    assert isinstance(compactPresentation.sad['e'], str)
+    assert wardAuthz.said not in json.dumps(compactPresentation.sad)
 
     # --- Schema teeth. ---
     # A capability outside the vocabulary is rejected in the AuthZ payload...
@@ -1253,21 +1452,21 @@ def _far(byDigest, near, label):
     return byDigest[said]
 
 
-def _platform_accepts_grant(grantStream, offeredOrigin):
+def _platform_accepts_grant(grantStream, offeredOrigin, disclosee=SOCIAL):
     """The platform's grant-time verification, run on WHAT CAME OFF THE WIRE.
 
     Returns True or raises. Takes the signed grant STREAM -- body plus attachments --
     and nothing else, so there is no way for a credential the platform already held to
     stand in for one it was sent.
 
-    Four things happen in order:
+    Five things happen in order:
 
       1. Parse. Every nested artifact is reaped and self-verified as it is parsed: the
          SAID is recomputed over the disclosed content, using most-compact-form
          semantics so a partial disclosure verifies to the same 'd' as the full
          credential. A tampered payload dies here, and takes the whole stream with it.
-      2. Confirm the origin is the credential the OFFER committed to. Without this the
-         platform could be handed a different, perfectly valid authorization than the
+      2. Confirm the origin is the artifact the OFFER committed to. Without this the
+         platform could be handed a different, perfectly valid presentation than the
          one whose terms it agreed to -- terms follow the data.
       3. WALK THE DAG from that origin to find every other node, edge by edge, matching
          each edge's digest against the parsed artifacts. This is what the `o` field
@@ -1276,7 +1475,11 @@ def _platform_accepts_grant(grantStream, offeredOrigin):
          authority and which is the subject. It reads that from the origin's own edges,
          which the origin's issuer committed to. A substituted far node breaks the
          digest that names it.
-      4. Run the seven-check binding on the artifacts that walk produced.
+      4. Bind the origin itself: it must be Cara's, and it must be addressed to THIS
+         platform. A one-time origin only decorrelates; it does not authenticate, and
+         the audience check is what keeps a captured presentation from being replayed
+         somewhere else.
+      5. Run the seven-check binding on the authorization the walk reached.
 
     A complete verifier adds registry status (walk each 'rd' TEL for a revocation) and
     the Layer-2 question of whether the guardianship's issuer is competent to recognize
@@ -1293,11 +1496,13 @@ def _platform_accepts_grant(grantStream, offeredOrigin):
     assert result.serder.sad['a']['o'] == [offeredOrigin]   # terms follow the data
     byDigest = {nest.serder.said: nest.serder for nest in result.nests}
 
-    origin = byDigest[offeredOrigin]
-    authority = _far(byDigest, origin, 'authority')         # AuthZ -I2I-> guardianship
-    subject = _far(byDigest, origin, 'subject')             # AuthZ -E1E-> ward citizen
+    origin = byDigest[offeredOrigin]                        # the bespoke presentation
+    authz = _far(byDigest, origin, 'authz')                 # presentation -I2I-> AuthZ
+    authority = _far(byDigest, authz, 'authority')          # AuthZ -I2I-> guardianship
+    subject = _far(byDigest, authz, 'subject')              # AuthZ -E1E-> ward citizen
     guardianId = _far(byDigest, authority, 'citizen')       # guardianship -E1E-> Bob's
-    return _verify_authz_chain(origin, authority, subject, guardianId)
+    assert _verify_presentation(origin, authz, disclosee)
+    return _verify_authz_chain(authz, authority, subject, guardianId)
 
 
 def test_wardauthz_presentation_JSON():
@@ -1316,14 +1521,29 @@ def test_wardauthz_presentation_JSON():
     authorizing her is himself a state-endorsed person, and what routes and capabilities
     she holds. It learns neither person's name, birthdate or residence.
 
+    ONE EXCHANGE, NOT FIVE CHAINED MESSAGES. Every message carries the same transaction
+    id in its 'x' field, minted with the apply that opens the flow, so the five are bound
+    into one exchange rather than merely linked pairwise by 'p'. Merged main enforces it:
+    an apply whose 'x' is empty is rejected outright (IpexHandler.verify in
+    src/keri/acdc/ipexing.py), and every reply must repeat the opener's value.
+
+    CARA MINTS AN ORIGIN. The DAG she presents is rooted in a one-time presentation ACDC
+    (5) she issues to the platform for this exchange alone, edged I2I to the durable
+    authorization. The offer then commits to a digest nobody will ever see again, and the
+    authorization's own SAID stays behind that origin's compacted edge section until the
+    platform agrees. Without it, the offer's commitment IS the durable credential's SAID
+    -- the same value on every presentation Cara ever makes -- so a platform that spurns
+    still walks away with a permanent handle on her.
+
     THE EXCHANGE ENDS IN A VERIFICATION OF WHAT WAS TRANSMITTED. _platform_accepts_grant
     reconstructs every disclosed artifact from the grant body, recomputes its SAID over
-    the disclosed content, confirms the origin is the credential the offer committed to,
-    and only then runs the seven-check binding on the reconstructed objects. Three
-    negatives hold it honest: a substituted authority credential, an origin other than
-    the one offered, and a tampered payload are each refused. A presentation example
-    that verifies credentials it already had in scope proves nothing about the wire, and
-    every one of those negatives would pass unnoticed if it did.
+    the disclosed content, confirms the origin is the artifact the offer committed to,
+    and only then runs the bindings on the reconstructed objects. Four negatives hold it
+    honest: a substituted authority credential, an origin other than the one offered, a
+    tampered payload, and a presentation replayed at a platform it was not addressed to
+    are each refused. A presentation example that verifies credentials it already had in
+    scope proves nothing about the wire, and every one of those negatives would pass
+    unnoticed if it did.
     """
     kind = Kinds.json
     guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
@@ -1376,25 +1596,37 @@ def test_wardauthz_presentation_JSON():
     # path reaching a non-origin ACDC must cross the edge that links it -- the virtual
     # '_' component, standing for the jump from the near-side edge block to the top level
     # of the far-side ACDC (#1549). The same request written with non-empty prefixes:
-    #     origin:           "/"                          ["i", "a/i", "a/authz", "e"]
-    #     guardianship:     "/e/authority/_/"            ["i", "a", "e"]
-    #     ward citizen:     "/e/subject/_/"              ["a/i", "e"]
-    #     guardian citizen: "/e/authority/_/e/citizen/_/" ["a/i"]
+    #     presentation:     "/"                            ["i", "a", "e"]
+    #     authorization:    "/e/authz/_/"                  ["i", "a/i", "a/authz", "e"]
+    #     guardianship:     "/e/authz/_/e/authority/_/"    ["i", "a", "e"]
+    #     ward citizen:     "/e/authz/_/e/subject/_/"      ["a/i", "e"]
+    #     guardian citizen: "/e/authz/_/e/authority/_/e/citizen/_/"  ["a/i"]
     #
-    # The zeroth entry is the DAG's origin node (#1549). Here the origin is the AuthZ
-    # credential itself -- Cara presents a credential she HOLDS, so unlike the sibling
-    # examples the origin is not an envelope she issues. Its schema is still something
-    # the platform knows in advance, and for a stronger reason than usual: the platform
-    # is the resource the authorization is ABOUT, so the shape of the authorization it
-    # will accept is its own published requirement (@SmithSamuelM, #1542, on the
-    # applicant knowing the origin schema).
+    # The zeroth entry is the DAG's origin node (#1549). Here that is the BESPOKE
+    # PRESENTATION Cara mints for this exchange, not the authorization itself -- the
+    # reason is decorrelation and it is argued at the offer, which is where the cost of
+    # the alternative falls. Its schema is something the platform knows in advance, and
+    # for two reasons: the platform is the resource the authorization is ABOUT, so the
+    # shape it will accept is its own published requirement (@SmithSamuelM, #1542, on
+    # the applicant knowing the origin schema); and a bespoke origin is one-time only in
+    # its INSTANCES -- "the schema of the bespoke ACDC, however, is not one-time use. It
+    # acts as a permanent recipe" (#1627), which is what makes it requestable at all.
     #
     # WHAT THE PLATFORM ASKS FOR IS EXACTLY WHAT ITS BINDING NEEDS, and the discipline
-    # that produces this list is to walk _verify_authz_chain's seven checks and ask what
-    # each one reads. Anything the binding does not read is not requested; anything it
-    # does read must be requested, or the check cannot run on what arrives.
+    # that produces this list is to walk the two bindings -- _verify_presentation's three
+    # checks and _verify_authz_chain's seven -- and ask what each one reads. Anything the
+    # bindings do not read is not requested; anything they do read must be requested, or
+    # the check cannot run on what arrives.
     #
-    #   origin (AuthZ)   ["i", "a/i", "a/authz", "e"]
+    #   presentation     ["i", "a", "e"]
+    #       the issuer, for the same-holder check; the attribute section, whose issuee is
+    #       the audience check; and the edge section, without which the platform cannot
+    #       reach the authorization at all. The attribute section is asked for WHOLE for
+    #       the same reason the guardianship's is -- it is flat, so it discloses whole or
+    #       as one bare SAID and there is nothing in between. Here that costs one field
+    #       the binding does not read, the purpose, and it is written (_presentation_attr)
+    #       to carry no part of the answer precisely because it cannot be withheld.
+    #   authorization    ["i", "a/i", "a/authz", "e"]
     #       issuer and issuee for checks (1), (2) and (5); the payload for (6); and the
     #       EDGE SECTION, without which the platform cannot walk to any other node --
     #       every one of checks (1)-(4) reads an edge digest.
@@ -1422,8 +1654,11 @@ def test_wardauthz_presentation_JSON():
     # that node. The privacy point survives in the honest form: ask for the issuee, not
     # the person.
     authzSchemaSaid, _ = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
-    apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply",
-                     modifiers=dict(dp=[[authzSchemaSaid, "",
+    presentSchemaSaid, _ = _saidify_schema(dict(PRESENTATION_SCHEMA_MAD), kind=kind)
+    apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply", xid=XID,
+                     modifiers=dict(dp=[[presentSchemaSaid, "",
+                                         ["i", "a", "e"]],
+                                        [authzSchemaSaid, "",
                                          ["i", "a/i", "a/authz", "e"]],
                                         [guardian.sad['s']['$id'], "",
                                          ["i", "a", "e"]],
@@ -1436,68 +1671,114 @@ def test_wardauthz_presentation_JSON():
                                      ax=[False]),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
+    # The apply OPENS the flow, so it mints the transaction id and carries no prior.
+    assert apply.sad['x'] == XID and apply.sad['p'] == ""
+    assert apply.sad['ri'] == CARA              # ...and names its receiver explicitly
     dp = apply.sad['q']['dp']
-    assert [entry[0] for entry in dp] == [authzSchemaSaid, guardian.sad['s']['$id'],
+    assert [entry[0] for entry in dp] == [presentSchemaSaid, authzSchemaSaid,
+                                          guardian.sad['s']['$id'],
                                           wardCitizen.sad['s']['$id'],
                                           guardianCitizen.sad['s']['$id']]
     assert all(len(entry) == 3 for entry in dp)       # (schemaSAID, prefix, [paths])
-    assert [entry[1] for entry in dp] == ["", "", "", ""]  # no prefixes: paths relative
-    assert dp[0][2] == ["i", "a/i", "a/authz", "e"]   # origin: who, to whom, what, edges
-    assert dp[1][2] == ["i", "a", "e"]                # guardianship: flat 'a', so whole
-    assert dp[2][2] == ["a/i", "e"]                   # ward citizen: binding + encumbrance
-    assert dp[3][2] == ["a/i"]                        # guardian citizen: the issuee alone
+    assert [entry[1] for entry in dp] == ["", "", "", "", ""]  # no prefixes: paths relative
+    assert dp[0][2] == ["i", "a", "e"]                # origin: who, flat 'a', edges
+    assert dp[1][2] == ["i", "a/i", "a/authz", "e"]   # authz: who, to whom, what, edges
+    assert dp[2][2] == ["i", "a", "e"]                # guardianship: flat 'a', so whole
+    assert dp[3][2] == ["a/i", "e"]                   # ward citizen: binding + encumbrance
+    assert dp[4][2] == ["a/i"]                        # guardian citizen: the issuee alone
     assert all(not p.startswith("/") and not p.endswith("/")
                for _, _, paths in dp for p in paths)
-    assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the origin Cara actually holds
-    # Every node the binding reads is asked for, and every node in the DAG is a node the
-    # binding reads -- so the request covers the DAG exactly.
-    assert len(dp) == 4
+    assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the credential Cara holds...
+    assert presentSchemaSaid != authzSchemaSaid           # ...under an origin she mints
+    # Every node the bindings read is asked for, and every node in the DAG is a node the
+    # bindings read -- so the request covers the DAG exactly.
+    assert len(dp) == 5
     assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'ax'}
     assert 'g' not in apply.sad['a']            # governance lives in ACDC rules
     assert apply.sad['a']['ax'] == [False]      # unanchored exchange (#1613, #1627)
-    assert apply.said == "EM852Md0tpcxzoLO_ecuWlgZl-M_C7nnVC8gM2NUbJG-"
+    assert apply.said == "ELolLgcJkRPfrownK6b8NMRpD-tOJ0sFhxsh_g2mA2Kt"
 
-    # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
-    # offering, and binds the apply. It deliberately does NOT
-    # enumerate the issuer-committed source SAIDs (the guardianship, either citizen
-    # credential): those are stable correlators, and attaching them before the platform
-    # agrees would let a platform spurn and walk away with a persistent handle on both
-    # the ward and her parent. They arrive only post-agree, in the grant.
+    # 2. offer (Cara -> platform): Cara mints the origin, commits to its SAID in 'o', and
+    # attaches that origin's METADATA FORM as a nested artifact. That is the shape merged
+    # main builds and validates -- ipexing.offer() takes the origin, writes its SAID to
+    # 'a.o' and nests the artifact, and IpexHandler.verify refuses an offer whose first
+    # nest does not recompute to 'o'. The V1 'acdc' label this example used to carry is
+    # gone (#1629); the SAID it named now rides as the origin of a DAG rather than as a
+    # bare credential reference.
     #
-    # WHAT WITHHOLDING THEM DOES NOT BUY, and the sibling is the contrast that shows it.
-    # The one SAID this offer must commit to is the AuthZ credential's, and that is a
-    # credential Bob issued and Cara keeps: it is identical on every presentation she
-    # ever makes, so a platform that spurns still walks away with a stable handle on her.
-    # The sibling's origin is an envelope its discloser mints for the exchange, so a spurn
-    # there yields a digest never seen again. Decorrelation of the origin is something the
-    # represented shape gets for free and the ward-presents shape would have to buy -- by
-    # minting a per-exchange presentation ACDC that edges to the durable authorization,
-    # rather than offering the durable authorization itself as this example does.
-    # Its query block carries `dp` as an EMPTY list: the offer is SOLICITED (its `p`
+    # WHY THE ORIGIN IS MINTED RATHER THAN HELD, which is the decorrelation this shape
+    # would otherwise have to do without. Offering the durable authorization directly
+    # means committing to a SAID Bob issued and Cara keeps -- identical on every
+    # presentation she ever makes, so a platform that spurns walks away with a permanent
+    # handle on her. The sibling (#1530) never has this problem, because its origin is an
+    # envelope its discloser mints for the occasion. Here the envelope costs one extra
+    # signature and buys the same property: this offer commits to a digest that exists
+    # for one exchange.
+    #
+    # THE METADATA FORM IS WHAT MAKES THAT WORTH ANYTHING. The origin rides COMPACTIFIED
+    # -- attribute and edge sections collapsed to bare SAIDs -- so the offer discloses
+    # neither the purpose nor, decisively, the authorization SAID the edge section names.
+    # A fully-disclosed origin would put the durable correlator back on the wire and undo
+    # the whole point. What the platform CAN read pre-agree is the origin's schema and
+    # its rules SAID, which is exactly Sam's rationale for the metadata origin on #1629:
+    # the disclosee has to be able to agree to terms it can see, and the schema named in
+    # 'dp' does not carry the rule detail. Those terms are the AuthZ governance framework,
+    # published in the ACDC's own 'r' section rather than restated on the exchange
+    # (@ryan-hansen, #1595) -- so the two review points compose: governance belongs in the
+    # rules, and the metadata origin is how the disclosee sees it before it agrees.
+    #
+    # The issuer-committed source SAIDs (the guardianship, either citizen credential) stay
+    # off the offer entirely. Those are stable correlators on Cara AND on Bob, and they
+    # arrive only post-agree, in the grant.
+    #
+    # The query block carries `dp` as an EMPTY list: the offer is SOLICITED (its `p`
     # binds the apply), and an empty `dp` means "the same paths the apply asked for"
     # (#1549), so Cara restates nothing and the two messages cannot drift.
+    presentation = _ward_presentation(kind, wardAuthz=wardAuthz)
+    offerOrigin = _ward_presentation(kind, wardAuthz=wardAuthz, compactify=True)
+    assert offerOrigin.said == presentation.said       # same origin, less of it
     offer = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/offer", prior=apply.said,
-                     modifiers=dict(dp=[]),
-                     attributes=dict(acdc=wardAuthz.said, ax=[False]),
+                     xid=XID, modifiers=dict(dp=[]),
+                     attributes=dict(m="Here is the presentation you asked for.",
+                                     o=[presentation.said], ax=[False]),
                      stamp=OFFER_STAMP, kind=kind)
-    assert offer.sad['p'] == apply.said
+    caraSigner = _SIGNERS[2]                           # the ward's establishing key
+    offerStream = messagize(offer, sigers=[caraSigner.sign(ser=offer.raw, index=0)],
+                            nests=[_nest(offerOrigin)], framed=False, gvrsn=Vrsn_2_0)
+    assert offer.sad['p'] == apply.said and offer.sad['x'] == XID
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
     assert 'governance' not in offer.sad['a']          # ...and not on the exchange
-    assert set(offer.sad['a']) == {'acdc', 'ax'}
+    assert 'acdc' not in offer.sad['a']                # the V1 label is gone (#1629)
+    assert set(offer.sad['a']) == {'m', 'o', 'ax'}
+    assert offer.sad['a']['o'] == [presentation.said]
     assert offer.sad['a']['ax'] == [False]             # Cara agrees: no anchoring
-    assert offer.said == "EJLOZ700VVkuvhSEt2bilW3PLJhleyYwv2fCPlL9YPX1"
-    assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
-    assert b"Cara Carver" not in offer.raw and b"2009-04-10" not in offer.raw
-    assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
-    assert wardCitizen.said.encode() not in offer.raw
-    assert guardianCitizen.said.encode() not in offer.raw
+    assert offer.said == "EBfw_jTVTW2K4wJ6zcjFR1RqjjtJeA_KY2-52ZXOzP01"
+
+    # What the platform can read off the offer, decoded rather than grepped -- the nested
+    # body rides Texter-encoded, so a substring check on the raw stream proves nothing.
+    offerParsed = Parser(version=Vrsn_2_0).parse(ims=bytearray(offerStream), framed=False,
+                                                 processive=False)[0]
+    assert [nest.serder.said for nest in offerParsed.nests] == [presentation.said]
+    offerDecoded = bytes(offer.raw) + b"".join(bytes(nest.serder.raw)
+                                               for nest in offerParsed.nests)
+    assert presentation.said.encode() in offerDecoded  # the origin, and a one-time one
+    assert AUTHZ_RULES_SAID.encode() in offerDecoded   # the terms, visible pre-agree
+    # ...and nothing durable. The authorization's SAID is behind the origin's compacted
+    # edge section, so a platform that spurns here holds a digest and no correlator.
+    assert wardAuthz.said.encode() not in offerDecoded
+    assert guardian.said.encode() not in offerDecoded
+    assert wardCitizen.said.encode() not in offerDecoded
+    assert guardianCitizen.said.encode() not in offerDecoded
+    assert b"Cara Carver" not in offerDecoded and b"2009-04-10" not in offerDecoded
+    assert b"Exercise a guardian-authorized" not in offerDecoded   # purpose withheld too
 
     # 3. agree (platform -> Cara): acceptance, binding the offer SAID and signed by the
     # platform (via messagize -- the blessed genus-aware attachment path).
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
+                     xid=XID, attributes=dict(m="Agreed; disclose."),
                      stamp=AGREE_STAMP, kind=kind)
-    assert agree.sad['p'] == offer.said
-    assert agree.said == "EKv6Wm_IKLWjiJu5EpO_GB-goYAN-00poXEKjlxuLGuH"
+    assert agree.sad['p'] == offer.said and agree.sad['x'] == XID
+    assert agree.said == "ED4HHuzIAKtzEytlcUd1XssGiw8WDiZrK9ZwzCnctgI7"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1515,17 +1796,21 @@ def test_wardauthz_presentation_JSON():
     # THE DISCLOSED ARTIFACTS DO NOT RIDE IN 'a'. The attribute block carries only the
     # origin, and the credentials themselves are nested attachments on the signed grant
     # stream (#1595's V2 table: 'e' embeds dropped, "nested attachments, not embeds").
-    # The disclosures are the four the dp list asked for, each cut to the depth its entry
+    # The disclosures are the five the dp list asked for, each cut to the depth its entry
     # named; the ORDER they are attached in carries no meaning, because the platform
     # finds each one by following an edge digest rather than by position or label.
     disclosures = [
-        # dp[0] ["i", "a/i", "a/authz", "e"] -- the payload is asked for, so the
+        # dp[0] ["i", "a", "e"] -- the SAME origin the offer committed to, now disclosed
+        # in full rather than compacted. Its SAID is unchanged, which is what lets the
+        # platform check the grant against terms it agreed to before it saw any of this.
+        _disclose(presentation, kind),
+        # dp[1] ["i", "a/i", "a/authz", "e"] -- the payload is asked for, so the
         # attribute section rides expanded; so does 'e', to be walkable.
         _disclose(wardAuthz, kind),
-        # dp[1] ["i", "a", "e"] -- flat section, disclosed whole because that is the
+        # dp[2] ["i", "a", "e"] -- flat section, disclosed whole because that is the
         # only form it has.
         _disclose(guardian, kind),
-        # dp[2] ["a/i", "e"] and dp[3] ["a/i"] -- nested sections, compacted to the
+        # dp[3] ["a/i", "e"] and dp[4] ["a/i"] -- nested sections, compacted to the
         # issuee. Name, birthdate and residence stay bare SAIDs.
         _disclose(wardCitizen, kind, _issuee_only_attributes(wardCitizen, kind)),
         _disclose(guardianCitizen, kind,
@@ -1534,14 +1819,16 @@ def test_wardauthz_presentation_JSON():
 
     def disclose(agreeMsg, sig, keyState, nests=None):
         if not (agreeMsg.sad['r'] == "/ipex/agree" and agreeMsg.sad['p'] == offer.said
+                and agreeMsg.sad['x'] == XID
                 and keyState.verify(sig=sig.raw, ser=agreeMsg.raw)):
             return None, None
         nests = nests if nests is not None else disclosures
         serder = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/grant",
-                          prior=agreeMsg.said,
-                          attributes=dict(o=[wardAuthz.said], ax=[False]),
+                          prior=agreeMsg.said, xid=XID,
+                          attributes=dict(m="The disclosure you agreed to.",
+                                          o=[presentation.said], ax=[False]),
                           stamp=GRANT_STAMP, kind=kind)
-        caraSig = _SIGNERS[2].sign(ser=serder.raw, index=0)   # the discloser signs
+        caraSig = caraSigner.sign(ser=serder.raw, index=0)    # the discloser signs
         return serder, messagize(serder, sigers=[caraSig],
                                  nests=[_nest(d) for d in nests],
                                  framed=False, gvrsn=Vrsn_2_0)
@@ -1550,22 +1837,41 @@ def test_wardauthz_presentation_JSON():
     assert disclose(agree, _SIGNERS[0].sign(ser=agree.raw, index=0),
                     capturedKeyState) == (None, None)
     spurn = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/spurn", prior=offer.said,
+                     xid=XID, attributes=dict(m="Declined."),
                      stamp=AGREE_STAMP, kind=kind)
     assert disclose(spurn, svcSigner.sign(ser=spurn.raw, index=0),
+                    capturedKeyState) == (None, None)
+    # ...and neither does an agree from a DIFFERENT exchange, however well signed: the
+    # transaction id is what says which conversation a message belongs to.
+    strayAgree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree",
+                          prior=offer.said, xid=Diger(ser=b'another exchange').qb64,
+                          attributes=dict(m="Agreed; disclose."),
+                          stamp=AGREE_STAMP, kind=kind)
+    assert disclose(strayAgree, svcSigner.sign(ser=strayAgree.raw, index=0),
                     capturedKeyState) == (None, None)
 
     # The valid agree unlocks the grant.
     grant, grantStream = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "ELp4e7S22Uyj-IW2QKPqIq1H43s9GoIBfdiYBpVnZ2Ea"
+    assert grant.sad['x'] == XID == apply.sad['x']     # one exchange, five messages
+    assert grant.said == "EL5MZNCnb74_W59oSFtUc_Jj8qVjWmKLpqJydvbTvNr_"
 
     # The attribute block is the origin and nothing else: a ONE-ELEMENT LIST, which is
     # #1627's "Use Required Lists" form. That option is preferred there over a field map
     # precisely because `dp` is already a list, so writing the single-DAG case as a list
     # now is what keeps this example from needing a second edit when DAG soup lands.
+    # RECORDED DIVERGENCE FROM MERGED MAIN: #1629 landed 'o' as a scalar string, and
+    # IpexHandler.verify rejects a list. The list is written here because #1627 is where
+    # the shape is being decided and this is a worked example of that shape; the
+    # reconciliation is being argued in that discussion rather than papered over here.
     granted = grant.sad['a']
-    assert granted == dict(o=[wardAuthz.said], ax=[False])   # #1595, #1613, #1627
+    assert granted == dict(m="The disclosure you agreed to.",
+                           o=[presentation.said], ax=[False])   # #1595, #1613, #1627
     assert isinstance(granted['o'], list) and len(granted['o']) == 1   # one DAG
+    # The grant's origin is the offer's origin. Merged main permits them to differ --
+    # nothing in verify ties one to the other -- and this example declines the latitude,
+    # because the platform agreed to terms it could only read off the offered origin.
+    assert granted['o'] == offer.sad['a']['o']
 
     # The credentials are on the stream, not in the body -- one artifact per dp entry,
     # each still carrying the SAID of the FULL credential, because an ACDC's SAID is
@@ -1574,8 +1880,11 @@ def test_wardauthz_presentation_JSON():
     parsed = Parser(version=Vrsn_2_0).parse(ims=bytearray(grantStream), framed=False,
                                             processive=False)[0]
     onWire = {nest.serder.said: nest.serder.sad for nest in parsed.nests}
-    assert set(onWire) == {wardAuthz.said, guardian.said, wardCitizen.said,
-                           guardianCitizen.said}
+    assert set(onWire) == {presentation.said, wardAuthz.said, guardian.said,
+                           wardCitizen.said, guardianCitizen.said}
+    # The origin arrives expanded, and still recomputes to the SAID the offer named.
+    assert onWire[presentation.said]['a']['i'] == SOCIAL       # addressed to this platform
+    assert onWire[presentation.said]['e']['authz']['n'] == wardAuthz.said
     assert _authz_capabilities(onWire[wardAuthz.said]['a']['authz']) == {"read", "post",
                                                                         "message"}
     assert onWire[guardian.said]['a']['ward'] == CARA
@@ -1612,13 +1921,13 @@ def test_wardauthz_presentation_JSON():
 
     # The platform now runs the same binding a verifier runs anywhere -- on the stream it
     # RECEIVED, reparsed from scratch, not on anything it knew before.
-    assert _platform_accepts_grant(grantStream, wardAuthz.said)
+    assert _platform_accepts_grant(grantStream, presentation.said)
 
     # ...and the negatives that prove the acceptance is reading the wire. Each of these
     # would pass unnoticed if the platform verified credentials it already held.
     # (a) A guardianship over a different ward, substituted into the disclosed set. It is
-    # a perfectly valid ACDC and it parses; the origin's authority edge names the real
-    # guardianship, which is now missing from the stream, so the DAG walk stops.
+    # a perfectly valid ACDC and it parses; the authorization's authority edge names the
+    # real guardianship, which is now missing from the stream, so the DAG walk stops.
     otherGuardianAttr = dict(_guardian_attr(), ward=SOCIAL)
     _, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
     otherGuardian = acdcmap(israid=STATE, uuid=NONCES[N_GG_ACDC],
@@ -1627,31 +1936,46 @@ def test_wardauthz_presentation_JSON():
                             edge=dict(guardian.sad['e']), rule=GUARDIAN_RULES_SAID,
                             kind=kind)
     _, swapped = disclose(agree, svcSig, capturedKeyState,
-                          nests=[disclosures[0], otherGuardian,
-                                 disclosures[2], disclosures[3]])
+                          nests=[disclosures[0], disclosures[1], otherGuardian,
+                                 disclosures[3], disclosures[4]])
     with pytest.raises(AssertionError):
-        _platform_accepts_grant(swapped, wardAuthz.said)
-    # (b) An origin that is not the credential the offer committed to.
+        _platform_accepts_grant(swapped, presentation.said)
+    # (b) An origin that is not the artifact the offer committed to.
     with pytest.raises(AssertionError):
         _platform_accepts_grant(grantStream, guardian.said)
     # (c) A tampered payload. The forged AuthZ credential keeps the real credential's
     # 'd' but grants a capability the real one does not, so its SAID no longer recomputes
     # over its content. It is refused as it is parsed, and it voids the entire stream --
-    # the platform gets no artifacts at all rather than three good ones and a silent gap.
-    forged = json.loads(json.dumps(disclosures[0].sad))
+    # the platform gets no artifacts at all rather than four good ones and a silent gap.
+    forged = json.loads(json.dumps(disclosures[1].sad))
     forged['a']['authz']['rc']['social_store'] = ["purchase"]
     forgedAcdc = SerderACDC(sad=forged, makify=False, verify=False)
     assert forgedAcdc.said == wardAuthz.said           # it still CLAIMS to be hers
     _, tampered = disclose(agree, svcSig, capturedKeyState,
-                           nests=[forgedAcdc] + disclosures[1:])
+                           nests=[disclosures[0], forgedAcdc] + disclosures[2:])
     with pytest.raises(AssertionError):
-        _platform_accepts_grant(tampered, wardAuthz.said)
+        _platform_accepts_grant(tampered, presentation.said)
+    # (d) REPLAY AT ANOTHER PLATFORM, which is the negative the bespoke origin earns.
+    # Every artifact here is genuine and every SAID recomputes -- this is the real
+    # disclosure, captured verbatim. It is refused anyway, because the origin names the
+    # platform it was minted for and the whole DAG hangs from that name. Without an
+    # addressed origin, a disclosure is bearer-grade: whoever holds the bytes can present
+    # them anywhere the same credentials are accepted.
+    with pytest.raises(AssertionError):
+        _platform_accepts_grant(grantStream, presentation.said, disclosee=STATE)
 
     # 5. admit (platform -> Cara): closes the exchange.
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
+                     xid=XID, attributes=dict(m="Received; access granted."),
                      stamp=ADMIT_STAMP, kind=kind)
-    assert admit.sad['p'] == grant.said
-    assert admit.said == "EBrp-miKYtL2_rG0HaY7Yu-jQj0s1WXozsduiZs9gJMB"
+    assert admit.sad['p'] == grant.said and admit.sad['x'] == XID
+    assert admit.said == "EPlc2DXeDAISnzH2P6Vy0pMkVqPhNXOPH0UZBC1NoLIc"
+
+    # Every message in the flow carries a human-readable 'm' and the one transaction id.
+    # Merged main requires both: IpexHandler.verify rejects any IPEX message whose
+    # attribute block has no 'm', and rejects an apply whose 'x' is empty.
+    for msg in (apply, offer, agree, grant, admit, spurn):
+        assert msg.sad['a']['m'] and msg.sad['x'] == XID
 
 
 # ---------------------------------------------------------------------------
@@ -1661,10 +1985,11 @@ def test_wardauthz_presentation_JSON():
 def test_wardauthz_serialization_kinds(kind):
     """Phases 1-4 invariants hold across every serialization kind, not just JSON.
 
-    Exercises the same graph -- four schemas, four credentials, the four pinned edge
-    operators, the full binding, the attenuation ceiling and the compact/expanded SAID
-    equality -- over CESR (the native KERI wire format) and CBOR/MGPK, asserting the
-    behavioral invariants without pinning per-kind SAIDs. (The no-PII-on-the-wire checks
+    Exercises the same graph -- the four durable credentials, the bespoke origin Cara
+    mints over them, all five pinned edge operators, both bindings, the attenuation
+    ceiling and the compact/expanded SAID equality -- over CESR (the native KERI wire
+    format) and CBOR/MGPK, asserting the behavioral invariants without pinning per-kind
+    SAIDs. (The no-PII-on-the-wire checks
     stay in the JSON phase: the CESR wire form base64-encodes the payload, so a plaintext
     substring check does not apply.)
     """
@@ -1706,6 +2031,23 @@ def test_wardauthz_serialization_kinds(kind):
                           compactify=True)
     assert compact.said == wardAuthz.said
     assert isinstance(compact.sad['e'], str)
+
+    # The bespoke origin builds, binds and compacts on every kind too -- including native
+    # CESR, where its purpose string and its routeless attribute block have to survive the
+    # same strict field-label grammar the AuthZ payload is pinned to.
+    presentation = _ward_presentation(kind, wardAuthz=wardAuthz)
+    assert_acdc_schema_valid(presentation)
+    assert 'rd' not in presentation.sad                # one-time: never registry-bound
+    assert _i2i_holds(presentation, wardAuthz)         # issuer Cara == issuee Cara
+    assert _verify_presentation(presentation, wardAuthz, SOCIAL)
+    with pytest.raises(AssertionError):                # ...and not at another platform
+        _verify_presentation(presentation, wardAuthz, STATE)
+    compactPresentation = _ward_presentation(kind, wardAuthz=wardAuthz, compactify=True)
+    assert compactPresentation.said == presentation.said
+    assert isinstance(compactPresentation.sad['e'], str)   # the offer's metadata form...
+    assert isinstance(compactPresentation.sad['a'], str)
+    # ...which is what keeps the durable correlator off an offer on every kind.
+    assert wardAuthz.said not in json.dumps(compactPresentation.sad)
 
     # The ward's minimal disclosure recomputes to the committed section SAID...
     disclosure = _issuee_only_attributes(wardCitizen, kind)

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -1250,24 +1250,28 @@ def test_wardauthz_presentation_JSON():
     # governance framework the platform will honor.
     #
     # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
-    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
-    # with ACDC-relative paths -- the construct settled in WebOfTrust/keripy discussion
-    # #1549, shared with tests/acdc/test_clc_disclosure.py,
-    # test_bulk_issuance_shared_registry.py and test_guardianship_presentation.py.
-    # A dict keyed by schema SAID cannot express a DAG holding two credentials of the
-    # same schema, which is why the construct is a list.
+    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, prefix, [paths])
+    # triples -- the construct settled in WebOfTrust/keripy discussion #1549, shared with
+    # tests/acdc/test_cp_disclosure.py, test_bulk_issuance_shared_registry.py and
+    # test_guardianship_presentation.py. A dict keyed by schema SAID cannot express a DAG
+    # holding two credentials of the same schema, which is why the construct is a list.
     #
-    # A leading '/' would make the path DAG-ABSOLUTE, rooted at the origin node, and an
-    # absolute path reaching a non-origin ACDC must cross the edge that links it -- the
-    # virtual '_' component, standing for the jump from the near-side edge block to the
-    # top level of the far-side ACDC (@SmithSamuelM, #1549). The same request in
-    # absolute form reads:
-    #     origin:       /i, /a/i, /a/authz
-    #     guardianship: /e/authority/_/a/i, /e/authority/_/a/ward, /e/authority/_/a/powers
-    #     ward citizen: /e/subject/_/a/i
-    # Relative form is used because this DAG has no optional edges, so the breadth-first
-    # ordering of `dp` is gapless and each entry's ACDC is unambiguous without restating
-    # the route to it.
+    # The middle element is a path PREFIX: the DAG-absolute route to the ACDC that the
+    # entry's schema SAID names. It is either the empty string or a route that both
+    # begins and ends with '/', and the effective path is prefix + entry concatenated
+    # with no delimiter inserted, so an entry in the path list never begins with '/'
+    # (@SmithSamuelM, #1549).
+    #
+    # Every prefix here is EMPTY, which leaves the entry paths ACDC-RELATIVE: with no
+    # prefix naming it, an entry's ACDC is identified by the entry's POSITION, so the
+    # list runs breadth-first from the origin node and the zeroth entry is the origin.
+    # A '/'-rooted prefix would make the effective paths DAG-ABSOLUTE, and an absolute
+    # path reaching a non-origin ACDC must cross the edge that links it -- the virtual
+    # '_' component, standing for the jump from the near-side edge block to the top level
+    # of the far-side ACDC (#1549). The same request written with non-empty prefixes:
+    #     origin:       "/"                ["i", "a/i", "a/authz"]
+    #     guardianship: "/e/authority/_/"  ["a/i", "a/ward", "a/powers"]
+    #     ward citizen: "/e/subject/_/"    ["a/i"]
     #
     # The zeroth entry is the DAG's origin node (#1549). Here the origin is the AuthZ
     # credential itself -- Cara presents a credential she HOLDS, so unlike the sibling
@@ -1289,10 +1293,11 @@ def test_wardauthz_presentation_JSON():
     # meaning of the entries below it.
     authzSchemaSaid, _ = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply",
-                     modifiers=dict(dp=[[authzSchemaSaid, ["i", "a/i", "a/authz"]],
-                                        [guardian.sad['s']['$id'],
+                     modifiers=dict(dp=[[authzSchemaSaid, "",
+                                         ["i", "a/i", "a/authz"]],
+                                        [guardian.sad['s']['$id'], "",
                                          ["a/i", "a/ward", "a/powers"]],
-                                        [wardCitizen.sad['s']['$id'], ["a/i"]]]),
+                                        [wardCitizen.sad['s']['$id'], "", ["a/i"]]]),
                      attributes=dict(m="Prove a guardian authorized this minor to use "
                                        "this service, and show the scope.",
                                      g=AUTHZ_RULES_SAID),
@@ -1301,17 +1306,19 @@ def test_wardauthz_presentation_JSON():
     dp = apply.sad['q']['dp']
     assert [entry[0] for entry in dp] == [authzSchemaSaid, guardian.sad['s']['$id'],
                                           wardCitizen.sad['s']['$id']]
-    assert dp[0][1] == ["i", "a/i", "a/authz"]        # origin: who granted, to whom, what
-    assert dp[1][1] == ["a/i", "a/ward", "a/powers"]  # guardianship: whose, over whom, how far
-    assert dp[2][1] == ["a/i"]                        # ward citizen: the binding, nothing more
+    assert all(len(entry) == 3 for entry in dp)       # (schemaSAID, prefix, [paths])
+    assert [entry[1] for entry in dp] == ["", "", ""] # no prefixes: paths stay relative
+    assert dp[0][2] == ["i", "a/i", "a/authz"]        # origin: who granted, to whom, what
+    assert dp[1][2] == ["a/i", "a/ward", "a/powers"]  # guardianship: whose, over whom, how far
+    assert dp[2][2] == ["a/i"]                        # ward citizen: the binding, nothing more
     assert all(not p.startswith("/") and not p.endswith("/")
-               for _, paths in dp for p in paths)
+               for _, _, paths in dp for p in paths)
     assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the origin Cara actually holds
     # The guardian's own citizen credential is a node in the DAG and is asked for
     # nothing: the platform gating a minor has no business learning the parent's name.
     assert guardianCitizen.sad['s']['$id'] not in [entry[0] for entry in dp]
     assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EOXY2-SPW0zUrFhP5nNbTevRqA3BSLOd5hE1kMj5jrTO"
+    assert apply.said == "EOdPg07RtIzlFeSkwX8l5YAatqJLLInpRn-9Ww97Zihn"
 
     # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
     # offering and to the governance ref, and binds the apply. It deliberately does NOT
@@ -1328,7 +1335,7 @@ def test_wardauthz_presentation_JSON():
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
-    assert offer.said == "EDHveeZBrH4RY5IYf9otXqG-K7XPYpS8HUoH9cGfui_5"
+    assert offer.said == "EL0_DqqsSGKW-t4pjerj-27YHOPnwzOjqmc_eLHsyzKR"
     assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
     assert b"Cara Carver" not in offer.raw and b"2012-04-10" not in offer.raw
     assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
@@ -1340,7 +1347,7 @@ def test_wardauthz_presentation_JSON():
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said
-    assert agree.said == "ELUE4Z69F9ANJxBIGQey8-bPxs-ZSnP__WIVVQKtsj2R"
+    assert agree.said == "EK2dHqxhGQ7apRiYBMgEDtSw9KtjVji2PMIFwOVXP5w0"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1375,7 +1382,7 @@ def test_wardauthz_presentation_JSON():
     # The valid agree unlocks the grant.
     grant = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "EDhaDoGbAVOpoQOBXrmxBzSuM6lqhbXjiT3pTOrUc3kR"
+    assert grant.said == "EAOQ4viuiQX3R5bQ_7oU-hdfWc8vpKpDVhjwUigWaq98"
 
     # What the platform receives is exactly what it asked for and no more: the
     # authorization payload, the guardianship's scope, and a binding to Cara.
@@ -1409,7 +1416,7 @@ def test_wardauthz_presentation_JSON():
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EKl5NR5YbevNiqowBr2uKQtVU9wNKFsR2J30LTch63eF"
+    assert admit.said == "EC5styk29zfJWRUIg4Ku1vIY_8U2nVxIgpxPU7rAnah2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -72,18 +72,14 @@ import pytest
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
 
-from keri import Kinds, Ilks
+from keri import Kinds, Ilks, Vrsn_2_0
 from keri.core import (Salter, Noncer, Compactor, Mapper, Diger, Verfer,
-                       exchange, messagize)
+                       exchange, messagize, Codens, Counter, Parser, Texter)
 from keri.core.coring import MtrDex
 from keri.core.eventing import incept
 from keri.core.serdering import SerderACDC
 from keri.acdc import regcept, acdcmap
 from keri.help.helping import ATREX
-# keri's ValidationError, kept distinct from jsonschema's above: the two are raised by
-# different layers of this module (SAID recomputation vs wire-shape validation) and a
-# test that conflates them cannot say which one caught a defect.
-from keri.kering import ValidationError as SaidError
 
 
 # --- Reproducible example actors (see module docstring). ---
@@ -1230,36 +1226,77 @@ def _committed_a_said(acdc, kind):
     return compactor.said
 
 
-def _platform_accepts_grant(granted, offeredOrigin, kind):
-    """The platform's grant-time verification, run on WHAT IT WAS HANDED.
+def _nest(serder):
+    """Wrap one disclosed artifact as a V2 nested substream the parser will accept.
 
-    Returns True or raises. This is the step the exchange exists to reach, and it takes
-    nothing on trust from the test's own scope: every credential is reconstructed from
-    the grant body with SerderACDC(verify=True), which recomputes the SAID over the
-    disclosed content -- most-compact-form semantics, so a partial disclosure verifies
-    to the same 'd' as the full credential -- and raises if it does not match.
+    Shape borrowed from tests/acdc/test_ipexing.py, which round-trips the same
+    construct: a non-CESR body is enclosed in a NonNativeBodyGroup, and an artifact with
+    no attachments of its own still needs an empty AttachmentGroup so the parser can
+    tell where the substream ends.
+    """
+    body = bytes(serder.raw)
+    if serder.kind != Kinds.cesr:
+        body = Counter.enclose(qb64=Texter(raw=body).qb64b,
+                               code=Codens.NonNativeBodyGroup, version=Vrsn_2_0)
+    empty = Counter.enclose(qb64=b'', code=Codens.ControllerIdxSigs, version=Vrsn_2_0)
+    nested = bytearray(body)
+    nested.extend(Counter.enclose(qb64=empty, code=Codens.AttachmentGroup,
+                                  version=Vrsn_2_0))
+    return Counter.enclose(qb64=nested, code=Codens.BodyWithAttachmentGroup,
+                           version=Vrsn_2_0)
 
-    Three things happen in order:
 
-      1. Each of the four disclosed artifacts is reconstructed and self-verified. A
-         tampered payload dies here, because its recomputed SAID stops matching its 'd'.
-      2. The origin is confirmed to be the credential the OFFER committed to. Without
-         this the platform could be handed a different, perfectly valid authorization
-         than the one whose terms it agreed to -- terms follow the data.
-      3. The seven-check binding runs on the RECONSTRUCTED objects. Every edge digest is
-         therefore checked against a SAID recomputed from disclosed content, so
-         substituting any far node into the disclosed set breaks the edge that names it.
+def _far(byDigest, near, label):
+    """The far node of `near`'s `label` edge, looked up by the digest the edge names."""
+    said = near.sad['e'][label]['n']
+    assert said in byDigest              # the DAG the origin commits to must be complete
+    return byDigest[said]
+
+
+def _platform_accepts_grant(grantStream, offeredOrigin):
+    """The platform's grant-time verification, run on WHAT CAME OFF THE WIRE.
+
+    Returns True or raises. Takes the signed grant STREAM -- body plus attachments --
+    and nothing else, so there is no way for a credential the platform already held to
+    stand in for one it was sent.
+
+    Four things happen in order:
+
+      1. Parse. Every nested artifact is reaped and self-verified as it is parsed: the
+         SAID is recomputed over the disclosed content, using most-compact-form
+         semantics so a partial disclosure verifies to the same 'd' as the full
+         credential. A tampered payload dies here, and takes the whole stream with it.
+      2. Confirm the origin is the credential the OFFER committed to. Without this the
+         platform could be handed a different, perfectly valid authorization than the
+         one whose terms it agreed to -- terms follow the data.
+      3. WALK THE DAG from that origin to find every other node, edge by edge, matching
+         each edge's digest against the parsed artifacts. This is what the `o` field
+         buys over the bespoke labels it replaced: the platform is no longer trusting
+         the discloser's choice of key names to tell it which credential is the
+         authority and which is the subject. It reads that from the origin's own edges,
+         which the origin's issuer committed to. A substituted far node breaks the
+         digest that names it.
+      4. Run the seven-check binding on the artifacts that walk produced.
 
     A complete verifier adds registry status (walk each 'rd' TEL for a revocation) and
     the Layer-2 question of whether the guardianship's issuer is competent to recognize
     a guardianship. Both are out of scope at this altitude, as in _verify_authz_chain.
     """
-    origin = SerderACDC(sad=json.loads(json.dumps(granted['acdc'])), verify=True)
-    authority = SerderACDC(sad=json.loads(json.dumps(granted['authority'])), verify=True)
-    subject = SerderACDC(sad=json.loads(json.dumps(granted['subject'])), verify=True)
-    guardianId = SerderACDC(sad=json.loads(json.dumps(granted['guardianId'])),
-                            verify=True)
-    assert origin.said == offeredOrigin       # the terms agreed to are the terms received
+    ims = bytearray(grantStream)
+    results = Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, processive=False)
+    # A nested artifact whose SAID does not recompute over its content voids the WHOLE
+    # stream -- the parser returns nothing rather than handing back the good artifacts
+    # and dropping the bad one, so a tampered credential cannot be quietly ignored.
+    assert results and len(results) == 1
+    result = results[0]
+    assert result.serder.sad['r'] == "/ipex/grant"
+    assert result.serder.sad['a']['o'] == [offeredOrigin]   # terms follow the data
+    byDigest = {nest.serder.said: nest.serder for nest in result.nests}
+
+    origin = byDigest[offeredOrigin]
+    authority = _far(byDigest, origin, 'authority')         # AuthZ -I2I-> guardianship
+    subject = _far(byDigest, origin, 'subject')             # AuthZ -E1E-> ward citizen
+    guardianId = _far(byDigest, authority, 'citizen')       # guardianship -E1E-> Bob's
     return _verify_authz_chain(origin, authority, subject, guardianId)
 
 
@@ -1456,63 +1493,88 @@ def test_wardauthz_presentation_JSON():
     # independently of the request is a grant the platform cannot check its request
     # against, and it is how an example ends up teaching both "honor dp" and "send whole
     # credentials" in the same breath.
-    def disclose(agreeMsg, sig, keyState):
+    # THE DISCLOSED ARTIFACTS DO NOT RIDE IN 'a'. The attribute block carries only the
+    # origin, and the credentials themselves are nested attachments on the signed grant
+    # stream (#1595's V2 table: 'e' embeds dropped, "nested attachments, not embeds").
+    # The disclosures are the four the dp list asked for, each cut to the depth its entry
+    # named; the ORDER they are attached in carries no meaning, because the platform
+    # finds each one by following an edge digest rather than by position or label.
+    disclosures = [
+        # dp[0] ["i", "a/i", "a/authz", "e"] -- the payload is asked for, so the
+        # attribute section rides expanded; so does 'e', to be walkable.
+        _disclose(wardAuthz, kind),
+        # dp[1] ["i", "a", "e"] -- flat section, disclosed whole because that is the
+        # only form it has.
+        _disclose(guardian, kind),
+        # dp[2] ["a/i", "e"] and dp[3] ["a/i"] -- nested sections, compacted to the
+        # issuee. Name, birthdate and residence stay bare SAIDs.
+        _disclose(wardCitizen, kind, _issuee_only_attributes(wardCitizen, kind)),
+        _disclose(guardianCitizen, kind,
+                  _issuee_only_attributes(guardianCitizen, kind)),
+    ]
+
+    def disclose(agreeMsg, sig, keyState, nests=None):
         if not (agreeMsg.sad['r'] == "/ipex/agree" and agreeMsg.sad['p'] == offer.said
                 and keyState.verify(sig=sig.raw, ser=agreeMsg.raw)):
-            return None
-        return exchange(
-            sender=CARA, receiver=SOCIAL, route="/ipex/grant", prior=agreeMsg.said,
-            attributes=dict(
-                # dp[0] ["i", "a/i", "a/authz", "e"] -- the payload is asked for, so the
-                # attribute section rides expanded; so does 'e', to be walkable.
-                acdc=_disclose(wardAuthz, kind).sad,
-                # dp[1] ["i", "a", "e"] -- flat section, disclosed whole because that is
-                # the only form it has.
-                authority=_disclose(guardian, kind).sad,
-                # dp[2] ["a/i", "e"] and dp[3] ["a/i"] -- nested sections, compacted to
-                # the issuee. Name, birthdate and residence stay bare SAIDs.
-                subject=_disclose(wardCitizen, kind,
-                                  _issuee_only_attributes(wardCitizen, kind)).sad,
-                guardianId=_disclose(guardianCitizen, kind,
-                                     _issuee_only_attributes(guardianCitizen, kind)).sad),
-            stamp=GRANT_STAMP, kind=kind)
+            return None, None
+        nests = nests if nests is not None else disclosures
+        serder = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/grant",
+                          prior=agreeMsg.said,
+                          attributes=dict(o=[wardAuthz.said]),
+                          stamp=GRANT_STAMP, kind=kind)
+        caraSig = _SIGNERS[2].sign(ser=serder.raw, index=0)   # the discloser signs
+        return serder, messagize(serder, sigers=[caraSig],
+                                 nests=[_nest(d) for d in nests],
+                                 framed=False, gvrsn=Vrsn_2_0)
 
     # A forged signature or a spurn (decline) unlocks nothing.
     assert disclose(agree, _SIGNERS[0].sign(ser=agree.raw, index=0),
-                    capturedKeyState) is None
+                    capturedKeyState) == (None, None)
     spurn = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/spurn", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert disclose(spurn, svcSigner.sign(ser=spurn.raw, index=0),
-                    capturedKeyState) is None
+                    capturedKeyState) == (None, None)
 
     # The valid agree unlocks the grant.
-    grant = disclose(agree, svcSig, capturedKeyState)
+    grant, grantStream = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "EKjAC72RSOZekQ-6AoGjqbGOFu7PD6N2ojmN_1_sF_fy"
+    assert grant.said == "EBsZ8dlRvJsm5UOWVAWGDC4E6FqQtoWH-sOiSbNtpJ87"
 
-    # What the platform receives is one artifact per dp entry, disclosed to the requested
-    # depth. Each one still carries the SAID of the FULL credential, because an ACDC's
-    # SAID is computed over its most compact form -- which is what makes a partial
-    # disclosure verifiable rather than merely plausible.
+    # The attribute block is the origin and nothing else: a ONE-ELEMENT LIST, which is
+    # #1627's "Use Required Lists" form. That option is preferred there over a field map
+    # precisely because `dp` is already a list, so writing the single-DAG case as a list
+    # now is what keeps this example from needing a second edit when DAG soup lands.
     granted = grant.sad['a']
-    assert set(granted) == {'acdc', 'authority', 'subject', 'guardianId'}   # one per dp
-    assert granted['acdc']['d'] == wardAuthz.said
-    assert granted['authority']['d'] == guardian.said
-    assert granted['subject']['d'] == wardCitizen.said
-    assert granted['guardianId']['d'] == guardianCitizen.said
-    assert _authz_capabilities(granted['acdc']['a']['authz']) == {"read", "post",
-                                                                  "message"}
-    assert granted['authority']['a']['ward'] == CARA
-    assert granted['subject']['a']['i'] == CARA        # the ward bound by issuee...
-    assert isinstance(granted['subject']['a']['name'], str)   # ...attributes withheld
-    assert isinstance(granted['subject']['a']['dob'], str)
-    assert granted['guardianId']['a']['i'] == BOB      # the guardian likewise bound...
-    assert isinstance(granted['guardianId']['a']['name'], str)      # ...and withheld
-    assert isinstance(granted['guardianId']['a']['residence'], str)
-    assert b"Cara Carver" not in grant.raw             # name never on the wire
-    assert b"2009-04-10" not in grant.raw              # birthdate never on the wire
-    assert b"Bob Carver" not in grant.raw              # nor the parent's name...
-    assert b"Provo" not in grant.raw                   # ...nor where he lives
+    assert granted == dict(o=[wardAuthz.said])         # origin SAID only; #1595, #1627
+    assert isinstance(granted['o'], list) and len(granted['o']) == 1   # one DAG
+
+    # The credentials are on the stream, not in the body -- one artifact per dp entry,
+    # each still carrying the SAID of the FULL credential, because an ACDC's SAID is
+    # computed over its most compact form. That is what makes a partial disclosure
+    # verifiable rather than merely plausible.
+    parsed = Parser(version=Vrsn_2_0).parse(ims=bytearray(grantStream), framed=False,
+                                            processive=False)[0]
+    onWire = {nest.serder.said: nest.serder.sad for nest in parsed.nests}
+    assert set(onWire) == {wardAuthz.said, guardian.said, wardCitizen.said,
+                           guardianCitizen.said}
+    assert _authz_capabilities(onWire[wardAuthz.said]['a']['authz']) == {"read", "post",
+                                                                        "message"}
+    assert onWire[guardian.said]['a']['ward'] == CARA
+    assert onWire[wardCitizen.said]['a']['i'] == CARA          # the ward bound by issuee
+    assert isinstance(onWire[wardCitizen.said]['a']['name'], str)   # ...attrs withheld
+    assert isinstance(onWire[wardCitizen.said]['a']['dob'], str)
+    assert onWire[guardianCitizen.said]['a']['i'] == BOB       # the guardian likewise...
+    assert isinstance(onWire[guardianCitizen.said]['a']['name'], str)   # ...and withheld
+    assert isinstance(onWire[guardianCitizen.said]['a']['residence'], str)
+    # The PII checks run against the DECODED bodies rather than the stream: a nested
+    # non-CESR body rides Texter-encoded (base64) inside a NonNativeBodyGroup, so a
+    # plaintext substring check on grantStream would pass without proving anything. This
+    # is everything the platform can read after parsing, the grant body included.
+    decoded = bytes(grant.raw) + b"".join(bytes(nest.serder.raw) for nest in parsed.nests)
+    assert b"Cara Carver" not in decoded               # name never on the wire
+    assert b"2009-04-10" not in decoded                # birthdate never on the wire
+    assert b"Bob Carver" not in decoded                # nor the parent's name...
+    assert b"Provo" not in decoded                     # ...nor where he lives
     # Honest residual, asserted present rather than quietly avoided: the guardianship's
     # expiry -- Cara's 18th birthday -- crosses the wire and hands the platform her birth
     # month and day. The cause is structural and is named in the dp comment above:
@@ -1521,20 +1583,23 @@ def test_wardauthz_presentation_JSON():
     # credentials in this same grant, whose nested sections DO split. The fix is a
     # coarser expiry or a nested guardianship section, and both are schema decisions for
     # a deployment rather than something this example should invent.
-    assert b"2027-04-10" in grant.raw
+    assert b"2027-04-10" in decoded
     # The withheld blocks still recompute to the section SAID the credential commits to,
     # so the platform can prove the disclosure belongs to Cara's citizen credential.
-    check = Compactor(mad=dict(granted['subject']['a'], d=''), makify=True, kind=kind)
+    check = Compactor(mad=dict(onWire[wardCitizen.said]['a'], d=''), makify=True,
+                      kind=kind)
     check.compact()
     assert check.said == _committed_a_said(wardCitizen, kind)
 
-    # The platform now runs the same binding a verifier runs anywhere -- on the artifacts
-    # it was HANDED, reconstructed from the grant body, not on anything it knew before.
-    assert _platform_accepts_grant(granted, wardAuthz.said, kind)
+    # The platform now runs the same binding a verifier runs anywhere -- on the stream it
+    # RECEIVED, reparsed from scratch, not on anything it knew before.
+    assert _platform_accepts_grant(grantStream, wardAuthz.said)
 
     # ...and the negatives that prove the acceptance is reading the wire. Each of these
     # would pass unnoticed if the platform verified credentials it already held.
-    # (a) A guardianship over a different ward, substituted into the disclosed set.
+    # (a) A guardianship over a different ward, substituted into the disclosed set. It is
+    # a perfectly valid ACDC and it parses; the origin's authority edge names the real
+    # guardianship, which is now missing from the stream, so the DAG walk stops.
     otherGuardianAttr = dict(_guardian_attr(), ward=SOCIAL)
     _, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
     otherGuardian = acdcmap(israid=STATE, uuid=NONCES[N_GG_ACDC],
@@ -1542,23 +1607,32 @@ def test_wardauthz_presentation_JSON():
                             attribute=otherGuardianAttr, iseaid=BOB,
                             edge=dict(guardian.sad['e']), rule=GUARDIAN_RULES_SAID,
                             kind=kind)
-    swappedAuthority = dict(granted, authority=otherGuardian.sad)
+    _, swapped = disclose(agree, svcSig, capturedKeyState,
+                          nests=[disclosures[0], otherGuardian,
+                                 disclosures[2], disclosures[3]])
     with pytest.raises(AssertionError):
-        _platform_accepts_grant(swappedAuthority, wardAuthz.said, kind)
+        _platform_accepts_grant(swapped, wardAuthz.said)
     # (b) An origin that is not the credential the offer committed to.
     with pytest.raises(AssertionError):
-        _platform_accepts_grant(granted, guardian.said, kind)
-    # (c) A tampered payload: the SAID no longer recomputes over the content.
-    tampered = json.loads(json.dumps(granted))
-    tampered['acdc']['a']['authz']['rc']['social_store'] = ["purchase"]
-    with pytest.raises(SaidError):
-        _platform_accepts_grant(tampered, wardAuthz.said, kind)
+        _platform_accepts_grant(grantStream, guardian.said)
+    # (c) A tampered payload. The forged AuthZ credential keeps the real credential's
+    # 'd' but grants a capability the real one does not, so its SAID no longer recomputes
+    # over its content. It is refused as it is parsed, and it voids the entire stream --
+    # the platform gets no artifacts at all rather than three good ones and a silent gap.
+    forged = json.loads(json.dumps(disclosures[0].sad))
+    forged['a']['authz']['rc']['social_store'] = ["purchase"]
+    forgedAcdc = SerderACDC(sad=forged, makify=False, verify=False)
+    assert forgedAcdc.said == wardAuthz.said           # it still CLAIMS to be hers
+    _, tampered = disclose(agree, svcSig, capturedKeyState,
+                           nests=[forgedAcdc] + disclosures[1:])
+    with pytest.raises(AssertionError):
+        _platform_accepts_grant(tampered, wardAuthz.said)
 
     # 5. admit (platform -> Cara): closes the exchange.
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "ENOajOwvH82FgQMoSYWGkNS9vKLPpekz9Q3ST38SVMYJ"
+    assert admit.said == "EKo47dZ9mrm9nBK8ChGwy9bgayaTIdS1BgIrVqkeaMES"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -2,140 +2,100 @@
 """
 tests.acdc.test_ward_authz_presentation module
 
-Worked, working example of a DELEGATED AUTHORIZATION that the ward presents herself:
-a guardian issues his ward an ACDC carrying an attenuated slice of his own authority,
-and the ward -- not the guardian -- shows it to the service that gates the act. It is
-the shape @SmithSamuelM drew in WebOfTrust/keripy discussion #1550, in the diagram
-titled "Ward with Single Guardian Issues Authorization: Ward to Access Social", and it
-is the sibling of tests/acdc/test_guardianship_presentation.py, which models the
-OPPOSITE direction.
+Worked, working example of a DELEGATED AUTHORIZATION that the ward presents herself: a
+guardian issues his ward an ACDC carrying an attenuated slice of his own authority, and the
+ward -- not the guardian -- shows it to the service that gates the act. It is the shape
+@SmithSamuelM drew in WebOfTrust/keripy discussion #1550, in the diagram "Ward with Single
+Guardian Issues Authorization: Ward to Access Social".
 
-Scenario. Utah's social-media law conditions a minor's use of a social platform on
-verified parental authorization. Cara is 14. She controls her own keys -- she operates
-a phone, she can sign -- but she cannot self-assert entitlement to a service her
-parent gates. Bob, her custodial parent and state-recognized digital guardian, does
-NOT log in for her and does not present on her behalf. He issues her an ACDC that says
-which routes on the platform she may exercise and with which capabilities, drawn from
-(and no larger than) the authority the State recognized in him. Cara then walks up to
-the platform holding her own credential and presents it.
+TWO REGIMES, TWO MODULES. #1550 separates them by what the ward can physically do. Before a
+child can operate a device, "any use case where the child is required to present something
+or have something presented on their behalf it must be done by the parents", because the
+parent custodies her keys; the guardian presents ABOUT the ward, and the invariant is
+holder != subject, so a verifier can always tell that a guardian and not the ward is acting.
+That is the sibling, tests/acdc/test_guardianship_presentation.py (PR #1530), whose ward is
+a six-year-old. Once the child can act -- "Its only when the child becomes old enough to
+operate a computer by themselves ... In that case, the Parent would delegate to their child
+attenuated capabilities" -- she holds her own keys and acts as herself, bounded by the
+authorization she carries. That is THIS module, and #1550 assigns Utah's social-media case
+to it explicitly: "the parents' further ability to restrict social media access even for the
+ages 13-18 requires delegated authorization to the child from their parents(s) (guardians)".
+Bob Carver is the custodial parent in both modules -- his six-year-old Mia is the sibling's
+ward, his 14-year-old Cara is this one's.
 
-Two shapes, two regimes, both real. The guardian-presents shape (this module's sibling,
-PR #1530) fits the regime where the parent holds the ward's keys -- an infant, or an
-incapacitated adult -- and the guardian must speak for a subject who cannot act at all;
-there the load-bearing invariant is holder != subject, so a verifier can always tell
-that a guardian, not the ward, is acting. The ward-presents shape modeled HERE fits the
-regime where the ward controls her own keys and can act, but only within a scope her
-guardian sets; there the load-bearing invariant is attenuation -- the ward acts as
-herself, and what bounds her is the delegated authorization she carries, not a stand-in
-who acts for her. Sam's own text draws the same line ("at birth ... the parents could be
-the custodians of the child's digital identity", as against a ward old enough to operate
-a device), and the split into two modules matches the progression-of-examples approach he
-asked for in #1515.
+Scenario. Utah's social-media law conditions a minor's use of a platform on verified
+parental authorization. Cara operates a phone and can sign, but cannot self-assert
+entitlement to a service her parent gates. So Bob, rather than logging in for her, issues
+her an ACDC saying which routes she may exercise and with which capabilities -- drawn from,
+and no larger than, the authority the State recognized in him -- and she presents it.
 
 Four credentials, all v2 ACDCs, all registry-bound, each validated against a
 purpose-authored JSON Schema (Draft 2020-12):
 
-  1. Guardian as Citizen  -- State -> Bob.  Bob's own SEDI identity credential.
-  2. Guardian as Guardian -- State -> Bob.  The recognized guardianship. Its attribute
-     block carries BOTH the guardian's issuee AID and the WARD's AID (see the recorded
-     divergence below). One edge, to (1).
-  3. Ward as Citizen Ward -- State -> Cara. Cara's own SEDI identity credential, which
-     by its edge to (2) DECLARES ITSELF ENCUMBERED: the ward's own credential says that
-     a guardianship stands over it, so a verifier reading only Cara's credential learns
-     that her identity is not unencumbered.
-  4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry (not the State's). The
-     payload: the resource routes and capabilities Cara may exercise. Two edges, to (2)
-     and to (3).
+  1. Guardian as Citizen  -- State -> Bob.  His own SEDI identity credential.
+  2. Guardian as Guardian -- State -> Bob.  The recognized guardianship, whose attribute
+     block carries the WARD's AID as well as Bob's (see the divergence below). Edge to (1).
+  3. Ward as Citizen Ward -- State -> Cara. Her own SEDI identity credential, which by its
+     edge to (2) DECLARES ITSELF ENCUMBERED, so a verifier reading only her credential
+     learns that her identity is not unencumbered.
+  4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry (not the State's), carrying
+     the routes and capabilities she may exercise. Edges to (2) and (3).
 
-Four edges, four different operators, and getting each right is the security content of
-this example. Every one is PINNED by a schema const, so a mislabeled operator fails at
-wire validation rather than at the verifier's discretion:
+Four edges, four different operators, and getting each right is the security content here.
+Every one is PINNED by a schema const, so a mislabeled operator fails at wire validation:
 
-  * (4) -> (2), authority, I2I. The near ACDC's issuer is Bob and the far node's issuee
-    is Bob, which is exactly I2I's same-holder constraint. This edge is what proves Bob
-    HELD the authority he is delegating; without it the AuthZ credential is a stranger
-    asserting permissions over someone else's child.
-  * (4) -> (3), subject, E1E. The near ACDC's ISSUEE is Cara and the far node's issuee
-    is Cara -- same subject -- but the issuers differ (Bob issues (4), the State issues
-    (3)). I2I would demand issuer(near) == issuee(far), i.e. Bob == Cara, and would
-    therefore FALSELY REJECT a perfectly sound identity relation. E1E, the identity
-    operator added in PR #1527 out of discussion #1515, constrains the issuee only and
-    says nothing about the issuer, which is why it holds here. This is the SECOND
-    independent use case for E1E, and unlike the first (an age credential chaining to an
-    identity credential) it comes from Sam's own diagram rather than from the PR that
-    proposed the operator.
-  * (2) -> (1), citizen, E1E again. Same subject (Bob is the issuee of both), same
-    issuer (the State issues both). Same-issuer is not what makes it an identity
-    relation -- E1E is right because the relation binds two credentials of ONE subject,
-    and I2I would again demand issuer == issuee, i.e. State == Bob.
-  * (3) -> (2), guardian, NI2I. The near issuee is Cara and the far issuee is Bob:
-    DIFFERENT subjects, so neither I2I nor E1E applies. NI2I is the untargeted
-    reference -- it nullifies I2I's same-holder requirement and asserts nothing in its
-    place -- which is the correct operator for "my credential points at somebody else's
-    credential", here the encumbrance marker.
+  * (4) -> (2) authority, I2I: near issuer Bob == far issuee Bob, which proves Bob HELD
+    what he delegates. Without it the AuthZ credential is a stranger's assertion of
+    permissions over someone else's child.
+  * (4) -> (3) subject, E1E: same subject (Cara), different issuers (Bob vs the State).
+    I2I would demand Bob == Cara and would FALSELY REJECT a sound identity relation, where
+    E1E (PR #1527) constrains the issuee only. This is the second independent use case for
+    the operator, and unlike the first it comes from Sam's diagram rather than from the PR
+    that proposed it.
+  * (2) -> (1) citizen, E1E again: same subject, and here the same issuer too -- which is
+    not what makes it identity. I2I would demand State == Bob.
+  * (3) -> (2) guardian, NI2I: different subjects, so neither targeted operator applies.
+    The untargeted reference is right for "my credential points at somebody else's" --
+    here, the encumbrance marker.
 
-E1E carries the same caveat it carries in the sibling module: it is not yet in the ACDC
-spec's closed operator set {I2I, NI2I, DI2I, NOT}. A spec-default or pre-#1527 verifier
-does not reject an unknown operator, it COERCES it -- to I2I for a targeted far node,
-which then wrongly rejects both E1E edges here, or to NI2I for an untargeted one, which
-wrongly accepts unchecked. So this graph validates only against a #1527-or-later
-verifier, and rides that dependency until E1E is ratified (disc #1515).
+E1E carries the same caveat as in the sibling: it is not yet in the spec's closed operator
+set {I2I, NI2I, DI2I, NOT}, and a spec-default or pre-#1527 verifier COERCES an unknown
+operator rather than rejecting it -- to I2I for a targeted far node, wrongly rejecting both
+E1E edges here. So this graph needs a #1527-or-later verifier until E1E is ratified (#1515).
 
-Recorded divergence: where the ward AID lives. Sam's diagram puts the ward's AID in the
-ATTRIBUTE block of (2), next to the guardian's issuee AID; the sibling #1530 names the
-ward only by an EDGE. Both preserve holder != subject on the guardianship credential, so
-this is a DISCLOSURE choice rather than an impersonation one. The edge form is the better
-one on Sam's own argument from #1515 -- "an edge can also be blinded, which means that
-disclosure of the edge itself can be held back until the verifier (disclosee) has agreed
-not to exploit its correlatability" -- and an authority credential that both models agree
-is disclosed WHOLE cannot withhold an attribute the way it can withhold an edge, so the
-attribute placement hands every verifier the ward's AID before any contract terms are
-agreed. This module models SAM's placement, because it is his diagram; the question is
-open on #1550, so this is recorded as a divergence, not settled as a verdict. Phase 4
-shows the same argument arriving as an actual leak rather than a principle: the
-guardianship's expiry date is the ward's 18th birthday, and because the credential is
-disclosed whole it cannot be withheld, so the platform learns her birth month and day
-from a credential that is not hers.
+RECORDED DIVERGENCE: where the ward AID lives. Sam's diagram puts it in the ATTRIBUTE block
+of (2); the sibling names the ward only by an EDGE. Both preserve holder != subject, so this
+is a DISCLOSURE choice, and the edge form is better on Sam's own argument from #1515 that an
+edge "can also be blinded, which means that disclosure of the edge itself can be held back
+until the verifier (disclosee) has agreed not to exploit its correlatability" -- where an
+attribute in a WHOLE-disclosed credential cannot be held back at all. This module models
+SAM's placement because it is his diagram, and the question is open on #1550; Phase 4 shows
+the argument arriving as an actual leak, since the guardianship's expiry is Cara's 18th
+birthday and cannot be withheld.
 
-The AuthZ payload is ILLUSTRATIVE and its syntax is UNSETTLED. Sam says only that the
-field "contains the specifics of the authorization. The syntax TBD", and points at EVAC
-(Edge Verifiable Agent Control), whose sketch at the end of #1550 is a resource-
-capabilities map 'rc' of the form {resourceRoute: [capability, ...]}. That is what is
-modeled here, plus a time window, and it is marked illustrative in the schema
-description as well as here. The example's assertions deliberately do NOT reach into the
-block: every capability check goes through _authz_capabilities, so a later syntax change
-is one function, not a rewrite of the suite.
+The AuthZ payload is ILLUSTRATIVE and its syntax UNSETTLED. Sam says only that the field
+"contains the specifics of the authorization. The syntax TBD", and points at EVAC (Edge
+Verifiable Agent Control), sketched at the end of #1550 as a resource-capabilities map 'rc'
+of the form {resourceRoute: [capability, ...]}. That is modeled here, plus a time window,
+and no assertion reaches into it (the seam is _authz_capabilities, so a later syntax change
+is one function rather than a rewrite). One constraint on that syntax is not a matter of
+taste, and this example measured it by serializing rather than by arguing: a route written
+as a map LABEL falls under CESR's strict field-label grammar, so "social/feed" cannot be
+serialized in native CESR at all. The measurement, and the recommendation it produces for
+#1550 -- carry the route as a VALUE -- are at AUTHZ_BLOCK_SCHEMA.
 
-One constraint on that unsettled syntax is not a matter of taste, and this example
-measured it by serializing the block rather than by arguing about it. Making the
-resource route a map LABEL puts it under CESR's strict field-label grammar,
-^[a-zA-Z_][a-zA-Z0-9_]*$ (ATREX in src/keri/help/helping.py), which Labeler enforces on
-every native-CESR field map -- and an ACDC attribute section is always compacted through
-a strict Compactor, so there is no opting out. The obvious spelling of a route,
-"social/feed", therefore cannot be serialized in native CESR at all: it raises
-SerializeError. Routes here use '_' as the separator, the schema PINS them to that
-grammar with propertyNames so a JSON-only author cannot write a route the wire will not
-carry, and the finding is recorded for #1550: a syntax that wants real slash-separated
-routes has to carry the route as a VALUE, with 'rc' a list of {route, caps} objects,
-rather than as a label.
+The negative that earns its place: a guardian cannot delegate more than he holds, so (4)'s
+capability tokens must be a SUBSET of (2)'s 'powers'. Over-reach is a binding property
+rather than a shape property, so the greedy credential is schema-valid and the binding, not
+the schema, refuses it (Phase 3). Naming divergence from the sibling while reading 'powers':
+there it is the coarse statutory scope enum, carried here as 'scope'.
 
-The negative that earns its place: a guardian cannot delegate more than he holds. The
-capability tokens appearing anywhere in (4)'s AuthZ block must be a SUBSET of the
-'powers' the State recognized in (2). An AuthZ credential that reaches beyond them is
-still schema-valid -- over-reach is a binding property, not a shape property -- and is
-refused by _verify_authz_chain. Note a naming divergence from the sibling module while
-reading 'powers': there it is the coarse statutory scope enum (Utah prefers LIMITED
-guardianship), which here is carried separately as 'scope'; 'powers' in THIS module is
-the delegable capability set, because it is the thing the subset check is about.
-
-A note on altitude, the same one the siblings carry. This models the credential graph,
-the edge bindings and the registry binding at the data-structure level, built from the
-real v2 primitives in keri.acdc.messaging and keri.core (acdcmap, Compactor, Mapper,
-exchange). It does not stand up a Habery/keystore or route through
-keri.vdr.verifying.verifyChain: that v1 runtime needs a live Reger/Tevery, and PR #1527
-already unit-tests its real E1E branch there. Actor AIDs and every blinding nonce derive
-from fixed salts, so the module is reproducible; each actor AID is a self-addressing
-('E') transferable AID.
+A note on altitude, the same one the siblings carry. This models the credential graph, the
+edge bindings and the registry binding at the data-structure level, built from the real v2
+primitives in keri.acdc.messaging and keri.core (acdcmap, Compactor, Mapper, exchange). It
+does not stand up a Habery/keystore or route through keri.vdr.verifying.verifyChain, which
+needs a live Reger/Tevery; PR #1527 unit-tests its real E1E branch. Actor AIDs and nonces
+derive from fixed salts, so the module is reproducible.
 """
 
 import json
@@ -621,8 +581,10 @@ N_WC_ACDC, N_WC_E, N_WC_E_GUARD = 16, 17, 18
 # (4) ward AuthZ social: attribute uuid, acdc uuid, edge-section uuid, two edge uuids.
 N_AZ_A, N_AZ_ACDC, N_AZ_E, N_AZ_E_AUTH, N_AZ_E_SUBJ = 19, 20, 21, 22, 23
 
-# Cara's age at presentation (DOB 2012-04-10, presentation 2026-08-03). The 13-to-18
-# band is exactly the band Utah's social-media law regulates.
+# Cara's age at presentation (DOB 2012-04-10, presentation 2026-08-03). The 13-to-18 band
+# is exactly the band Utah's social-media law regulates, and the band in which a ward
+# operates her own device -- which is why the ward presents here and the guardian presents
+# in the sibling, whose ward is six (tests/acdc/test_guardianship_presentation.py).
 CARA_AGE = 14
 
 
@@ -1270,8 +1232,9 @@ def test_wardauthz_presentation_JSON():
 
     Cara walks up to the platform holding a credential issued TO her, and presents it
     herself. Bob is not in the exchange at all: he is a node in the DAG, not a party to
-    the conversation. That is the whole difference from the sibling module, where the
-    guardian is the discloser and the ward never speaks.
+    the conversation. That is the whole difference from
+    tests/acdc/test_guardianship_presentation.py, where the ward is too young to hold her
+    own keys, so the guardian is the discloser and the ward never speaks.
 
     The exchange is gated: apply, offer, agree, grant, admit, with the ward's citizen
     attributes crossing the wire only after the platform has signed an agree, and even
@@ -1289,7 +1252,7 @@ def test_wardauthz_presentation_JSON():
     # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
     # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
     # with ACDC-relative paths -- the construct settled in WebOfTrust/keripy discussion
-    # #1549, shared with tests/acdc/test_cp_disclosure.py,
+    # #1549, shared with tests/acdc/test_clc_disclosure.py,
     # test_bulk_issuance_shared_registry.py and test_guardianship_presentation.py.
     # A dict keyed by schema SAID cannot express a DAG holding two credentials of the
     # same schema, which is why the construct is a list.

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -1331,6 +1331,22 @@ def test_wardauthz_presentation_JSON():
 
     # 1. apply (platform -> Cara): the challenge -- which schemas and which fields.
     #
+    # It carries the ANCHORED-EXCHANGE field 'ax' in the attribute block (#1613), as a
+    # LIST of booleans -- one element per DAG, and this presentation is a single DAG
+    # (#1627's "Use Required Lists", the same shape as the grant's 'o' for the same
+    # reason). The value is False, and the field is present-and-false rather than absent
+    # so its shape is visible: #1613 treats a missing 'ax' as no anchoring requirement,
+    # so the two are equivalent here.
+    #
+    # False is the honest value. A truthy 'ax' would oblige Cara to anchor the grant in
+    # her own KEL, and this module is data-structure-level throughout -- there is no KEL
+    # to anchor in. It is worth saying that a real deployment might well set it: Cara is
+    # the issuee presenting her own entitlement, which is exactly the replay case #1613
+    # wants a fresh proof-of-control for. Note also that the mandatory rule at #1613 does
+    # not fire here -- it binds when an ACDC in the DAG signals a presentation-anchor
+    # registry via 'rd' and 'i' at the top level of its ATTRIBUTE block, and no
+    # credential in this graph carries 'rd' there (it sits at the ACDC top level).
+    #
     # It does NOT name a governance framework. An earlier draft carried the AuthZ rules
     # SAID here as 'g' and again in the offer as 'governance', which was two labels for
     # a pointer the credential already publishes in its own rules section (asserted in
@@ -1416,7 +1432,8 @@ def test_wardauthz_presentation_JSON():
                                         [guardianCitizen.sad['s']['$id'], "",
                                          ["a/i"]]]),
                      attributes=dict(m="Prove a guardian authorized this minor account "
-                                       "holder's settings, and show the scope."),
+                                       "holder's settings, and show the scope.",
+                                     ax=[False]),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
     dp = apply.sad['q']['dp']
@@ -1435,9 +1452,10 @@ def test_wardauthz_presentation_JSON():
     # Every node the binding reads is asked for, and every node in the DAG is a node the
     # binding reads -- so the request covers the DAG exactly.
     assert len(dp) == 4
-    assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m'}
+    assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'ax'}
     assert 'g' not in apply.sad['a']            # governance lives in ACDC rules
-    assert apply.said == "EK8c54LovECAuyNpNjuRdCvPxrDFQe1cRgMMN7Y9bSaK"
+    assert apply.sad['a']['ax'] == [False]      # unanchored exchange (#1613, #1627)
+    assert apply.said == "EM852Md0tpcxzoLO_ecuWlgZl-M_C7nnVC8gM2NUbJG-"
 
     # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
     # offering, and binds the apply. It deliberately does NOT
@@ -1460,13 +1478,14 @@ def test_wardauthz_presentation_JSON():
     # (#1549), so Cara restates nothing and the two messages cannot drift.
     offer = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/offer", prior=apply.said,
                      modifiers=dict(dp=[]),
-                     attributes=dict(acdc=wardAuthz.said),
+                     attributes=dict(acdc=wardAuthz.said, ax=[False]),
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
     assert 'governance' not in offer.sad['a']          # ...and not on the exchange
-    assert set(offer.sad['a']) == {'acdc'}
-    assert offer.said == "EKmxlQFMSOUZNu4t_pMSFX-0ACyaYfVkIv0YzLloTZ_j"
+    assert set(offer.sad['a']) == {'acdc', 'ax'}
+    assert offer.sad['a']['ax'] == [False]             # Cara agrees: no anchoring
+    assert offer.said == "EJLOZ700VVkuvhSEt2bilW3PLJhleyYwv2fCPlL9YPX1"
     assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
     assert b"Cara Carver" not in offer.raw and b"2009-04-10" not in offer.raw
     assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
@@ -1478,7 +1497,7 @@ def test_wardauthz_presentation_JSON():
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said
-    assert agree.said == "EJMvaBejL2_tduOfBDcrPLKlsoE0xhES3qRArCOPcRNM"
+    assert agree.said == "EKv6Wm_IKLWjiJu5EpO_GB-goYAN-00poXEKjlxuLGuH"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1520,7 +1539,7 @@ def test_wardauthz_presentation_JSON():
         nests = nests if nests is not None else disclosures
         serder = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/grant",
                           prior=agreeMsg.said,
-                          attributes=dict(o=[wardAuthz.said]),
+                          attributes=dict(o=[wardAuthz.said], ax=[False]),
                           stamp=GRANT_STAMP, kind=kind)
         caraSig = _SIGNERS[2].sign(ser=serder.raw, index=0)   # the discloser signs
         return serder, messagize(serder, sigers=[caraSig],
@@ -1538,14 +1557,14 @@ def test_wardauthz_presentation_JSON():
     # The valid agree unlocks the grant.
     grant, grantStream = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "EBsZ8dlRvJsm5UOWVAWGDC4E6FqQtoWH-sOiSbNtpJ87"
+    assert grant.said == "ELp4e7S22Uyj-IW2QKPqIq1H43s9GoIBfdiYBpVnZ2Ea"
 
     # The attribute block is the origin and nothing else: a ONE-ELEMENT LIST, which is
     # #1627's "Use Required Lists" form. That option is preferred there over a field map
     # precisely because `dp` is already a list, so writing the single-DAG case as a list
     # now is what keeps this example from needing a second edit when DAG soup lands.
     granted = grant.sad['a']
-    assert granted == dict(o=[wardAuthz.said])         # origin SAID only; #1595, #1627
+    assert granted == dict(o=[wardAuthz.said], ax=[False])   # #1595, #1613, #1627
     assert isinstance(granted['o'], list) and len(granted['o']) == 1   # one DAG
 
     # The credentials are on the stream, not in the body -- one artifact per dp entry,
@@ -1632,7 +1651,7 @@ def test_wardauthz_presentation_JSON():
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EKo47dZ9mrm9nBK8ChGwy9bgayaTIdS1BgIrVqkeaMES"
+    assert admit.said == "EBrp-miKYtL2_rG0HaY7Yu-jQj0s1WXozsduiZs9gJMB"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -1,0 +1,1519 @@
+# -*- coding: utf-8 -*-
+"""
+tests.acdc.test_ward_authz_presentation module
+
+Worked, working example of a DELEGATED AUTHORIZATION that the ward presents herself:
+a guardian issues his ward an ACDC carrying an attenuated slice of his own authority,
+and the ward -- not the guardian -- shows it to the service that gates the act. It is
+the shape @SmithSamuelM drew in WebOfTrust/keripy discussion #1550, in the diagram
+titled "Ward with Single Guardian Issues Authorization: Ward to Access Social", and it
+is the sibling of tests/acdc/test_guardianship_presentation.py, which models the
+OPPOSITE direction.
+
+Scenario. Utah's social-media law conditions a minor's use of a social platform on
+verified parental authorization. Cara is 14. She controls her own keys -- she operates
+a phone, she can sign -- but she cannot self-assert entitlement to a service her
+parent gates. Bob, her custodial parent and state-recognized digital guardian, does
+NOT log in for her and does not present on her behalf. He issues her an ACDC that says
+which routes on the platform she may exercise and with which capabilities, drawn from
+(and no larger than) the authority the State recognized in him. Cara then walks up to
+the platform holding her own credential and presents it.
+
+Two shapes, two regimes, both real. The guardian-presents shape (this module's sibling,
+PR #1530) fits the regime where the parent holds the ward's keys -- an infant, or an
+incapacitated adult -- and the guardian must speak for a subject who cannot act at all;
+there the load-bearing invariant is holder != subject, so a verifier can always tell
+that a guardian, not the ward, is acting. The ward-presents shape modeled HERE fits the
+regime where the ward controls her own keys and can act, but only within a scope her
+guardian sets; there the load-bearing invariant is attenuation -- the ward acts as
+herself, and what bounds her is the delegated authorization she carries, not a stand-in
+who acts for her. Sam's own text draws the same line ("at birth ... the parents could be
+the custodians of the child's digital identity", as against a ward old enough to operate
+a device), and the split into two modules matches the progression-of-examples approach he
+asked for in #1515.
+
+Four credentials, all v2 ACDCs, all registry-bound, each validated against a
+purpose-authored JSON Schema (Draft 2020-12):
+
+  1. Guardian as Citizen  -- State -> Bob.  Bob's own SEDI identity credential.
+  2. Guardian as Guardian -- State -> Bob.  The recognized guardianship. Its attribute
+     block carries BOTH the guardian's issuee AID and the WARD's AID (see the recorded
+     divergence below). One edge, to (1).
+  3. Ward as Citizen Ward -- State -> Cara. Cara's own SEDI identity credential, which
+     by its edge to (2) DECLARES ITSELF ENCUMBERED: the ward's own credential says that
+     a guardianship stands over it, so a verifier reading only Cara's credential learns
+     that her identity is not unencumbered.
+  4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry (not the State's). The
+     payload: the resource routes and capabilities Cara may exercise. Two edges, to (2)
+     and to (3).
+
+Four edges, four different operators, and getting each right is the security content of
+this example. Every one is PINNED by a schema const, so a mislabeled operator fails at
+wire validation rather than at the verifier's discretion:
+
+  * (4) -> (2), authority, I2I. The near ACDC's issuer is Bob and the far node's issuee
+    is Bob, which is exactly I2I's same-holder constraint. This edge is what proves Bob
+    HELD the authority he is delegating; without it the AuthZ credential is a stranger
+    asserting permissions over someone else's child.
+  * (4) -> (3), subject, E1E. The near ACDC's ISSUEE is Cara and the far node's issuee
+    is Cara -- same subject -- but the issuers differ (Bob issues (4), the State issues
+    (3)). I2I would demand issuer(near) == issuee(far), i.e. Bob == Cara, and would
+    therefore FALSELY REJECT a perfectly sound identity relation. E1E, the identity
+    operator added in PR #1527 out of discussion #1515, constrains the issuee only and
+    says nothing about the issuer, which is why it holds here. This is the SECOND
+    independent use case for E1E, and unlike the first (an age credential chaining to an
+    identity credential) it comes from Sam's own diagram rather than from the PR that
+    proposed the operator.
+  * (2) -> (1), citizen, E1E again. Same subject (Bob is the issuee of both), same
+    issuer (the State issues both). Same-issuer is not what makes it an identity
+    relation -- E1E is right because the relation binds two credentials of ONE subject,
+    and I2I would again demand issuer == issuee, i.e. State == Bob.
+  * (3) -> (2), guardian, NI2I. The near issuee is Cara and the far issuee is Bob:
+    DIFFERENT subjects, so neither I2I nor E1E applies. NI2I is the untargeted
+    reference -- it nullifies I2I's same-holder requirement and asserts nothing in its
+    place -- which is the correct operator for "my credential points at somebody else's
+    credential", here the encumbrance marker.
+
+E1E carries the same caveat it carries in the sibling module: it is not yet in the ACDC
+spec's closed operator set {I2I, NI2I, DI2I, NOT}. A spec-default or pre-#1527 verifier
+does not reject an unknown operator, it COERCES it -- to I2I for a targeted far node,
+which then wrongly rejects both E1E edges here, or to NI2I for an untargeted one, which
+wrongly accepts unchecked. So this graph validates only against a #1527-or-later
+verifier, and rides that dependency until E1E is ratified (disc #1515).
+
+Recorded divergence: where the ward AID lives. Sam's diagram puts the ward's AID in the
+ATTRIBUTE block of (2), next to the guardian's issuee AID; the sibling #1530 names the
+ward only by an EDGE. Both preserve holder != subject on the guardianship credential, so
+this is a DISCLOSURE choice rather than an impersonation one. The edge form is the better
+one on Sam's own argument from #1515 -- "an edge can also be blinded, which means that
+disclosure of the edge itself can be held back until the verifier (disclosee) has agreed
+not to exploit its correlatability" -- and an authority credential that both models agree
+is disclosed WHOLE cannot withhold an attribute the way it can withhold an edge, so the
+attribute placement hands every verifier the ward's AID before any contract terms are
+agreed. This module models SAM's placement, because it is his diagram; the question is
+open on #1550, so this is recorded as a divergence, not settled as a verdict. Phase 4
+shows the same argument arriving as an actual leak rather than a principle: the
+guardianship's expiry date is the ward's 18th birthday, and because the credential is
+disclosed whole it cannot be withheld, so the platform learns her birth month and day
+from a credential that is not hers.
+
+The AuthZ payload is ILLUSTRATIVE and its syntax is UNSETTLED. Sam says only that the
+field "contains the specifics of the authorization. The syntax TBD", and points at EVAC
+(Edge Verifiable Agent Control), whose sketch at the end of #1550 is a resource-
+capabilities map 'rc' of the form {resourceRoute: [capability, ...]}. That is what is
+modeled here, plus a time window, and it is marked illustrative in the schema
+description as well as here. The example's assertions deliberately do NOT reach into the
+block: every capability check goes through _authz_capabilities, so a later syntax change
+is one function, not a rewrite of the suite.
+
+One constraint on that unsettled syntax is not a matter of taste, and this example
+measured it by serializing the block rather than by arguing about it. Making the
+resource route a map LABEL puts it under CESR's strict field-label grammar,
+^[a-zA-Z_][a-zA-Z0-9_]*$ (ATREX in src/keri/help/helping.py), which Labeler enforces on
+every native-CESR field map -- and an ACDC attribute section is always compacted through
+a strict Compactor, so there is no opting out. The obvious spelling of a route,
+"social/feed", therefore cannot be serialized in native CESR at all: it raises
+SerializeError. Routes here use '_' as the separator, the schema PINS them to that
+grammar with propertyNames so a JSON-only author cannot write a route the wire will not
+carry, and the finding is recorded for #1550: a syntax that wants real slash-separated
+routes has to carry the route as a VALUE, with 'rc' a list of {route, caps} objects,
+rather than as a label.
+
+The negative that earns its place: a guardian cannot delegate more than he holds. The
+capability tokens appearing anywhere in (4)'s AuthZ block must be a SUBSET of the
+'powers' the State recognized in (2). An AuthZ credential that reaches beyond them is
+still schema-valid -- over-reach is a binding property, not a shape property -- and is
+refused by _verify_authz_chain. Note a naming divergence from the sibling module while
+reading 'powers': there it is the coarse statutory scope enum (Utah prefers LIMITED
+guardianship), which here is carried separately as 'scope'; 'powers' in THIS module is
+the delegable capability set, because it is the thing the subset check is about.
+
+A note on altitude, the same one the siblings carry. This models the credential graph,
+the edge bindings and the registry binding at the data-structure level, built from the
+real v2 primitives in keri.acdc.messaging and keri.core (acdcmap, Compactor, Mapper,
+exchange). It does not stand up a Habery/keystore or route through
+keri.vdr.verifying.verifyChain: that v1 runtime needs a live Reger/Tevery, and PR #1527
+already unit-tests its real E1E branch there. Actor AIDs and every blinding nonce derive
+from fixed salts, so the module is reproducible; each actor AID is a self-addressing
+('E') transferable AID.
+"""
+
+import json
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+from keri import Kinds, Ilks
+from keri.core import (Salter, Noncer, Compactor, Mapper, Diger, Verfer,
+                       exchange, messagize)
+from keri.core.coring import MtrDex
+from keri.core.eventing import incept
+from keri.acdc import regcept, acdcmap
+from keri.help.helping import ATREX
+
+
+# --- Reproducible example actors (see module docstring). ---
+# Four actors, each a self-addressing ('E') transferable AID: its prefix is the SAID of
+# an inception event committing to the actor's current signing key and a digest of its
+# pre-rotated next key. Eight signers from one fixed salt: _SIGNERS[0..3] are the four
+# actors' current signing keys (State, Bob, Cara, the social service) and _SIGNERS[4..7]
+# are their matching pre-rotated next keys.
+_SIGNERS = Salter(raw=b'wardauthzexamsal').signers(count=8, transferable=True,
+                                                   temp=True)
+
+
+def _actor_aid(cur, nxt):
+    """Self-addressing (E) AID: the SAID of an inception committing to cur + next(nxt)."""
+    return incept(keys=[cur.verfer.qb64],
+                  ndigs=[Diger(ser=nxt.verfer.qb64b).qb64],
+                  code=MtrDex.Blake3_256).pre
+
+
+# STATE = the Utah state agency that endorses citizens and recognizes guardianships;
+# BOB = the custodial parent (guardian); CARA = the 14-year-old ward; SOCIAL = the
+# social-media platform that must gate a minor's access on parental authorization.
+STATE, BOB, CARA, SOCIAL = (_actor_aid(_SIGNERS[i], _SIGNERS[i + 4]) for i in range(4))
+
+# Per-example blinding nonces, derived (not pasted) from a distinct raw prefix so this
+# file shares no nonce values with the sibling examples.
+RAWS = [b'wardauthzexamra' + b'%0x' % (i,) for i in range(32)]
+NONCES = [Noncer(raw=raw).qb64 for raw in RAWS]
+
+
+def _saidify_schema(mad, kind=Kinds.json):
+    """Compute a JSON Schema's SAID and return (said, schema-with-$id).
+
+    Mirrors the sibling examples: run the schema map through a Mapper that
+    self-addresses the '$id' field (which must be first, as its position is part of the
+    serialization the SAID digests). Mapper deep-copies its input, so the caller's
+    schema map is never mutated.
+    """
+    mapper = Mapper(mad=mad, makify=True, strict=False, saids={"$id": 'E'},
+                    saidive=True, kind=kind)
+    return mapper.said, mapper.mad
+
+
+def assert_acdc_schema_valid(acdc, schema=None):
+    """Validate a worked-example ACDC against its JSON Schema (Draft 2020-12).
+
+    Identical in intent to the helper in the sibling examples: it proves the schema is
+    itself well-formed and that the ACDC instance conforms to the schema it commits to
+    in its own 's' section. When the schema section has been compacted to a bare SAID
+    string, pass the schema explicitly.
+    """
+    if schema is None:
+        schema = acdc.sad['s']
+        if not isinstance(schema, dict):
+            raise ValueError("schema section is compacted to a SAID; pass "
+                             "schema= (e.g. the expanded ACDC's sad['s'])")
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(acdc.sad)
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# Purpose-authored JSON Schemas (Draft 2020-12). Authored as maps with "$id" first so
+# _saidify_schema can self-address them per wire kind.
+# ---------------------------------------------------------------------------
+
+def _disclosable_block(attr, attr_schema, desc):
+    """One partially-disclosable block schema: oneOf(block SAID, block detail).
+
+    A nested attribute block has one shape -- oneOf(block SAID, {d, u, <attr>}). A
+    withheld block travels as its bare SAID and leaks nothing (its own blinding nonce
+    'u' means a low-entropy value cannot be brute-forced from the SAID).
+    """
+    return {
+        "description": f"{desc} block",
+        "oneOf": [
+            {"description": f"{desc} block SAID", "type": "string"},
+            {"description": f"{desc} block detail", "type": "object",
+             "required": ["d", "u", attr],
+             "properties": {"d": {"description": "Block SAID", "type": "string"},
+                            "u": {"description": "Block UUID", "type": "string"},
+                            attr: attr_schema},
+             "additionalProperties": False},
+        ],
+    }
+
+
+# acm is a fixed-field format: it always carries (possibly empty) e and r sections even
+# when unused, so the schema must admit them.
+_EMPTY_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
+
+
+def _edge_schema(op_const, desc):
+    """One edge schema whose operator is PINNED to a single value (const op_const).
+
+    Pinning the operator in the schema is what makes each of this example's four
+    relationships schema-enforced rather than conventional: the I2I authority edge, the
+    two E1E identity edges and the NI2I encumbrance edge cannot be silently swapped for
+    one another without failing wire validation. It also means E1E is never INFERRED --
+    an unlabeled identity edge would default to I2I, which is the wrong answer here.
+    """
+    return {
+        "oneOf": [
+            {"type": "string"},
+            {"type": "object", "required": ["d", "n", "o"],
+             "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                            "n": {"description": f"{desc}: far node SAID",
+                                  "type": "string"},
+                            "s": {"description": "Far node schema SAID",
+                                  "type": "string"},
+                            "o": {"description": f"Edge operator ({desc})",
+                                  "const": op_const}}}]}
+
+
+# --- The SEDI citizen credential, shared shape for (1) Bob's and (3) Cara's. ---
+# Fixed, well-labeled identity fields, so an attribute section with individually
+# partially-disclosable nested blocks is the right model: labels give clean paths and
+# clean partial disclosure. The issuee 'i' is the citizen. Cara's differs from Bob's in
+# exactly one way -- it carries the encumbrance edge -- so the schema is authored twice
+# rather than shared, since the edge section is what a verifier reads to tell an
+# unencumbered citizen credential from a ward's.
+def _citizen_properties():
+    """The identity attribute properties both citizen credentials carry."""
+    return {
+        "d": {"description": "Section SAID", "type": "string"},
+        "u": {"description": "Section UUID", "type": "string"},
+        "i": {"description": "Issuee (the citizen) AID", "type": "string"},
+        "name": _disclosable_block("name",
+            {"description": "Full name", "type": "string"}, "Name"),
+        "dob": _disclosable_block("dob",
+            {"description": "Date of birth", "type": "string", "format": "date"},
+            "DOB"),
+        "residence": _disclosable_block("residence",
+            {"description": "Residence", "type": "string"}, "Residence"),
+    }
+
+
+# --- (1) Guardian as Citizen: the guardian's own SEDI identity credential. ---
+# State -> Bob. Registry-bound. No edges: an adult citizen credential stands alone,
+# which is precisely the contrast the ward's credential draws.
+GUARDIAN_CITIZEN_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "SEDI Citizen Credential",
+    "description": "State-endorsed SEDI identity credential for an adult citizen; "
+                   "attributes carried as individually partially-disclosable nested "
+                   "blocks. Stands alone: no encumbrance edge.",
+    "credentialType": "SEDI_Citizen",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a", "r"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer (the State agency) AID", "type": "string"},
+        "rd": {"description": "Registry SAID", "type": "string"},
+        "s": {"description": "Schema Section",
+              "oneOf": [{"type": "string"}, {"type": "object"}]},
+        "a": {"description": "Attribute section with individually-disclosable blocks",
+              "oneOf": [
+                  {"description": "Attribute Section SAID", "type": "string"},
+                  {"description": "Attribute detail", "type": "object",
+                   "required": ["d", "u", "i", "name", "dob", "residence"],
+                   "properties": _citizen_properties(),
+                   "additionalProperties": False}]},
+        "e": _EMPTY_OR_SECTION,
+        "r": {"description": "SAID of the SEDI citizen governance framework",
+              "type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+# --- (3) Ward as Citizen Ward: the ward's own SEDI identity credential. ---
+# State -> Cara. Identical attribute shape to (1), plus ONE required edge back to the
+# guardianship credential (2). That edge is the point: the ward's own credential
+# DECLARES that it is encumbered, so a verifier who reads only Cara's credential learns
+# that a guardianship stands over her identity. Its operator is NI2I, and it must be:
+# the near issuee is Cara and the far issuee is Bob, which are different subjects, so
+# neither the delegative I2I nor the identity E1E applies.
+WARD_CITIZEN_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "SEDI Ward Citizen Credential",
+    "description": "State-endorsed SEDI identity credential for a citizen under "
+                   "guardianship. Same attribute shape as the adult citizen credential, "
+                   "plus a REQUIRED NI2I edge to the guardianship credential -- the "
+                   "ward's own credential declares that it is encumbered.",
+    "credentialType": "SEDI_CitizenWard",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a", "e", "r"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer (the State agency) AID", "type": "string"},
+        "rd": {"description": "Registry SAID", "type": "string"},
+        "s": {"description": "Schema Section",
+              "oneOf": [{"type": "string"}, {"type": "object"}]},
+        "a": {"description": "Attribute section with individually-disclosable blocks",
+              "oneOf": [
+                  {"description": "Attribute Section SAID", "type": "string"},
+                  {"description": "Attribute detail", "type": "object",
+                   "required": ["d", "u", "i", "name", "dob", "residence"],
+                   "properties": _citizen_properties(),
+                   "additionalProperties": False}]},
+        "e": {"description": "Edge section: the encumbrance edge to the guardianship",
+              "oneOf": [
+                  {"type": "string"},
+                  {"type": "object", "required": ["d", "guardian"],
+                   "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                                  "guardian": _edge_schema(
+                                      "NI2I", "encumbrance: a guardianship over this "
+                                              "citizen, held by someone else")},
+                   "additionalProperties": False}]},
+        "r": {"description": "SAID of the SEDI ward governance framework",
+              "type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+# The delegable capability vocabulary. 'powers' on the guardianship credential (2) is
+# drawn from it, and so is every capability list in the AuthZ credential (4); the subset
+# check is what keeps (4) inside (2). Note the naming divergence from the sibling module
+# recorded in the docstring: 'powers' there is the coarse statutory scope enum, which
+# here is 'scope'.
+CAPABILITIES = ["read", "post", "message", "profile", "configure", "purchase",
+                "livestream"]
+
+# The coarse statutory scope enum, the same vocabulary the sibling module carries. Utah
+# prefers LIMITED guardianship, so a verifier checks the specific act against scope
+# before it ever looks at the fine-grained capabilities.
+SCOPES = ["plenary", "healthCare", "residence", "education", "personalRecords",
+          "socialBenefits", "digitalIdentity", "contracts"]
+
+# --- (2) Guardian as Guardian: the recognized guardianship. ---
+# State -> Bob, registry-bound (guardianship terminates dynamically, so a verifier MUST
+# check current status rather than trusting a date). Disclosed WHOLE: a verifier needs
+# basis + scope + powers + validity together, so the attribute section is flat.
+#
+# SAM'S PLACEMENT, and the recorded divergence: the ward's AID sits in the ATTRIBUTE
+# block, next to the guardian's issuee AID, exactly as drawn in #1550. The sibling #1530
+# names the ward by edge instead. See the module docstring for why the edge form is
+# better for disclosure and why this is recorded rather than decided.
+GUARDIAN_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "SEDI Digital Guardian",
+    "description": "SEDI legal-recognition layer for a digital guardian (Utah Code "
+                   "63A-20). Held by the guardian (issuee); the WARD's AID is carried "
+                   "in the attribute block per the #1550 diagram (the sibling #1530 "
+                   "names the ward by edge instead). Registry-bound: guardianship "
+                   "terminates dynamically. One E1E edge to the guardian's own citizen "
+                   "credential.",
+    "credentialType": "SEDI_Guardian",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a", "e", "r"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer = the recognizing State agency", "type": "string"},
+        "rd": {"description": "Registry SAID -- MANDATORY (dynamic termination)",
+               "type": "string"},
+        "s": {"description": "Schema Section",
+              "oneOf": [{"type": "string"}, {"type": "object"}]},
+        "a": {"description": "The recognized guardianship (disclosed whole)",
+              "oneOf": [
+                  {"description": "Attribute Section SAID", "type": "string"},
+                  {"type": "object",
+                   "required": ["d", "u", "i", "ward", "basis", "scope", "powers",
+                                "fiduciary", "effectiveDate"],
+                   "properties": {
+                       "d": {"description": "Section SAID", "type": "string"},
+                       "u": {"description": "Section UUID", "type": "string"},
+                       "i": {"description": "Issuee = the GUARDIAN's AID",
+                             "type": "string"},
+                       "ward": {"description": "The WARD's AID, in the attribute block "
+                                               "per the #1550 diagram",
+                                "type": "string"},
+                       "basis": {"description": "Which statutory basis",
+                                 "enum": ["designatedRepresentative", "custodialParent",
+                                          "courtGuardianMinor",
+                                          "courtGuardianIncapacitated"]},
+                       "scope": {"description": "Coarse statutory scope (Utah prefers "
+                                                "LIMITED guardianship)",
+                                 "type": "array", "minItems": 1, "uniqueItems": True,
+                                 "items": {"enum": SCOPES}},
+                       "powers": {"description": "The DELEGABLE capability set: the "
+                                                 "ceiling on any authorization the "
+                                                 "guardian issues to the ward",
+                                  "type": "array", "minItems": 1, "uniqueItems": True,
+                                  "items": {"enum": CAPABILITIES}},
+                       "fiduciary": {"enum": ["bestInterest", "substitutedJudgment"]},
+                       "effectiveDate": {"type": "string", "format": "date"},
+                       "expiryDate": {"type": "string", "format": "date"},
+                   },
+                   "additionalProperties": False}]},
+        "e": {"description": "Edge section: E1E to the guardian's own citizen credential",
+              "oneOf": [
+                  {"type": "string"},
+                  {"type": "object", "required": ["d", "citizen"],
+                   "properties": {"d": {"type": "string"}, "u": {"type": "string"},
+                                  "citizen": _edge_schema(
+                                      "E1E", "identity: the guardian's own citizen "
+                                             "credential, same subject")},
+                   "additionalProperties": False}]},
+        "r": {"description": "SAID of the SEDI guardianship governance framework",
+              "type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+# --- (4) Ward AuthZ Social: the delegated authorization. ---
+# Bob -> Cara, in BOB'S OWN registry. This is the credential the ward presents. Its
+# attribute block carries the AuthZ payload; its two edges are the security content.
+#
+# ILLUSTRATIVE PAYLOAD, SYNTAX UNSETTLED. Sam says of the AuthZ field only that it
+# "contains the specifics of the authorization. The syntax TBD", and points at EVAC
+# (Edge Verifiable Agent Control), sketched at the end of #1550 as a resource-
+# capabilities map 'rc' of the form {resourceRoute: [capability, ...]}. That shape is
+# adopted here verbatim rather than a third vocabulary being invented, plus a time
+# window, and additionalProperties stays OPEN so a later syntax can grow into the slot.
+#
+# ONE MEASURED CONSTRAINT ON THAT SYNTAX, which this example surfaced by serializing it.
+# Making the resource route a map LABEL puts it under CESR's strict field-label grammar,
+# ATREX = ^[a-zA-Z_][a-zA-Z0-9_]*$ (src/keri/help/helping.py), enforced by Labeler for
+# every native-CESR field map -- and an ACDC attribute section is always compacted
+# through a strict Compactor, so this is not optional. A route written the obvious way,
+# "social/feed", therefore CANNOT be serialized in native CESR at all: it raises
+# SerializeError, not a validation warning. Routes here use '_' as the separator so the
+# example serializes on every kind, and the constraint is PINNED below by propertyNames
+# rather than merely observed. A syntax that wants real slash-separated routes has to
+# carry the route as a VALUE -- 'rc' as a list of {route, caps} objects -- rather than
+# as a label. That is a genuine input to the TBD, and it is why this block is worth
+# serializing over CESR rather than JSON alone.
+_ROUTE_PATTERN = "^[a-zA-Z_][a-zA-Z0-9_]*$"     # CESR's strict field-label grammar
+AUTHZ_BLOCK_SCHEMA = {
+    "description": "ILLUSTRATIVE authorization payload; SYNTAX UNSETTLED. Modeled on "
+                   "the EVAC (Edge Verifiable Agent Control) sketch in WebOfTrust/"
+                   "keripy discussion #1550: a resource-capabilities map 'rc' of the "
+                   "form {resourceRoute: [capability, ...]}, here with a time window. "
+                   "Because the route is a map LABEL it is constrained to CESR's strict "
+                   "field-label grammar, so a slash-separated route is not representable "
+                   "in native CESR; a syntax needing those must carry the route as a "
+                   "value instead. Additional properties are ALLOWED so a later syntax "
+                   "can extend this block without invalidating the example.",
+    "type": "object",
+    "required": ["rc"],
+    "properties": {
+        "rc": {"description": "Resource-capabilities map: route -> capability list. "
+                              "Route labels are pinned to CESR's strict field-label "
+                              "grammar, which native-CESR serialization enforces.",
+               "type": "object", "minProperties": 1,
+               "propertyNames": {"pattern": _ROUTE_PATTERN},
+               "additionalProperties": {"type": "array", "minItems": 1,
+                                        "uniqueItems": True,
+                                        "items": {"enum": CAPABILITIES}}},
+        "window": {"description": "Time window over which the authorization is live",
+                   "type": "object",
+                   "required": ["start", "end"],
+                   "properties": {
+                       "start": {"type": "string"},
+                       "end": {"type": "string"},
+                       "dailyHours": {"description": "Local clock window, e.g. "
+                                                     "16:00-20:00",
+                                      "type": "string"},
+                       "tz": {"description": "IANA time zone", "type": "string"}},
+                   "additionalProperties": True},
+    },
+    "additionalProperties": True,
+}
+
+AUTHZ_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Ward AuthZ Social",
+    "description": "A guardian-issued delegated authorization the WARD holds and "
+                   "presents herself. Issuer = the guardian, issuee = the ward, bound "
+                   "to the GUARDIAN's own registry. Two pinned edges: I2I to the "
+                   "guardianship credential (the guardian held what he delegates) and "
+                   "E1E to the ward's own citizen credential (same subject, different "
+                   "issuers -- the case I2I would falsely reject).",
+    "credentialType": "WardAuthZSocial",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a", "e", "r"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer = the GUARDIAN (not the State)", "type": "string"},
+        "rd": {"description": "Registry SAID -- the GUARDIAN's own registry",
+               "type": "string"},
+        "s": {"description": "Schema Section",
+              "oneOf": [{"type": "string"}, {"type": "object"}]},
+        "a": {"description": "Attribute Section carrying the authorization payload",
+              "oneOf": [
+                  {"description": "Attribute Section SAID", "type": "string"},
+                  {"type": "object",
+                   "required": ["d", "u", "i", "authz", "issuedAt"],
+                   "properties": {
+                       "d": {"description": "Section SAID", "type": "string"},
+                       "u": {"description": "Section UUID", "type": "string"},
+                       "i": {"description": "Issuee = the WARD's AID", "type": "string"},
+                       "authz": AUTHZ_BLOCK_SCHEMA,
+                       "issuedAt": {"type": "string"}},
+                   "additionalProperties": False}]},
+        "e": {"description": "Edge section: I2I authority + E1E subject",
+              "oneOf": [
+                  {"type": "string"},
+                  {"type": "object", "required": ["d", "authority", "subject"],
+                   "properties": {
+                       "d": {"type": "string"}, "u": {"type": "string"},
+                       "authority": _edge_schema(
+                           "I2I", "the guardian holds this authority"),
+                       "subject": _edge_schema(
+                           "E1E", "identity: the ward's own citizen credential, same "
+                                  "subject, different issuer")},
+                   "additionalProperties": False}]},
+        "r": {"description": "SAID of the delegated-authorization governance framework",
+              "type": "string"},
+    },
+    "additionalProperties": False,
+}
+
+# Published governance frameworks, referenced BY SAID rather than authored here. Each is
+# a PLACEHOLDER digest of a description string, standing in for the SAID a real
+# deployment computes over the governance document.
+CITIZEN_RULES_SAID = Diger(ser=b'SEDI citizen governance framework v1').qb64
+WARD_RULES_SAID = Diger(ser=b'SEDI ward governance framework v1').qb64
+GUARDIAN_RULES_SAID = Diger(ser=b'SEDI guardianship governance framework v1').qb64
+AUTHZ_RULES_SAID = Diger(
+    ser=b'SEDI delegated-authorization governance framework v1').qb64
+
+# Registry inception timestamps: the State's citizen registry, the State's guardianship
+# registry, and the guardian's OWN registry that the AuthZ credential binds to.
+REG_CITIZEN_STAMP = "2026-01-05T12:00:00.000000+00:00"
+REG_GUARDIAN_STAMP = "2026-01-06T12:00:00.000000+00:00"
+REG_AUTHZ_STAMP = "2026-07-01T12:00:00.000000+00:00"
+
+# Fixed timestamps for the credentials and the IPEX exn messages (kept stable so SAIDs
+# are reproducible).
+AUTHZ_STAMP = "2026-08-01T09:00:00.000000+00:00"
+APPLY_STAMP = "2026-08-03T18:00:00.000000+00:00"
+OFFER_STAMP = "2026-08-03T18:01:00.000000+00:00"
+AGREE_STAMP = "2026-08-03T18:02:00.000000+00:00"
+GRANT_STAMP = "2026-08-03T18:03:00.000000+00:00"
+ADMIT_STAMP = "2026-08-03T18:04:00.000000+00:00"
+
+# --- Blinding-nonce / uuid slot allocation: each NONCES[i] used at most once. ---
+# three registries.
+N_REG_CITIZEN, N_REG_GUARDIAN, N_REG_AUTHZ = 0, 1, 2
+# (1) guardian-as-citizen: attribute uuid + three block nonces + acdc uuid.
+N_GC_A, N_GC_NAME, N_GC_DOB, N_GC_RES, N_GC_ACDC = 3, 4, 5, 6, 7
+# (2) guardian-as-guardian: attribute uuid, acdc uuid, edge-section uuid, one edge uuid.
+N_GG_A, N_GG_ACDC, N_GG_E, N_GG_E_CIT = 8, 9, 10, 11
+# (3) ward-as-citizen: attribute uuid + three block nonces + acdc uuid, edge-section
+# uuid, one edge uuid.
+N_WC_A, N_WC_NAME, N_WC_DOB, N_WC_RES = 12, 13, 14, 15
+N_WC_ACDC, N_WC_E, N_WC_E_GUARD = 16, 17, 18
+# (4) ward AuthZ social: attribute uuid, acdc uuid, edge-section uuid, two edge uuids.
+N_AZ_A, N_AZ_ACDC, N_AZ_E, N_AZ_E_AUTH, N_AZ_E_SUBJ = 19, 20, 21, 22, 23
+
+# Cara's age at presentation (DOB 2012-04-10, presentation 2026-08-03). The 13-to-18
+# band is exactly the band Utah's social-media law regulates.
+CARA_AGE = 14
+
+
+def _citizen_registry(kind):
+    """The State's citizen registry inception (rip event): (1) and (3) bind to it."""
+    return regcept(israid=STATE, uuid=NONCES[N_REG_CITIZEN], stamp=REG_CITIZEN_STAMP,
+                   kind=kind)
+
+
+def _guardian_registry(kind):
+    """The State's guardianship registry inception. Guardianship terminates dynamically
+    (majority, restored capacity, court order), so (2) is registry-bound and a verifier
+    checks current status rather than trusting the expiry date."""
+    return regcept(israid=STATE, uuid=NONCES[N_REG_GUARDIAN], stamp=REG_GUARDIAN_STAMP,
+                   kind=kind)
+
+
+def _authz_registry(kind):
+    """The GUARDIAN's OWN registry. (4) is issued by Bob, not the State, so it binds to
+    Bob's registry -- which is also where he revokes the authorization when he changes
+    his mind, without the State being involved at all. This registry independence is a
+    structural consequence of the ward-presents shape: the delegation is the guardian's
+    act, so its lifecycle is the guardian's to manage."""
+    return regcept(israid=BOB, uuid=NONCES[N_REG_AUTHZ], stamp=REG_AUTHZ_STAMP,
+                   kind=kind)
+
+
+def _guardian_citizen_attr():
+    """Bob's citizen attribute section (a fresh map each call).
+
+    Attributive: the issuee ('i') is inserted at the top of the section by acdcmap via
+    iseaid, and each identity attribute is its own individually-blinded (own 'u'),
+    self-addressing (own 'd') nested block, so it can be disclosed or withheld
+    independently of the others.
+    """
+    return dict(d='', u=NONCES[N_GC_A],
+                name=dict(d='', u=NONCES[N_GC_NAME], name="Bob Carver"),
+                dob=dict(d='', u=NONCES[N_GC_DOB], dob="1988-02-17"),
+                residence=dict(d='', u=NONCES[N_GC_RES], residence="Provo UT"))
+
+
+def _ward_citizen_attr():
+    """Cara's citizen attribute section (a fresh map each call). Same shape as Bob's --
+    what distinguishes a ward's citizen credential is the encumbrance EDGE, not the
+    attributes."""
+    return dict(d='', u=NONCES[N_WC_A],
+                name=dict(d='', u=NONCES[N_WC_NAME], name="Cara Carver"),
+                dob=dict(d='', u=NONCES[N_WC_DOB], dob="2012-04-10"),
+                residence=dict(d='', u=NONCES[N_WC_RES], residence="Provo UT"))
+
+
+def _guardian_attr(powers=None):
+    """Bob's guardianship attribute section (a fresh map each call).
+
+    Disclosed whole (flat, not selectively disclosable): a verifier needs basis + scope
+    + powers + validity together. basis = custodialParent (the inherent parental right);
+    scope limited to digitalIdentity; powers is the DELEGABLE capability set, and it is
+    the ceiling every AuthZ credential Bob issues must stay under. 'ward' carries Cara's
+    AID in the attribute block per Sam's #1550 diagram (see the module docstring's
+    recorded divergence).
+    """
+    if powers is None:
+        powers = ["read", "post", "message", "profile", "configure"]
+    return dict(d='', u=NONCES[N_GG_A],
+                ward=CARA,
+                basis="custodialParent",
+                scope=["digitalIdentity"],
+                powers=list(powers),
+                fiduciary="bestInterest",
+                # The date the State RECOGNIZED the digital guardianship, deliberately
+                # not the date the parental right arose. For a custodial parent the
+                # latter is the ward's birth date, and an authority credential that both
+                # models agree is disclosed WHOLE cannot withhold an attribute -- so an
+                # effectiveDate of 2012-04-10 would hand every verifier Cara's exact
+                # birthdate while her own citizen credential was carefully withholding
+                # it. That is the docstring's disclosure argument arriving as a concrete
+                # leak rather than a principle, and it is dodged here rather than
+                # asserted, since a real deployment records the recognition date anyway.
+                effectiveDate="2026-01-06",
+                # Majority: Cara's 18th birthday. This DOES leak her birth month and day
+                # (2030-04-10 minus 18 years), and is left in as an honest residual --
+                # a termination date is load-bearing for a verifier in a way an
+                # effective date is not, so the fix is a coarser expiry (a quarter, a
+                # year) rather than dropping the field, and that is a schema decision
+                # for a deployment rather than something this example should invent.
+                expiryDate="2030-04-10")
+
+
+def _authz_block():
+    """The ILLUSTRATIVE AuthZ payload (a fresh map each call).
+
+    EVAC-shaped (#1550): 'rc' maps a resource route to the capability list the ward may
+    exercise on it, and 'window' bounds when. Bob grants Cara a read-only feed, posting
+    on her own posts route, and direct messages -- and does NOT grant 'purchase',
+    'livestream' or anything else he holds. The capability tokens here are a strict
+    subset of the 'powers' in the guardianship credential, which is the property
+    _verify_authz_chain enforces.
+    """
+    return dict(rc={"social_feed": ["read"],
+                    "social_posts": ["read", "post"],
+                    "social_dm": ["read", "message"]},
+                window=dict(start="2026-08-01T00:00:00+00:00",
+                            end="2026-11-30T23:59:59+00:00",
+                            dailyHours="16:00-20:00",
+                            tz="America/Denver"))
+
+
+def _authz_capabilities(authz):
+    """Every capability token appearing anywhere in an AuthZ payload, as a set.
+
+    THE syntax-insulation seam. The AuthZ block's syntax is explicitly unsettled
+    (#1550), so no assertion in this module reaches into it directly: the subset check,
+    the over-reach negative and the serialization-kinds test all ask this function. When
+    the syntax changes, this function changes and nothing else does.
+    """
+    caps = set()
+    for capabilities in authz.get('rc', {}).values():
+        caps.update(capabilities)
+    return caps
+
+
+def _guardian_citizen(kind, reg=None):
+    """(1) Guardian as Citizen: the State's SEDI identity credential for Bob.
+
+    Registry-bound, disclosed by compaction, no edges. It is the far node of the
+    guardianship credential's E1E edge, which is what ties the recognized guardian to a
+    state-endorsed human rather than to a bare AID.
+    """
+    if reg is None:
+        reg = _citizen_registry(kind)
+    _, schema = _saidify_schema(dict(GUARDIAN_CITIZEN_SCHEMA_MAD), kind=kind)
+    return acdcmap(israid=STATE, uuid=NONCES[N_GC_ACDC], regid=reg.said, schema=schema,
+                   attribute=_guardian_citizen_attr(), iseaid=BOB,
+                   rule=CITIZEN_RULES_SAID, kind=kind)
+
+
+def _guardian_credential(kind, guardianCitizen=None, reg=None, powers=None):
+    """(2) Guardian as Guardian: the State's recognition of Bob as Cara's guardian.
+
+    Held by Bob (issuee), carrying Cara's AID in the attribute block per the #1550
+    diagram. One edge, to Bob's own citizen credential, operator E1E: same subject (Bob
+    is the issuee of both), and I2I would demand issuer == issuee, i.e. State == Bob,
+    which is false -- so the identity operator from PR #1527 is the only correct label.
+    Registry-bound because guardianship terminates dynamically.
+    """
+    if guardianCitizen is None:
+        guardianCitizen = _guardian_citizen(kind)
+    if reg is None:
+        reg = _guardian_registry(kind)
+    _, schema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
+    edge = dict(d='', u=NONCES[N_GG_E],
+                citizen=dict(d='', u=NONCES[N_GG_E_CIT], n=guardianCitizen.said,
+                             s=guardianCitizen.sad['s']['$id'], o='E1E'))
+    return acdcmap(israid=STATE, uuid=NONCES[N_GG_ACDC], regid=reg.said, schema=schema,
+                   attribute=_guardian_attr(powers=powers), iseaid=BOB, edge=edge,
+                   rule=GUARDIAN_RULES_SAID, kind=kind)
+
+
+def _ward_citizen(kind, guardian=None, reg=None):
+    """(3) Ward as Citizen Ward: the State's SEDI identity credential for Cara.
+
+    Same attribute shape as Bob's, plus the encumbrance edge to the guardianship
+    credential, operator NI2I: the near issuee is Cara and the far issuee is Bob, so the
+    subjects differ and the edge is a plain reference. The edge is what makes the ward's
+    OWN credential declare that it is encumbered -- a verifier reading only Cara's
+    credential learns a guardianship stands over her identity, which is exactly what a
+    service gating a minor needs to know before it looks for an authorization.
+    """
+    if guardian is None:
+        guardian = _guardian_credential(kind)
+    if reg is None:
+        reg = _citizen_registry(kind)
+    _, schema = _saidify_schema(dict(WARD_CITIZEN_SCHEMA_MAD), kind=kind)
+    edge = dict(d='', u=NONCES[N_WC_E],
+                guardian=dict(d='', u=NONCES[N_WC_E_GUARD], n=guardian.said,
+                              s=guardian.sad['s']['$id'], o='NI2I'))
+    return acdcmap(israid=STATE, uuid=NONCES[N_WC_ACDC], regid=reg.said, schema=schema,
+                   attribute=_ward_citizen_attr(), iseaid=CARA, edge=edge,
+                   rule=WARD_RULES_SAID, kind=kind)
+
+
+def _ward_authz(kind, guardian=None, wardCitizen=None, reg=None, authz=None,
+                compactify=False):
+    """(4) Ward AuthZ Social: the delegated authorization Cara holds and presents.
+
+    Issuer = BOB (not the State), issuee = CARA, bound to BOB's own registry. Its two
+    edges are the security content of the whole example:
+
+      authority (I2I) -> (2). Near issuer is Bob, far issuee is Bob: the same-holder
+        constraint, and the proof that Bob held the authority he is attenuating.
+      subject (E1E)   -> (3). Near issuee is Cara, far issuee is Cara -- same subject --
+        but the issuers differ (Bob vs the State). I2I would demand issuer(near) ==
+        issuee(far), i.e. Bob == Cara, and would falsely reject a sound identity
+        relation. E1E (PR #1527) constrains only the issuee, which is why it holds. This
+        is the second independent use case for the operator, and it comes from Sam's own
+        diagram in #1550 rather than from the PR that proposed it.
+    """
+    if guardian is None:
+        guardian = _guardian_credential(kind)
+    if wardCitizen is None:
+        wardCitizen = _ward_citizen(kind, guardian=guardian)
+    if reg is None:
+        reg = _authz_registry(kind)
+    if authz is None:
+        authz = _authz_block()
+    _, schema = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
+    attribute = dict(d='', u=NONCES[N_AZ_A], authz=authz, issuedAt=AUTHZ_STAMP)
+    edge = dict(d='', u=NONCES[N_AZ_E],
+                authority=dict(d='', u=NONCES[N_AZ_E_AUTH], n=guardian.said,
+                               s=guardian.sad['s']['$id'], o='I2I'),
+                subject=dict(d='', u=NONCES[N_AZ_E_SUBJ], n=wardCitizen.said,
+                             s=wardCitizen.sad['s']['$id'], o='E1E'))
+    return acdcmap(israid=BOB, uuid=NONCES[N_AZ_ACDC], regid=reg.said, schema=schema,
+                   attribute=attribute, iseaid=CARA, edge=edge, rule=AUTHZ_RULES_SAID,
+                   kind=kind, compactify=compactify)
+
+
+def _credential_graph(kind, powers=None, authz=None):
+    """Build all four credentials in dependency order and return them.
+
+    Order is forced by the edges: (1) has none, (2) edges to (1), (3) edges to (2), and
+    (4) edges to both (2) and (3). The DAG is therefore a chain with one fork at the
+    bottom, which is what lets a single presentation of (4) reach every other node.
+    """
+    citizenReg = _citizen_registry(kind)
+    guardianCitizen = _guardian_citizen(kind, reg=citizenReg)
+    guardian = _guardian_credential(kind, guardianCitizen=guardianCitizen, powers=powers)
+    wardCitizen = _ward_citizen(kind, guardian=guardian, reg=citizenReg)
+    wardAuthz = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
+                            authz=authz)
+    return guardianCitizen, guardian, wardCitizen, wardAuthz
+
+
+def _i2i_holds(near, far):
+    """Would the DELEGATIVE I2I operator hold on this edge? (issuer(near) == issuee(far))
+
+    Used to show what the two E1E edges cost if an implementer, or a pre-#1527 verifier
+    that coerces an unknown operator, treats them as I2I: the answer is False in both
+    cases, so I2I does not merely under-specify the relation, it REJECTS it.
+    """
+    return near.sad['i'] == far.iseaid
+
+
+# ---------------------------------------------------------------------------
+# The verifier's binding for a ward-presented delegated authorization.
+# ---------------------------------------------------------------------------
+def _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen,
+                        scope="digitalIdentity"):
+    """The security property, checked as a whole. Returns True or raises AssertionError.
+
+    An AuthZ credential the WARD presents authorizes the act only if every one of these
+    holds. As in the sibling module, the schema const-pins make a mislabeled operator
+    unrepresentable on the wire, but the BINDING -- the correspondence between the AIDs
+    those edges connect -- is app-layer logic an implementer must port, not something
+    the operator labels achieve on their own.
+
+      1. Authority (I2I): the AuthZ credential's issuer is the issuee of the
+         guardianship credential its 'authority' edge points at. Bob issued it and Bob
+         holds the guardianship, so the delegation traces to a recognized authority.
+      2. Subject (E1E): the AuthZ credential's issuee is the issuee of the ward's own
+         citizen credential its 'subject' edge points at -- the same human -- while the
+         two ISSUERS differ, which is the shape I2I would falsely reject.
+      3. Guardian identity (E1E): the guardianship credential's issuee is the issuee of
+         the guardian's own citizen credential, so the recognized guardian is a
+         state-endorsed person and not a bare AID.
+      4. Encumbrance (NI2I): the ward's citizen credential points at THIS guardianship,
+         and the two subjects differ, which is why the operator is the untargeted NI2I.
+      5. Ward/guardian correspondence: the ward named in the guardianship credential is
+         the same AID as the issuee of the AuthZ credential and of the ward's citizen
+         credential. Without this an attacker with any valid guardianship could issue
+         an authorization to any child.
+      6. Attenuation: every capability delegated by the AuthZ block is one the
+         guardianship credential's 'powers' actually confers. A guardian cannot delegate
+         more than he holds.
+      7. Scope: the coarse statutory scope covers the act (Utah prefers LIMITED
+         guardianship, so the specific act is checked against scope before the
+         fine-grained capabilities are read at all).
+
+    Two checks a COMPLETE verifier adds are out of scope at this altitude, exactly as in
+    the sibling module: grounding the guardianship credential's ISSUER as an authority
+    competent to recognize a guardianship (a Layer-2 trust-root check), and enforcing
+    each edge's 's' far-node schema constraint, which the reference verifyChain also
+    omits. Registry status is a third: (2) and (4) are both registry-bound and a real
+    verifier checks that both are currently issued.
+    """
+    e = wardAuthz.sad['e']
+    # (1) authority I2I: the delegator held what he delegated.
+    assert e['authority']['o'] == 'I2I'
+    assert e['authority']['n'] == guardian.said
+    assert wardAuthz.sad['i'] == guardian.iseaid          # issuer(near) == issuee(far)
+    # (2) subject E1E: same subject, different issuers -- the case I2I rejects.
+    assert e['subject']['o'] == 'E1E'
+    assert e['subject']['n'] == wardCitizen.said
+    assert wardAuthz.iseaid is not None                   # E1E needs a targeted near node
+    assert wardAuthz.iseaid == wardCitizen.iseaid         # the identity relation
+    assert wardAuthz.sad['i'] != wardCitizen.sad['i']     # ...across different issuers
+    # (3) guardian identity E1E: the guardian is a state-endorsed person.
+    gEdge = guardian.sad['e']['citizen']
+    assert gEdge['o'] == 'E1E'
+    assert gEdge['n'] == guardianCitizen.said
+    assert guardian.iseaid == guardianCitizen.iseaid
+    # (4) encumbrance NI2I: the ward's own credential points at THIS guardianship, and
+    # the subjects differ, which is what disqualifies both targeted operators.
+    wEdge = wardCitizen.sad['e']['guardian']
+    assert wEdge['o'] == 'NI2I'
+    assert wEdge['n'] == guardian.said
+    assert wardCitizen.iseaid != guardian.iseaid
+    # (5) ward/guardian correspondence: one ward, named consistently everywhere.
+    assert guardian.sad['a']['ward'] == wardAuthz.iseaid
+    assert guardian.sad['a']['ward'] == wardCitizen.iseaid
+    # (6) attenuation: the delegated capabilities are a subset of the delegable powers.
+    delegated = _authz_capabilities(wardAuthz.sad['a']['authz'])
+    assert delegated                                      # a payload that grants nothing
+    assert delegated <= set(guardian.sad['a']['powers'])  # ...cannot be checked
+    # (7) scope: the coarse statutory scope covers the act.
+    assert scope in guardian.sad['a']['scope']
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: the four schemas and the helpers that saidify and validate them.
+# ---------------------------------------------------------------------------
+def test_wardauthz_schemas_JSON():
+    """Phase 1: four purpose-authored Draft 2020-12 schemas, each self-addressed.
+
+    Every ACDC in this example commits to a real schema in its own 's' section, so the
+    schemas come first and are asserted here on their own terms: each is a well-formed
+    Draft 2020-12 document, each saidifies to a stable '$id', and the four SAIDs are
+    distinct (the ward's citizen credential and the guardian's share an attribute shape
+    but are NOT the same schema -- the ward's requires the encumbrance edge, which is
+    what a verifier reads to tell them apart).
+
+    The schema is also where the four edge operators are pinned, so the pins are
+    asserted directly rather than only through the credentials that carry them.
+    """
+    kind = Kinds.json
+    gcSaid, gcSchema = _saidify_schema(dict(GUARDIAN_CITIZEN_SCHEMA_MAD), kind=kind)
+    ggSaid, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
+    wcSaid, wcSchema = _saidify_schema(dict(WARD_CITIZEN_SCHEMA_MAD), kind=kind)
+    azSaid, azSchema = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
+
+    for said, schema in ((gcSaid, gcSchema), (ggSaid, ggSchema),
+                         (wcSaid, wcSchema), (azSaid, azSchema)):
+        Draft202012Validator.check_schema(schema)
+        assert schema['$id'] == said                # self-addressed, '$id' first
+        assert said.startswith('E')                 # Blake3-256 SAID
+    assert len({gcSaid, ggSaid, wcSaid, azSaid}) == 4
+    assert gcSaid == "EJVQ1b7CfiAQiq3MB0ffqaM6W3UT_6UW182Hvs9os7dS"
+    assert ggSaid == "ENv3zT7Ni1yl8WOE4dIby4thRGXCKrgHMLqG86K1voFd"
+    assert wcSaid == "EGg6ihxJmig7CE0cFSuxdQF6Gl4ByVTQqP5qYK8R6bW6"
+    assert azSaid == "EP_6kA4inOsIK6DjNEy_qEPUF-vTExbfda1R_NgcPBVo"
+
+    # The four operator pins, read straight off the schemas. Each edge property's 'o'
+    # is a const, so the operator is part of the shape rather than a convention.
+    def pinned(schema, edgeName):
+        return schema['properties']['e']['oneOf'][1]['properties'][edgeName][
+            'oneOf'][1]['properties']['o']['const']
+
+    assert pinned(azSchema, 'authority') == 'I2I'   # (4) -> (2), same-holder
+    assert pinned(azSchema, 'subject') == 'E1E'     # (4) -> (3), identity
+    assert pinned(ggSchema, 'citizen') == 'E1E'     # (2) -> (1), identity
+    assert pinned(wcSchema, 'guardian') == 'NI2I'   # (3) -> (2), reference
+
+    # The AuthZ payload is illustrative and its syntax unsettled, so the block is
+    # deliberately OPEN: an unknown sibling of 'rc' validates, and a later syntax can
+    # grow into the slot without invalidating anything already written.
+    authzProps = azSchema['properties']['a']['oneOf'][1]['properties']['authz']
+    assert authzProps['additionalProperties'] is True
+    assert "SYNTAX UNSETTLED" in authzProps['description']
+    assert "#1550" in authzProps['description']
+    # ...but the ONE part of it that is not free: because an EVAC resource route is a map
+    # LABEL, native-CESR serialization holds it to CESR's strict field-label grammar, so
+    # the schema pins routes to exactly that grammar rather than letting a JSON-only
+    # author write a route the wire cannot carry.
+    assert authzProps['properties']['rc']['propertyNames']['pattern'] == _ROUTE_PATTERN
+    assert _ROUTE_PATTERN == ATREX.decode()      # the same rule Labeler enforces
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: the four credentials, their registries and their edges.
+# ---------------------------------------------------------------------------
+def test_wardauthz_credentials_JSON():
+    """Phase 2: the four-credential graph from Sam's #1550 diagram, built and validated.
+
+    The State issues three -- Bob's citizen credential, the guardianship that recognizes
+    him, and Cara's citizen credential -- and BOB issues the fourth, the delegated
+    authorization, in his OWN registry. That last fact is the structural signature of
+    the ward-presents shape: the delegation is the guardian's act, so its lifecycle is
+    his to manage and he can revoke it without the State being involved.
+
+    Asserted here: issuer and issuee of each credential; that all four are registry-
+    bound and that (4)'s registry is Bob's rather than the State's; that each validates
+    against its own schema; that the ward's citizen credential declares its encumbrance;
+    and that the schema has teeth -- an unrecognized capability, an empty powers list
+    and a missing encumbrance edge are each rejected.
+    """
+    kind = Kinds.json
+    guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
+
+    # (1) Guardian as Citizen: State -> Bob, registry-bound, no edges.
+    assert guardianCitizen.ilk == Ilks.acm
+    assert guardianCitizen.sad['i'] == STATE
+    assert guardianCitizen.iseaid == BOB
+    assert guardianCitizen.sad['rd'] == _citizen_registry(kind).said
+    assert guardianCitizen.sad['r'] == CITIZEN_RULES_SAID
+    assert guardianCitizen.said == "EPA-I6kmtswtU_Zgvy1Btlp3Hh8e_llzuMjy3pbD_mpZ"
+    assert_acdc_schema_valid(guardianCitizen)
+
+    # (2) Guardian as Guardian: State -> Bob, the ward named in the ATTRIBUTE block
+    # (Sam's placement), one E1E edge to (1).
+    assert guardian.sad['i'] == STATE
+    assert guardian.iseaid == BOB
+    assert guardian.sad['a']['ward'] == CARA         # the divergence, made concrete
+    assert guardian.sad['a']['basis'] == "custodialParent"
+    assert guardian.sad['a']['scope'] == ["digitalIdentity"]
+    assert guardian.sad['rd'] == _guardian_registry(kind).said
+    assert guardian.sad['r'] == GUARDIAN_RULES_SAID
+    assert guardian.sad['e']['citizen']['n'] == guardianCitizen.said
+    assert guardian.sad['e']['citizen']['o'] == 'E1E'
+    assert guardian.said == "ENEm2GEIE0XFi4GqMsHFmCtPracHA5xDn0IRrTXnWjr9"
+    assert_acdc_schema_valid(guardian)
+
+    # (3) Ward as Citizen Ward: State -> Cara, and its edge is what declares that this
+    # citizen credential is ENCUMBERED -- a verifier reading only Cara's credential
+    # learns a guardianship stands over her identity.
+    assert wardCitizen.sad['i'] == STATE
+    assert wardCitizen.iseaid == CARA
+    assert wardCitizen.sad['rd'] == _citizen_registry(kind).said    # same State registry
+    assert wardCitizen.sad['r'] == WARD_RULES_SAID
+    assert wardCitizen.sad['e']['guardian']['n'] == guardian.said
+    assert wardCitizen.sad['e']['guardian']['o'] == 'NI2I'
+    assert wardCitizen.said == "EExThcF5yAjSgBXb6QCxWFKsT8PUZliRX64vRRn-mD46"
+    assert_acdc_schema_valid(wardCitizen)
+
+    # (4) Ward AuthZ Social: BOB -> Cara, in BOB's own registry, two edges.
+    assert wardAuthz.sad['i'] == BOB                 # NOT the State
+    assert wardAuthz.iseaid == CARA
+    assert wardAuthz.sad['rd'] == _authz_registry(kind).said
+    assert wardAuthz.sad['rd'] != guardian.sad['rd']   # the guardian's own lifecycle
+    assert wardAuthz.sad['r'] == AUTHZ_RULES_SAID
+    assert wardAuthz.sad['e']['authority']['n'] == guardian.said
+    assert wardAuthz.sad['e']['authority']['o'] == 'I2I'
+    assert wardAuthz.sad['e']['subject']['n'] == wardCitizen.said
+    assert wardAuthz.sad['e']['subject']['o'] == 'E1E'
+    assert wardAuthz.said == "EBzcl80p5eNMjk4cg-L-XI-cOrm3oZibqd84bypZloTB"
+    authzSchema = assert_acdc_schema_valid(wardAuthz)
+
+    # The payload rides in the attribute block, reached only through the seam so the
+    # assertions survive a syntax change (#1550: "The syntax TBD").
+    assert _authz_capabilities(wardAuthz.sad['a']['authz']) == {"read", "post",
+                                                                "message"}
+
+    # A private ACDC: the compact and expanded forms share one SAID, so a ward can hand
+    # over the compact form and expand only what a verifier has agreed to receive.
+    compact = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
+                          compactify=True)
+    assert compact.said == wardAuthz.said
+    assert isinstance(wardAuthz.sad['e'], dict)      # sections inline...
+    assert isinstance(compact.sad['e'], str)         # ...vs collapsed to a SAID
+    assert_acdc_schema_valid(compact, schema=authzSchema)
+
+    # --- Schema teeth. ---
+    # A capability outside the vocabulary is rejected in the AuthZ payload...
+    badCap = json.loads(json.dumps(wardAuthz.sad))
+    badCap["a"]["authz"]["rc"]["social_feed"] = ["exfiltrate"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(authzSchema).validate(badCap)
+    # ...and an AuthZ credential with no resource routes at all is rejected, so a
+    # payload cannot be vacuously "valid" by granting nothing.
+    emptyRc = json.loads(json.dumps(wardAuthz.sad))
+    emptyRc['a']['authz']['rc'] = {}
+    with pytest.raises(ValidationError):
+        Draft202012Validator(authzSchema).validate(emptyRc)
+    # A slash-separated resource route -- the obvious way to write one, and the way the
+    # EVAC sketch reads -- is rejected, because as a map LABEL it is outside CESR's
+    # strict field-label grammar and would raise SerializeError on the native-CESR wire
+    # rather than merely validating oddly. The schema catches it at authoring time.
+    slashRoute = json.loads(json.dumps(wardAuthz.sad))
+    slashRoute['a']['authz']['rc']["social/store"] = ["read"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(authzSchema).validate(slashRoute)
+
+    guardianSchema = assert_acdc_schema_valid(guardian)
+    emptyPowers = json.loads(json.dumps(guardian.sad))
+    emptyPowers['a']['powers'] = []
+    with pytest.raises(ValidationError):
+        Draft202012Validator(guardianSchema).validate(emptyPowers)
+    # The ward's AID is REQUIRED in the attribute block on Sam's placement, so dropping
+    # it fails validation -- the divergence is enforced, not merely described.
+    noWard = json.loads(json.dumps(guardian.sad))
+    del noWard['a']['ward']
+    with pytest.raises(ValidationError):
+        Draft202012Validator(guardianSchema).validate(noWard)
+
+    # A ward citizen credential without its encumbrance edge is rejected: the schema is
+    # what makes "this identity is under guardianship" non-optional.
+    wardSchema = assert_acdc_schema_valid(wardCitizen)
+    noEncumbrance = json.loads(json.dumps(wardCitizen.sad))
+    noEncumbrance['e'] = {"d": wardCitizen.sad['e']['d']}
+    with pytest.raises(ValidationError):
+        Draft202012Validator(wardSchema).validate(noEncumbrance)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: the binding, the operator negatives, and the attenuation negative.
+# ---------------------------------------------------------------------------
+def test_wardauthz_chain_and_negatives_JSON():
+    """Phase 3: _verify_authz_chain holds, and each way of breaking it is caught.
+
+    The positive case first: the honest four-credential graph satisfies all seven checks
+    in _verify_authz_chain. Then the three families of negative:
+
+      * Operator negatives (schema-level). Each of the four edges has its operator
+        pinned by a const, so relabeling any one of them fails wire validation. The two
+        E1E edges get an extra assertion apiece showing WHY the pin matters: the
+        delegative I2I does not merely under-specify those relations, it would reject
+        them, because in both cases issuer(near) != issuee(far).
+      * Correspondence negatives (binding-level). A guardianship over a DIFFERENT ward,
+        and an authorization whose authority edge points at a guardianship Bob does not
+        hold, are both well-formed and both refused.
+      * The attenuation negative, which is the one that earns its place here: a guardian
+        cannot delegate more than he holds. An AuthZ credential granting 'purchase' --
+        a capability in the vocabulary but NOT in the guardianship's powers -- is fully
+        schema-valid, and is refused by the binding. That is the point: over-reach is a
+        relational property between two credentials, so no amount of schema authoring on
+        the AuthZ credential alone can catch it.
+    """
+    kind = Kinds.json
+    guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
+
+    # The honest graph binds.
+    assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
+
+    # --- Operator negatives (schema): a mislabeled operator never reaches a verifier. ---
+    authzSchema = assert_acdc_schema_valid(wardAuthz)
+    swapped = json.loads(json.dumps(wardAuthz.sad))
+    swapped['e']['authority']['o'] = 'NI2I'          # authority downgraded to a reference
+    with pytest.raises(ValidationError):
+        Draft202012Validator(authzSchema).validate(swapped)
+    coerced = json.loads(json.dumps(wardAuthz.sad))
+    coerced['e']['subject']['o'] = 'I2I'             # identity edge relabeled delegative
+    with pytest.raises(ValidationError):
+        Draft202012Validator(authzSchema).validate(coerced)
+
+    guardianSchema = assert_acdc_schema_valid(guardian)
+    badCitizenEdge = json.loads(json.dumps(guardian.sad))
+    badCitizenEdge['e']['citizen']['o'] = 'I2I'
+    with pytest.raises(ValidationError):
+        Draft202012Validator(guardianSchema).validate(badCitizenEdge)
+
+    wardSchema = assert_acdc_schema_valid(wardCitizen)
+    badEncumbranceEdge = json.loads(json.dumps(wardCitizen.sad))
+    badEncumbranceEdge['e']['guardian']['o'] = 'E1E'   # subjects differ: not an identity
+    with pytest.raises(ValidationError):
+        Draft202012Validator(wardSchema).validate(badEncumbranceEdge)
+
+    # WHY the E1E pins matter: on both identity edges the delegative I2I would REJECT,
+    # not merely under-specify. A pre-#1527 verifier that coerces an unknown operator to
+    # I2I for a targeted far node therefore refuses this graph outright.
+    assert not _i2i_holds(wardAuthz, wardCitizen)      # Bob != Cara
+    assert not _i2i_holds(guardian, guardianCitizen)   # the State != Bob
+    # ...while the one genuine I2I edge does hold.
+    assert _i2i_holds(wardAuthz, guardian)             # Bob == Bob
+
+    # --- Correspondence negatives (binding). ---
+    # (a) A guardianship over a different ward. Every edge is well-formed and every
+    # operator correct; check (5) fails, because the authority is over somebody else.
+    otherGuardianAttr = dict(_guardian_attr(), ward=SOCIAL)
+    _, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
+    otherGuardian = acdcmap(israid=STATE, uuid=NONCES[N_GG_ACDC],
+                            regid=_guardian_registry(kind).said, schema=ggSchema,
+                            attribute=otherGuardianAttr, iseaid=BOB,
+                            edge=dict(guardian.sad['e']), rule=GUARDIAN_RULES_SAID,
+                            kind=kind)
+    assert_acdc_schema_valid(otherGuardian)            # well-formed...
+    with pytest.raises(AssertionError):                # ...and refused
+        _verify_authz_chain(wardAuthz, otherGuardian, wardCitizen, guardianCitizen)
+
+    # (b) An authority edge pointing at a guardianship Bob is not the issuee of. Here the
+    # far node is the ward's own citizen credential (issuee Cara), so check (1)'s
+    # same-holder constraint fails.
+    with pytest.raises(AssertionError):
+        _verify_authz_chain(wardAuthz, wardCitizen, wardCitizen, guardianCitizen)
+
+    # --- The attenuation negative: a guardian cannot delegate more than he holds. ---
+    overreach = dict(_authz_block())
+    overreach['rc'] = dict(overreach['rc'], **{"social_store": ["purchase"]})
+    greedy = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
+                         authz=overreach)
+    # It is entirely schema-valid: 'purchase' is in the capability vocabulary, and the
+    # AuthZ credential has no way to know what its issuer holds.
+    assert_acdc_schema_valid(greedy)
+    assert "purchase" in _authz_capabilities(greedy.sad['a']['authz'])
+    assert "purchase" not in guardian.sad['a']['powers']
+    # The binding refuses it: check (6) compares the two credentials.
+    with pytest.raises(AssertionError):
+        _verify_authz_chain(greedy, guardian, wardCitizen, guardianCitizen)
+    # And the same over-reaching payload becomes legitimate the moment the State
+    # recognizes the broader power -- which is the proof that the check is about the
+    # RELATION between the two credentials and not about the payload's contents.
+    broaderGuardian = _guardian_credential(
+        kind, guardianCitizen=guardianCitizen,
+        powers=["read", "post", "message", "profile", "configure", "purchase"])
+    broaderAuthz = _ward_authz(kind, guardian=broaderGuardian,
+                               wardCitizen=_ward_citizen(kind, guardian=broaderGuardian),
+                               authz=overreach)
+    assert _verify_authz_chain(broaderAuthz, broaderGuardian,
+                               _ward_citizen(kind, guardian=broaderGuardian),
+                               guardianCitizen)
+
+    # Scope, check (7): an act outside the coarse statutory scope is refused before the
+    # fine-grained capabilities are consulted at all.
+    with pytest.raises(AssertionError):
+        _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen,
+                            scope="healthCare")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Cara presents the AuthZ credential herself, over IPEX.
+# ---------------------------------------------------------------------------
+def _ward_id_disclosure(wardCitizen, kind):
+    """Cara's minimal disclosure of her citizen credential: issuee only.
+
+    The platform needs to BIND the ward -- to see that the AuthZ credential's issuee and
+    the citizen credential's issuee are the same person -- not to read her name, her
+    birthdate or where she lives. The citizen credential is attributive, so disclosure
+    is by compaction: each nested block collapses to its bare SAID and the mix recomputes
+    to the same committed section SAID.
+    """
+    compactor = Compactor(mad=dict(wardCitizen.sad['a']), makify=True, kind=kind)
+    compactor.compact()
+    compactor.expand(greedy=True)          # populates .partials (incl. the compact one)
+    return dict(compactor.partials[('',)].mad)
+
+
+def _committed_a_said(acdc, kind):
+    """The SAID an ACDC commits to for its attribute section (its most-compact form)."""
+    compactor = Compactor(mad=dict(acdc.sad['a']), makify=True, kind=kind)
+    compactor.compact()
+    return compactor.said
+
+
+def test_wardauthz_presentation_JSON():
+    """Phase 4: the ward presents her own authorization -- a self-presentation.
+
+    Cara walks up to the platform holding a credential issued TO her, and presents it
+    herself. Bob is not in the exchange at all: he is a node in the DAG, not a party to
+    the conversation. That is the whole difference from the sibling module, where the
+    guardian is the discloser and the ward never speaks.
+
+    The exchange is gated: apply, offer, agree, grant, admit, with the ward's citizen
+    attributes crossing the wire only after the platform has signed an agree, and even
+    then only as bare SAIDs -- the platform learns that Cara is the subject of a
+    state-endorsed citizen credential under guardianship, and learns her authorized
+    routes and capabilities, and learns nothing else about her.
+    """
+    kind = Kinds.json
+    guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
+    assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
+
+    # 1. apply (platform -> Cara): the challenge -- which schemas, which fields, and the
+    # governance framework the platform will honor.
+    #
+    # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
+    # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, [paths]) pairs
+    # with ACDC-relative paths -- the construct settled in WebOfTrust/keripy discussion
+    # #1549, shared with tests/acdc/test_cp_disclosure.py,
+    # test_bulk_issuance_shared_registry.py and test_guardianship_presentation.py.
+    # A dict keyed by schema SAID cannot express a DAG holding two credentials of the
+    # same schema, which is why the construct is a list.
+    #
+    # A leading '/' would make the path DAG-ABSOLUTE, rooted at the origin node, and an
+    # absolute path reaching a non-origin ACDC must cross the edge that links it -- the
+    # virtual '_' component, standing for the jump from the near-side edge block to the
+    # top level of the far-side ACDC (@SmithSamuelM, #1549). The same request in
+    # absolute form reads:
+    #     origin:       /i, /a/i, /a/authz
+    #     guardianship: /e/authority/_/a/i, /e/authority/_/a/ward, /e/authority/_/a/powers
+    #     ward citizen: /e/subject/_/a/i
+    # Relative form is used because this DAG has no optional edges, so the breadth-first
+    # ordering of `dp` is gapless and each entry's ACDC is unambiguous without restating
+    # the route to it.
+    #
+    # The zeroth entry is the DAG's origin node (#1549). Here the origin is the AuthZ
+    # credential itself -- Cara presents a credential she HOLDS, so unlike the sibling
+    # examples the origin is not an envelope she issues. Its schema is still something
+    # the platform knows in advance, and for a stronger reason than usual: the platform
+    # is the resource the authorization is ABOUT, so the shape of the authorization it
+    # will accept is its own published requirement (@SmithSamuelM, #1542, on the
+    # applicant knowing the origin schema).
+    #
+    # What the platform asks for is exactly the shape of the question it has to answer.
+    # From the origin: who issued this authorization, to whom, and what does it grant.
+    # From the guardianship: who holds it, over which ward, and how far his powers run --
+    # the three fields the attenuation check needs. From the ward's citizen credential:
+    # the issuee alone, which is all that is needed to bind Cara to the authorization.
+    # Guardian-as-Citizen (node 1) is a node in this DAG and carries NO entry, because
+    # nothing is requested from it: the platform has no business knowing Bob's name or
+    # where he lives. Entries are therefore a breadth-first-ordered SUBSET of the DAG,
+    # and each still names its own schema SAID, so a skipped node cannot shift the
+    # meaning of the entries below it.
+    authzSchemaSaid, _ = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
+    apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply",
+                     modifiers=dict(dp=[[authzSchemaSaid, ["i", "a/i", "a/authz"]],
+                                        [guardian.sad['s']['$id'],
+                                         ["a/i", "a/ward", "a/powers"]],
+                                        [wardCitizen.sad['s']['$id'], ["a/i"]]]),
+                     attributes=dict(m="Prove a guardian authorized this minor to use "
+                                       "this service, and show the scope.",
+                                     g=AUTHZ_RULES_SAID),
+                     stamp=APPLY_STAMP, kind=kind)
+    assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
+    dp = apply.sad['q']['dp']
+    assert [entry[0] for entry in dp] == [authzSchemaSaid, guardian.sad['s']['$id'],
+                                          wardCitizen.sad['s']['$id']]
+    assert dp[0][1] == ["i", "a/i", "a/authz"]        # origin: who granted, to whom, what
+    assert dp[1][1] == ["a/i", "a/ward", "a/powers"]  # guardianship: whose, over whom, how far
+    assert dp[2][1] == ["a/i"]                        # ward citizen: the binding, nothing more
+    assert all(not p.startswith("/") and not p.endswith("/")
+               for _, paths in dp for p in paths)
+    assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the origin Cara actually holds
+    # The guardian's own citizen credential is a node in the DAG and is asked for
+    # nothing: the platform gating a minor has no business learning the parent's name.
+    assert guardianCitizen.sad['s']['$id'] not in [entry[0] for entry in dp]
+    assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'g'}
+    assert apply.said == "EOXY2-SPW0zUrFhP5nNbTevRqA3BSLOd5hE1kMj5jrTO"
+
+    # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
+    # offering and to the governance ref, and binds the apply. It deliberately does NOT
+    # enumerate the issuer-committed source SAIDs (the guardianship, either citizen
+    # credential): those are stable correlators, and attaching them before the platform
+    # agrees would let a platform spurn and walk away with a persistent handle on both
+    # the ward and her parent. They arrive only post-agree, in the grant.
+    # Its query block carries `dp` as an EMPTY list: the offer is SOLICITED (its `p`
+    # binds the apply), and an empty `dp` means "the same paths the apply asked for"
+    # (#1549), so Cara restates nothing and the two messages cannot drift.
+    offer = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/offer", prior=apply.said,
+                     modifiers=dict(dp=[]),
+                     attributes=dict(acdc=wardAuthz.said, governance=AUTHZ_RULES_SAID),
+                     stamp=OFFER_STAMP, kind=kind)
+    assert offer.sad['p'] == apply.said
+    assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
+    assert offer.said == "EDHveeZBrH4RY5IYf9otXqG-K7XPYpS8HUoH9cGfui_5"
+    assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
+    assert b"Cara Carver" not in offer.raw and b"2012-04-10" not in offer.raw
+    assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
+    assert wardCitizen.said.encode() not in offer.raw
+    assert guardianCitizen.said.encode() not in offer.raw
+
+    # 3. agree (platform -> Cara): acceptance, binding the offer SAID and signed by the
+    # platform (via messagize -- the blessed genus-aware attachment path).
+    agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
+                     stamp=AGREE_STAMP, kind=kind)
+    assert agree.sad['p'] == offer.said
+    assert agree.said == "ELUE4Z69F9ANJxBIGQey8-bPxs-ZSnP__WIVVQKtsj2R"
+    svcSigner = _SIGNERS[3]                            # the platform's establishing key
+    svcSig = svcSigner.sign(ser=agree.raw, index=0)
+    signedAgree = messagize(agree, sigers=[svcSig])
+    assert bytes(agree.raw) in signedAgree
+    capturedKeyState = Verfer(qb64=svcSigner.verfer.qb64)
+    assert capturedKeyState.verify(sig=svcSig.raw, ser=agree.raw)
+
+    # 4. The gate: Cara discloses only when handed a valid, signed, offer-binding agree.
+    # The grant carries the EXPANDED AuthZ credential (edges visible, so the platform can
+    # walk the chain), the guardianship credential it edges to (disclosed whole, as an
+    # authority credential must be), and her own citizen credential compacted to the
+    # issuee alone.
+    def disclose(agreeMsg, sig, keyState):
+        if not (agreeMsg.sad['r'] == "/ipex/agree" and agreeMsg.sad['p'] == offer.said
+                and keyState.verify(sig=sig.raw, ser=agreeMsg.raw)):
+            return None
+        return exchange(sender=CARA, receiver=SOCIAL, route="/ipex/grant",
+                        prior=agreeMsg.said,
+                        attributes=dict(acdc=wardAuthz.sad,
+                                        authority=guardian.sad,
+                                        subject=_ward_id_disclosure(wardCitizen, kind)),
+                        stamp=GRANT_STAMP, kind=kind)
+
+    # A forged signature or a spurn (decline) unlocks nothing.
+    assert disclose(agree, _SIGNERS[0].sign(ser=agree.raw, index=0),
+                    capturedKeyState) is None
+    spurn = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/spurn", prior=offer.said,
+                     stamp=AGREE_STAMP, kind=kind)
+    assert disclose(spurn, svcSigner.sign(ser=spurn.raw, index=0),
+                    capturedKeyState) is None
+
+    # The valid agree unlocks the grant.
+    grant = disclose(agree, svcSig, capturedKeyState)
+    assert grant is not None and grant.sad['p'] == agree.said
+    assert grant.said == "EDhaDoGbAVOpoQOBXrmxBzSuM6lqhbXjiT3pTOrUc3kR"
+
+    # What the platform receives is exactly what it asked for and no more: the
+    # authorization payload, the guardianship's scope, and a binding to Cara.
+    granted = grant.sad['a']
+    assert _authz_capabilities(granted['acdc']['a']['authz']) == {"read", "post",
+                                                                  "message"}
+    assert granted['authority']['a']['ward'] == CARA
+    assert granted['subject']['i'] == CARA             # the ward bound by issuee...
+    assert isinstance(granted['subject']['name'], str)  # ...with every attribute withheld
+    assert isinstance(granted['subject']['dob'], str)
+    assert b"Cara Carver" not in grant.raw             # name never on the wire
+    assert b"2012-04-10" not in grant.raw              # birthdate never on the wire
+    assert b"Bob Carver" not in grant.raw              # nor the parent's identity
+    # Honest residual, asserted present rather than quietly avoided: the guardianship
+    # credential is disclosed WHOLE, so its expiry -- Cara's 18th birthday -- crosses the
+    # wire and hands the platform her birth month and day. An attribute in a
+    # whole-disclosed authority credential cannot be withheld the way an edge can, which
+    # is the disclosure argument of the module docstring showing up as an actual leak.
+    assert b"2030-04-10" in grant.raw
+    # The withheld blocks still recompute to the section SAID the credential commits to,
+    # so the platform can prove the disclosure belongs to Cara's citizen credential.
+    check = Compactor(mad=dict(granted['subject'], d=''), makify=True, kind=kind)
+    check.compact()
+    assert check.said == _committed_a_said(wardCitizen, kind)
+
+    # The platform now runs the same binding a verifier runs anywhere, on the credentials
+    # it was handed -- which is the point of the whole exchange.
+    assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
+
+    # 5. admit (platform -> Cara): closes the exchange.
+    admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
+                     stamp=ADMIT_STAMP, kind=kind)
+    assert admit.sad['p'] == grant.said
+    assert admit.said == "EKl5NR5YbevNiqowBr2uKQtVU9wNKFsR2J30LTch63eF"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: the invariants hold across every serialization kind.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("kind", [Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk])
+def test_wardauthz_serialization_kinds(kind):
+    """Phases 1-4 invariants hold across every serialization kind, not just JSON.
+
+    Exercises the same graph -- four schemas, four credentials, the four pinned edge
+    operators, the full binding, the attenuation ceiling and the compact/expanded SAID
+    equality -- over CESR (the native KERI wire format) and CBOR/MGPK, asserting the
+    behavioral invariants without pinning per-kind SAIDs. (The no-PII-on-the-wire checks
+    stay in the JSON phase: the CESR wire form base64-encodes the payload, so a plaintext
+    substring check does not apply.)
+    """
+    guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
+    for acdc in (guardianCitizen, guardian, wardCitizen, wardAuthz):
+        assert acdc.ilk == Ilks.acm and acdc.kind == kind
+        assert acdc.sad['rd']                          # registry-bound on every kind
+        assert_acdc_schema_valid(acdc)
+
+    # The four operators survive every kind, and so does the whole binding.
+    assert wardAuthz.sad['e']['authority']['o'] == 'I2I'
+    assert wardAuthz.sad['e']['subject']['o'] == 'E1E'
+    assert guardian.sad['e']['citizen']['o'] == 'E1E'
+    assert wardCitizen.sad['e']['guardian']['o'] == 'NI2I'
+    assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
+
+    # The two identity edges are the ones a coerce-to-I2I verifier would reject.
+    assert not _i2i_holds(wardAuthz, wardCitizen)
+    assert not _i2i_holds(guardian, guardianCitizen)
+    assert _i2i_holds(wardAuthz, guardian)
+
+    # Issuer independence: the State issues three, the guardian issues the fourth into
+    # his own registry.
+    assert guardianCitizen.sad['i'] == guardian.sad['i'] == wardCitizen.sad['i'] == STATE
+    assert wardAuthz.sad['i'] == BOB
+    assert wardAuthz.sad['rd'] != guardian.sad['rd']
+
+    # Attenuation holds on every kind, and over-reach is refused on every kind.
+    overreach = dict(_authz_block())
+    overreach['rc'] = dict(overreach['rc'], **{"social_store": ["purchase"]})
+    greedy = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
+                         authz=overreach)
+    assert_acdc_schema_valid(greedy)                   # schema-valid...
+    with pytest.raises(AssertionError):                # ...and refused by the binding
+        _verify_authz_chain(greedy, guardian, wardCitizen, guardianCitizen)
+
+    # Compact and expanded forms share one SAID on every kind.
+    compact = _ward_authz(kind, guardian=guardian, wardCitizen=wardCitizen,
+                          compactify=True)
+    assert compact.said == wardAuthz.said
+    assert isinstance(compact.sad['e'], str)
+
+    # The ward's minimal disclosure recomputes to the committed section SAID.
+    disclosure = _ward_id_disclosure(wardCitizen, kind)
+    assert disclosure['i'] == CARA
+    check = Compactor(mad=dict(disclosure, d=''), makify=True, kind=kind)
+    check.compact()
+    assert check.said == _committed_a_said(wardCitizen, kind)
+
+
+if __name__ == "__main__":
+    test_wardauthz_schemas_JSON()
+    test_wardauthz_credentials_JSON()
+    test_wardauthz_chain_and_negatives_JSON()
+    test_wardauthz_presentation_JSON()
+    for _kind in (Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk):
+        test_wardauthz_serialization_kinds(_kind)

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -77,8 +77,13 @@ from keri.core import (Salter, Noncer, Compactor, Mapper, Diger, Verfer,
                        exchange, messagize)
 from keri.core.coring import MtrDex
 from keri.core.eventing import incept
+from keri.core.serdering import SerderACDC
 from keri.acdc import regcept, acdcmap
 from keri.help.helping import ATREX
+# keri's ValidationError, kept distinct from jsonschema's above: the two are raised by
+# different layers of this module (SAID recomputation vs wire-shape validation) and a
+# test that conflates them cannot say which one caught a defect.
+from keri.kering import ValidationError as SaidError
 
 
 # --- Reproducible example actors (see module docstring). ---
@@ -1175,19 +1180,47 @@ def test_wardauthz_chain_and_negatives_JSON():
 # ---------------------------------------------------------------------------
 # Phase 4: Cara presents the AuthZ credential herself, over IPEX.
 # ---------------------------------------------------------------------------
-def _ward_id_disclosure(wardCitizen, kind):
-    """Cara's minimal disclosure of her citizen credential: issuee only.
+def _issuee_only_attributes(acdc, kind):
+    """An attributive credential's attribute section reduced to its issuee.
 
-    The platform needs to BIND the ward -- to see that the AuthZ credential's issuee and
-    the citizen credential's issuee are the same person -- not to read her name, her
-    birthdate or where she lives. The citizen credential is attributive, so disclosure
-    is by compaction: each nested block collapses to its bare SAID and the mix recomputes
-    to the same committed section SAID.
+    The platform needs to BIND a person -- to see that two credentials name the same
+    issuee -- not to read a name, a birthdate or a residence. Both citizen credentials
+    here are attributive with individually-disclosable nested blocks, so disclosure is
+    by compaction: each nested block collapses to its bare SAID, the issuee stays in the
+    clear, and the mix recomputes to the same committed section SAID.
     """
-    compactor = Compactor(mad=dict(wardCitizen.sad['a']), makify=True, kind=kind)
+    compactor = Compactor(mad=dict(acdc.sad['a']), makify=True, kind=kind)
     compactor.compact()
     compactor.expand(greedy=True)          # populates .partials (incl. the compact one)
     return dict(compactor.partials[('',)].mad)
+
+
+def _disclose(acdc, kind, attribute=None):
+    """Rebuild `acdc` as the partial disclosure that carries `attribute`.
+
+    THE reason a disclosure can be verified at all. An ACDC's SAID is computed over its
+    MOST COMPACT form, so every partial mix of the same sections commits to the same
+    'd'. Handing the platform a credential whose attribute section is compacted to the
+    issuee therefore hands it something that still recomputes to the credential SAID the
+    edges point at -- which is what lets the platform run the binding on what it
+    received instead of on what it was told. `attribute=None` discloses the section
+    whole (the right call for a FLAT section, which cannot be split; see _guardian_attr).
+    """
+    sad = acdc.sad
+    if attribute is None:
+        attribute = sad['a']
+    # The schema rides as a BARE SAID, not as the whole block. The disclosee named that
+    # SAID in its own dp, so it already has the schema; shipping the block back would be
+    # pure bulk -- and worse than bulk, because the block enumerates the FIELD NAMES of
+    # every withheld element, which is exactly what compacting a section is meant to
+    # hide. (The sibling module makes the sharper version of this point: there the block
+    # would name every age threshold the credential carries.)
+    schema = sad['s']['$id'] if isinstance(sad['s'], dict) else sad['s']
+    return acdcmap(israid=sad['i'], uuid=sad.get('u'), regid=sad.get('rd'),
+                   schema=schema, attribute=json.loads(json.dumps(attribute)),
+                   iseaid=acdc.iseaid,
+                   edge=json.loads(json.dumps(sad['e'])) if 'e' in sad else None,
+                   rule=sad.get('r'), kind=kind)
 
 
 def _committed_a_said(acdc, kind):
@@ -1195,6 +1228,39 @@ def _committed_a_said(acdc, kind):
     compactor = Compactor(mad=dict(acdc.sad['a']), makify=True, kind=kind)
     compactor.compact()
     return compactor.said
+
+
+def _platform_accepts_grant(granted, offeredOrigin, kind):
+    """The platform's grant-time verification, run on WHAT IT WAS HANDED.
+
+    Returns True or raises. This is the step the exchange exists to reach, and it takes
+    nothing on trust from the test's own scope: every credential is reconstructed from
+    the grant body with SerderACDC(verify=True), which recomputes the SAID over the
+    disclosed content -- most-compact-form semantics, so a partial disclosure verifies
+    to the same 'd' as the full credential -- and raises if it does not match.
+
+    Three things happen in order:
+
+      1. Each of the four disclosed artifacts is reconstructed and self-verified. A
+         tampered payload dies here, because its recomputed SAID stops matching its 'd'.
+      2. The origin is confirmed to be the credential the OFFER committed to. Without
+         this the platform could be handed a different, perfectly valid authorization
+         than the one whose terms it agreed to -- terms follow the data.
+      3. The seven-check binding runs on the RECONSTRUCTED objects. Every edge digest is
+         therefore checked against a SAID recomputed from disclosed content, so
+         substituting any far node into the disclosed set breaks the edge that names it.
+
+    A complete verifier adds registry status (walk each 'rd' TEL for a revocation) and
+    the Layer-2 question of whether the guardianship's issuer is competent to recognize
+    a guardianship. Both are out of scope at this altitude, as in _verify_authz_chain.
+    """
+    origin = SerderACDC(sad=json.loads(json.dumps(granted['acdc'])), verify=True)
+    authority = SerderACDC(sad=json.loads(json.dumps(granted['authority'])), verify=True)
+    subject = SerderACDC(sad=json.loads(json.dumps(granted['subject'])), verify=True)
+    guardianId = SerderACDC(sad=json.loads(json.dumps(granted['guardianId'])),
+                            verify=True)
+    assert origin.said == offeredOrigin       # the terms agreed to are the terms received
+    return _verify_authz_chain(origin, authority, subject, guardianId)
 
 
 def test_wardauthz_presentation_JSON():
@@ -1206,11 +1272,21 @@ def test_wardauthz_presentation_JSON():
     tests/acdc/test_guardianship_presentation.py, where the ward is too young to hold her
     own keys, so the guardian is the discloser and the ward never speaks.
 
-    The exchange is gated: apply, offer, agree, grant, admit, with the ward's citizen
-    attributes crossing the wire only after the platform has signed an agree, and even
-    then only as bare SAIDs -- the platform learns that Cara is the subject of a
-    state-endorsed citizen credential under guardianship, and learns her authorized
-    routes and capabilities, and learns nothing else about her.
+    The exchange is gated: apply, offer, agree, grant, admit, with either citizen
+    credential's attributes crossing the wire only after the platform has signed an
+    agree, and even then only as bare SAIDs -- the platform learns that Cara is the
+    subject of a state-endorsed citizen credential under guardianship, that the guardian
+    authorizing her is himself a state-endorsed person, and what routes and capabilities
+    she holds. It learns neither person's name, birthdate or residence.
+
+    THE EXCHANGE ENDS IN A VERIFICATION OF WHAT WAS TRANSMITTED. _platform_accepts_grant
+    reconstructs every disclosed artifact from the grant body, recomputes its SAID over
+    the disclosed content, confirms the origin is the credential the offer committed to,
+    and only then runs the seven-check binding on the reconstructed objects. Three
+    negatives hold it honest: a substituted authority credential, an origin other than
+    the one offered, and a tampered payload are each refused. A presentation example
+    that verifies credentials it already had in scope proves nothing about the wire, and
+    every one of those negatives would pass unnoticed if it did.
     """
     kind = Kinds.json
     guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
@@ -1239,9 +1315,10 @@ def test_wardauthz_presentation_JSON():
     # path reaching a non-origin ACDC must cross the edge that links it -- the virtual
     # '_' component, standing for the jump from the near-side edge block to the top level
     # of the far-side ACDC (#1549). The same request written with non-empty prefixes:
-    #     origin:       "/"                ["i", "a/i", "a/authz"]
-    #     guardianship: "/e/authority/_/"  ["a/i", "a/ward", "a/powers"]
-    #     ward citizen: "/e/subject/_/"    ["a/i"]
+    #     origin:           "/"                          ["i", "a/i", "a/authz", "e"]
+    #     guardianship:     "/e/authority/_/"            ["i", "a", "e"]
+    #     ward citizen:     "/e/subject/_/"              ["a/i", "e"]
+    #     guardian citizen: "/e/authority/_/e/citizen/_/" ["a/i"]
     #
     # The zeroth entry is the DAG's origin node (#1549). Here the origin is the AuthZ
     # credential itself -- Cara presents a credential she HOLDS, so unlike the sibling
@@ -1251,25 +1328,48 @@ def test_wardauthz_presentation_JSON():
     # will accept is its own published requirement (@SmithSamuelM, #1542, on the
     # applicant knowing the origin schema).
     #
-    # What the platform asks for is exactly the shape of the question it has to answer.
-    # From the origin: who issued this authorization, to whom, and what does it grant.
-    # From the guardianship: who holds it, over which ward, and how far his powers run --
-    # the three fields the attenuation check needs. From the ward's citizen credential:
-    # the issuee alone, which is all that is needed to bind Cara to the authorization.
-    # Guardian-as-Citizen (node 1) is a node in this DAG and carries NO entry, because
-    # nothing is requested from it: the platform has no business knowing Bob's name or
-    # where he lives. Entries are therefore a breadth-first-ordered SUBSET of the DAG,
-    # and each still names its own schema SAID, so a skipped node cannot shift the
-    # meaning of the entries below it. (The sibling's list asks something of every node
-    # its DAG reaches, so it is gapless -- one entry per node. Both are legal; a gap is
-    # only safe because the schema SAID travels with each entry.)
+    # WHAT THE PLATFORM ASKS FOR IS EXACTLY WHAT ITS BINDING NEEDS, and the discipline
+    # that produces this list is to walk _verify_authz_chain's seven checks and ask what
+    # each one reads. Anything the binding does not read is not requested; anything it
+    # does read must be requested, or the check cannot run on what arrives.
+    #
+    #   origin (AuthZ)   ["i", "a/i", "a/authz", "e"]
+    #       issuer and issuee for checks (1), (2) and (5); the payload for (6); and the
+    #       EDGE SECTION, without which the platform cannot walk to any other node --
+    #       every one of checks (1)-(4) reads an edge digest.
+    #   guardianship     ["i", "a", "e"]
+    #       the whole attribute section, not a field list. _guardian_attr is FLAT by
+    #       design -- basis, scope, powers and validity are meant to be read together --
+    #       and a flat section discloses whole or as one bare SAID, with nothing in
+    #       between. Asking for "a/ward" and "a/powers" individually would name paths no
+    #       disclosure mechanism can produce from this credential. Plus 'e' for check (3).
+    #   ward citizen     ["a/i", "e"]
+    #       the issuee, which binds Cara to the authorization, and the edge section,
+    #       without which check (4) -- the encumbrance -- cannot be evaluated at all.
+    #   guardian citizen ["a/i"]
+    #       the issuee alone. Check (3) asks whether the recognized guardian is a
+    #       state-endorsed person rather than a bare AID, and that is answered by the
+    #       issuee and the edge digest that reaches it. Bob's name, birthdate and
+    #       residence stay bare SAIDs: this credential's attribute section IS nested, so
+    #       unlike the guardianship it can be split, and the platform learns nothing
+    #       about the parent beyond the fact that the State endorsed him.
+    #
+    # So the list is GAPLESS -- one entry per node, breadth-first from the origin -- like
+    # the sibling's. An earlier draft of this example skipped the guardian's citizen
+    # credential on the grounds that the platform had no business learning anything about
+    # Bob; that was a privacy claim the binding could not afford, because check (3) reads
+    # that node. The privacy point survives in the honest form: ask for the issuee, not
+    # the person.
     authzSchemaSaid, _ = _saidify_schema(dict(AUTHZ_SCHEMA_MAD), kind=kind)
     apply = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/apply",
                      modifiers=dict(dp=[[authzSchemaSaid, "",
-                                         ["i", "a/i", "a/authz"]],
+                                         ["i", "a/i", "a/authz", "e"]],
                                         [guardian.sad['s']['$id'], "",
-                                         ["a/i", "a/ward", "a/powers"]],
-                                        [wardCitizen.sad['s']['$id'], "", ["a/i"]]]),
+                                         ["i", "a", "e"]],
+                                        [wardCitizen.sad['s']['$id'], "",
+                                         ["a/i", "e"]],
+                                        [guardianCitizen.sad['s']['$id'], "",
+                                         ["a/i"]]]),
                      attributes=dict(m="Prove a guardian authorized this minor account "
                                        "holder's settings, and show the scope.",
                                      g=AUTHZ_RULES_SAID),
@@ -1277,20 +1377,22 @@ def test_wardauthz_presentation_JSON():
     assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
     dp = apply.sad['q']['dp']
     assert [entry[0] for entry in dp] == [authzSchemaSaid, guardian.sad['s']['$id'],
-                                          wardCitizen.sad['s']['$id']]
+                                          wardCitizen.sad['s']['$id'],
+                                          guardianCitizen.sad['s']['$id']]
     assert all(len(entry) == 3 for entry in dp)       # (schemaSAID, prefix, [paths])
-    assert [entry[1] for entry in dp] == ["", "", ""] # no prefixes: paths stay relative
-    assert dp[0][2] == ["i", "a/i", "a/authz"]        # origin: who granted, to whom, what
-    assert dp[1][2] == ["a/i", "a/ward", "a/powers"]  # guardianship: whose, over whom, how far
-    assert dp[2][2] == ["a/i"]                        # ward citizen: the binding, nothing more
+    assert [entry[1] for entry in dp] == ["", "", "", ""]  # no prefixes: paths relative
+    assert dp[0][2] == ["i", "a/i", "a/authz", "e"]   # origin: who, to whom, what, edges
+    assert dp[1][2] == ["i", "a", "e"]                # guardianship: flat 'a', so whole
+    assert dp[2][2] == ["a/i", "e"]                   # ward citizen: binding + encumbrance
+    assert dp[3][2] == ["a/i"]                        # guardian citizen: the issuee alone
     assert all(not p.startswith("/") and not p.endswith("/")
                for _, _, paths in dp for p in paths)
     assert authzSchemaSaid == wardAuthz.sad['s']['$id']   # the origin Cara actually holds
-    # The guardian's own citizen credential is a node in the DAG and is asked for
-    # nothing: the platform has no business learning the parent's name or residence.
-    assert guardianCitizen.sad['s']['$id'] not in [entry[0] for entry in dp]
+    # Every node the binding reads is asked for, and every node in the DAG is a node the
+    # binding reads -- so the request covers the DAG exactly.
+    assert len(dp) == 4
     assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "EMeUXBWGbmhe5MvD0DTPD1ckI5MyscpSC92qVzcOJFxk"
+    assert apply.said == "ECpsd2btQ79rndSrOrK9j4wKCq48o7_IXGRESV717T-K"
 
     # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
     # offering and to the governance ref, and binds the apply. It deliberately does NOT
@@ -1317,7 +1419,7 @@ def test_wardauthz_presentation_JSON():
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
-    assert offer.said == "EHwBEyvCRbsccjyS_UFNHBYbT7tRq8Z_s4jKD9eSc3LQ"
+    assert offer.said == "EGKqASGat52SaGBi9mLmdCUmu9ovXlrQtsQHc6WDdA60"
     assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
     assert b"Cara Carver" not in offer.raw and b"2009-04-10" not in offer.raw
     assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
@@ -1329,7 +1431,7 @@ def test_wardauthz_presentation_JSON():
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said
-    assert agree.said == "EIcfwLEL6zJ_4TegWOY30qOYAwq8jCYKlxhaLzXfH6Ea"
+    assert agree.said == "EF_BoANaVLJrqsMwHX21FYTeEOTWN9Q-t7p2Jr9kNkX-"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1338,20 +1440,32 @@ def test_wardauthz_presentation_JSON():
     assert capturedKeyState.verify(sig=svcSig.raw, ser=agree.raw)
 
     # 4. The gate: Cara discloses only when handed a valid, signed, offer-binding agree.
-    # The grant carries the EXPANDED AuthZ credential (edges visible, so the platform can
-    # walk the chain), the guardianship credential it edges to (disclosed whole, as an
-    # authority credential must be), and her own citizen credential compacted to the
-    # issuee alone.
+    # The grant carries ONE ARTIFACT PER dp ENTRY, in the same breadth-first order, each
+    # disclosed to the depth its entry asked for and no further. Building it from the dp
+    # list rather than from what is convenient is the whole discipline: a grant assembled
+    # independently of the request is a grant the platform cannot check its request
+    # against, and it is how an example ends up teaching both "honor dp" and "send whole
+    # credentials" in the same breath.
     def disclose(agreeMsg, sig, keyState):
         if not (agreeMsg.sad['r'] == "/ipex/agree" and agreeMsg.sad['p'] == offer.said
                 and keyState.verify(sig=sig.raw, ser=agreeMsg.raw)):
             return None
-        return exchange(sender=CARA, receiver=SOCIAL, route="/ipex/grant",
-                        prior=agreeMsg.said,
-                        attributes=dict(acdc=wardAuthz.sad,
-                                        authority=guardian.sad,
-                                        subject=_ward_id_disclosure(wardCitizen, kind)),
-                        stamp=GRANT_STAMP, kind=kind)
+        return exchange(
+            sender=CARA, receiver=SOCIAL, route="/ipex/grant", prior=agreeMsg.said,
+            attributes=dict(
+                # dp[0] ["i", "a/i", "a/authz", "e"] -- the payload is asked for, so the
+                # attribute section rides expanded; so does 'e', to be walkable.
+                acdc=_disclose(wardAuthz, kind).sad,
+                # dp[1] ["i", "a", "e"] -- flat section, disclosed whole because that is
+                # the only form it has.
+                authority=_disclose(guardian, kind).sad,
+                # dp[2] ["a/i", "e"] and dp[3] ["a/i"] -- nested sections, compacted to
+                # the issuee. Name, birthdate and residence stay bare SAIDs.
+                subject=_disclose(wardCitizen, kind,
+                                  _issuee_only_attributes(wardCitizen, kind)).sad,
+                guardianId=_disclose(guardianCitizen, kind,
+                                     _issuee_only_attributes(guardianCitizen, kind)).sad),
+            stamp=GRANT_STAMP, kind=kind)
 
     # A forged signature or a spurn (decline) unlocks nothing.
     assert disclose(agree, _SIGNERS[0].sign(ser=agree.raw, index=0),
@@ -1364,41 +1478,77 @@ def test_wardauthz_presentation_JSON():
     # The valid agree unlocks the grant.
     grant = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "ECPr0RSNH4H__JNu5Bex2TSaMH_bnlb2P3-4C_Pk41wd"
+    assert grant.said == "EBGFcsDsSCMeanK53iNBxmwLadlFWxhPA9obTg_KTHjs"
 
-    # What the platform receives is exactly what it asked for and no more: the
-    # authorization payload, the guardianship's scope, and a binding to Cara.
+    # What the platform receives is one artifact per dp entry, disclosed to the requested
+    # depth. Each one still carries the SAID of the FULL credential, because an ACDC's
+    # SAID is computed over its most compact form -- which is what makes a partial
+    # disclosure verifiable rather than merely plausible.
     granted = grant.sad['a']
+    assert set(granted) == {'acdc', 'authority', 'subject', 'guardianId'}   # one per dp
+    assert granted['acdc']['d'] == wardAuthz.said
+    assert granted['authority']['d'] == guardian.said
+    assert granted['subject']['d'] == wardCitizen.said
+    assert granted['guardianId']['d'] == guardianCitizen.said
     assert _authz_capabilities(granted['acdc']['a']['authz']) == {"read", "post",
                                                                   "message"}
     assert granted['authority']['a']['ward'] == CARA
-    assert granted['subject']['i'] == CARA             # the ward bound by issuee...
-    assert isinstance(granted['subject']['name'], str)  # ...with every attribute withheld
-    assert isinstance(granted['subject']['dob'], str)
+    assert granted['subject']['a']['i'] == CARA        # the ward bound by issuee...
+    assert isinstance(granted['subject']['a']['name'], str)   # ...attributes withheld
+    assert isinstance(granted['subject']['a']['dob'], str)
+    assert granted['guardianId']['a']['i'] == BOB      # the guardian likewise bound...
+    assert isinstance(granted['guardianId']['a']['name'], str)      # ...and withheld
+    assert isinstance(granted['guardianId']['a']['residence'], str)
     assert b"Cara Carver" not in grant.raw             # name never on the wire
     assert b"2009-04-10" not in grant.raw              # birthdate never on the wire
-    assert b"Bob Carver" not in grant.raw              # nor the parent's identity
-    # Honest residual, asserted present rather than quietly avoided: the guardianship
-    # credential is disclosed WHOLE, so its expiry -- Cara's 18th birthday -- crosses the
-    # wire and hands the platform her birth month and day. An attribute in a
-    # whole-disclosed authority credential cannot be withheld the way an edge can, which
-    # is the disclosure argument of the module docstring showing up as an actual leak.
+    assert b"Bob Carver" not in grant.raw              # nor the parent's name...
+    assert b"Provo" not in grant.raw                   # ...nor where he lives
+    # Honest residual, asserted present rather than quietly avoided: the guardianship's
+    # expiry -- Cara's 18th birthday -- crosses the wire and hands the platform her birth
+    # month and day. The cause is structural and is named in the dp comment above:
+    # _guardian_attr is FLAT, so its section discloses whole or not at all, and the
+    # platform's request could not have asked for less. Compare the two citizen
+    # credentials in this same grant, whose nested sections DO split. The fix is a
+    # coarser expiry or a nested guardianship section, and both are schema decisions for
+    # a deployment rather than something this example should invent.
     assert b"2027-04-10" in grant.raw
     # The withheld blocks still recompute to the section SAID the credential commits to,
     # so the platform can prove the disclosure belongs to Cara's citizen credential.
-    check = Compactor(mad=dict(granted['subject'], d=''), makify=True, kind=kind)
+    check = Compactor(mad=dict(granted['subject']['a'], d=''), makify=True, kind=kind)
     check.compact()
     assert check.said == _committed_a_said(wardCitizen, kind)
 
-    # The platform now runs the same binding a verifier runs anywhere, on the credentials
-    # it was handed -- which is the point of the whole exchange.
-    assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
+    # The platform now runs the same binding a verifier runs anywhere -- on the artifacts
+    # it was HANDED, reconstructed from the grant body, not on anything it knew before.
+    assert _platform_accepts_grant(granted, wardAuthz.said, kind)
+
+    # ...and the negatives that prove the acceptance is reading the wire. Each of these
+    # would pass unnoticed if the platform verified credentials it already held.
+    # (a) A guardianship over a different ward, substituted into the disclosed set.
+    otherGuardianAttr = dict(_guardian_attr(), ward=SOCIAL)
+    _, ggSchema = _saidify_schema(dict(GUARDIAN_SCHEMA_MAD), kind=kind)
+    otherGuardian = acdcmap(israid=STATE, uuid=NONCES[N_GG_ACDC],
+                            regid=_guardian_registry(kind).said, schema=ggSchema,
+                            attribute=otherGuardianAttr, iseaid=BOB,
+                            edge=dict(guardian.sad['e']), rule=GUARDIAN_RULES_SAID,
+                            kind=kind)
+    swappedAuthority = dict(granted, authority=otherGuardian.sad)
+    with pytest.raises(AssertionError):
+        _platform_accepts_grant(swappedAuthority, wardAuthz.said, kind)
+    # (b) An origin that is not the credential the offer committed to.
+    with pytest.raises(AssertionError):
+        _platform_accepts_grant(granted, guardian.said, kind)
+    # (c) A tampered payload: the SAID no longer recomputes over the content.
+    tampered = json.loads(json.dumps(granted))
+    tampered['acdc']['a']['authz']['rc']['social_store'] = ["purchase"]
+    with pytest.raises(SaidError):
+        _platform_accepts_grant(tampered, wardAuthz.said, kind)
 
     # 5. admit (platform -> Cara): closes the exchange.
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EIHZtaug8QZLED1659uJMKchvzttEnE7UmarnwiUOo5y"
+    assert admit.said == "EK1gyvwKLaUKxMev9I-MuSZt9v5Cxx68fnASopakqSid"
 
 
 # ---------------------------------------------------------------------------
@@ -1454,12 +1604,24 @@ def test_wardauthz_serialization_kinds(kind):
     assert compact.said == wardAuthz.said
     assert isinstance(compact.sad['e'], str)
 
-    # The ward's minimal disclosure recomputes to the committed section SAID.
-    disclosure = _ward_id_disclosure(wardCitizen, kind)
+    # The ward's minimal disclosure recomputes to the committed section SAID...
+    disclosure = _issuee_only_attributes(wardCitizen, kind)
     assert disclosure['i'] == CARA
     check = Compactor(mad=dict(disclosure, d=''), makify=True, kind=kind)
     check.compact()
     assert check.said == _committed_a_said(wardCitizen, kind)
+    # ...and the credential rebuilt around it still carries the FULL credential's SAID,
+    # on every kind. This is what the platform's acceptance rests on: a partial
+    # disclosure is verifiable because an ACDC commits to its most compact form.
+    partial = _disclose(wardCitizen, kind, disclosure)
+    assert partial.said == wardCitizen.said
+    assert isinstance(partial.sad['a']['name'], str)   # still withheld
+    # ...and the schema rides as a bare SAID, so the disclosure does not hand back a
+    # block naming every field it just took the trouble to withhold.
+    assert partial.sad['s'] == wardCitizen.sad['s']['$id']
+    assert isinstance(partial.sad['s'], str)
+    assert SerderACDC(sad=json.loads(json.dumps(partial.sad)),
+                      verify=True).said == wardCitizen.said
 
 
 if __name__ == "__main__":

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -2,112 +2,67 @@
 """
 tests.acdc.test_ward_authz_presentation module
 
-Worked, working example of a DELEGATED AUTHORIZATION that the ward presents herself: a
-guardian issues his ward an ACDC carrying an attenuated slice of his own authority, and the
-ward -- not the guardian -- shows it to the service that gates the act. It is the shape
-@SmithSamuelM drew in WebOfTrust/keripy discussion #1550, in the diagram "Ward with Single
-Guardian Issues Authorization: Ward to Access Social".
+Worked, working example of a DELEGATED AUTHORIZATION the ward presents herself: a guardian
+issues his ward an ACDC carrying an attenuated slice of his own authority, and the ward --
+not the guardian -- shows it to the service that gates the act. It is the shape
+@SmithSamuelM drew in #1550, "Ward with Single Guardian Issues Authorization: Ward to
+Access Social".
 
-TWO REGIMES, TWO MODULES, and the split is statutory. Utah Code 63A-20-302(3)(a): "If an
-individual is unable to apply for a state-endorsed digital identity due to the individual's
-youth or incapacitation, the application may be made on behalf of that individual by the
-individual's digital guardian." A ward who cannot act -- an infant, or an adult who has lost
-capacity -- has a guardian who custodies her keys and presents ABOUT her, and there the
-invariant is holder != subject, so a verifier can always tell that a guardian and not the
-ward is acting. That is the sibling, tests/acdc/test_guardianship_presentation.py (PR
-#1530), whose ward is a seven-year-old. A ward who CAN act holds her own keys and acts as
-herself, bounded by what her guardian has authorized. That is THIS module, and the
-invariant here is attenuation rather than holder != subject. Bob Carver is the custodial
-parent in both -- his seven-year-old Mia is the sibling's ward, his 17-year-old Cara is
-this one's.
+TWO REGIMES, TWO MODULES, split where Utah Code 63A-20-302(3)(a) splits them: a ward
+"unable to apply ... due to the individual's youth or incapacitation" has a guardian who
+acts on her behalf. That ward is the sibling's -- seven-year-old Mia, in
+tests/acdc/test_guardianship_presentation.py (PR #1530), whose guardian custodies her keys,
+where the invariant is holder != subject. A ward who CAN act is this module's --
+17-year-old Cara, bounded by the authorization she carries, where the invariant is
+attenuation. Bob Carver is the custodial parent in both.
 
-Scenario, under Utah's Minor Protection in Social Media Act (Utah Code 13-71). Cara is 17,
-so she is a "minor" (13-71-101(8): under 18, unemancipated, unmarried), and a social media
-company must run an age assurance system that identifies her as one (13-71-201). Being a
-minor does NOT gate her account: it forces maximum-privacy defaults, limiting visibility,
-sharing and direct messaging to connected accounts (13-71-202). Two platform duties then
-turn on her parent's authority. She may not change those defaults without verifiable
-parental consent (13-71-204(1)), and the supervisory tools she may activate are configured
-by "an individual selected by the Utah minor account holder", who sets daily time limits
-and mandatory breaks (13-71-203). Both are authority Bob holds and Cara exercises, so he
-issues her an ACDC naming the routes, capabilities and daily window she may use -- drawn
-from, and no larger than, what the State recognized in him -- and SHE presents it.
+Scenario, under Utah's Minor Protection in Social Media Act. Being a minor does not gate
+Cara's account; it forces maximum-privacy defaults on it (13-71-202). Two duties then turn
+on her parent: she cannot change those defaults without verifiable parental consent
+(13-71-204(1)), and the supervisory tools she activates are configured by an individual she
+selects, who sets daily time limits (13-71-203). Both are authority Bob holds and Cara
+exercises, so he issues her an ACDC naming the routes, capabilities and daily window she may
+use, and SHE presents it. NOT claimed: that the ACDC is statutory consent. 13-71-101(18)
+defines that as a notice ritual running toward the parent, and this runs the other way, so
+it models the parental AUTHORITY those duties rely on rather than the ceremony.
 
-WHAT THIS EXAMPLE DOES NOT CLAIM. 13-71-101(18) defines "verifiable parental consent" as a
-notice ritual running toward the parent: the service gives the parent advance notice of its
-information practices, and receives confirmation that the parent received it. An AuthZ
-credential runs the other way -- a parent-issued, cryptographically verifiable grant the
-ward carries -- so it models the parental AUTHORITY that 13-71-204(1) and 13-71-203 make
-load-bearing, not the statutory consent ceremony. A deployment wanting both would pair
-them; nothing here substitutes for the notice.
-
-Four credentials, all v2 ACDCs, all registry-bound, each validated against a
-purpose-authored JSON Schema (Draft 2020-12):
+Four credentials, registry-bound, each validated against a purpose-authored JSON Schema:
 
   1. Guardian as Citizen  -- State -> Bob.  His own SEDI identity credential.
-  2. Guardian as Guardian -- State -> Bob.  The recognized guardianship, whose attribute
-     block carries the WARD's AID as well as Bob's (see the divergence below). Edge to (1).
-  3. Ward as Citizen Ward -- State -> Cara. Her own SEDI identity credential, which by its
-     edge to (2) DECLARES ITSELF ENCUMBERED, so a verifier reading only her credential
-     learns that her identity is not unencumbered.
-  4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry (not the State's), carrying
-     the routes and capabilities she may exercise. Edges to (2) and (3).
+  2. Guardian as Guardian -- State -> Bob.  The guardianship, carrying the WARD's AID in its
+     attribute block (see the divergence below). Edge to (1).
+  3. Ward as Citizen Ward -- State -> Cara. Her identity credential, DECLARING ITSELF
+     ENCUMBERED by its edge to (2).
+  4. Ward AuthZ Social    -- Bob -> Cara, in BOB's OWN registry. Edges to (2) and (3).
 
-Four edges, four different operators, and getting each right is the security content here.
-Every one is PINNED by a schema const, so a mislabeled operator fails at wire validation:
+Four edges, four operators, each PINNED by a schema const so a mislabel fails wire
+validation. Each is argued where it is built; in brief:
 
-  * (4) -> (2) authority, I2I: near issuer Bob == far issuee Bob, which proves Bob HELD
-    what he delegates. Without it the AuthZ credential is a stranger's assertion of
-    permissions over someone else's child.
-  * (4) -> (3) subject, E1E: same subject (Cara), different issuers (Bob vs the State).
-    I2I would demand Bob == Cara and would FALSELY REJECT a sound identity relation, where
-    E1E (PR #1527) constrains the issuee only. This is the second independent use case for
-    the operator, and unlike the first it comes from Sam's diagram rather than from the PR
-    that proposed it.
-  * (2) -> (1) citizen, E1E again: same subject, and here the same issuer too -- which is
-    not what makes it identity. I2I would demand State == Bob.
-  * (3) -> (2) guardian, NI2I: different subjects, so neither targeted operator applies.
-    The untargeted reference is right for "my credential points at somebody else's" --
-    here, the encumbrance marker.
+  (4)->(2) authority  I2I   near issuer Bob == far issuee Bob: Bob held what he delegates.
+  (4)->(3) subject    E1E   same subject, different issuers; I2I would demand Bob == Cara.
+  (2)->(1) citizen    E1E   same subject again; I2I would demand State == Bob.
+  (3)->(2) guardian   NI2I  different subjects, so only the untargeted operator applies.
 
-E1E carries the same caveat as in the sibling: it is not yet in the spec's closed operator
-set {I2I, NI2I, DI2I, NOT}, and a spec-default or pre-#1527 verifier COERCES an unknown
-operator rather than rejecting it -- to I2I for a targeted far node, wrongly rejecting both
-E1E edges here. So this graph needs a #1527-or-later verifier until E1E is ratified (#1515).
+The two E1E edges are why this graph is more than a diagram: E1E (PR #1527, disc #1515) is
+not yet in the spec's closed operator set, so a verifier that coerces an unknown operator to
+I2I rejects both outright rather than merely under-specifying them.
 
-RECORDED DIVERGENCE: where the ward AID lives. Sam's diagram puts it in the ATTRIBUTE block
-of (2); the sibling names the ward only by an EDGE. Both preserve holder != subject, so this
-is a DISCLOSURE choice, and the edge form is better on Sam's own argument from #1515 that an
-edge "can also be blinded, which means that disclosure of the edge itself can be held back
-until the verifier (disclosee) has agreed not to exploit its correlatability" -- where a
-whole-disclosed attribute cannot be held back at all. This module models SAM's placement
-because it is his diagram, and the question is open on #1550; Phase 4 shows the argument
-arriving as an actual leak, since the guardianship's expiry is Cara's 18th birthday.
+RECORDED DIVERGENCE: where the ward AID lives. Sam's diagram puts it in (2)'s ATTRIBUTE
+block, the sibling names the ward by EDGE, and both preserve holder != subject -- so it is a
+DISCLOSURE choice, and the edge is better on Sam's own #1515 argument that an edge "can also
+be blinded" until the disclosee accepts terms, where a whole-disclosed attribute cannot be
+withheld at all. This module follows SAM because it is his diagram; Phase 4 shows the cost,
+the guardianship's expiry being Cara's 18th birthday.
 
-The AuthZ payload is ILLUSTRATIVE and its syntax UNSETTLED. Sam says only that the field
-"contains the specifics of the authorization. The syntax TBD", and points at EVAC (Edge
-Verifiable Agent Control), sketched at the end of #1550 as a resource-capabilities map 'rc'
-of the form {resourceRoute: [capability, ...]}. That is modeled here, plus the time window
-13-71-203 makes relevant, and no assertion reaches into it (the seam is
-_authz_capabilities, so a syntax change is one function rather than a rewrite). One
-constraint on that syntax is not taste, and this example measured it by serializing rather
-than arguing: a route written as a map LABEL falls under CESR's strict field-label grammar,
-so "social/feed" cannot be serialized in native CESR at all. The measurement, and the
-recommendation it produces for #1550 -- carry the route as a VALUE -- are at
-AUTHZ_BLOCK_SCHEMA.
-
-The negative that earns its place: a guardian cannot delegate more than he holds, so (4)'s
-capability tokens must be a SUBSET of (2)'s 'powers'. Over-reach is a binding property
-rather than a shape property, so the greedy credential is schema-valid and the binding, not
-the schema, refuses it (Phase 3). Naming divergence from the sibling while reading 'powers':
-there it is the coarse statutory scope enum, carried here as 'scope'.
-
-A note on altitude, the same one the siblings carry. This models the credential graph, the
-edge bindings and the registry binding at the data-structure level, built from the real v2
-primitives in keri.acdc.messaging and keri.core (acdcmap, Compactor, Mapper, exchange). It
-does not stand up a Habery/keystore or route through keri.vdr.verifying.verifyChain, which
-needs a live Reger/Tevery; PR #1527 unit-tests its real E1E branch. Actor AIDs and nonces
-derive from fixed salts, so the module is reproducible.
+Three things stated once and detailed at the code. The AuthZ payload is ILLUSTRATIVE and its
+syntax UNSETTLED ("The syntax TBD", #1550), modeled on EVAC's 'rc' map and insulated behind
+_authz_capabilities; the constraint the build measured -- a route cannot be a map LABEL in
+native CESR -- is at AUTHZ_BLOCK_SCHEMA. Over-reach is relational rather than structural, so
+an AuthZ credential exceeding (2)'s 'powers' is schema-valid and only the binding refuses it
+(Phase 3); note 'powers' here is the delegable capability set, where the sibling's statutory
+scope enum is 'scope'. And the altitude is the siblings': the credential graph, edge
+bindings and registry binding at the data-structure level on real v2 primitives, with no
+Habery/keystore and no verifyChain, which needs a live Reger/Tevery.
 """
 
 import json

--- a/tests/acdc/test_ward_authz_presentation.py
+++ b/tests/acdc/test_ward_authz_presentation.py
@@ -1292,8 +1292,16 @@ def test_wardauthz_presentation_JSON():
     guardianCitizen, guardian, wardCitizen, wardAuthz = _credential_graph(kind)
     assert _verify_authz_chain(wardAuthz, guardian, wardCitizen, guardianCitizen)
 
-    # 1. apply (platform -> Cara): the challenge -- which schemas, which fields, and the
-    # governance framework the platform will honor.
+    # 1. apply (platform -> Cara): the challenge -- which schemas and which fields.
+    #
+    # It does NOT name a governance framework. An earlier draft carried the AuthZ rules
+    # SAID here as 'g' and again in the offer as 'governance', which was two labels for
+    # a pointer the credential already publishes in its own rules section (asserted in
+    # Phase 2: wardAuthz.sad['r'] == AUTHZ_RULES_SAID). Jurisdiction and safe-harbor
+    # belong in the ACDC 'r' section, not on the exchange (@ryan-hansen, #1595). If a
+    # disclosee ever needs to state a governance REQUIREMENT -- which is a different
+    # claim from the issuer's assertion, and could in principle disagree with it -- that
+    # is a field to define in #1595 rather than a label to reuse here.
     #
     # The field-level ask rides the disclosure-paths `dp` field of the QUERY section
     # `q` (exchange(modifiers=...)), as an ORDERED LIST of (schemaSAID, prefix, [paths])
@@ -1371,8 +1379,7 @@ def test_wardauthz_presentation_JSON():
                                         [guardianCitizen.sad['s']['$id'], "",
                                          ["a/i"]]]),
                      attributes=dict(m="Prove a guardian authorized this minor account "
-                                       "holder's settings, and show the scope.",
-                                     g=AUTHZ_RULES_SAID),
+                                       "holder's settings, and show the scope."),
                      stamp=APPLY_STAMP, kind=kind)
     assert apply.sad['r'] == "/ipex/apply" and apply.sad['i'] == SOCIAL
     dp = apply.sad['q']['dp']
@@ -1391,11 +1398,12 @@ def test_wardauthz_presentation_JSON():
     # Every node the binding reads is asked for, and every node in the DAG is a node the
     # binding reads -- so the request covers the DAG exactly.
     assert len(dp) == 4
-    assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m', 'g'}
-    assert apply.said == "ECpsd2btQ79rndSrOrK9j4wKCq48o7_IXGRESV717T-K"
+    assert 'disclose' not in apply.sad['a'] and set(apply.sad['a']) == {'m'}
+    assert 'g' not in apply.sad['a']            # governance lives in ACDC rules
+    assert apply.said == "EK8c54LovECAuyNpNjuRdCvPxrDFQe1cRgMMN7Y9bSaK"
 
     # 2. offer (Cara -> platform): commits ONLY to the SAID of the credential she is
-    # offering and to the governance ref, and binds the apply. It deliberately does NOT
+    # offering, and binds the apply. It deliberately does NOT
     # enumerate the issuer-committed source SAIDs (the guardianship, either citizen
     # credential): those are stable correlators, and attaching them before the platform
     # agrees would let a platform spurn and walk away with a persistent handle on both
@@ -1415,11 +1423,13 @@ def test_wardauthz_presentation_JSON():
     # (#1549), so Cara restates nothing and the two messages cannot drift.
     offer = exchange(sender=CARA, receiver=SOCIAL, route="/ipex/offer", prior=apply.said,
                      modifiers=dict(dp=[]),
-                     attributes=dict(acdc=wardAuthz.said, governance=AUTHZ_RULES_SAID),
+                     attributes=dict(acdc=wardAuthz.said),
                      stamp=OFFER_STAMP, kind=kind)
     assert offer.sad['p'] == apply.said
     assert offer.sad['q']['dp'] == []                  # solicited: "as per the apply"
-    assert offer.said == "EGKqASGat52SaGBi9mLmdCUmu9ovXlrQtsQHc6WDdA60"
+    assert 'governance' not in offer.sad['a']          # ...and not on the exchange
+    assert set(offer.sad['a']) == {'acdc'}
+    assert offer.said == "EKmxlQFMSOUZNu4t_pMSFX-0ACyaYfVkIv0YzLloTZ_j"
     assert wardAuthz.said.encode() in offer.raw        # the discloser's own commitment
     assert b"Cara Carver" not in offer.raw and b"2009-04-10" not in offer.raw
     assert guardian.said.encode() not in offer.raw     # issuer commitments withheld...
@@ -1431,7 +1441,7 @@ def test_wardauthz_presentation_JSON():
     agree = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/agree", prior=offer.said,
                      stamp=AGREE_STAMP, kind=kind)
     assert agree.sad['p'] == offer.said
-    assert agree.said == "EF_BoANaVLJrqsMwHX21FYTeEOTWN9Q-t7p2Jr9kNkX-"
+    assert agree.said == "EJMvaBejL2_tduOfBDcrPLKlsoE0xhES3qRArCOPcRNM"
     svcSigner = _SIGNERS[3]                            # the platform's establishing key
     svcSig = svcSigner.sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[svcSig])
@@ -1478,7 +1488,7 @@ def test_wardauthz_presentation_JSON():
     # The valid agree unlocks the grant.
     grant = disclose(agree, svcSig, capturedKeyState)
     assert grant is not None and grant.sad['p'] == agree.said
-    assert grant.said == "EBGFcsDsSCMeanK53iNBxmwLadlFWxhPA9obTg_KTHjs"
+    assert grant.said == "EKjAC72RSOZekQ-6AoGjqbGOFu7PD6N2ojmN_1_sF_fy"
 
     # What the platform receives is one artifact per dp entry, disclosed to the requested
     # depth. Each one still carries the SAID of the FULL credential, because an ACDC's
@@ -1548,7 +1558,7 @@ def test_wardauthz_presentation_JSON():
     admit = exchange(sender=SOCIAL, receiver=CARA, route="/ipex/admit", prior=grant.said,
                      stamp=ADMIT_STAMP, kind=kind)
     assert admit.sad['p'] == grant.said
-    assert admit.said == "EK1gyvwKLaUKxMev9I-MuSZt9v5Cxx68fnASopakqSid"
+    assert admit.said == "ENOajOwvH82FgQMoSYWGkNS9vKLPpekz9Q3ST38SVMYJ"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This adds a worked, working ACDC v2 example — `tests/acdc/test_ward_authz_presentation.py` — of the guardianship pattern that @SmithSamuelM proposed in discussion #1550, "Ward with Single Guardian Issues Authorization: Ward to Access Social": the guardian issues a delegated authorization ACDC **to** the ward, and the **ward presents it herself**.

That is the inverse of the sibling in #1530, and both are real. #1530 models the guardian presenting *about* the ward, which fits an infant or an incapacitated adult — the parent holds and manages the ward's keys. This one models a teen who controls her own keys but whose access her parent authorizes. Bob Carver is the custodial parent in both PRs; Mia is the young-child ward; Cara is this one's teenager.

In this example, Cara gets maximum-privacy defaults (Utah 13-71-202), and two duties then turn on the parent: she may not change those defaults without verifiable parental consent (13-71-204(1)), and the supervisory tools she may activate are configured by "an individual selected by the Utah minor account holder", who sets daily time limits and mandatory breaks (13-71-203). Both are authority the guardian holds and the **ward** exercises — which is the shape being modeled — and the daily window in the AuthZ payload stops being decoration.

Here are the credentials in this example. Each is tied to a registry and each is validated against a purpose-authored JSON Schema:

1. **Guardian as Citizen** — State → Bob. His own SEDI identity credential.
2. **Guardian as Guardian** — State → Bob. The recognized guardianship, carrying the ward's AID in the attribute block per the #1550 diagram.
3. **Ward as Citizen Ward** — State → Cara. Her own SEDI identity credential, which by its edge to (2) **declares itself encumbered**.
4. **Ward AuthZ Social** — Bob → Cara, in **Bob's own registry**, carrying the routes and capabilities she may exercise. The payload is marked *illustrative* in both the schema `description` and the docstring, since #1550 says the syntax is TBD.

There are four interesting edges, each pinned by a schema `const`:

| edge | from → to | operator | why |
|---|---|---|---|
| authority | AuthZ → guardianship | `I2I` | Bob issues the AuthZ and is the guardianship's issuee |
| subject | AuthZ → ward's citizen credential | `E1E` | same issuee (Cara), different issuers (Bob vs the State) |
| guardian identity | guardianship → guardian's citizen credential | `E1E` | same issuee (Bob), and `I2I` would be false |
| encumbrance | ward's citizen credential → guardianship | `NI2I` | issuees differ; a reference, not a delegation |

Here's what the example exercises:

- **E1E, positively and negatively.** On both identity edges the delegative `I2I` would *reject* rather than merely under-specify, because the issuers differ, while it holds on the one genuine delegation edge. A second use case for the operator added in #1527, and it comes from Sam's diagram rather than from this example's convenience.
- **Attenuation.** A guardian delegating **more than he holds** is fully schema-valid and is refused only by the binding logic — then the same payload becomes legitimate under a broader guardianship, so the check is visibly about the relation between two credentials, not the shape of one.
- **A gated IPEX exchange with the ward as discloser.** Her citizen attributes cross the wire only after the platform signs an agree, and then only as bare SAIDs that still recompute to the committed section SAID.