### PR TITLE
Add tests for tests examples with IPEX

### DIFF
--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -1313,11 +1313,489 @@ def test_age_identity_edge_E1E_JSON():
         _verify_identity_edge(age, sedi, "E" + "A" * 43)
 
 
+JOB_SEDI_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "SEDI Job-Application Identity Credential",
+    "description": "SEDI identity subset for employment screening, authored for "
+                   "graduated disclosure rather than proof-of-age.",
+    "credentialType": "SEDI_JobIdentity",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"description": "Issuer (State) AID", "type": "string"},
+        "rd": {"description": "Registry SAID", "type": "string"},
+        "s": _EMPTY_OR_SECTION,
+        "a": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object",
+                 "required": ["d", "u", "i", "legalName", "address", "phone",
+                              "biometric", "dob"],
+                 "properties": {
+                     "d": {"type": "string"},
+                     "u": {"type": "string"},
+                     "i": {"type": "string"},
+                     "legalName": _disclosable_block(
+                         "legalName",
+                         {"type": "string"},
+                         "LegalName"),
+                     "address": _disclosable_block(
+                         "address",
+                         {"type": "string"},
+                         "Address"),
+                     "phone": _disclosable_block(
+                         "phone",
+                         {"type": "string"},
+                         "Phone"),
+                     "biometric": _disclosable_block(
+                         "biometric",
+                         {"type": "string"},
+                         "Biometric"),
+                     "dob": _disclosable_block(
+                         "dob",
+                         {"type": "string", "format": "date"},
+                         "DOB"),
+                 },
+                 "additionalProperties": False},
+            ],
+        },
+        "e": _EMPTY_OR_SECTION,
+        "r": _EMPTY_OR_SECTION,
+    },
+    "additionalProperties": False,
+}
+
+FOOD_HANDLER_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Food Handler Permit Credential",
+    "description": "Food-handler entitlement credential linked back to a SEDI core "
+                   "identity via an E1E identity edge.",
+    "credentialType": "FoodHandlerPermit",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "rd", "s", "a", "e"],
+    "properties": {
+        "v": {"description": "ACDC version string", "type": "string"},
+        "t": {"description": "Message type", "const": "acm"},
+        "d": {"description": "Message SAID", "type": "string"},
+        "u": {"description": "Message UUID", "type": "string"},
+        "i": {"type": "string"},
+        "rd": {"type": "string"},
+        "s": _EMPTY_OR_SECTION,
+        "a": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object",
+                 "required": ["d", "u", "i", "permitId", "category", "status",
+                              "expires", "jurisdiction"],
+                 "properties": {
+                     "d": {"type": "string"},
+                     "u": {"type": "string"},
+                     "i": {"type": "string"},
+                     "permitId": {"type": "string"},
+                     "category": {"type": "string"},
+                     "status": {"type": "string"},
+                     "expires": {"type": "string", "format": "date"},
+                     "jurisdiction": {"type": "string"},
+                 },
+                 "additionalProperties": False},
+            ],
+        },
+        "e": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object",
+                 "required": ["d", "identity"],
+                 "properties": {"d": {"type": "string"},
+                                "u": {"type": "string"},
+                                "identity": _E1E_EDGE_SCHEMA},
+                 "additionalProperties": False},
+            ],
+        },
+        "r": _EMPTY_OR_SECTION,
+    },
+    "additionalProperties": False,
+}
+
+JOB_PRESENTATION_SCHEMA_MAD = {
+    "$id": "",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Job Application Presentation ACDC",
+    "description": "Holder-issued job-application presentation binding the SEDI "
+                   "subset and the linked entitlement to one applicant.",
+    "credentialType": "JobApplicationPresentation",
+    "version": "1.0.0",
+    "type": "object",
+    "required": ["v", "d", "i", "s", "a", "e"],
+    "properties": {
+        "v": {"type": "string"},
+        "t": {"const": "acm"},
+        "d": {"type": "string"},
+        "u": {"type": "string"},
+        "i": {"type": "string"},
+        "s": _EMPTY_OR_SECTION,
+        "a": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object",
+                 "required": ["d", "u", "i", "role", "employer", "submitted"],
+                 "properties": {
+                     "d": {"type": "string"},
+                     "u": {"type": "string"},
+                     "i": {"type": "string"},
+                     "role": {"type": "string"},
+                     "employer": {"type": "string"},
+                     "submitted": {"type": "string"},
+                 },
+                 "additionalProperties": False},
+            ],
+        },
+        "e": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "object",
+                 "required": ["d", "identity", "entitlement"],
+                 "properties": {"d": {"type": "string"},
+                                "u": {"type": "string"},
+                                "identity": _I2I_EDGE_SCHEMA,
+                                "entitlement": _I2I_EDGE_SCHEMA},
+                 "additionalProperties": False},
+            ],
+        },
+        "r": _EMPTY_OR_SECTION,
+    },
+    "additionalProperties": False,
+}
+
+
+JOB_RAWS = [b'jobappdisclosur' + b'%0x' % (i,) for i in range(18)]
+JOB_NONCES = [Noncer(raw=raw).qb64 for raw in JOB_RAWS]
+J_SEDI_A, J_SEDI_NAME, J_SEDI_ADDRESS, J_SEDI_PHONE, J_SEDI_BIOMETRIC, J_SEDI_DOB, \
+    J_SEDI_ACDC, J_PERMIT_A, J_PERMIT_ACDC, J_PERMIT_E, J_PERMIT_E_ID, J_PRESENT_A, \
+    J_PRESENT_ACDC, J_PRESENT_E, J_PRESENT_E_ID, J_PRESENT_E_ENT, J_REG_STATE, \
+    J_REG_PERMIT = range(18)
+
+
+def test_job_application_entitlement_presentation_JSON():
+    """Job-application flow: SEDI subset plus linked food-handler entitlement.
+
+    This keeps the Daniel/Sam CLC exchange shape but swaps the second credential from
+    proof-of-age to an entitlement. The employer first applies for DAG-scoped
+    disclosure, the holder offers a holder-issued presentation that binds the two
+    source credentials, a signed agree opens the gate, and the grant carries both
+    artifacts: a graduated-disclosure SEDI subset and the linked entitlement.
+
+    Workflow/UX sketch, at the test level:
+      1. Employer asks for exactly the fields it needs for hiring.
+      2. Holder preview/offers the one-time presentation without leaking PII.
+      3. Holder releases the actual data only after the employer signs agree.
+
+    If the employer later needs a separate work-age proof, that should be a second
+    apply/offer/agree/grant flow keyed to an age-threshold credential rather than
+    broadening this entitlement flow.
+    """
+    kind = Kinds.json
+
+    # Build registries and self-addressed schemas for the two source credentials
+    # and the holder-issued presentation.
+    regState = regcept(israid=STATE, uuid=JOB_NONCES[J_REG_STATE],
+                       stamp="2026-03-10T12:00:00.000000+00:00", kind=kind)
+    regPermit = regcept(israid=ENDORSER, uuid=JOB_NONCES[J_REG_PERMIT],
+                        stamp="2026-03-11T12:00:00.000000+00:00", kind=kind)
+    _, jobSediSchema = _saidify_schema(dict(JOB_SEDI_SCHEMA_MAD), kind=kind)
+    _, permitSchema = _saidify_schema(dict(FOOD_HANDLER_SCHEMA_MAD), kind=kind)
+    _, presentationSchema = _saidify_schema(dict(JOB_PRESENTATION_SCHEMA_MAD),
+                                            kind=kind)
+
+    # Build the employment-oriented SEDI source credential. The nested blocks let
+    # the holder reveal name/address/phone/biometric later while withholding DOB.
+    sedi = acdcmap(
+        israid=STATE,
+        uuid=JOB_NONCES[J_SEDI_ACDC],
+        regid=regState.said,
+        schema=jobSediSchema,
+        attribute=dict(
+            d='',
+            u=JOB_NONCES[J_SEDI_A],
+            legalName=dict(d='', u=JOB_NONCES[J_SEDI_NAME],
+                           legalName="Alice Anders"),
+            address=dict(d='', u=JOB_NONCES[J_SEDI_ADDRESS],
+                         address="220 E 300 S, Salt Lake City UT 84111"),
+            phone=dict(d='', u=JOB_NONCES[J_SEDI_PHONE],
+                       phone="+1-801-555-0100"),
+            biometric=dict(d='', u=JOB_NONCES[J_SEDI_BIOMETRIC],
+                           biometric="face-template-sha256:4d0ff9ce-job-app"),
+            dob=dict(d='', u=JOB_NONCES[J_SEDI_DOB], dob="2000-03-15"),
+        ),
+        iseaid=ALICE,
+        kind=kind,
+    )
+    # Build the entitlement credential and chain it back to the SEDI credential
+    # with an E1E identity edge.
+    permit = acdcmap(
+        israid=ENDORSER,
+        uuid=JOB_NONCES[J_PERMIT_ACDC],
+        regid=regPermit.said,
+        schema=permitSchema,
+        attribute=dict(d='', u=JOB_NONCES[J_PERMIT_A], i=ALICE,
+                       permitId="UT-FH-2026-00917",
+                       category="food-handler",
+                       status="active",
+                       expires="2027-08-31",
+                       jurisdiction="Salt Lake County Health Department"),
+        edge=dict(d='', u=JOB_NONCES[J_PERMIT_E],
+                  identity=dict(d='', u=JOB_NONCES[J_PERMIT_E_ID], n=sedi.said,
+                                s=sedi.sad['s']['$id'], o='E1E')),
+        kind=kind,
+    )
+    # Build the expanded holder-issued presentation that binds both source
+    # credentials to this one job-application flow.
+    presentation = acdcmap(
+        israid=ALICE,
+        uuid=JOB_NONCES[J_PRESENT_ACDC],
+        schema=presentationSchema,
+        attribute=dict(d='', u=JOB_NONCES[J_PRESENT_A], i=CLUB,
+                       role="crew-member / food-handler",
+                       employer="Downtown Burger",
+                       submitted="2026-08-04"),
+        edge=dict(
+            d='',
+            u=JOB_NONCES[J_PRESENT_E],
+            identity=dict(d='', u=JOB_NONCES[J_PRESENT_E_ID], n=sedi.said,
+                          s=sedi.sad['s']['$id'], o='I2I'),
+            entitlement=dict(d='', u=JOB_NONCES[J_PRESENT_E_ENT], n=permit.said,
+                             s=permit.sad['s']['$id'], o='I2I'),
+        ),
+        kind=kind,
+    )
+    # Build the compact form of the same presentation so the grant can carry the
+    # smaller wire representation while keeping the same SAID.
+    presentationCompact = acdcmap(
+        israid=ALICE,
+        uuid=JOB_NONCES[J_PRESENT_ACDC],
+        schema=presentationSchema,
+        attribute=dict(d='', u=JOB_NONCES[J_PRESENT_A], i=CLUB,
+                       role="crew-member / food-handler",
+                       employer="Downtown Burger",
+                       submitted="2026-08-04"),
+        edge=dict(
+            d='',
+            u=JOB_NONCES[J_PRESENT_E],
+            identity=dict(d='', u=JOB_NONCES[J_PRESENT_E_ID], n=sedi.said,
+                          s=sedi.sad['s']['$id'], o='I2I'),
+            entitlement=dict(d='', u=JOB_NONCES[J_PRESENT_E_ENT], n=permit.said,
+                             s=permit.sad['s']['$id'], o='I2I'),
+        ),
+        kind=kind,
+        compactify=True,
+    )
+
+    # Validate every artifact and assert the presentation binds one holder to one
+    # identity credential and one entitlement credential.
+    assert_acdc_schema_valid(sedi)
+    assert_acdc_schema_valid(permit)
+    schema = assert_acdc_schema_valid(presentation)
+    assert_acdc_schema_valid(presentationCompact, schema=schema)
+    assert presentation.said == presentationCompact.said
+    assert presentation.sad['i'] == sedi.iseaid == permit.iseaid == ALICE
+    assert presentation.sad['e']['identity']['o'] == 'I2I'
+    assert presentation.sad['e']['entitlement']['o'] == 'I2I'
+    assert sedi.sad['rd'] and permit.sad['rd']
+    assert _verify_identity_edge(permit, sedi, sedi.sad['s']['$id'])
+
+    # Build the dp request in breadth-first order from the presentation DAG's
+    # origin node. Each entry is a compact triple:
+    #   [schema SAID, DAG-absolute path prefix, list of ACDC-relative paths]
+    # The _ component is the virtual DAG hop from an edge block to the far ACDC.
+    requestedDp = [
+        [presentation.sad['s']['$id'], "/", [
+            "i",
+            "a/i",
+            "a/role",
+            "a/employer",
+            "a/submitted",
+        ]],
+        [sedi.sad['s']['$id'], "/e/identity/_/", [
+            "i",
+            "a/i",
+            "a/legalName",
+            "a/address",
+            "a/phone",
+            "a/biometric",
+        ]],
+        [permit.sad['s']['$id'], "/e/entitlement/_/", [
+            "i",
+            "a/i",
+            "a/permitId",
+            "a/category",
+            "a/status",
+            "a/expires",
+            "e/identity/n",
+            "e/identity/s",
+        ]],
+    ]
+
+    # Build apply: the employer asks for the origin presentation plus the linked
+    # SEDI subset and entitlement using the normalized dp field.
+    apply = exchange(
+        sender=CLUB,
+        receiver=ALICE,
+        route="/ipex/apply",
+        attributes=dict(
+            m="Show the SEDI identity subset and the linked food-handler permit.",
+            dp=requestedDp,
+        ),
+        stamp="2026-08-04T15:00:00.000000+00:00",
+        kind=kind,
+    )
+    # Assert the apply carries the expected dp triples in BFS order:
+    # root presentation first, then SEDI, then the permit.
+    assert apply.sad['r'] == "/ipex/apply"
+    assert apply.sad['a']['dp'] == requestedDp
+    assert apply.sad['a']['dp'][0][0] == presentation.sad['s']['$id']
+    assert apply.sad['a']['dp'][0][1] == "/"
+    assert apply.sad['a']['dp'][1][1] == "/e/identity/_/"
+    assert apply.sad['a']['dp'][2][1] == "/e/entitlement/_/"
+
+    # Build offer: Alice commits to the one-time presentation. Because this
+    # offer is solicited and does not narrow or widen the request, an empty dp
+    # means "same disclosure plan as the apply".
+    offer = exchange(
+        sender=ALICE,
+        receiver=CLUB,
+        route="/ipex/offer",
+        prior=apply.said,
+        attributes=dict(acdc=presentation.said, dp=[]),
+        stamp="2026-08-04T15:01:00.000000+00:00",
+        kind=kind,
+    )
+    # Assert the offer binds the apply and still carries no disclosed identity data.
+    assert offer.sad['p'] == apply.said
+    assert offer.sad['a']['dp'] == []
+    assert b"Alice Anders" not in offer.raw
+    assert b"220 E 300 S" not in offer.raw
+    assert b"+1-801-555-0100" not in offer.raw
+    assert b"2000-03-15" not in offer.raw
+    assert sedi.said.encode() not in offer.raw
+    assert permit.said.encode() not in offer.raw
+
+    # Build agree and sign it with the employer's key. The holder will only
+    # disclose once this signed acceptance verifies against captured key state.
+    agree = exchange(sender=CLUB, receiver=ALICE, route="/ipex/agree",
+                     prior=offer.said, stamp="2026-08-04T15:02:00.000000+00:00",
+                     kind=kind)
+    employerSig = _SIGNERS[3].sign(ser=agree.raw, index=0)
+    signedAgree = messagize(agree, sigers=[employerSig])
+    capturedKeyState = Verfer(qb64=_SIGNERS[3].verfer.qb64)
+    # Assert the agree binds the offer and that the captured key state verifies it.
+    assert agree.sad['p'] == offer.said
+    assert bytes(agree.raw) in signedAgree
+    assert capturedKeyState.verify(sig=employerSig.raw, ser=agree.raw)
+
+    # Reject a signature over the otherwise-correct agree body made by the wrong
+    # signer. The bytes come from a real test key, but not the employer's key, so
+    # from the employer's perspective it is a forgery.
+    forged = _SIGNERS[0].sign(ser=agree.raw, index=0)
+    assert not capturedKeyState.verify(sig=forged.raw, ser=agree.raw)
+    # Build and verify a signed spurn to prove that a valid decline still does
+    # not count as agreement for unlocking the disclosure.
+    spurn = exchange(sender=CLUB, receiver=ALICE, route="/ipex/spurn",
+                     prior=offer.said, stamp="2026-08-04T15:02:00.000000+00:00",
+                     kind=kind)
+    spurnSig = _SIGNERS[3].sign(ser=spurn.raw, index=0)
+    assert spurn.sad['r'] != "/ipex/agree"
+    assert spurn.sad['p'] == offer.said
+    assert capturedKeyState.verify(sig=spurnSig.raw, ser=spurn.raw)
+
+    # Re-check the real agreement, then prepare the mixed SEDI disclosure: start
+    # from the fully compact form and expand only the employment fields.
+    assert agree.sad['r'] == "/ipex/agree"
+    assert agree.sad['p'] == offer.said
+    assert capturedKeyState.verify(sig=employerSig.raw, ser=agree.raw)
+    identityCompactor = Compactor(mad=dict(sedi.sad['a']), makify=True, kind=kind)
+    identityCompactor.compact()
+    identityCompactor.expand(greedy=True)
+    identityDisclosure = dict(identityCompactor.partials[('',)].mad)
+    for field in ("legalName", "address", "phone", "biometric"):
+        identityDisclosure[field] = sedi.sad['a'][field]
+    # Build grant: carry the compact presentation, the partial SEDI disclosure,
+    # and the linked entitlement only after a valid agree has been established.
+    grant = exchange(
+        sender=ALICE,
+        receiver=CLUB,
+        route="/ipex/grant",
+        prior=agree.said,
+        attributes=dict(
+            acdc=presentationCompact.sad,
+            identity=identityDisclosure,
+            entitlement=dict(a=dict(permit.sad['a']), e=dict(permit.sad['e'])),
+        ),
+        stamp="2026-08-04T15:03:00.000000+00:00",
+        kind=kind,
+    )
+    # Assert the grant follows the agree and that only the intended identity
+    # subset appears on the wire.
+    assert grant is not None
+    assert grant.sad['r'] == "/ipex/grant"
+    assert grant.sad['p'] == agree.said
+    assert b"Alice Anders" in grant.raw
+    assert b"220 E 300 S" in grant.raw
+    assert b"+1-801-555-0100" in grant.raw
+    assert b"face-template-sha256:4d0ff9ce-job-app" in grant.raw
+    assert b"2000-03-15" not in grant.raw
+    assert b"over21" not in grant.raw and b"over16" not in grant.raw
+
+    # Assert the identity disclosure reveals the requested fields but leaves DOB
+    # compacted as a bare SAID, then recompute the section SAID to prove the
+    # mixed disclosure still belongs to the committed SEDI credential.
+    identityDisc = grant.sad['a']['identity']
+    assert identityDisc['i'] == ALICE
+    assert isinstance(identityDisc['legalName'], dict)
+    assert isinstance(identityDisc['address'], dict)
+    assert isinstance(identityDisc['phone'], dict)
+    assert isinstance(identityDisc['biometric'], dict)
+    assert isinstance(identityDisc['dob'], str)
+    check = Compactor(mad=dict(identityDisc, d=''), makify=True, kind=kind)
+    check.compact()
+    assert check.said == _committed_a_said(sedi, kind)
+
+    # Assert the entitlement disclosure carries the permit data plus the E1E edge
+    # that chains the entitlement back to the original SEDI credential.
+    entitlementDisc = grant.sad['a']['entitlement']
+    assert entitlementDisc['a']['i'] == ALICE
+    assert entitlementDisc['a']['permitId'] == "UT-FH-2026-00917"
+    assert entitlementDisc['a']['category'] == "food-handler"
+    assert entitlementDisc['a']['status'] == "active"
+    assert entitlementDisc['e']['identity']['o'] == 'E1E'
+    assert entitlementDisc['e']['identity']['n'] == sedi.said
+    assert entitlementDisc['e']['identity']['s'] == sedi.sad['s']['$id']
+
+    # Verify the compact presentation the employer received is the exact artifact
+    # it previously accepted in the offer/agree exchange.
+    assert _club_accepts_grant(grant.sad['a']['acdc'], presentation.said,
+                               presentation.sad['s'])
+
+    # Build admit to close the exchange after the employer has received the grant.
+    admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",
+                     prior=grant.said, stamp="2026-08-04T15:04:00.000000+00:00",
+                     kind=kind)
+    assert admit.sad['r'] == "/ipex/admit"
+    assert admit.sad['p'] == grant.said
+
+
 if __name__ == "__main__":
     test_source_credentials_and_graduated_disclosure_JSON()
     test_age_identity_edge_E1E_JSON()
     test_bespoke_presentation_acdc_JSON()
     test_gated_ipex_exchange_JSON()
     test_accountability_and_terms_follow_data_JSON()
+    test_job_application_entitlement_presentation_JSON()
     for _kind in (Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk):
         test_clc_serialization_kinds(_kind)

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -160,9 +160,11 @@ def _disclosable_block(attr, attr_schema, desc):
         ],
     }
 
-# acm/acg are fixed-field formats: they always carry (possibly empty) e and r sections
-# even when unused, so the schema must admit them.
-_EMPTY_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
+# ACDC sections may appear either expanded as an object or compacted to the SAID
+# of that section. Schema sections use this directly; edge/rule sections reuse it
+# because acm/acg carry those fields even when they are compact.
+_SAID_OR_SECTION = {"oneOf": [{"type": "string"}, {"type": "object"}]}
+_EMPTY_OR_SECTION = _SAID_OR_SECTION
 
 # One E1E identity edge, pinned by schema (const "E1E"). This is the SEDI core-identity
 # <-> entitlement relationship (keripy discussion #1515): the near ACDC's issuee is the
@@ -1330,7 +1332,7 @@ JOB_SEDI_SCHEMA_MAD = {
         "u": {"description": "Message UUID", "type": "string"},
         "i": {"description": "Issuer (State) AID", "type": "string"},
         "rd": {"description": "Registry SAID", "type": "string"},
-        "s": _EMPTY_OR_SECTION,
+        "s": _SAID_OR_SECTION,
         "a": {
             "oneOf": [
                 {"type": "string"},
@@ -1388,7 +1390,7 @@ FOOD_HANDLER_SCHEMA_MAD = {
         "u": {"description": "Message UUID", "type": "string"},
         "i": {"type": "string"},
         "rd": {"type": "string"},
-        "s": _EMPTY_OR_SECTION,
+        "s": _SAID_OR_SECTION,
         "a": {
             "oneOf": [
                 {"type": "string"},
@@ -1440,7 +1442,7 @@ JOB_PRESENTATION_SCHEMA_MAD = {
         "d": {"type": "string"},
         "u": {"type": "string"},
         "i": {"type": "string"},
-        "s": _EMPTY_OR_SECTION,
+        "s": _SAID_OR_SECTION,
         "a": {
             "oneOf": [
                 {"type": "string"},
@@ -1601,8 +1603,8 @@ def test_job_application_entitlement_presentation_JSON():
     # identity credential and one entitlement credential.
     assert_acdc_schema_valid(sedi)
     assert_acdc_schema_valid(permit)
-    schema = assert_acdc_schema_valid(presentation)
-    assert_acdc_schema_valid(presentationCompact, schema=schema)
+    presentationSchemaExpanded = assert_acdc_schema_valid(presentation)
+    assert_acdc_schema_valid(presentationCompact, schema=presentationSchemaExpanded)
     assert presentation.said == presentationCompact.said
     assert presentation.sad['i'] == sedi.iseaid == permit.iseaid == ALICE
     assert presentation.sad['e']['identity']['o'] == 'I2I'
@@ -1693,17 +1695,17 @@ def test_job_application_entitlement_presentation_JSON():
                      kind=kind)
     employerSig = _SIGNERS[3].sign(ser=agree.raw, index=0)
     signedAgree = messagize(agree, sigers=[employerSig])
-    capturedKeyState = Verfer(qb64=_SIGNERS[3].verfer.qb64)
+    capturedEmployerKeyState = Verfer(qb64=_SIGNERS[3].verfer.qb64)
     # Assert the agree binds the offer and that the captured key state verifies it.
     assert agree.sad['p'] == offer.said
     assert bytes(agree.raw) in signedAgree
-    assert capturedKeyState.verify(sig=employerSig.raw, ser=agree.raw)
+    assert capturedEmployerKeyState.verify(sig=employerSig.raw, ser=agree.raw)
 
     # Reject a signature over the otherwise-correct agree body made by the wrong
     # signer. The bytes come from a real test key, but not the employer's key, so
     # from the employer's perspective it is a forgery.
-    forged = _SIGNERS[0].sign(ser=agree.raw, index=0)
-    assert not capturedKeyState.verify(sig=forged.raw, ser=agree.raw)
+    wrongSignerSig = _SIGNERS[0].sign(ser=agree.raw, index=0)
+    assert not capturedEmployerKeyState.verify(sig=wrongSignerSig.raw, ser=agree.raw)
     # Build and verify a signed spurn to prove that a valid decline still does
     # not count as agreement for unlocking the disclosure.
     spurn = exchange(sender=CLUB, receiver=ALICE, route="/ipex/spurn",
@@ -1712,13 +1714,13 @@ def test_job_application_entitlement_presentation_JSON():
     spurnSig = _SIGNERS[3].sign(ser=spurn.raw, index=0)
     assert spurn.sad['r'] != "/ipex/agree"
     assert spurn.sad['p'] == offer.said
-    assert capturedKeyState.verify(sig=spurnSig.raw, ser=spurn.raw)
+    assert capturedEmployerKeyState.verify(sig=spurnSig.raw, ser=spurn.raw)
 
     # Re-check the real agreement, then prepare the mixed SEDI disclosure: start
     # from the fully compact form and expand only the employment fields.
     assert agree.sad['r'] == "/ipex/agree"
     assert agree.sad['p'] == offer.said
-    assert capturedKeyState.verify(sig=employerSig.raw, ser=agree.raw)
+    assert capturedEmployerKeyState.verify(sig=employerSig.raw, ser=agree.raw)
     identityCompactor = Compactor(mad=dict(sedi.sad['a']), makify=True, kind=kind)
     identityCompactor.compact()
     identityCompactor.expand(greedy=True)
@@ -1762,9 +1764,9 @@ def test_job_application_entitlement_presentation_JSON():
     assert isinstance(identityDisc['phone'], dict)
     assert isinstance(identityDisc['biometric'], dict)
     assert isinstance(identityDisc['dob'], str)
-    check = Compactor(mad=dict(identityDisc, d=''), makify=True, kind=kind)
-    check.compact()
-    assert check.said == _committed_a_said(sedi, kind)
+    identityCheck = Compactor(mad=dict(identityDisc, d=''), makify=True, kind=kind)
+    identityCheck.compact()
+    assert identityCheck.said == _committed_a_said(sedi, kind)
 
     # Assert the entitlement disclosure carries the permit data plus the E1E edge
     # that chains the entitlement back to the original SEDI credential.
@@ -1780,7 +1782,7 @@ def test_job_application_entitlement_presentation_JSON():
     # Verify the compact presentation the employer received is the exact artifact
     # it previously accepted in the offer/agree exchange.
     assert _club_accepts_grant(grant.sad['a']['acdc'], presentation.said,
-                               presentation.sad['s'])
+                               presentationSchemaExpanded)
 
     # Build admit to close the exchange after the employer has received the grant.
     admit = exchange(sender=CLUB, receiver=ALICE, route="/ipex/admit",

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -24,8 +24,12 @@ from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError, ValidationError
 
 from keri import Vrsn_2_0, Kinds, Protocols, Ilks
-from keri.core import Noncer, Blinder, GenDex, Aggor, Compactor, Diger, DigDex
-from keri.acdc import regcept, blindate, acdcmap, acdcagg
+from keri.core import (Noncer, Blinder, GenDex, Aggor, Compactor, Diger,
+                       DigDex, Parser)
+from keri.acdc import (regcept, blindate, acdcmap, acdcagg, loadHandlers,
+                       grant as ipexGrant, admit as ipexAdmit)
+from keri.app import openHby
+from keri.peer import Exchanger
 
 
 # Spec-aligned example fixtures (see test_acdc_examples_setup in the spec tests).
@@ -229,6 +233,202 @@ def test_registry_issuance_lifecycle_JSON():
     assert reunblinder.crew == revokedBlinder.crew
 
 
+def test_registry_issuance_lifecycle_IPEX_JSON():
+    """Same lifecycle as the worked example, but transported through IPEX.
+
+    This stays distinct from test_clc_disclosure.py's gated exchange. The point
+    here is not pre-disclosure negotiation; it is to carry the foundational
+    registry artifacts inside the IPEX builders and route them through the real
+    IPEX handlers we have today.
+
+    The current ``ipexing.grant`` builder gives us three carried artifacts:
+    ``acdc`` (the credential), ``iss`` (the current registry update), and
+    ``anc`` (one ancillary artifact). For this registry lifecycle example we use
+    that ancillary slot for the registry inception (`rip`) itself, so one bare
+    grant snapshots the whole state package the holder needs:
+
+      credential + current `bup` state + originating registry `rip`
+
+    A second bare grant later carries the revoked-state snapshot. Each bare
+    grant is acknowledged by an IPEX admit.
+    """
+
+    class Recorder:
+        def __init__(self):
+            self.items = []
+
+        def add(self, attrs):
+            self.items.append(attrs)
+
+    with openHby(name="ipex-registry-lifecycle",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        amy = hby.makeHab(name="amy", version=Vrsn_2_0, kind=Kinds.json)
+        bob = hby.makeHab(name="bob", version=Vrsn_2_0, kind=Kinds.json)
+
+        # Rebuild the same artifact pattern as the JSON worked example, but with
+        # live Hab AIDs because the current IPEX builders sign through Hab.
+        regStamp = '2025-07-04T17:50:00.000000+00:00'
+        ripper = regcept(israid=amy.pre, uuid=NONCES[0], stamp=regStamp)
+        assert ripper.ilk == Ilks.rip
+        regid = ripper.said
+
+        attribute = dict(d='', u=NONCES[7], name="Sunspot College", level="gold")
+        acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=regid,
+                       attribute=attribute, iseaid=bob.pre)
+        assert acdc.ilk == Ilks.acm
+        assert acdc.sad['rd'] == regid
+        assert acdc.sad['a']['i'] == bob.pre
+        assert_acdc_schema_valid(acdc)
+
+        salt = NONCES[15]
+        issuedBlinder = Blinder.blind(acdc=acdc.said, state='issued', salt=salt, sn=1)
+        issued = blindate(regid=regid, prior=regid, blid=issuedBlinder.said,
+                          sn=1, stamp='2025-08-01T18:06:10.988921+00:00')
+        revokedBlinder = Blinder.blind(acdc=acdc.said, state='revoked', salt=salt, sn=2)
+        revoked = blindate(regid=regid, prior=issued.said, blid=revokedBlinder.said,
+                           sn=2, stamp='2025-09-01T18:06:10.988921+00:00')
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        # Bare grant 1: the issued-state snapshot. In today's builder shape the
+        # lifecycle package is encoded as:
+        #   acdc = credential, iss = current `bup`, anc = registry inception `rip`
+        issuedGrant, issuedGrantAtc = ipexGrant(
+            hab=amy,
+            recp=bob.pre,
+            message="Issued registry snapshot",
+            acdc=acdc,
+            iss=issued,
+            anc=ripper,
+        )
+        issuedGrantIms = bytearray(issuedGrant.raw)
+        issuedGrantIms.extend(issuedGrantAtc)
+        issuedGrantResults = Parser(version=Vrsn_2_0).parse(ims=issuedGrantIms,
+                                                            framed=False,
+                                                            processive=False)
+        assert issuedGrantIms == bytearray()
+        assert len(issuedGrantResults) == 1
+        issuedGrantResult = issuedGrantResults[0]
+        assert issuedGrantResult.serder.said == issuedGrant.said
+        assert issuedGrantResult.serder.ked['r'] == "/ipex/grant"
+        assert issuedGrantResult.serder.ked['p'] == ""          # bare grant opens the flow
+        assert issuedGrantResult.serder.ked['a']['i'] == bob.pre
+        assert issuedGrantResult.serder.ked['a']['acdc'] == acdc.said
+        assert issuedGrantResult.serder.ked['a']['iss'] == issued.said
+        assert issuedGrantResult.serder.ked['a']['anc'] == ripper.said
+        assert [nest.serder.said for nest in issuedGrantResult.nests] == [
+            acdc.said, issued.said, ripper.said
+        ]
+        issuedGrantWire = bytes(issuedGrant.raw) + bytes(issuedGrantAtc)
+        # The disclosed credential is present on the wire, but the registry state
+        # word itself remains hidden because the nested `bup` is blindable
+        assert b'issued' not in issuedGrantWire
+        assert b'revoked' not in issuedGrantWire
+
+        # Route the same message through the real IPEX handlers and persist it
+        issuedGrantDispatch = bytearray(issuedGrant.raw)
+        issuedGrantDispatch.extend(issuedGrantAtc)
+        Parser(version=Vrsn_2_0).parse(ims=issuedGrantDispatch, framed=False, exc=exc)
+        assert issuedGrantDispatch == bytearray()
+
+        # Assert that it was stored
+        storedIssuedGrant = hby.db.exns.get(keys=(issuedGrant.said,))
+        assert storedIssuedGrant is not None
+        assert storedIssuedGrant.ked['a']['iss'] == issued.said
+        assert storedIssuedGrant.ked['a']['anc'] == ripper.said
+
+        issuedAdmit, issuedAdmitAtc = ipexAdmit(
+            hab=bob,
+            message="Received issued snapshot",
+            grant=issuedGrant,
+        )
+        issuedAdmitIms = bytearray(issuedAdmit.raw)
+        issuedAdmitIms.extend(issuedAdmitAtc)
+        Parser(version=Vrsn_2_0).parse(ims=issuedAdmitIms, framed=False, exc=exc)
+        assert issuedAdmitIms == bytearray()
+        storedIssuedAdmit = hby.db.exns.get(keys=(issuedAdmit.said,))
+        assert storedIssuedAdmit is not None
+        assert storedIssuedAdmit.ked['p'] == issuedGrant.said
+
+        # The holder/verifier can now pull the carried `bup` out of the IPEX
+        # grant and perform the same unblinding confirmation as in the base test
+        issuedNest = issuedGrantResult.nests[1].serder
+        unblinder = Blinder.unblind(said=issuedNest.sad['b'], acdc=acdc.said,
+                                    states=['issued', 'revoked'], salt=salt, sn=1)
+        assert unblinder is not None
+        assert unblinder.state == 'issued'
+        assert unblinder.acdc == acdc.said
+        assert unblinder.crew == issuedBlinder.crew
+
+        # Bare grant 2: later the issuer ships the revoked-state snapshot the
+        # same way, again through the handler chain.
+        revokedGrant, revokedGrantAtc = ipexGrant(
+            hab=amy,
+            recp=bob.pre,
+            message="Revoked registry snapshot",
+            acdc=acdc,
+            iss=revoked,
+            anc=ripper,
+        )
+        revokedGrantIms = bytearray(revokedGrant.raw)
+        revokedGrantIms.extend(revokedGrantAtc)
+        revokedGrantResults = Parser(version=Vrsn_2_0).parse(ims=revokedGrantIms,
+                                                             framed=False,
+                                                             processive=False)
+        assert revokedGrantIms == bytearray()
+        assert len(revokedGrantResults) == 1
+        revokedGrantResult = revokedGrantResults[0]
+        assert revokedGrantResult.serder.ked['r'] == "/ipex/grant"
+        assert revokedGrantResult.serder.ked['p'] == ""
+        assert revokedGrantResult.serder.ked['a']['iss'] == revoked.said
+        assert revokedGrantResult.serder.ked['a']['anc'] == ripper.said
+        assert [nest.serder.said for nest in revokedGrantResult.nests] == [
+            acdc.said, revoked.said, ripper.said
+        ]
+        revokedGrantWire = bytes(revokedGrant.raw) + bytes(revokedGrantAtc)
+        assert b'issued' not in revokedGrantWire
+        assert b'revoked' not in revokedGrantWire
+
+        revokedGrantDispatch = bytearray(revokedGrant.raw)
+        revokedGrantDispatch.extend(revokedGrantAtc)
+        Parser(version=Vrsn_2_0).parse(ims=revokedGrantDispatch, framed=False, exc=exc)
+        assert revokedGrantDispatch == bytearray()
+        storedRevokedGrant = hby.db.exns.get(keys=(revokedGrant.said,))
+        assert storedRevokedGrant is not None
+        assert storedRevokedGrant.ked['a']['iss'] == revoked.said
+
+        revokedAdmit, revokedAdmitAtc = ipexAdmit(
+            hab=bob,
+            message="Received revoked snapshot",
+            grant=revokedGrant,
+        )
+        revokedAdmitIms = bytearray(revokedAdmit.raw)
+        revokedAdmitIms.extend(revokedAdmitAtc)
+        Parser(version=Vrsn_2_0).parse(ims=revokedAdmitIms, framed=False, exc=exc)
+        assert revokedAdmitIms == bytearray()
+        storedRevokedAdmit = hby.db.exns.get(keys=(revokedAdmit.said,))
+        assert storedRevokedAdmit is not None
+        assert storedRevokedAdmit.ked['p'] == revokedGrant.said
+
+        revokedNest = revokedGrantResult.nests[1].serder
+        reunblinder = Blinder.unblind(said=revokedNest.sad['b'], acdc=acdc.said,
+                                      states=['issued', 'revoked'], salt=salt, sn=2)
+        assert reunblinder is not None
+        assert reunblinder.state == 'revoked'
+        assert reunblinder.acdc == acdc.said
+        assert reunblinder.crew == revokedBlinder.crew
+
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/grant", "Issued registry snapshot"),
+            ("/exn/ipex/admit", "Received issued snapshot"),
+            ("/exn/ipex/grant", "Revoked registry snapshot"),
+            ("/exn/ipex/admit", "Received revoked snapshot"),
+        ]
+
+
 def test_selective_disclosure_aggregate_JSON():
     """Example: issuer plans for selective disclosure via an aggregate section.
 
@@ -314,6 +514,158 @@ def test_selective_disclosure_aggregate_JSON():
     # Tamper evidence: altering a disclosed value breaks AGID verification.
     tampered = [disclosed[0], dict(disclosed[1], i=AMY), disclosed[2], disclosed[3]]
     assert not Aggor.verifyDisclosure(tampered, kind=kind)
+
+
+def test_selective_disclosure_aggregate_IPEX_JSON():
+    """Selective aggregate disclosure carried through the real IPEX grant path.
+
+    The sibling JSON worked example proves the disclosure math directly on the
+    aggregate section. This companion test packages the selectively disclosed
+    *variant of that same ACDC* inside a real IPEX `grant`, routes it through the
+    v2 IPEX handlers, and shows that the verifier can still validate the carried
+    disclosure against the committed AGID while the withheld values stay off the
+    wire.
+    """
+
+    class Recorder:
+        def __init__(self):
+            self.items = []
+
+        def add(self, attrs):
+            self.items.append(attrs)
+
+    with openHby(name="ipex-selective-aggregate",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        amy = hby.makeHab(name="amy", version=Vrsn_2_0, kind=Kinds.json)
+        bob = hby.makeHab(name="bob", version=Vrsn_2_0, kind=Kinds.json)
+        vic = hby.makeHab(name="vic", version=Vrsn_2_0, kind=Kinds.json)
+
+        kind = Kinds.json
+        ripper = regcept(israid=amy.pre, uuid=NONCES[3],
+                         stamp='2025-07-04T17:50:00.000000+00:00')
+
+        # Issuer-side setup mirrors the original example, but with live Habs for
+        # the transport actors that will sign the outer IPEX messages.
+        iael = ["",
+                dict(d='', u=NONCES[0], i=bob.pre),
+                dict(d='', u=NONCES[1], score=96),
+                dict(d='', u=NONCES[2], name="Zoe Doe")]
+        aggor = Aggor(ael=iael, makify=True, kind=kind)
+        agid = aggor.agid
+
+        acdc = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+                       aggregate=aggor.ael, kind=kind)
+        compact = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+                          aggregate=agid, kind=kind)
+        schema = assert_acdc_schema_valid(acdc)
+        assert_acdc_schema_valid(compact, schema=schema)
+        assert acdc.said == compact.said
+        assert acdc.iseaid == bob.pre
+
+        # A fully collapsed disclosure variant still commits to the same top-level
+        # ACDC SAID: the holder can present only element SAIDs and preserve the
+        # commitment.
+        full, k = aggor.disclose()
+        assert k == kind
+        assert Aggor.verifyDisclosure(full, kind=kind)
+        collapsed = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+                            aggregate=full, kind=kind)
+        assert collapsed.said == acdc.said
+
+        # Holder-side selective disclosure: reveal only the issuee element and
+        # withhold the score/name elements as bare SAIDs.
+        disclosed, k = aggor.disclose(indices=[1])
+        assert k == kind
+        selective = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+                            aggregate=disclosed, kind=kind)
+        assert selective.said == acdc.said
+        assert_acdc_schema_valid(selective, schema=schema)
+        assert selective.sad['A'][0] == agid
+        assert isinstance(selective.sad['A'][1], dict)
+        assert selective.sad['A'][1]['i'] == bob.pre
+        assert isinstance(selective.sad['A'][2], str)
+        assert isinstance(selective.sad['A'][3], str)
+        assert 'Zoe Doe' not in json.dumps(selective.sad['A'])
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        # The holder (Bob) presents Amy's credential to the verifier (Vic). The
+        # outer IPEX sender is Bob, while the nested ACDC issuer remains Amy.
+        grant, grantAtc = ipexGrant(
+            hab=bob,
+            recp=vic.pre,
+            message="Selective aggregate disclosure",
+            acdc=selective,
+        )
+        grantIms = bytearray(grant.raw)
+        grantIms.extend(grantAtc)
+        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
+                                                      framed=False,
+                                                      processive=False)
+        assert grantIms == bytearray()
+        assert len(grantResults) == 1
+        grantResult = grantResults[0]
+        assert grantResult.serder.said == grant.said
+        assert grantResult.serder.ked['r'] == "/ipex/grant"
+        assert grantResult.serder.ked['p'] == ""        # bare grant opens the flow
+        assert grantResult.serder.ked['i'] == bob.pre   # holder/discloser
+        assert grantResult.serder.ked['a']['i'] == vic.pre
+        assert grantResult.serder.ked['a']['acdc'] == selective.said
+        assert [nest.serder.said for nest in grantResult.nests] == [selective.said]
+
+        carried = grantResult.nests[0].serder
+        assert carried.said == acdc.said                # same credential commitment
+        assert carried.sad['i'] == amy.pre              # still Amy's credential
+        assert carried.iseaid == bob.pre                # held by Bob
+        assert carried.sad['A'][0] == agid
+        assert isinstance(carried.sad['A'][1], dict)
+        assert carried.sad['A'][1]['i'] == bob.pre
+        assert isinstance(carried.sad['A'][2], str)
+        assert isinstance(carried.sad['A'][3], str)
+
+        grantWire = bytes(grant.raw) + bytes(grantAtc)
+        # The carried selective disclosure reveals only the chosen element: the
+        # withheld name value never appears on the IPEX wire message.
+        assert b'Zoe Doe' not in grantWire
+
+        # Verifier-side check: recomputing the AGID over the mixed disclosure
+        # still verifies the selective presentation against the committed
+        # aggregate, and any tampering breaks that proof.
+        assert Aggor.verifyDisclosure(carried.sad['A'], kind=kind)
+        tampered = [carried.sad['A'][0],
+                    dict(carried.sad['A'][1], i=amy.pre),
+                    carried.sad['A'][2],
+                    carried.sad['A'][3]]
+        assert not Aggor.verifyDisclosure(tampered, kind=kind)
+
+        grantDispatch = bytearray(grant.raw)
+        grantDispatch.extend(grantAtc)
+        Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
+        assert grantDispatch == bytearray()
+        storedGrant = hby.db.exns.get(keys=(grant.said,))
+        assert storedGrant is not None
+        assert storedGrant.ked['a']['acdc'] == selective.said
+
+        admit, admitAtc = ipexAdmit(
+            hab=vic,
+            message="Received selective aggregate disclosure",
+            grant=grant,
+        )
+        admitIms = bytearray(admit.raw)
+        admitIms.extend(admitAtc)
+        Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
+        assert admitIms == bytearray()
+        storedAdmit = hby.db.exns.get(keys=(admit.said,))
+        assert storedAdmit is not None
+        assert storedAdmit.ked['p'] == grant.said
+
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/grant", "Selective aggregate disclosure"),
+            ("/exn/ipex/admit", "Received selective aggregate disclosure"),
+        ]
 
 
 def test_partial_disclosure_compaction_JSON():
@@ -457,6 +809,252 @@ def test_partial_disclosure_compaction_JSON():
     assert mixed['grades']['math'] == 4                     # verifier sees the revealed block
 
 
+def test_partial_disclosure_compaction_IPEX_JSON():
+    """Graduated partial disclosures carried through the real IPEX grant path.
+
+    The sibling JSON worked example proves the compaction math directly on
+    private ACDCs and nested section blocks. This companion test packages those
+    same disclosure variants into real IPEX `grant` messages, routes them
+    through the v2 handlers, and shows that the carried artifacts preserve the
+    same top-level commitments while only the intended sections appear on the
+    wire.
+    """
+
+    class Recorder:
+        def __init__(self):
+            self.items = []
+
+        def add(self, attrs):
+            self.items.append(attrs)
+
+    with openHby(name="ipex-partial-compaction",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        amy = hby.makeHab(name="amy", version=Vrsn_2_0, kind=Kinds.json)
+        bob = hby.makeHab(name="bob", version=Vrsn_2_0, kind=Kinds.json)
+        vic = hby.makeHab(name="vic", version=Vrsn_2_0, kind=Kinds.json)
+
+        kind = Kinds.json
+        ripper = regcept(israid=amy.pre, uuid=NONCES[0],
+                         stamp='2025-07-04T17:50:00.000000+00:00')
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        def ipexExn(acdc, message, admitMessage):
+            grant, grantAtc = ipexGrant(
+                hab=bob,
+                recp=vic.pre,
+                message=message,
+                acdc=acdc,
+            )
+            grantIms = bytearray(grant.raw)
+            grantIms.extend(grantAtc)
+            grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
+                                                          framed=False,
+                                                          processive=False)
+            assert grantIms == bytearray()
+            assert len(grantResults) == 1
+            grantResult = grantResults[0]
+            assert grantResult.serder.said == grant.said
+            assert grantResult.serder.ked['r'] == "/ipex/grant"
+            assert grantResult.serder.ked['p'] == ""
+            assert grantResult.serder.ked['i'] == bob.pre
+            assert grantResult.serder.ked['a']['i'] == vic.pre
+            assert grantResult.serder.ked['a']['acdc'] == acdc.said
+            assert [nest.serder.said for nest in grantResult.nests] == [acdc.said]
+            wire = bytes(grant.raw) + bytes(grantAtc)
+
+            grantDispatch = bytearray(grant.raw)
+            grantDispatch.extend(grantAtc)
+            Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
+            assert grantDispatch == bytearray()
+            storedGrant = hby.db.exns.get(keys=(grant.said,))
+            assert storedGrant is not None
+            assert storedGrant.ked['a']['acdc'] == acdc.said
+
+            admit, admitAtc = ipexAdmit(
+                hab=vic,
+                message=admitMessage,
+                grant=grant,
+            )
+            admitIms = bytearray(admit.raw)
+            admitIms.extend(admitAtc)
+            Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
+            assert admitIms == bytearray()
+            storedAdmit = hby.db.exns.get(keys=(admit.said,))
+            assert storedAdmit is not None
+            assert storedAdmit.ked['p'] == grant.said
+
+            return grantResult, wire
+
+        # Part A: disclose only the rule section while withholding attributes as
+        # a bare SAID, then carry that partial ACDC through IPEX.
+        ruleText = "AS IS basis. MUST NOT be shared."
+        attrMad = dict(d='', u=NONCES[7], name="Bob Student", gpa=4)
+        ruleMad = dict(d='', l=ruleText)
+        expanded = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+                           attribute=dict(attrMad), iseaid=bob.pre, rule=dict(ruleMad),
+                           compactify=False, kind=kind)
+        compact = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+                          attribute=dict(attrMad), iseaid=bob.pre, rule=dict(ruleMad),
+                          compactify=True, kind=kind)
+        assert expanded.said == compact.said             # same commitment either way
+        schema = assert_acdc_schema_valid(expanded)
+        assert_acdc_schema_valid(compact, schema=schema)
+        
+        assert b"Bob Student" not in compact.raw
+        assert b"MUST NOT" not in compact.raw
+
+        # Build the rule section disclosure
+        ruleOnly = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+                           schema=compact.sad['s'], attribute=compact.sad['a'],
+                           rule=expanded.sad['r'], kind=kind)
+        assert ruleOnly.said == compact.said == expanded.said
+        assert_acdc_schema_valid(ruleOnly, schema=schema)
+        assert isinstance(ruleOnly.sad['a'], str)
+        assert isinstance(ruleOnly.sad['r'], dict)
+
+        ruleGrantResult, ruleWire = ipexExn(
+            ruleOnly,
+            "Rule section disclosure",
+            "Received rule section disclosure",
+        )
+        carriedRule = ruleGrantResult.nests[0].serder
+        assert carriedRule.said == expanded.said
+        assert carriedRule.sad['i'] == amy.pre
+        assert isinstance(carriedRule.sad['a'], str)
+        assert isinstance(carriedRule.sad['r'], dict)
+        recomputedRule = Compactor(mad=dict(carriedRule.sad['r'], d=''),
+                                   makify=True,
+                                   kind=kind)
+        assert recomputedRule.said == compact.sad['r']
+        assert carriedRule.sad['r']['l'] == ruleText
+        assert b"Bob Student" not in carriedRule.raw
+        assert b"gpa" not in carriedRule.raw
+        assert ruleText.encode() in carriedRule.raw
+        assert b"Bob Student" not in ruleWire
+
+        # Part B: the same credential commitment can first withhold a nested
+        # grades block, then later reveal it, without changing the ACDC SAID.
+        nested = dict(d='', u=NONCES[7], i=bob.pre, name="Bob Student",
+                      grades=dict(d='', u=NONCES[8], math=4, english=3))
+        compactor = Compactor(mad=nested, makify=True, kind=kind)
+        compactor.compact()
+        sectSaid = compactor.said
+        compactor.expand(greedy=True)
+        
+        withheld = compactor.partials[('', )]
+        revealed = compactor.partials[('.grades', )]
+
+        gradesBase = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+                             attribute=nested, kind=kind)
+        gradesSchema = assert_acdc_schema_valid(gradesBase)
+        gradesWithheld = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+                                 schema=gradesBase.sad['s'], attribute=withheld.mad,
+                                 kind=kind)
+        gradesRevealed = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+                                 schema=gradesBase.sad['s'], attribute=revealed.mad,
+                                 kind=kind)
+        assert withheld.said == sectSaid and revealed.said == sectSaid
+        assert gradesWithheld.said == gradesRevealed.said == gradesBase.said
+        assert_acdc_schema_valid(gradesWithheld, schema=gradesSchema)
+        assert_acdc_schema_valid(gradesRevealed, schema=gradesSchema)
+
+        withheldGrantResult, withheldWire = ipexExn(
+            gradesWithheld,
+            "Grades withheld partial disclosure",
+            "Received grades-withheld partial disclosure",
+        )
+        carriedWithheld = withheldGrantResult.nests[0].serder
+        assert carriedWithheld.said == gradesBase.said
+        assert carriedWithheld.sad['i'] == amy.pre
+        assert carriedWithheld.iseaid == bob.pre
+        assert isinstance(carriedWithheld.sad['a']['grades'], str)
+        withheldCheck = Compactor(mad=dict(carriedWithheld.sad['a'], d=''),
+                                  makify=True,
+                                  kind=kind)
+        withheldCheck.compact()
+        assert withheldCheck.said == sectSaid
+        assert b"math" not in carriedWithheld.raw
+        assert b"math" not in withheldWire
+
+        revealedGrantResult, revealedWire = ipexExn(
+            gradesRevealed,
+            "Grades revealed partial disclosure",
+            "Received grades-revealed partial disclosure",
+        )
+        carriedRevealed = revealedGrantResult.nests[0].serder
+        assert carriedRevealed.said == gradesBase.said
+        assert carriedRevealed.sad['i'] == amy.pre
+        assert carriedRevealed.iseaid == bob.pre
+        assert isinstance(carriedRevealed.sad['a']['grades'], dict)
+        assert carriedRevealed.sad['a']['grades']['math'] == 4
+        revealedCheck = Compactor(mad=dict(carriedRevealed.sad['a'], d=''),
+                                  makify=True,
+                                  kind=kind)
+        revealedCheck.compact()
+        assert revealedCheck.said == sectSaid
+        assert b"math" in carriedRevealed.raw
+
+        # Part C: carry a mixed nested disclosure where grades are revealed but
+        # the address block stays compacted to its SAID.
+        multi = dict(d='', u=NONCES[7], i=bob.pre, name="Bob Student",
+                     grades=dict(d='', u=NONCES[8], math=4, english=3),
+                     address=dict(d='', u=NONCES[9], street="Main", number=5, zip="90210"))
+        mc = Compactor(mad=multi, makify=True, kind=kind)
+        mc.compact()
+        multiSaid = mc.said
+        mc.expand(greedy=True)
+        allCompact = mc.partials[('', )].mad
+        allExpanded = next(v.mad for k, v in mc.partials.items() if k != ('', ))
+        mixed = dict(allCompact)
+        mixed['grades'] = allExpanded['grades']
+
+        mixedBase = acdcmap(israid=amy.pre, uuid=NONCES[12], regid=ripper.said,
+                            attribute=multi, kind=kind)
+        mixedSchema = assert_acdc_schema_valid(mixedBase)
+        mixedAcdc = acdcmap(israid=amy.pre, uuid=NONCES[12], regid=ripper.said,
+                            schema=mixedBase.sad['s'], attribute=mixed, kind=kind)
+        assert mixedAcdc.said == mixedBase.said
+        assert_acdc_schema_valid(mixedAcdc, schema=mixedSchema)
+
+        mixedGrantResult, mixedWire = ipexExn(
+            mixedAcdc,
+            "Mixed nested partial disclosure",
+            "Received mixed nested partial disclosure",
+        )
+        carriedMixed = mixedGrantResult.nests[0].serder
+        assert carriedMixed.said == mixedBase.said
+        assert carriedMixed.sad['i'] == amy.pre
+        assert carriedMixed.iseaid == bob.pre
+        assert isinstance(carriedMixed.sad['a']['grades'], dict)
+        assert carriedMixed.sad['a']['grades']['math'] == 4
+        assert isinstance(carriedMixed.sad['a']['address'], str)
+        mixedCheck = Compactor(mad=dict(carriedMixed.sad['a'], d=''),
+                               makify=True,
+                               kind=kind)
+        mixedCheck.compact()
+        assert mixedCheck.said == multiSaid
+        assert b"math" in carriedMixed.raw
+        assert b"Main" not in carriedMixed.raw
+        assert b"90210" not in carriedMixed.raw
+        assert b"Main" not in mixedWire
+        assert b"90210" not in mixedWire
+
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/grant", "Rule section disclosure"),
+            ("/exn/ipex/admit", "Received rule section disclosure"),
+            ("/exn/ipex/grant", "Grades withheld partial disclosure"),
+            ("/exn/ipex/admit", "Received grades-withheld partial disclosure"),
+            ("/exn/ipex/grant", "Grades revealed partial disclosure"),
+            ("/exn/ipex/admit", "Received grades-revealed partial disclosure"),
+            ("/exn/ipex/grant", "Mixed nested partial disclosure"),
+            ("/exn/ipex/admit", "Received mixed nested partial disclosure"),
+        ]
+
+
 def test_blindable_registry_correlation_minimizing_JSON():
     """Example: correlation-minimizing state disclosure from a blindable registry.
 
@@ -568,6 +1166,177 @@ def test_blindable_registry_correlation_minimizing_JSON():
                                          states=states, salt=salt, sn=2)
     assert holderAtRevocation is not None
     assert holderAtRevocation.state == 'revoked'
+
+
+def test_blindable_registry_correlation_minimizing_IPEX_JSON():
+    """Per-event blind disclosure carried through the real IPEX grant path.
+
+    The sibling JSON worked example proves that a disclosed blind reads exactly
+    one blindable registry update and no others. This companion test packages
+    those blinded registry updates as nested `bup` artifacts inside real IPEX
+    `grant` messages, routes them through the v2 handlers, and shows that the
+    verifier can unblind only the event whose per-sn nonce the holder chooses to
+    disclose out of band. The IPEX wire itself never carries the salt or either
+    cleartext state word.
+    """
+
+    class Recorder:
+        def __init__(self):
+            self.items = []
+
+        def add(self, attrs):
+            self.items.append(attrs)
+
+    with openHby(name="ipex-correlation-minimizing",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        amy = hby.makeHab(name="amy", version=Vrsn_2_0, kind=Kinds.json)
+        bob = hby.makeHab(name="bob", version=Vrsn_2_0, kind=Kinds.json)
+        vic = hby.makeHab(name="vic", version=Vrsn_2_0, kind=Kinds.json)
+
+        kind = Kinds.json
+        states = ['issued', 'revoked']
+
+        ripper = regcept(israid=amy.pre, uuid=NONCES[0],
+                         stamp='2025-07-04T17:50:00.000000+00:00')
+        acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+                       attribute=dict(d='', u=NONCES[7], name="Sunspot College",
+                                      level="gold"),
+                       iseaid=bob.pre, kind=kind)
+        assert_acdc_schema_valid(acdc)
+        salt = NONCES[15]
+
+        issuedBlinder = Blinder.blind(acdc=acdc.said, state='issued', salt=salt, sn=1)
+        revokedBlinder = Blinder.blind(acdc=acdc.said, state='revoked', salt=salt, sn=2)
+        assert issuedBlinder.said != revokedBlinder.said
+        assert issuedBlinder.uuid != revokedBlinder.uuid
+
+        issued = blindate(regid=ripper.said, prior=ripper.said, blid=issuedBlinder.said,
+                          sn=1, stamp='2025-08-01T18:06:10.988921+00:00')
+        revoked = blindate(regid=ripper.said, prior=issued.said, blid=revokedBlinder.said,
+                           sn=2, stamp='2025-09-01T18:06:10.988921+00:00')
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        def ipexExn(iss, message, admitMessage):
+            grant, grantAtc = ipexGrant(
+                hab=bob,
+                recp=vic.pre,
+                message=message,
+                acdc=acdc,
+                iss=iss,
+                anc=ripper,
+            )
+            grantIms = bytearray(grant.raw)
+            grantIms.extend(grantAtc)
+            grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
+                                                          framed=False,
+                                                          processive=False)
+            assert grantIms == bytearray()
+            assert len(grantResults) == 1
+            grantResult = grantResults[0]
+            assert grantResult.serder.said == grant.said
+            assert grantResult.serder.ked['r'] == "/ipex/grant"
+            assert grantResult.serder.ked['p'] == ""
+            assert grantResult.serder.ked['i'] == bob.pre
+            assert grantResult.serder.ked['a']['i'] == vic.pre
+            assert grantResult.serder.ked['a']['acdc'] == acdc.said
+            assert grantResult.serder.ked['a']['iss'] == iss.said
+            assert grantResult.serder.ked['a']['anc'] == ripper.said
+            assert [nest.serder.said for nest in grantResult.nests] == [
+                acdc.said, iss.said, ripper.said
+            ]
+            wire = bytes(grant.raw) + bytes(grantAtc)
+
+            grantDispatch = bytearray(grant.raw)
+            grantDispatch.extend(grantAtc)
+            Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
+            assert grantDispatch == bytearray()
+            storedGrant = hby.db.exns.get(keys=(grant.said,))
+            assert storedGrant is not None
+            assert storedGrant.ked['a']['acdc'] == acdc.said
+            assert storedGrant.ked['a']['iss'] == iss.said
+            assert storedGrant.ked['a']['anc'] == ripper.said
+
+            admit, admitAtc = ipexAdmit(
+                hab=vic,
+                message=admitMessage,
+                grant=grant,
+            )
+            admitIms = bytearray(admit.raw)
+            admitIms.extend(admitAtc)
+            Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
+            assert admitIms == bytearray()
+            storedAdmit = hby.db.exns.get(keys=(admit.said,))
+            assert storedAdmit is not None
+            assert storedAdmit.ked['p'] == grant.said
+
+            return grantResult, wire
+
+        # Bob presents the issuance-state snapshot to Vic. The IPEX grant carries
+        # the blinded registry update, but not the per-event nonce Vic needs to
+        # interpret it; that nonce is modeled here as the separately-shared
+        # issuedBlinder.uuid, just as in the JSON example.
+        issuedGrantResult, issuedWire = ipexExn(
+            issued,
+            "Current registry snapshot",
+            "Received current registry snapshot",
+        )
+        carriedIssued = issuedGrantResult.nests[1].serder
+        assert carriedIssued.said == issued.said
+        assert carriedIssued.sad['b'] == issuedBlinder.said
+        assert b'issued' not in carriedIssued.raw
+        assert b'revoked' not in carriedIssued.raw
+        assert issuedBlinder.uuid.encode() not in issuedWire
+        assert revokedBlinder.uuid.encode() not in issuedWire
+
+        verifierAtIssuance = Blinder.unblind(said=carriedIssued.sad['b'],
+                                             uuid=issuedBlinder.uuid,
+                                             acdc=acdc.said, states=states)
+        assert verifierAtIssuance is not None
+        assert verifierAtIssuance.state == 'issued'
+        assert verifierAtIssuance.acdc == acdc.said
+
+        # Later the holder sends a new blinded registry snapshot. A verifier that
+        # remembers only the earlier nonce still cannot read this later event.
+        revokedGrantResult, revokedWire = ipexExn(
+            revoked,
+            "Later registry snapshot",
+            "Received later registry snapshot",
+        )
+        carriedRevoked = revokedGrantResult.nests[1].serder
+        assert carriedRevoked.said == revoked.said
+        assert carriedRevoked.sad['b'] == revokedBlinder.said
+        assert b'issued' not in carriedRevoked.raw
+        assert b'revoked' not in carriedRevoked.raw
+        assert issuedBlinder.uuid.encode() not in revokedWire
+        assert revokedBlinder.uuid.encode() not in revokedWire
+
+        laterPeek = Blinder.unblind(said=carriedRevoked.sad['b'],
+                                    uuid=issuedBlinder.uuid,
+                                    acdc=acdc.said, states=states)
+        assert laterPeek is None
+
+        earlierPeek = Blinder.unblind(said=carriedIssued.sad['b'],
+                                      uuid=revokedBlinder.uuid,
+                                      acdc=acdc.said, states=states)
+        assert earlierPeek is None
+
+        holderAtRevocation = Blinder.unblind(said=carriedRevoked.sad['b'],
+                                             acdc=acdc.said,
+                                             states=states, salt=salt, sn=2)
+        assert holderAtRevocation is not None
+        assert holderAtRevocation.state == 'revoked'
+        assert holderAtRevocation.acdc == acdc.said
+
+        assert [(item["r"], item["m"]) for item in recorder.items] == [
+            ("/exn/ipex/grant", "Current registry snapshot"),
+            ("/exn/ipex/admit", "Received current registry snapshot"),
+            ("/exn/ipex/grant", "Later registry snapshot"),
+            ("/exn/ipex/admit", "Received later registry snapshot"),
+        ]
 
 
 @pytest.mark.parametrize("kind", [Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk])

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -68,6 +68,66 @@ def assert_acdc_schema_valid(acdc, schema=None):
     return schema
 
 
+class Recorder:
+    def __init__(self):
+        self.items = []
+
+    def add(self, attrs):
+        self.items.append(attrs)
+
+
+def ipexExn(*, hby, exc, sender, receiver, message, admitMessage,
+            acdc, iss=None, anc=None):
+    """Round-trip one IPEX grant and its admit, returning the parsed grant."""
+    grant, grantAtc = ipexGrant(hab=sender, recp=receiver.pre, message=message,
+                                acdc=acdc, iss=iss, anc=anc)
+    grantIms = bytearray(grant.raw)
+    grantIms.extend(grantAtc)
+    grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms, framed=False,
+                                                  processive=False)
+    assert grantIms == bytearray()
+    assert len(grantResults) == 1
+    grantResult = grantResults[0]
+    assert grantResult.serder.said == grant.said
+    assert grantResult.serder.ked['r'] == "/ipex/grant"
+    assert grantResult.serder.ked['p'] == ""
+    assert grantResult.serder.ked['i'] == sender.pre
+    assert grantResult.serder.ked['a']['i'] == receiver.pre
+    assert grantResult.serder.ked['a']['acdc'] == acdc.said
+    nestSaids = [acdc.said]
+    if iss is not None:
+        assert grantResult.serder.ked['a']['iss'] == iss.said
+        nestSaids.append(iss.said)
+    if anc is not None:
+        assert grantResult.serder.ked['a']['anc'] == anc.said
+        nestSaids.append(anc.said)
+    assert [nest.serder.said for nest in grantResult.nests] == nestSaids
+    wire = bytes(grant.raw) + bytes(grantAtc)
+
+    grantDispatch = bytearray(grant.raw)
+    grantDispatch.extend(grantAtc)
+    Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
+    assert grantDispatch == bytearray()
+    storedGrant = hby.db.exns.get(keys=(grant.said,))
+    assert storedGrant is not None
+    assert storedGrant.ked['a']['acdc'] == acdc.said
+    if iss is not None:
+        assert storedGrant.ked['a']['iss'] == iss.said
+    if anc is not None:
+        assert storedGrant.ked['a']['anc'] == anc.said
+
+    admit, admitAtc = ipexAdmit(hab=receiver, message=admitMessage, grant=grant)
+    admitIms = bytearray(admit.raw)
+    admitIms.extend(admitAtc)
+    Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
+    assert admitIms == bytearray()
+    storedAdmit = hby.db.exns.get(keys=(admit.said,))
+    assert storedAdmit is not None
+    assert storedAdmit.ked['p'] == grant.said
+
+    return grantResult, wire
+
+
 def test_schema_validation_harness_has_teeth():
     """The schema-validation harness must actually reject bad input.
 
@@ -190,6 +250,7 @@ def test_registry_issuance_lifecycle_JSON():
     assert 'ts' not in issued.sad and 'td' not in issued.sad
     assert b'issued' not in issued.raw
     assert acdcSaid.encode() not in issued.raw
+    assert salt.encode() not in issued.raw
 
     # --- Step 4: confirm the state by unblinding. ---
     # Unblinding = recompute the blinded state's SAID (the 'b'/blid value) over
@@ -224,6 +285,7 @@ def test_registry_issuance_lifecycle_JSON():
     assert revoked.sad['p'] == issued.said  # chains onto the issuance update
     assert revoked.sad['n'] == "2"
     assert revoked.said == "ENACMzpaiMMcdpQRBA4IbbqjUMcoJ_wBBsbhwpg_MYJM"
+    assert salt.encode() not in revoked.raw
 
     reunblinder = Blinder.unblind(said=revoked.sad['b'], acdc=acdcSaid,
                                   states=['issued', 'revoked'], salt=salt, sn=2)
@@ -252,13 +314,6 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
     A second bare grant later carries the revoked-state snapshot. Each bare
     grant is acknowledged by an IPEX admit.
     """
-
-    class Recorder:
-        def __init__(self):
-            self.items = []
-
-        def add(self, attrs):
-            self.items.append(attrs)
 
     with openHby(name="ipex-registry-lifecycle",
                  base="test",
@@ -296,62 +351,23 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
         # Bare grant 1: the issued-state snapshot. In today's builder shape the
         # lifecycle package is encoded as:
         #   acdc = credential, iss = current `bup`, anc = registry inception `rip`
-        issuedGrant, issuedGrantAtc = ipexGrant(
-            hab=amy,
-            recp=bob.pre,
+        issuedGrantResult, issuedGrantWire = ipexExn(
+            hby=hby,
+            exc=exc,
+            sender=amy,
+            receiver=bob,
             message="Issued registry snapshot",
+            admitMessage="Received issued snapshot",
             acdc=acdc,
             iss=issued,
             anc=ripper,
         )
-        issuedGrantIms = bytearray(issuedGrant.raw)
-        issuedGrantIms.extend(issuedGrantAtc)
-        issuedGrantResults = Parser(version=Vrsn_2_0).parse(ims=issuedGrantIms,
-                                                            framed=False,
-                                                            processive=False)
-        assert issuedGrantIms == bytearray()
-        assert len(issuedGrantResults) == 1
-        issuedGrantResult = issuedGrantResults[0]
-        assert issuedGrantResult.serder.said == issuedGrant.said
-        assert issuedGrantResult.serder.ked['r'] == "/ipex/grant"
-        assert issuedGrantResult.serder.ked['p'] == ""          # bare grant opens the flow
         assert issuedGrantResult.serder.ked['a']['i'] == bob.pre
-        assert issuedGrantResult.serder.ked['a']['acdc'] == acdc.said
-        assert issuedGrantResult.serder.ked['a']['iss'] == issued.said
-        assert issuedGrantResult.serder.ked['a']['anc'] == ripper.said
-        assert [nest.serder.said for nest in issuedGrantResult.nests] == [
-            acdc.said, issued.said, ripper.said
-        ]
-        issuedGrantWire = bytes(issuedGrant.raw) + bytes(issuedGrantAtc)
         # The disclosed credential is present on the wire, but the registry state
         # word itself remains hidden because the nested `bup` is blindable
         assert b'issued' not in issuedGrantWire
         assert b'revoked' not in issuedGrantWire
-
-        # Route the same message through the real IPEX handlers and persist it
-        issuedGrantDispatch = bytearray(issuedGrant.raw)
-        issuedGrantDispatch.extend(issuedGrantAtc)
-        Parser(version=Vrsn_2_0).parse(ims=issuedGrantDispatch, framed=False, exc=exc)
-        assert issuedGrantDispatch == bytearray()
-
-        # Assert that it was stored
-        storedIssuedGrant = hby.db.exns.get(keys=(issuedGrant.said,))
-        assert storedIssuedGrant is not None
-        assert storedIssuedGrant.ked['a']['iss'] == issued.said
-        assert storedIssuedGrant.ked['a']['anc'] == ripper.said
-
-        issuedAdmit, issuedAdmitAtc = ipexAdmit(
-            hab=bob,
-            message="Received issued snapshot",
-            grant=issuedGrant,
-        )
-        issuedAdmitIms = bytearray(issuedAdmit.raw)
-        issuedAdmitIms.extend(issuedAdmitAtc)
-        Parser(version=Vrsn_2_0).parse(ims=issuedAdmitIms, framed=False, exc=exc)
-        assert issuedAdmitIms == bytearray()
-        storedIssuedAdmit = hby.db.exns.get(keys=(issuedAdmit.said,))
-        assert storedIssuedAdmit is not None
-        assert storedIssuedAdmit.ked['p'] == issuedGrant.said
+        assert salt.encode() not in issuedGrantWire
 
         # The holder/verifier can now pull the carried `bup` out of the IPEX
         # grant and perform the same unblinding confirmation as in the base test
@@ -365,53 +381,20 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
 
         # Bare grant 2: later the issuer ships the revoked-state snapshot the
         # same way, again through the handler chain.
-        revokedGrant, revokedGrantAtc = ipexGrant(
-            hab=amy,
-            recp=bob.pre,
+        revokedGrantResult, revokedGrantWire = ipexExn(
+            hby=hby,
+            exc=exc,
+            sender=amy,
+            receiver=bob,
             message="Revoked registry snapshot",
+            admitMessage="Received revoked snapshot",
             acdc=acdc,
             iss=revoked,
             anc=ripper,
         )
-        revokedGrantIms = bytearray(revokedGrant.raw)
-        revokedGrantIms.extend(revokedGrantAtc)
-        revokedGrantResults = Parser(version=Vrsn_2_0).parse(ims=revokedGrantIms,
-                                                             framed=False,
-                                                             processive=False)
-        assert revokedGrantIms == bytearray()
-        assert len(revokedGrantResults) == 1
-        revokedGrantResult = revokedGrantResults[0]
-        assert revokedGrantResult.serder.ked['r'] == "/ipex/grant"
-        assert revokedGrantResult.serder.ked['p'] == ""
-        assert revokedGrantResult.serder.ked['a']['iss'] == revoked.said
-        assert revokedGrantResult.serder.ked['a']['anc'] == ripper.said
-        assert [nest.serder.said for nest in revokedGrantResult.nests] == [
-            acdc.said, revoked.said, ripper.said
-        ]
-        revokedGrantWire = bytes(revokedGrant.raw) + bytes(revokedGrantAtc)
         assert b'issued' not in revokedGrantWire
         assert b'revoked' not in revokedGrantWire
-
-        revokedGrantDispatch = bytearray(revokedGrant.raw)
-        revokedGrantDispatch.extend(revokedGrantAtc)
-        Parser(version=Vrsn_2_0).parse(ims=revokedGrantDispatch, framed=False, exc=exc)
-        assert revokedGrantDispatch == bytearray()
-        storedRevokedGrant = hby.db.exns.get(keys=(revokedGrant.said,))
-        assert storedRevokedGrant is not None
-        assert storedRevokedGrant.ked['a']['iss'] == revoked.said
-
-        revokedAdmit, revokedAdmitAtc = ipexAdmit(
-            hab=bob,
-            message="Received revoked snapshot",
-            grant=revokedGrant,
-        )
-        revokedAdmitIms = bytearray(revokedAdmit.raw)
-        revokedAdmitIms.extend(revokedAdmitAtc)
-        Parser(version=Vrsn_2_0).parse(ims=revokedAdmitIms, framed=False, exc=exc)
-        assert revokedAdmitIms == bytearray()
-        storedRevokedAdmit = hby.db.exns.get(keys=(revokedAdmit.said,))
-        assert storedRevokedAdmit is not None
-        assert storedRevokedAdmit.ked['p'] == revokedGrant.said
+        assert salt.encode() not in revokedGrantWire
 
         revokedNest = revokedGrantResult.nests[1].serder
         reunblinder = Blinder.unblind(said=revokedNest.sad['b'], acdc=acdc.said,
@@ -527,13 +510,6 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
     wire.
     """
 
-    class Recorder:
-        def __init__(self):
-            self.items = []
-
-        def add(self, attrs):
-            self.items.append(attrs)
-
     with openHby(name="ipex-selective-aggregate",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -594,27 +570,15 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
 
         # The holder (Bob) presents Amy's credential to the verifier (Vic). The
         # outer IPEX sender is Bob, while the nested ACDC issuer remains Amy.
-        grant, grantAtc = ipexGrant(
-            hab=bob,
-            recp=vic.pre,
+        grantResult, grantWire = ipexExn(
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
             message="Selective aggregate disclosure",
+            admitMessage="Received selective aggregate disclosure",
             acdc=selective,
         )
-        grantIms = bytearray(grant.raw)
-        grantIms.extend(grantAtc)
-        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
-                                                      framed=False,
-                                                      processive=False)
-        assert grantIms == bytearray()
-        assert len(grantResults) == 1
-        grantResult = grantResults[0]
-        assert grantResult.serder.said == grant.said
-        assert grantResult.serder.ked['r'] == "/ipex/grant"
-        assert grantResult.serder.ked['p'] == ""        # bare grant opens the flow
-        assert grantResult.serder.ked['i'] == bob.pre   # holder/discloser
-        assert grantResult.serder.ked['a']['i'] == vic.pre
-        assert grantResult.serder.ked['a']['acdc'] == selective.said
-        assert [nest.serder.said for nest in grantResult.nests] == [selective.said]
 
         carried = grantResult.nests[0].serder
         assert carried.said == acdc.said                # same credential commitment
@@ -626,10 +590,12 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
         assert isinstance(carried.sad['A'][2], str)
         assert isinstance(carried.sad['A'][3], str)
 
-        grantWire = bytes(grant.raw) + bytes(grantAtc)
         # The carried selective disclosure reveals only the chosen element: the
-        # withheld name value never appears on the IPEX wire message.
+        # withheld name value and the withheld elements' own blinding nonces
+        # never appear on the IPEX wire message.
         assert b'Zoe Doe' not in grantWire
+        assert NONCES[1].encode() not in grantWire
+        assert NONCES[2].encode() not in grantWire
 
         # Verifier-side check: recomputing the AGID over the mixed disclosure
         # still verifies the selective presentation against the committed
@@ -640,27 +606,6 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
                     carried.sad['A'][2],
                     carried.sad['A'][3]]
         assert not Aggor.verifyDisclosure(tampered, kind=kind)
-
-        grantDispatch = bytearray(grant.raw)
-        grantDispatch.extend(grantAtc)
-        Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
-        assert grantDispatch == bytearray()
-        storedGrant = hby.db.exns.get(keys=(grant.said,))
-        assert storedGrant is not None
-        assert storedGrant.ked['a']['acdc'] == selective.said
-
-        admit, admitAtc = ipexAdmit(
-            hab=vic,
-            message="Received selective aggregate disclosure",
-            grant=grant,
-        )
-        admitIms = bytearray(admit.raw)
-        admitIms.extend(admitAtc)
-        Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
-        assert admitIms == bytearray()
-        storedAdmit = hby.db.exns.get(keys=(admit.said,))
-        assert storedAdmit is not None
-        assert storedAdmit.ked['p'] == grant.said
 
         assert [(item["r"], item["m"]) for item in recorder.items] == [
             ("/exn/ipex/grant", "Selective aggregate disclosure"),
@@ -820,13 +765,6 @@ def test_partial_disclosure_compaction_IPEX_JSON():
     wire.
     """
 
-    class Recorder:
-        def __init__(self):
-            self.items = []
-
-        def add(self, attrs):
-            self.items.append(attrs)
-
     with openHby(name="ipex-partial-compaction",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -841,53 +779,6 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        def ipexExn(acdc, message, admitMessage):
-            grant, grantAtc = ipexGrant(
-                hab=bob,
-                recp=vic.pre,
-                message=message,
-                acdc=acdc,
-            )
-            grantIms = bytearray(grant.raw)
-            grantIms.extend(grantAtc)
-            grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
-                                                          framed=False,
-                                                          processive=False)
-            assert grantIms == bytearray()
-            assert len(grantResults) == 1
-            grantResult = grantResults[0]
-            assert grantResult.serder.said == grant.said
-            assert grantResult.serder.ked['r'] == "/ipex/grant"
-            assert grantResult.serder.ked['p'] == ""
-            assert grantResult.serder.ked['i'] == bob.pre
-            assert grantResult.serder.ked['a']['i'] == vic.pre
-            assert grantResult.serder.ked['a']['acdc'] == acdc.said
-            assert [nest.serder.said for nest in grantResult.nests] == [acdc.said]
-            wire = bytes(grant.raw) + bytes(grantAtc)
-
-            grantDispatch = bytearray(grant.raw)
-            grantDispatch.extend(grantAtc)
-            Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
-            assert grantDispatch == bytearray()
-            storedGrant = hby.db.exns.get(keys=(grant.said,))
-            assert storedGrant is not None
-            assert storedGrant.ked['a']['acdc'] == acdc.said
-
-            admit, admitAtc = ipexAdmit(
-                hab=vic,
-                message=admitMessage,
-                grant=grant,
-            )
-            admitIms = bytearray(admit.raw)
-            admitIms.extend(admitAtc)
-            Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
-            assert admitIms == bytearray()
-            storedAdmit = hby.db.exns.get(keys=(admit.said,))
-            assert storedAdmit is not None
-            assert storedAdmit.ked['p'] == grant.said
-
-            return grantResult, wire
 
         # Part A: disclose only the rule section while withholding attributes as
         # a bare SAID, then carry that partial ACDC through IPEX.
@@ -917,9 +808,13 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert isinstance(ruleOnly.sad['r'], dict)
 
         ruleGrantResult, ruleWire = ipexExn(
-            ruleOnly,
-            "Rule section disclosure",
-            "Received rule section disclosure",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            acdc=ruleOnly,
+            message="Rule section disclosure",
+            admitMessage="Received rule section disclosure",
         )
         carriedRule = ruleGrantResult.nests[0].serder
         assert carriedRule.said == expanded.said
@@ -935,6 +830,7 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert b"gpa" not in carriedRule.raw
         assert ruleText.encode() in carriedRule.raw
         assert b"Bob Student" not in ruleWire
+        assert NONCES[7].encode() not in ruleWire
 
         # Part B: the same credential commitment can first withhold a nested
         # grades block, then later reveal it, without changing the ACDC SAID.
@@ -963,9 +859,13 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert_acdc_schema_valid(gradesRevealed, schema=gradesSchema)
 
         withheldGrantResult, withheldWire = ipexExn(
-            gradesWithheld,
-            "Grades withheld partial disclosure",
-            "Received grades-withheld partial disclosure",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            acdc=gradesWithheld,
+            message="Grades withheld partial disclosure",
+            admitMessage="Received grades-withheld partial disclosure",
         )
         carriedWithheld = withheldGrantResult.nests[0].serder
         assert carriedWithheld.said == gradesBase.said
@@ -979,11 +879,16 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert withheldCheck.said == sectSaid
         assert b"math" not in carriedWithheld.raw
         assert b"math" not in withheldWire
+        assert NONCES[8].encode() not in withheldWire
 
         revealedGrantResult, revealedWire = ipexExn(
-            gradesRevealed,
-            "Grades revealed partial disclosure",
-            "Received grades-revealed partial disclosure",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            acdc=gradesRevealed,
+            message="Grades revealed partial disclosure",
+            admitMessage="Received grades-revealed partial disclosure",
         )
         carriedRevealed = revealedGrantResult.nests[0].serder
         assert carriedRevealed.said == gradesBase.said
@@ -1021,9 +926,13 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert_acdc_schema_valid(mixedAcdc, schema=mixedSchema)
 
         mixedGrantResult, mixedWire = ipexExn(
-            mixedAcdc,
-            "Mixed nested partial disclosure",
-            "Received mixed nested partial disclosure",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            acdc=mixedAcdc,
+            message="Mixed nested partial disclosure",
+            admitMessage="Received mixed nested partial disclosure",
         )
         carriedMixed = mixedGrantResult.nests[0].serder
         assert carriedMixed.said == mixedBase.said
@@ -1042,6 +951,7 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert b"90210" not in carriedMixed.raw
         assert b"Main" not in mixedWire
         assert b"90210" not in mixedWire
+        assert NONCES[9].encode() not in mixedWire
 
         assert [(item["r"], item["m"]) for item in recorder.items] == [
             ("/exn/ipex/grant", "Rule section disclosure"),
@@ -1180,13 +1090,6 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
     cleartext state word.
     """
 
-    class Recorder:
-        def __init__(self):
-            self.items = []
-
-        def add(self, attrs):
-            self.items.append(attrs)
-
     with openHby(name="ipex-correlation-minimizing",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -1220,75 +1123,27 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
 
-        def ipexExn(iss, message, admitMessage):
-            grant, grantAtc = ipexGrant(
-                hab=bob,
-                recp=vic.pre,
-                message=message,
-                acdc=acdc,
-                iss=iss,
-                anc=ripper,
-            )
-            grantIms = bytearray(grant.raw)
-            grantIms.extend(grantAtc)
-            grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
-                                                          framed=False,
-                                                          processive=False)
-            assert grantIms == bytearray()
-            assert len(grantResults) == 1
-            grantResult = grantResults[0]
-            assert grantResult.serder.said == grant.said
-            assert grantResult.serder.ked['r'] == "/ipex/grant"
-            assert grantResult.serder.ked['p'] == ""
-            assert grantResult.serder.ked['i'] == bob.pre
-            assert grantResult.serder.ked['a']['i'] == vic.pre
-            assert grantResult.serder.ked['a']['acdc'] == acdc.said
-            assert grantResult.serder.ked['a']['iss'] == iss.said
-            assert grantResult.serder.ked['a']['anc'] == ripper.said
-            assert [nest.serder.said for nest in grantResult.nests] == [
-                acdc.said, iss.said, ripper.said
-            ]
-            wire = bytes(grant.raw) + bytes(grantAtc)
-
-            grantDispatch = bytearray(grant.raw)
-            grantDispatch.extend(grantAtc)
-            Parser(version=Vrsn_2_0).parse(ims=grantDispatch, framed=False, exc=exc)
-            assert grantDispatch == bytearray()
-            storedGrant = hby.db.exns.get(keys=(grant.said,))
-            assert storedGrant is not None
-            assert storedGrant.ked['a']['acdc'] == acdc.said
-            assert storedGrant.ked['a']['iss'] == iss.said
-            assert storedGrant.ked['a']['anc'] == ripper.said
-
-            admit, admitAtc = ipexAdmit(
-                hab=vic,
-                message=admitMessage,
-                grant=grant,
-            )
-            admitIms = bytearray(admit.raw)
-            admitIms.extend(admitAtc)
-            Parser(version=Vrsn_2_0).parse(ims=admitIms, framed=False, exc=exc)
-            assert admitIms == bytearray()
-            storedAdmit = hby.db.exns.get(keys=(admit.said,))
-            assert storedAdmit is not None
-            assert storedAdmit.ked['p'] == grant.said
-
-            return grantResult, wire
-
         # Bob presents the issuance-state snapshot to Vic. The IPEX grant carries
         # the blinded registry update, but not the per-event nonce Vic needs to
         # interpret it; that nonce is modeled here as the separately-shared
         # issuedBlinder.uuid, just as in the JSON example.
         issuedGrantResult, issuedWire = ipexExn(
-            issued,
-            "Current registry snapshot",
-            "Received current registry snapshot",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            message="Current registry snapshot",
+            admitMessage="Received current registry snapshot",
+            acdc=acdc,
+            iss=issued,
+            anc=ripper,
         )
         carriedIssued = issuedGrantResult.nests[1].serder
         assert carriedIssued.said == issued.said
         assert carriedIssued.sad['b'] == issuedBlinder.said
         assert b'issued' not in carriedIssued.raw
         assert b'revoked' not in carriedIssued.raw
+        assert salt.encode() not in issuedWire
         assert issuedBlinder.uuid.encode() not in issuedWire
         assert revokedBlinder.uuid.encode() not in issuedWire
 
@@ -1302,15 +1157,22 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
         # Later the holder sends a new blinded registry snapshot. A verifier that
         # remembers only the earlier nonce still cannot read this later event.
         revokedGrantResult, revokedWire = ipexExn(
-            revoked,
-            "Later registry snapshot",
-            "Received later registry snapshot",
+            hby=hby,
+            exc=exc,
+            sender=bob,
+            receiver=vic,
+            message="Later registry snapshot",
+            admitMessage="Received later registry snapshot",
+            acdc=acdc,
+            iss=revoked,
+            anc=ripper,
         )
         carriedRevoked = revokedGrantResult.nests[1].serder
         assert carriedRevoked.said == revoked.said
         assert carriedRevoked.sad['b'] == revokedBlinder.said
         assert b'issued' not in carriedRevoked.raw
         assert b'revoked' not in carriedRevoked.raw
+        assert salt.encode() not in revokedWire
         assert issuedBlinder.uuid.encode() not in revokedWire
         assert revokedBlinder.uuid.encode() not in revokedWire
 
@@ -1370,6 +1232,7 @@ def test_examples_serialization_kinds(kind):
                       stamp='2025-08-01T18:06:10.988921+00:00', kind=kind)
     assert issued.ilk == Ilks.bup and issued.sad['b'] == blinder.said
     assert b'issued' not in issued.raw            # state stays blinded on every kind
+    assert salt.encode() not in issued.raw        # the shared salt never rides the wire
 
     unblinder = Blinder.unblind(said=blinder.said, acdc=acdc.said,
                                 states=['issued', 'revoked'], salt=salt, sn=1)
@@ -1412,8 +1275,12 @@ def test_examples_serialization_kinds(kind):
 
 if __name__ == "__main__":
     test_registry_issuance_lifecycle_JSON()
+    test_registry_issuance_lifecycle_IPEX_JSON()
     test_selective_disclosure_aggregate_JSON()
+    test_selective_disclosure_aggregate_IPEX_JSON()
     test_partial_disclosure_compaction_JSON()
+    test_partial_disclosure_compaction_IPEX_JSON()
     test_blindable_registry_correlation_minimizing_JSON()
+    test_blindable_registry_correlation_minimizing_IPEX_JSON()
     for _kind in (Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk):
         test_examples_serialization_kinds(_kind)


### PR DESCRIPTION
- Add IPEX-backed companion tests in test_examples.py for:
  - `test_registry_issuance_lifecycle_IPEX_JSON`
  - `test_selective_disclosure_aggregate_IPEX_JSON`
  - `test_partial_disclosure_compaction_IPEX_JSON`
  - `test_blindable_registry_correlation_minimizing_IPEX_JSON`

- Use `keri.acdc.ipexing` flow in each test:
  - `ipexGrant`
  - `ipexAdmit`
  - `loadHandlers`
  - `Exchanger`
  - `Parser`

- Verify that Daniel’s worked-example artifacts can be transported as IPEX `exn` messages while preserving the same ACDC/TEL commitments and SAIDs.

- Assert the privacy properties still hold after transport:
  - selectively withheld fields stay hidden
  - blinded registry states stay unreadable without the correct per-event nonce
  - salts/nonces are not carried on the IPEX wire