### PR TITLE
fix(eventing): make QNF escrow retries idempotent

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5160,11 +5160,15 @@ class Kevery:
             cigars (list): of non-transferable receipts
         """
         cigars = cigars if cigars is not None else []
+        qnfkey = (prefixer.qb64, serder.said)
+        if self.db.qnfs.get(keys=qnfkey):
+            return
+
         dgkey = dgKey(prefixer.qb64b, serder.saidb)
         self.db.putDts(dgkey, helping.nowIso8601().encode("utf-8"))
         self.db.putSigs(dgkey, [siger.qb64b for siger in sigers])
         self.db.putEvt(dgkey, serder.raw)
-        self.db.qnfs.add(keys=(prefixer.qb64, serder.said), val=serder.saidb)
+        self.db.qnfs.add(keys=qnfkey, val=serder.saidb)
 
         for cigar in cigars:
             self.db.addRct(key=dgkey, val=cigar.verfer.qb64b + cigar.qb64b)

--- a/tests/app/test_querying.py
+++ b/tests/app/test_querying.py
@@ -4,6 +4,7 @@ keri.app.querying module
 
 """
 import logging
+from unittest import mock
 
 from hio.base import doing
 
@@ -179,3 +180,30 @@ def test_query_not_found_escrow():
 
         subHab.kvy.processQueryNotFound()
         assert subHab.db.qnfs.get(dgkey) == []
+
+
+def test_query_not_found_escrow_idempotency():
+    with habbing.openHby() as inqHby, \
+            habbing.openHby() as subHby, \
+            habbing.openHby() as tgtHby:
+        inqHab = inqHby.makeHab(name="inquisitor")
+        subHab = subHby.makeHab(name="subject")
+        tgtHab = tgtHby.makeHab(name="target")
+
+        psr = parsing.Parser()
+        psr.parseOne(ims=bytearray(inqHab.makeOwnInception()), kvy=subHab.kvy)
+        assert inqHab.pre in subHab.kevers
+        assert tgtHab.pre not in subHab.kevers
+
+        qry = inqHab.query(tgtHab.pre, route="ksn", src=inqHab.pre)
+        serder = serdering.SerderKERI(raw=qry)
+        qnfkey = (inqHab.pre, serder.said)
+
+        psr.parseOne(ims=bytearray(qry), kvy=subHab.kvy)
+        assert subHab.db.qnfs.get(keys=qnfkey)
+
+        with mock.patch.object(subHab.db, "putDts", wraps=subHab.db.putDts) as putDts:
+            for _ in range(3):
+                subHab.kvy.processQueryNotFound()
+        putDts.assert_not_called()
+        assert subHab.db.qnfs.get(keys=qnfkey)


### PR DESCRIPTION
## Summary

- stop re-persisting a query that is already present in the active query-not-found escrow
- use `qnfs` membership as the idempotency boundary instead of retained backing records
- add one focused regression covering repeated internal QNF processing

## Why

`processQueryNotFound()` reprocesses an unresolved query on every escrow pass. That path calls `escrowQueryNotFoundEvent()` again, which repeats the persistence calls even though the query is already active in `qnfs`.

This is a corrected v1.2.14 follow-up to [Rodolfo Miranda's original PR #1474](https://github.com/WebOfTrust/keripy/pull/1474), which identified the retry-loop problem. The guard here checks the escrow-specific `qnfs` entry rather than `dtss`; newly created query objects have new SAIDs and continue through normal first-time enrollment.

Related issue: #1473.

## Validation

```text
./venv/bin/python -m pytest -q tests/app/test_querying.py -k 'query_not_found'
2 passed, 1 deselected
```
