### PR TITLE
feat(parsing): optional fault sink so embedders can tell stream failures apart

### DIFF
--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -16,7 +16,7 @@ from ..kering import (Colds, sniff, Vrsn_2_0, Ilks,
                       UnexpectedCountCodeError, MaterialError, ValidationError,
                       QueryNotFoundError, ExtractionError, ShortageError,
                       ColdStartError, InvalidVersionError,
-                      SizedGroupError, TopLevelStreamError)
+                      SizedGroupError, TopLevelStreamError, KeriError)
 
 from .coring import (Seqner, Cigar, Diger, Noncer, Labeler, Number, Verser,
                      Dater, Verfer, Prefixer, Saider, Texter)
@@ -68,6 +68,119 @@ class MsgParseDom:
         return iter(asdict(self))
 
 
+Dispositionage = namedtuple("Dispositionage", 'flush resume group')  # fault disposition
+Disps = Dispositionage(flush='flush', resume='resume', group='group')
+# flush means the rest of the stream was deleted to force a cold restart so
+#     whatever followed the fault was discarded unparsed
+# resume means only the faulted msg was dropped and parsing resumed with the
+#     next msg in the stream
+# group means the enclosing sized group had already been preflushed (stripped)
+#     from the stream so parsing resumed after that group
+
+
+@dataclass(frozen=True)
+class Fault:
+    """Fault is a structured record of one error the Parser recovered from.
+    The Parser logs and swallows such errors so that its stream tolerance is
+    preserved. When a fault sink is provided it also appends one Fault per
+    recovered error, so an embedder can discriminate causes without reading log
+    prose or database residue. See Parser .faults.
+
+    Attributes:
+        kind (str): class name of the most specific KeriError in the cause
+            chain of .ex, e.g. 'ShortageError', 'ColdStartError',
+            'MissingWitnessSignatureError'. Falls back to the class name of .ex
+            itself when no KeriError appears in the chain. Suitable for
+            branching and for serialization. See faultKind.
+        disp (str): stream disposition the Parser chose, from Disps, one of
+            'flush', 'resume', or 'group'.
+        offset (int|None): count of bytes consumed from the stream when the
+            fault was recovered, that is, how far into the stream parsing got.
+            Exact for a fixed stream parsed by .parse or .parseOne. A lower
+            bound for a live stream appended to while parsing. None when the
+            fault was recovered below the level that owns the stream, which is
+            the case for post extraction faults, which carry .pre .sn and
+            .said instead.
+        pre (str|None): qb64 AID of the msg that faulted, when the msg had
+            already been extracted, otherwise None
+        sn (int|None): sequence number of the msg that faulted, when known
+        said (str|None): qb64 SAID of the msg that faulted, when known
+        ex (Exception|None): the exception as caught, with its cause chain
+            intact, so nothing is lost for a consumer that wants more"""
+    kind: str = ''
+    disp: str = ''
+    offset: int = None
+    pre: str = None
+    sn: int = None
+    said: str = None
+    ex: Exception = None
+
+    def __iter__(self):
+        return iter(asdict(self))
+
+
+def faultKind(ex):
+    """Returns str class name of the most specific KeriError in the cause chain
+    of exception ex, or the class name of ex itself when the chain holds no
+    KeriError.
+
+    The parser rewraps as it unwinds, most notably groupParsator's
+    `raise ExtractionError from ex`, so the class of the exception a handler
+    catches is often less specific than the class that named the actual fault.
+    Following __cause__ recovers the specific one, and preferring the most
+    derived KeriError keeps a wrapped AttributeError from masking the
+    ValidationError raised from it.
+
+    Parameters:
+        ex (Exception): exception to derive kind from"""
+    best = None
+    seen = set()
+    cause = ex
+    while cause is not None and id(cause) not in seen:  # guard cyclic chains
+        seen.add(id(cause))
+        if isinstance(cause, KeriError):
+            if best is None or len(type(cause).__mro__) > len(type(best).__mro__):
+                best = cause
+        cause = cause.__cause__
+    return type(best if best is not None else ex).__name__
+
+
+def _peek(obj, name):
+    """Returns attribute name of obj or None when unavailable. Capturing a
+    fault must never itself raise, so every attribute read of a partially
+    parsed msg goes through here.
+
+    Parameters:
+        obj (object|None): object to read attribute from
+        name (str): attribute name"""
+    try:
+        return getattr(obj, name, None)
+    except Exception:
+        return None
+
+
+def _fault(faults, ex, disp, offset=None, serder=None):
+    """Appends a Fault built from ex to fault sink faults when faults is
+    provided. No-op when faults is None so an embedder that has not opted in
+    pays nothing.
+
+    Parameters:
+        faults (Deck|list|None): fault sink to append to. None means no sink
+        ex (Exception): exception as caught
+        disp (str): stream disposition from Disps
+        offset (int|None): count of bytes consumed from the stream when known
+        serder (Serder|None): msg that faulted when it was already extracted"""
+    if faults is None:
+        return
+    faults.append(Fault(kind=faultKind(ex),
+                        disp=disp,
+                        offset=offset,
+                        pre=_peek(serder, 'pre'),
+                        sn=_peek(serder, 'sn'),
+                        said=_peek(serder, 'said'),
+                        ex=ex))
+
+
 
 class Parser:
     """Parser is stream parser that processes an incoming message stream.
@@ -95,6 +208,13 @@ class Parser:
         vry (``Verfifier``): credential verifier with wallet storage
         local (bool): True means event source is local (protected) for validation
             False means event source is remote (unprotected) for validation
+        faults (Deck|list|None): default fault sink. When not None the parser
+            appends one Fault to it, in addition to the logging it already
+            does, for each error it recovers from. None, the default, means
+            collect nothing, so behavior is unchanged for embedders that do
+            not opt in. Anything with an .append method works, such as a
+            hio.help.decking.Deck, a collections.deque, or a list. A sink
+            given per call overrides this default.
 
     Properties:
         genus (str): genus portion of default CESR code table protocol genus code
@@ -185,7 +305,7 @@ class Parser:
 
     def __init__(self, ims=None, framed=True, piped=False, kvy=None,
                  tvy=None, exc=None, rvy=None, vry=None, local=False,
-                 version=Vrsn_2_0):
+                 version=Vrsn_2_0, faults=None):
         """
         Initialize instance:
 
@@ -203,7 +323,9 @@ class Parser:
             local (bool): True means event source is local (protected) for validation
                 False means event source is remote (unprotected) for validation
             version (Versionage): instance of version portion of genus version code
-                for default code table"""
+                for default code table
+            faults (Deck|list|None): default fault sink for recovered errors.
+                None means collect nothing"""
         self.ims = ims if ims is not None else bytearray()
         self.framed = True if framed else False  # extract until end-of-stream
         self.piped = True if piped else False  # use pipeline processor
@@ -213,6 +335,7 @@ class Parser:
         self.rvy = rvy
         self.vry = vry
         self.local = True if local else False
+        self.faults = faults  # None means do not collect faults
 
         self._genus = GenDex.KERI  # only supports KERI
         self.version = version  # provided version may be earlier than supported version
@@ -355,7 +478,7 @@ class Parser:
 
     def parse(self, ims=None, framed=None, piped=None, kvy=None, tvy=None,
               exc=None, rvy=None, vry=None, local=None, version=None,
-              processive=True):
+              processive=True, faults=None):
         """Processes all messages from incoming message stream, ims,
         when provided. Otherwise process messages from .ims
         Returns when ims is empty.
@@ -382,6 +505,8 @@ class Parser:
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
                     testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults
 
             New Logic:
                 Attachments must all have counters so know if txt or bny format for
@@ -399,7 +524,8 @@ class Parser:
                                     vry=vry,
                                     local=local,
                                     version=version,
-                                    processive=processive)
+                                    processive=processive,
+                                    faults=faults)
 
         while True:
             try:
@@ -413,7 +539,7 @@ class Parser:
 
     def parseOne(self, ims=None, framed=True, piped=False, kvy=None, tvy=None,
                  exc=None, rvy=None, vry=None, local=None, version=None,
-                 processive=True):
+                 processive=True, faults=None):
         """Processes one messages from incoming message stream, ims,
         when provided. Otherwise process message from .ims
         Returns once one message is processed.
@@ -439,6 +565,8 @@ class Parser:
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
                     testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults
 
 
             New Logic:
@@ -457,7 +585,8 @@ class Parser:
                                      vry=vry,
                                      local=local,
                                      version=version,
-                                     processive=processive)
+                                     processive=processive,
+                                     faults=faults)
         while True:
             try:
                 next(parsator)
@@ -470,7 +599,7 @@ class Parser:
 
     def allParsator(self, ims=None, framed=None, piped=None, kvy=None,
                     tvy=None, exc=None, rvy=None, vry=None, local=None,
-                    version=None, processive=True):
+                    version=None, processive=True, faults=None):
         """Returns generator to parse all messages from incoming message stream,
         ims until ims is exhausted (empty) then returns.
         Generator completes as soon as ims is empty.
@@ -497,6 +626,8 @@ class Parser:
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
                     testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults
 
 
             New Logic:
@@ -517,9 +648,12 @@ class Parser:
         vry = vry if vry is not None else self.vry
         local = local if local is not None else self.local
         local = True if local else False
+        faults = faults if faults is not None else self.faults
 
         result = None
+        consumed = 0  # bytes consumed from ims so far, for fault offsets
         while ims:  # only process until ims empty (differs here from parsator)
+            extant = len(ims)  # stream size at start of pass, for fault offsets
             try:
                 result = yield from self.groupParsator(ims=ims,
                                                         framed=framed,
@@ -531,7 +665,8 @@ class Parser:
                                                         vry=vry,
                                                         local=local,
                                                         version=version,
-                                                        processive=processive)
+                                                        processive=processive,
+                                                        faults=faults)
 
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -539,12 +674,16 @@ class Parser:
                     logger.exception("Parser sized group error: %s", ex)
                 else:
                     logger.error("Parser sized group error: %s", ex)
+                _fault(faults, ex, Disps.group,
+                       offset=consumed + max(0, extant - len(ims)))
 
             except (ColdStartError, ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("Parser msg extraction error: %s", ex)
                 else:
                     logger.error("Parser msg extraction error: %s", ex)
+                _fault(faults, ex, Disps.flush,
+                       offset=consumed + max(0, extant - len(ims)))
                 del ims[:]  # delete rest of stream to force cold restart
 
             except (ValidationError, Exception) as ex:  # non Extraction Error
@@ -554,6 +693,9 @@ class Parser:
                     logger.exception("Parser msg non-extraction error: %s", ex)
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.error("Parser msg non-extraction error: %s", ex)
+                _fault(faults, ex, Disps.resume,
+                       offset=consumed + max(0, extant - len(ims)))
+            consumed += max(0, extant - len(ims))
             yield
 
         return result  # debug parsing when not processive
@@ -561,7 +703,7 @@ class Parser:
 
     def onceParsator(self, ims=None, framed=None, piped=None, kvy=None,
                      tvy=None, exc=None, rvy=None, vry=None, local=None,
-                     version=None, processive=True):
+                     version=None, processive=True, faults=None):
         """Returns generator to parse one message from incoming message stream, ims.
         If ims not provided parse messages from .ims
 
@@ -586,6 +728,8 @@ class Parser:
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
                     testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults
 
 
             New Logic:
@@ -606,15 +750,20 @@ class Parser:
         vry = vry if vry is not None else self.vry
         local = local if local is not None else self.local
         local = True if local else False
+        faults = faults if faults is not None else self.faults
 
         result = None
+        serder = None  # msg body once extracted, for fault locus
+        consumed = 0  # bytes consumed from ims so far, for fault offsets
         while True:
+            extant = len(ims)  # stream size at start of pass, for fault offsets
             try:
                 exts = yield from self.msgParsator(ims=ims,
                                                       framed=framed,
                                                       piped=piped,
                                                       local=local,
                                                       version=version)
+                serder = exts.serder  # extracted so fault locus now available
 
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -622,14 +771,19 @@ class Parser:
                     logger.exception("Kevery sized group error: %s", ex)
                 else:
                     logger.error("Kevery sized group error: %s", ex)
+                _fault(faults, ex, Disps.group,
+                       offset=consumed + max(0, extant - len(ims)))
 
             except (ColdStartError, ExtractionError, Exception) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("Kevery msg extraction error: %s", ex)
                 else:
                     logger.error("Kevery msg extraction error: %s", ex)
+                _fault(faults, ex, Disps.flush,
+                       offset=consumed + max(0, extant - len(ims)))
                 del ims[:]  # delete rest of stream to force cold restart
 
+            consumed += max(0, extant - len(ims))
             if processive:
                 try:
                     result = self.msgProcess(exts=asdict(exts),
@@ -646,6 +800,7 @@ class Parser:
                         logger.exception("Kevery msg non-extraction error: %s", ex)
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.error("Kevery msg non-extraction error: %s", ex)
+                    _fault(faults, ex, Disps.resume, serder=serder)
                 finally:
                     result = True
                     break
@@ -658,7 +813,7 @@ class Parser:
 
     def parsator(self, ims=None, framed=None, piped=None, kvy=None, tvy=None,
                  exc=None, rvy=None, vry=None, local=None, version=None,
-                 processive=True):
+                 processive=True, faults=None):
         """Returns generator to continually parse messages from incoming message
         stream, ims. Empty yields when ims is emply. Does not return.
         Useful for always running servers.
@@ -687,6 +842,8 @@ class Parser:
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
                     testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults
 
 
             New Logic:
@@ -707,9 +864,12 @@ class Parser:
         vry = vry if vry is not None else self.vry
         local = local if local is not None else self.local
         local = True if local else False
+        faults = faults if faults is not None else self.faults
 
         result = None
+        consumed = 0  # bytes consumed from ims so far, for fault offsets
         while True:  # continuous stream processing (differs here from allParsator)
+            extant = len(ims)  # stream size at start of pass, for fault offsets
             try:
                 result = yield from self.groupParsator(ims=ims,
                                                    framed=framed,
@@ -721,7 +881,8 @@ class Parser:
                                                    vry=vry,
                                                    local=local,
                                                    version=version,
-                                                   processive=processive)
+                                                   processive=processive,
+                                                   faults=faults)
 
 
             except SizedGroupError as ex:  # error inside sized group
@@ -730,12 +891,16 @@ class Parser:
                     logger.exception("Parser sized group error: %s", ex)
                 else:
                     logger.error("Parser sized group error: %s", ex)
+                _fault(faults, ex, Disps.group,
+                       offset=consumed + max(0, extant - len(ims)))
 
             except (ColdStartError, ExtractionError) as ex:  # some extraction error
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("Parser msg extraction error: %s", ex)
                 else:
                     logger.error("Parser msg extraction error: %s", ex)
+                _fault(faults, ex, Disps.flush,
+                       offset=consumed + max(0, extant - len(ims)))
                 del ims[:]  # delete rest of stream to force cold restart
 
             except (ValidationError, Exception) as ex:  # non Extraction Error
@@ -745,6 +910,9 @@ class Parser:
                     logger.exception("Parser msg non-extraction error: %s", ex)
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.error("Parser msg non-extraction error: %s", ex)
+                _fault(faults, ex, Disps.resume,
+                       offset=consumed + max(0, extant - len(ims)))
+            consumed += max(0, extant - len(ims))
             yield
 
         return result  # should never return
@@ -752,7 +920,7 @@ class Parser:
 
     def groupParsator(self, ims=None, framed=True, piped=False, kvy=None,
                     tvy=None, exc=None, rvy=None, vry=None, local=None,
-                    version=None, processive=True):
+                    version=None, processive=True, faults=None):
         """Returns generator to parse nested GenericGroups whose outermost nesting
         appears at the top-level of an incoming message stream.
 
@@ -778,12 +946,15 @@ class Parser:
                 None means do not change default
             processive (bool): True means process messages as they are parsed
                 False means do not process parse only, useful for
-                    testing and debugging"""
+                    testing and debugging
+            faults (Deck|list|None): fault sink for errors recovered from while
+                parsing. None means use default .faults"""
         if ims is None:
             ims = self.ims
 
         local = local if local is not None else self.local
         local = True if local else False
+        faults = faults if faults is not None else self.faults
 
         self.version = version  # when not None which sets .methods .codes .mucodes .sucodes
 
@@ -885,6 +1056,8 @@ class Parser:
                         if logger.isEnabledFor(logging.DEBUG):
                             logger.error("GroupParsator error post extraction of "
                                          "msg+atc : %s", ex)
+                        # msg body already extracted so the fault carries its locus
+                        _fault(faults, ex, Disps.resume, serder=exts.serder)
 
                         continue
                 else:

--- a/src/keri/core/parsing.py
+++ b/src/keri/core/parsing.py
@@ -72,8 +72,8 @@ Dispositionage = namedtuple("Dispositionage", 'flush resume group')  # fault dis
 Disps = Dispositionage(flush='flush', resume='resume', group='group')
 # flush means the rest of the stream was deleted to force a cold restart so
 #     whatever followed the fault was discarded unparsed
-# resume means only the faulted msg was dropped and parsing resumed with the
-#     next msg in the stream
+# resume means the parser declined this msg and resumed with the next one in
+#     the stream. It does NOT mean the msg was rejected, see Fault
 # group means the enclosing sized group had already been preflushed (stripped)
 #     from the stream so parsing resumed after that group
 
@@ -82,31 +82,60 @@ Disps = Dispositionage(flush='flush', resume='resume', group='group')
 class Fault:
     """Fault is a structured record of one error the Parser recovered from.
     The Parser logs and swallows such errors so that its stream tolerance is
-    preserved. When a fault sink is provided it also appends one Fault per
-    recovered error, so an embedder can discriminate causes without reading log
-    prose or database residue. See Parser .faults.
+    preserved. When a fault sink is provided it also appends a Fault, so an
+    embedder can discriminate causes without reading log prose or database
+    residue. See Parser .faults.
+
+    A Fault records what the parse loop did, not what became of the msg. This
+    distinction is the one an embedder is most likely to get wrong:
+
+    - It is NOT a validation verdict. Kevery escrows an event and then raises,
+      so OutOfOrderError, MissingWitnessSignatureError, MissingDelegationError
+      and LikelyDuplicitousError all yield a Fault for an event that a later
+      .processEscrows() may accept in full. Reading a Fault as "this msg was
+      rejected" turns ordinary out of order KEL traffic into a hard failure.
+    - It is NOT evidence. Duplicity is proven by placing two verifiable KELs
+      side by side, and the conflicting event is already preserved in the
+      duplicitous escrow. A Fault is one observer's local disposition, neither
+      nonrepudiable nor transferable, and 'Likely' in LikelyDuplicitousError is
+      deliberate.
+    - It is NOT a complete inventory of everything the stream lost. Errors
+      recovered inside a processor rather than by the parse loop do not appear,
+      .msgProcess recovers QueryNotFoundError this way, and Kevery drops msgs
+      by allow and deny list policy without raising at all. An empty sink does
+      not mean the whole stream was processed.
 
     Attributes:
-        kind (str): class name of the most specific KeriError in the cause
-            chain of .ex, e.g. 'ShortageError', 'ColdStartError',
+        kind (str): class name of the most specific KeriError in the chain of
+            .ex, e.g. 'ShortageError', 'ColdStartError',
             'MissingWitnessSignatureError'. Falls back to the class name of .ex
-            itself when no KeriError appears in the chain. Suitable for
-            branching and for serialization. See faultKind.
+            itself when the chain holds no KeriError. See faultKind.
+            This is keripy's internal exception taxonomy, not a normative
+            protocol one. It is not pinned across releases, the same condition
+            may surface under different names depending on where in the stream
+            it is met, and other KERI implementations do not share it. Branch
+            on it by all means, but treat an unrecognized kind as a fault to
+            handle rather than as no fault at all. .disp is the stable axis.
         disp (str): stream disposition the Parser chose, from Disps, one of
             'flush', 'resume', or 'group'.
-        offset (int|None): count of bytes consumed from the stream when the
-            fault was recovered, that is, how far into the stream parsing got.
-            Exact for a fixed stream parsed by .parse or .parseOne. A lower
-            bound for a live stream appended to while parsing. None when the
-            fault was recovered below the level that owns the stream, which is
-            the case for post extraction faults, which carry .pre .sn and
-            .said instead.
+        offset (int|None): lower bound on the count of bytes this parse call
+            consumed from the stream before the fault was recovered. Exact for
+            a fixed stream handed to .parse or .parseOne, and there it locates
+            where the stream stopped making sense. For a live stream appended
+            to while parsing it undercounts, without bound, so it is a
+            diagnostic and not a position to resync from. None when the fault
+            was recovered below the level that owns the stream, which is the
+            case for post extraction faults, which carry .pre .sn and .said
+            instead.
         pre (str|None): qb64 AID of the msg that faulted, when the msg had
             already been extracted, otherwise None
         sn (int|None): sequence number of the msg that faulted, when known
         said (str|None): qb64 SAID of the msg that faulted, when known
-        ex (Exception|None): the exception as caught, with its cause chain
-            intact, so nothing is lost for a consumer that wants more"""
+        ex (Exception|None): the exception as caught, with its chain intact, so
+            nothing is lost for a consumer that wants more. Its traceback is
+            cleared, since retaining one would pin the parser frames and with
+            them the whole parsed msg, for every fault a remote peer can
+            provoke. See _release"""
     kind: str = ''
     disp: str = ''
     offset: int = None
@@ -119,30 +148,66 @@ class Fault:
         return iter(asdict(self))
 
 
+def _chain(ex):
+    """Yields ex and then each exception it was raised from, outermost first.
+
+    Follows __cause__ when the raise was explicit, `raise X from Y`, and
+    __context__ otherwise, since the parser chains both ways: groupParsator
+    uses `raise ExtractionError from ex` but all four SizedGroupError raise
+    sites are bare raises inside an except block, which set __context__ only.
+    A context suppressed by `from None` ends the walk, as the raiser intended.
+
+    Parameters:
+        ex (Exception|None): exception to walk from"""
+    seen = set()
+    while ex is not None and id(ex) not in seen:  # guard cyclic chains
+        seen.add(id(ex))
+        yield ex
+        if ex.__cause__ is not None:
+            ex = ex.__cause__
+        elif ex.__suppress_context__:
+            ex = None
+        else:
+            ex = ex.__context__
+
+
 def faultKind(ex):
-    """Returns str class name of the most specific KeriError in the cause chain
-    of exception ex, or the class name of ex itself when the chain holds no
+    """Returns str class name of the most specific KeriError in the chain of
+    exception ex, or the class name of ex itself when the chain holds no
     KeriError.
 
     The parser rewraps as it unwinds, most notably groupParsator's
     `raise ExtractionError from ex`, so the class of the exception a handler
     catches is often less specific than the class that named the actual fault.
-    Following __cause__ recovers the specific one, and preferring the most
-    derived KeriError keeps a wrapped AttributeError from masking the
-    ValidationError raised from it.
+    Walking the chain recovers the specific one. Preferring the most derived
+    KeriError keeps a wrapped AttributeError from masking the ValidationError
+    raised from it, and on a tie the innermost wins, so a SizedGroupError
+    wrapping a ShortageError reports the shortage. What made the group fail is
+    the kind. That it was a group is the disposition, carried by .disp.
 
     Parameters:
         ex (Exception): exception to derive kind from"""
     best = None
-    seen = set()
-    cause = ex
-    while cause is not None and id(cause) not in seen:  # guard cyclic chains
-        seen.add(id(cause))
+    for cause in _chain(ex):
         if isinstance(cause, KeriError):
-            if best is None or len(type(cause).__mro__) > len(type(best).__mro__):
+            if best is None or len(type(cause).__mro__) >= len(type(best).__mro__):
                 best = cause
-        cause = cause.__cause__
     return type(best if best is not None else ex).__name__
+
+
+def _release(ex):
+    """Clears the traceback from ex and every exception it was raised from, so
+    a retained Fault does not pin the parser frames the exception unwound
+    through, and with them the whole parsed msg. Returns ex.
+
+    The parser is discarding ex either way, and has already logged it, so the
+    frames are of no further use to it.
+
+    Parameters:
+        ex (Exception): exception to strip frames from"""
+    for cause in _chain(ex):
+        cause.__traceback__ = None
+    return ex
 
 
 def _peek(obj, name):
@@ -172,13 +237,18 @@ def _fault(faults, ex, disp, offset=None, serder=None):
         serder (Serder|None): msg that faulted when it was already extracted"""
     if faults is None:
         return
-    faults.append(Fault(kind=faultKind(ex),
-                        disp=disp,
-                        offset=offset,
-                        pre=_peek(serder, 'pre'),
-                        sn=_peek(serder, 'sn'),
-                        said=_peek(serder, 'said'),
-                        ex=ex))
+    try:  # .append is embedder code running inside the parser's except arms,
+        # so a sink that raises must not escape and rob the arm of the flush
+        # or resume it was about to perform
+        faults.append(Fault(kind=faultKind(ex),
+                            disp=disp,
+                            offset=offset,
+                            pre=_peek(serder, 'pre'),
+                            sn=_peek(serder, 'sn'),
+                            said=_peek(serder, 'said'),
+                            ex=_release(ex)))
+    except Exception as rex:
+        logger.error("Parser could not record fault: %s", rex)
 
 
 
@@ -209,12 +279,18 @@ class Parser:
         local (bool): True means event source is local (protected) for validation
             False means event source is remote (unprotected) for validation
         faults (Deck|list|None): default fault sink. When not None the parser
-            appends one Fault to it, in addition to the logging it already
-            does, for each error it recovers from. None, the default, means
-            collect nothing, so behavior is unchanged for embedders that do
-            not opt in. Anything with an .append method works, such as a
-            hio.help.decking.Deck, a collections.deque, or a list. A sink
-            given per call overrides this default.
+            appends a Fault to it, in addition to the logging it does either
+            way, for each error the parse loop recovers from. None, the
+            default, means collect nothing. Anything with an .append method
+            works, and one that raises is caught rather than allowed to escape
+            the parse arm it ran in. A sink given per call overrides this
+            default.
+            Bound the sink for anything long lived. A parsator serving a
+            remote peer faults as often as that peer sends malformed bytes, so
+            an unbounded list or Deck grows with attacker supplied input.
+            collections.deque(maxlen=n) is the safe default. Read the Fault
+            docstring before branching on what arrives, a Fault is not a
+            validation verdict.
 
     Properties:
         genus (str): genus portion of default CESR code table protocol genus code
@@ -754,9 +830,11 @@ class Parser:
 
         result = None
         serder = None  # msg body once extracted, for fault locus
+        extracted = False  # True once a msg substream came out of the stream
         consumed = 0  # bytes consumed from ims so far, for fault offsets
         while True:
             extant = len(ims)  # stream size at start of pass, for fault offsets
+            extracted = False
             try:
                 exts = yield from self.msgParsator(ims=ims,
                                                       framed=framed,
@@ -764,6 +842,7 @@ class Parser:
                                                       local=local,
                                                       version=version)
                 serder = exts.serder  # extracted so fault locus now available
+                extracted = True
 
             except SizedGroupError as ex:  # error inside sized group
                 # processOneIter already flushed group so do not flush stream
@@ -800,7 +879,10 @@ class Parser:
                         logger.exception("Kevery msg non-extraction error: %s", ex)
                     if logger.isEnabledFor(logging.DEBUG):
                         logger.error("Kevery msg non-extraction error: %s", ex)
-                    _fault(faults, ex, Disps.resume, serder=serder)
+                    if extracted:  # when extraction already failed the arm above
+                        # flushed the stream and exts is unbound, so anything
+                        # raised here is an artifact of that, not a new fault
+                        _fault(faults, ex, Disps.resume, serder=serder)
                 finally:
                     result = True
                     break

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -13,7 +13,8 @@ from hio.help import ogler
 
 
 from keri.kering import (ValidationError, Vrsn_1_0, Vrsn_2_0, Kinds,
-                         ExtractionError, ShortageError, OutOfOrderError)
+                         ExtractionError, ShortageError, OutOfOrderError,
+                         SizedGroupError)
 from keri.core.parsing import Fault, Disps, faultKind
 
 from keri.core import (Counter, Diger, GenDex, Codens, Seqner, Dater, Texter, Pather,
@@ -5175,11 +5176,9 @@ def test_parser_fault_sink_silent_when_clean():
         assert not faults  # nothing went wrong so nothing was collected
         assert serder.pre in kvy.kevers  # and the event was accepted
 
-    """Done Test"""
-
 
 def test_fault_kind():
-    """Test that faultKind names the most specific KeriError in the cause chain.
+    """Test that faultKind names the most specific KeriError in the chain.
 
     The parser rewraps as it unwinds so the class a handler catches is often
     less specific than the class that named the fault"""
@@ -5201,9 +5200,26 @@ def test_fault_kind():
     except ValidationError as ex:
         assert faultKind(ex) == 'ValidationError'  # not the non-KeriError cause
 
-    assert faultKind(RuntimeError("not ours")) == 'RuntimeError'
+    # msgParsator raises SizedGroupError without `from ex`, so the original is
+    # on __context__ rather than __cause__. Both hold the same shape of loss
+    try:
+        try:
+            raise ShortageError("ran short")
+        except ShortageError:
+            raise SizedGroupError("group of size=92")
+    except SizedGroupError as ex:
+        assert ex.__cause__ is None  # implicit chaining, so nothing on __cause__
+        assert faultKind(ex) == 'ShortageError'  # the group is the disp, not the kind
 
-    """Done Test"""
+    try:  # an explicit `from` suppresses context, which must not be followed
+        try:
+            raise ShortageError("unrelated, already being handled")
+        except ShortageError:
+            raise ValidationError("the real fault") from None
+    except ValidationError as ex:
+        assert faultKind(ex) == 'ValidationError'
+
+    assert faultKind(RuntimeError("not ours")) == 'RuntimeError'
 
 
 def test_parser_fault_truncated_stream():
@@ -5232,8 +5248,6 @@ def test_parser_fault_truncated_stream():
         assert fault.said is None
         assert isinstance(fault.ex, ExtractionError)
 
-    """Done Test"""
-
 
 def test_parser_fault_cold_start():
     """Test that a desynced stream, one that starts on an attachment instead of
@@ -5260,8 +5274,6 @@ def test_parser_fault_cold_start():
         assert fault.disp == Disps.flush
         assert fault.offset == 0  # stream never made sense at all
         assert fault.pre is None
-
-    """Done Test"""
 
 
 def test_parser_fault_post_extraction():
@@ -5293,16 +5305,13 @@ def test_parser_fault_post_extraction():
         assert fault.sn == 0
         assert fault.said == serder.said
 
-    """Done Test"""
-
 
 def test_parser_fault_discriminates_and_resumes():
     """Test that an out of order event is distinguishable from a stream that
     does not parse, and that the msgs after it still parse.
 
-    This is the discrimination an embedder cannot make today. Both conditions
-    establish less than the stream should, and .parse returns normally for
-    both"""
+    Both conditions establish less than the stream should, and .parse returns
+    normally for both, so the kind is the only thing that tells them apart"""
     logger.setLevel("ERROR")
     signers, serder, msg = faultFixture()
 
@@ -5331,8 +5340,6 @@ def test_parser_fault_discriminates_and_resumes():
 
         # resumed, so the inception behind the bad event was still accepted
         assert serder.pre in kvy.kevers
-
-    """Done Test"""
 
 
 def test_parser_fault_sized_group():
@@ -5369,8 +5376,6 @@ def test_parser_fault_sized_group():
         # only the group was lost, so the msg behind it was still accepted
         assert serder.pre in kvy.kevers
 
-    """Done Test"""
-
 
 def test_parser_fault_sink_on_parse_one():
     """Test that .parseOne reports faults the same way .parse does"""
@@ -5393,17 +5398,64 @@ def test_parser_fault_sink_on_parse_one():
         assert faults[0].pre == serder.pre
         assert faults[0].said == serder.said
 
+        # .onceParsator falls through into .msgProcess after a failed
+        # extraction, where exts is unbound. That fall-through logs, but it
+        # must not reach the sink as a second fault claiming the stream
+        # resumed when the arm above it flushed
         faults = []
         parser.parseOne(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+        assert len(faults) == 1
         assert faults[0].kind == 'ShortageError'
         assert faults[0].disp == Disps.flush
         assert faults[0].offset == len(serder.raw) + 4
-        # note: .onceParsator falls through into .msgProcess after a failed
-        # extraction, where exts is unbound, so a spurious follow-on fault may
-        # trail this one. Deliberately not asserted either way here, since that
-        # is a parser bug this sink only makes visible
 
-    """Done Test"""
+
+def test_parser_fault_sink_that_raises():
+    """Test that a sink which raises cannot escape parse or rob the parser of
+    the flush that forces a cold restart.
+
+    The sink runs embedder code inside the parser's own except arms, so it is
+    the one place a fault can turn into a worse fault than the one it records"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    class Rejector(list):
+        """Stands in for a bounded queue, a closed file, or a socket sink"""
+        def append(self, item):
+            raise RuntimeError("sink is closed")
+
+    ims = bytearray(msg)[:-20]  # truncated, so extraction fails and flushes
+    ims.extend(msg)  # followed by a well formed msg the flush should discard
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        parser.parse(ims=ims, kvy=kvy, faults=Rejector())  # must not raise
+
+        assert not ims  # flushed, so the cold restart the arm exists for happened
+        assert serder.pre not in kvy.kevers  # and nothing behind it was accepted
+
+
+def test_parser_fault_releases_parsed_message():
+    """Test that a Fault does not pin the frames it was raised from.
+
+    A retained traceback pins the parser's locals, and therefore the whole
+    parsed msg, for every fault a remote peer can provoke"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+
+        ex = faults[0].ex
+        while ex is not None:  # nothing in the chain holds a frame
+            assert ex.__traceback__ is None
+            ex = ex.__cause__ or ex.__context__
 
 
 def test_parser_fault_sink_never_raises():
@@ -5427,8 +5479,6 @@ def test_parser_fault_sink_never_raises():
         parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
         parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
         assert len(faults) == 1
-
-    """Done Test"""
 
 
 def test_parser_fault_sink_on_live_stream():
@@ -5457,8 +5507,6 @@ def test_parser_fault_sink_on_live_stream():
         assert len(faults) == 1
         assert faults[0].kind == 'ColdStartError'
         assert faults[0].disp == Disps.flush
-
-    """Done Test"""
 
 
 def test_parser_fault_unexpected_error():
@@ -5491,7 +5539,54 @@ def test_parser_fault_unexpected_error():
         assert faults[0].kind == 'InvalidVersionError'
         assert faults[0].disp == Disps.resume
 
-    """Done Test"""
+
+def test_parser_fault_v2_streams():
+    """Test that faults surface the same way for CESR v2 streams, both JSON
+    bodies and native CESR ones.
+
+    The sink sits in the parse loop's except arms rather than in any version
+    specific path, so nothing about it should depend on the version. This pins
+    that, since native bodies are v2 only and reach .msgProcess by a different
+    route than a JSON body does"""
+    logger.setLevel("ERROR")
+    signers = Salter(raw=b"ABCDEFGH01234567").signers(count=8, path='psr', temp=True)
+
+    for kind in (Kinds.json, Kinds.cesr):
+        serder = incept(keys=[signers[0].verfer.qb64],
+                        ndigs=[Diger(ser=signers[1].verfer.qb64b).qb64],
+                        version=Vrsn_2_0, kind=kind)
+        aims = bytearray(signers[0].sign(serder.raw, index=0).qb64b)
+        msg = bytearray(serder.raw)
+        msg.extend(Counter.enclose(qb64=aims, code=Codens.ControllerIdxSigs))
+
+        unsigned = bytearray(serder.raw)  # empty sig group, so it extracts
+        unsigned.extend(Counter.enclose(qb64=bytearray(),
+                                        code=Codens.ControllerIdxSigs))
+
+        with openDB(name="validator") as valDB:
+            kvy = Kevery(db=valDB, lax=False, local=False)
+            parser = Parser(version=Vrsn_2_0)
+
+            faults = []
+            parser.parse(ims=bytearray(msg), kvy=kvy, faults=faults)
+            assert not faults
+            assert serder.pre in kvy.kevers
+
+            faults = []
+            parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+            assert len(faults) == 1
+            assert faults[0].kind == 'ShortageError'
+            assert faults[0].disp == Disps.flush
+            assert faults[0].offset > 0
+
+            faults = []
+            parser.parse(ims=bytearray(unsigned), kvy=kvy, faults=faults)
+            assert len(faults) == 1
+            assert faults[0].kind == 'ValidationError'
+            assert faults[0].disp == Disps.resume
+            assert faults[0].pre == serder.pre  # identity survives for both kinds
+            assert faults[0].sn == 0
+            assert faults[0].said == serder.said
 
 
 def test_parser_fault_sink_instance_default():
@@ -5513,8 +5608,6 @@ def test_parser_fault_sink_instance_default():
         parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=oneoff)
         assert len(oneoff) == 1  # per call sink got it
         assert len(standing) == 1  # and the standing sink did not
-
-    """Done Test"""
 
 
 if __name__ == "__main__":
@@ -5540,7 +5633,10 @@ if __name__ == "__main__":
     test_parser_fault_discriminates_and_resumes()
     test_parser_fault_sized_group()
     test_parser_fault_sink_on_parse_one()
+    test_parser_fault_sink_that_raises()
+    test_parser_fault_releases_parsed_message()
     test_parser_fault_sink_never_raises()
     test_parser_fault_sink_on_live_stream()
     test_parser_fault_unexpected_error()
+    test_parser_fault_v2_streams()
     test_parser_fault_sink_instance_default()

--- a/tests/core/test_parsing.py
+++ b/tests/core/test_parsing.py
@@ -4,6 +4,7 @@ tests.core.test_parsing module
 
 """
 import os
+from collections import deque
 from dataclasses import asdict
 
 import pytest
@@ -11,7 +12,9 @@ import pytest
 from hio.help import ogler
 
 
-from keri.kering import ValidationError, Vrsn_1_0, Vrsn_2_0, Kinds
+from keri.kering import (ValidationError, Vrsn_1_0, Vrsn_2_0, Kinds,
+                         ExtractionError, ShortageError, OutOfOrderError)
+from keri.core.parsing import Fault, Disps, faultKind
 
 from keri.core import (Counter, Diger, GenDex, Codens, Seqner, Dater, Texter, Pather,
                        Blinder, Mediar, TypeMedia, Sealer, SealKind, Verser,
@@ -5130,6 +5133,390 @@ def test_parser_v2_substream():
         """Done Test"""
 
 
+def faultFixture():
+    """Returns (signers, serder, msg) for a well formed v1 inception plus its
+    attached controller signature. Shared setup for the fault sink tests below.
+
+    Returns:
+        signers (list[Signer]): transferable signers, [0] signs the inception
+        serder (SerderKERI): the inception event
+        msg (bytearray): serder.raw plus a ControllerIdxSigs group of one sig"""
+    signers = Salter(raw=b"ABCDEFGH01234567").signers(count=8, path='psr', temp=True)
+    serder = incept(keys=[signers[0].verfer.qb64],
+                    ndigs=[Diger(ser=signers[1].verfer.qb64b).qb64], **V1_KWA)
+    msg = bytearray(serder.raw)
+    msg.extend(Counter(Codens.ControllerIdxSigs, count=1, version=Vrsn_1_0).qb64b)
+    msg.extend(signers[0].sign(serder.raw, index=0).qb64b)
+    return signers, serder, msg
+
+
+def test_parser_fault_sink_default_off():
+    """Test that the fault sink is opt-in, so an embedder that does not ask for
+    one collects nothing and pays nothing"""
+    parser = Parser()
+    assert parser.faults is None  # off unless asked for
+
+    faults = []
+    parser = Parser(faults=faults)
+    assert parser.faults is faults  # sink is held, not copied
+
+
+def test_parser_fault_sink_silent_when_clean():
+    """Test that a well formed stream produces no faults and still parses"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parse(ims=bytearray(msg), kvy=kvy, faults=faults)
+        assert not faults  # nothing went wrong so nothing was collected
+        assert serder.pre in kvy.kevers  # and the event was accepted
+
+    """Done Test"""
+
+
+def test_fault_kind():
+    """Test that faultKind names the most specific KeriError in the cause chain.
+
+    The parser rewraps as it unwinds so the class a handler catches is often
+    less specific than the class that named the fault"""
+    assert faultKind(ShortageError("need more")) == 'ShortageError'
+
+    try:  # what groupParsator does to an extraction error as it unwinds
+        try:
+            raise ShortageError("need more")
+        except ShortageError as ex:
+            raise ExtractionError from ex
+    except ExtractionError as ex:
+        assert faultKind(ex) == 'ShortageError'  # not the bare wrapper
+
+    try:  # what msgProcess does when it has no processor to dispatch to
+        try:
+            raise AttributeError("no kevery")
+        except AttributeError as ex:
+            raise ValidationError("no kevery to process") from ex
+    except ValidationError as ex:
+        assert faultKind(ex) == 'ValidationError'  # not the non-KeriError cause
+
+    assert faultKind(RuntimeError("not ours")) == 'RuntimeError'
+
+    """Done Test"""
+
+
+def test_parser_fault_truncated_stream():
+    """Test that a stream cut short surfaces as a flushed ShortageError"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        # cut into the attached signature so the body and its counter extract
+        # but the signature itself runs short
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+
+        assert serder.pre not in kvy.kevers  # nothing was established
+        assert len(faults) == 1
+        fault = faults[0]
+        assert isinstance(fault, Fault)
+        assert fault.kind == 'ShortageError'  # ran short, so more bytes may help
+        assert fault.disp == Disps.flush  # rest of stream discarded
+        assert fault.offset == len(serder.raw) + 4  # body plus its sig counter
+        assert fault.pre is None  # never got far enough to know whose msg it was
+        assert fault.sn is None
+        assert fault.said is None
+        assert isinstance(fault.ex, ExtractionError)
+
+    """Done Test"""
+
+
+def test_parser_fault_cold_start():
+    """Test that a desynced stream, one that starts on an attachment instead of
+    a message, surfaces as a flushed ColdStartError and not as a shortage"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    # attachments with no message body in front of them, as a receiver would
+    # see after resyncing mid stream
+    orphan = bytearray(Counter(Codens.ControllerIdxSigs, count=1,
+                               version=Vrsn_2_0).qb64b)
+    orphan.extend(signers[0].sign(serder.raw, index=0).qb64b)
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_2_0)
+
+        faults = []
+        parser.parse(ims=bytearray(orphan), kvy=kvy, faults=faults)
+
+        assert len(faults) == 1
+        fault = faults[0]
+        assert fault.kind == 'ColdStartError'  # desynced, more bytes will not help
+        assert fault.disp == Disps.flush
+        assert fault.offset == 0  # stream never made sense at all
+        assert fault.pre is None
+
+    """Done Test"""
+
+
+def test_parser_fault_post_extraction():
+    """Test that a msg which extracts but fails validation surfaces as a
+    resumed fault carrying the identity of the msg that failed"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    # the inception with an empty signature group, so it extracts cleanly and
+    # then fails validation for want of signatures
+    unsigned = bytearray(serder.raw)
+    unsigned.extend(Counter(Codens.ControllerIdxSigs, count=0,
+                            version=Vrsn_1_0).qb64b)
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parse(ims=bytearray(unsigned), kvy=kvy, faults=faults)
+
+        assert serder.pre not in kvy.kevers
+        assert len(faults) == 1
+        fault = faults[0]
+        assert fault.kind == 'ValidationError'
+        assert fault.disp == Disps.resume  # stream was not flushed
+        assert fault.offset is None  # locus is the msg, not a byte position
+        assert fault.pre == serder.pre  # extraction succeeded so identity is known
+        assert fault.sn == 0
+        assert fault.said == serder.said
+
+    """Done Test"""
+
+
+def test_parser_fault_discriminates_and_resumes():
+    """Test that an out of order event is distinguishable from a stream that
+    does not parse, and that the msgs after it still parse.
+
+    This is the discrimination an embedder cannot make today. Both conditions
+    establish less than the stream should, and .parse returns normally for
+    both"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    # an interaction event for an identifier whose inception has not been seen
+    ixn = interact(pre=serder.pre, dig=serder.said, sn=5, **V1_KWA)
+    msgs = bytearray(ixn.raw)
+    msgs.extend(Counter(Codens.ControllerIdxSigs, count=1, version=Vrsn_1_0).qb64b)
+    msgs.extend(signers[0].sign(ixn.raw, index=0).qb64b)
+    msgs.extend(msg)  # the well formed inception follows it
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parse(ims=bytearray(msgs), kvy=kvy, faults=faults)
+
+        assert len(faults) == 1
+        fault = faults[0]
+        assert fault.kind == 'OutOfOrderError'  # not merely 'ValidationError'
+        assert fault.disp == Disps.resume
+        assert fault.pre == ixn.pre
+        assert fault.sn == 5
+        assert fault.said == ixn.said
+        assert isinstance(fault.ex, OutOfOrderError)
+
+        # resumed, so the inception behind the bad event was still accepted
+        assert serder.pre in kvy.kevers
+
+    """Done Test"""
+
+
+def test_parser_fault_sized_group():
+    """Test that a fault inside a sized group is reported as such, since the
+    group was already stripped from the stream and only its contents are lost"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    # generic group contents are attachments with no message body in front of
+    # them, so extracting inside the group fails. All CESR so quadlet aligned
+    inner = bytearray(Counter(Codens.ControllerIdxSigs, count=1,
+                              version=Vrsn_1_0).qb64b)
+    inner.extend(signers[0].sign(serder.raw, index=0).qb64b)
+    assert len(inner) % 4 == 0
+
+    msgs = bytearray(Counter(Codens.GenericGroup, count=len(inner) // 4,
+                             version=Vrsn_1_0).qb64b)
+    msgs.extend(inner)
+    msgs.extend(msg)  # the well formed inception follows the bad group
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parse(ims=bytearray(msgs), kvy=kvy, faults=faults)
+
+        assert len(faults) == 1
+        fault = faults[0]
+        assert fault.kind == 'SizedGroupError'
+        assert fault.disp == Disps.group  # group lost, stream not flushed
+        assert fault.offset == len(msgs) - len(msg)  # end of the failed group
+
+        # only the group was lost, so the msg behind it was still accepted
+        assert serder.pre in kvy.kevers
+
+    """Done Test"""
+
+
+def test_parser_fault_sink_on_parse_one():
+    """Test that .parseOne reports faults the same way .parse does"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    unsigned = bytearray(serder.raw)
+    unsigned.extend(Counter(Codens.ControllerIdxSigs, count=0,
+                            version=Vrsn_1_0).qb64b)
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        faults = []
+        parser.parseOne(ims=bytearray(unsigned), kvy=kvy, faults=faults)
+        assert len(faults) == 1
+        assert faults[0].kind == 'ValidationError'
+        assert faults[0].disp == Disps.resume
+        assert faults[0].pre == serder.pre
+        assert faults[0].said == serder.said
+
+        faults = []
+        parser.parseOne(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+        assert faults[0].kind == 'ShortageError'
+        assert faults[0].disp == Disps.flush
+        assert faults[0].offset == len(serder.raw) + 4
+        # note: .onceParsator falls through into .msgProcess after a failed
+        # extraction, where exts is unbound, so a spurious follow-on fault may
+        # trail this one. Deliberately not asserted either way here, since that
+        # is a parser bug this sink only makes visible
+
+    """Done Test"""
+
+
+def test_parser_fault_sink_never_raises():
+    """Test that collecting a fault cannot itself break parsing, whatever the
+    sink is handed"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_1_0)
+
+        # a deque works as well as a list, since only .append is used
+        faults = deque()
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+        assert len(faults) == 1
+        assert faults[0].kind == 'ShortageError'
+
+        # and a bounded one does not grow without limit on a long lived stream
+        faults = deque(maxlen=1)
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=faults)
+        assert len(faults) == 1
+
+    """Done Test"""
+
+
+def test_parser_fault_sink_on_live_stream():
+    """Test that the always running .parsator reports faults, since a server
+    parsing a live stream is the case an embedder most needs to diagnose"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    orphan = bytearray(Counter(Codens.ControllerIdxSigs, count=1,
+                               version=Vrsn_2_0).qb64b)
+    orphan.extend(signers[0].sign(serder.raw, index=0).qb64b)
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_2_0)
+
+        ims = bytearray()
+        faults = []
+        parsator = parser.parsator(ims=ims, kvy=kvy, faults=faults)
+        next(parsator)  # nothing in the stream yet
+        assert not faults
+
+        ims.extend(orphan)  # stream goes bad while the server is running
+        next(parsator)
+
+        assert len(faults) == 1
+        assert faults[0].kind == 'ColdStartError'
+        assert faults[0].disp == Disps.flush
+
+    """Done Test"""
+
+
+def test_parser_fault_unexpected_error():
+    """Test that an error which is neither an extraction failure nor a post
+    extraction validation failure still reaches the sink instead of vanishing.
+
+    A substream that declares a CESR major version the parser does not support
+    raises InvalidVersionError, which is a MaterialError, so it unwinds past
+    every handler that names a cause and lands in the blanket arm"""
+    logger.setLevel("ERROR")
+
+    # generic group whose contents declare an unsupported genus version
+    gvc = Counter(countB64=Counter.verToB64(major=3, minor=0),
+                  code=Codens.KERIACDCGenusVersion, version=Vrsn_2_0)
+    inner = bytearray(gvc.qb64b)
+    assert len(inner) % 4 == 0
+
+    msgs = bytearray(Counter(Codens.GenericGroup, count=len(inner) // 4,
+                             version=Vrsn_2_0).qb64b)
+    msgs.extend(inner)
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        parser = Parser(version=Vrsn_2_0)
+
+        faults = []
+        parser.parse(ims=bytearray(msgs), kvy=kvy, faults=faults)
+
+        assert len(faults) == 1
+        assert faults[0].kind == 'InvalidVersionError'
+        assert faults[0].disp == Disps.resume
+
+    """Done Test"""
+
+
+def test_parser_fault_sink_instance_default():
+    """Test that a sink given to the Parser is used by calls that do not
+    provide one of their own, and that a per call sink overrides it"""
+    logger.setLevel("ERROR")
+    signers, serder, msg = faultFixture()
+
+    with openDB(name="validator") as valDB:
+        kvy = Kevery(db=valDB, lax=False, local=False)
+        standing = []
+        parser = Parser(version=Vrsn_1_0, faults=standing)
+
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy)
+        assert len(standing) == 1
+        assert standing[0].kind == 'ShortageError'
+
+        oneoff = []
+        parser.parse(ims=bytearray(msg)[:-20], kvy=kvy, faults=oneoff)
+        assert len(oneoff) == 1  # per call sink got it
+        assert len(standing) == 1  # and the standing sink did not
+
+    """Done Test"""
+
+
 if __name__ == "__main__":
     test_parser_v1_basic()
     test_parser_v1_version()
@@ -5144,3 +5531,16 @@ if __name__ == "__main__":
     test_group_parsator()
     test_parse_native_cesr_fixed_field()
     test_parser_v2_substream()
+    test_parser_fault_sink_default_off()
+    test_parser_fault_sink_silent_when_clean()
+    test_fault_kind()
+    test_parser_fault_truncated_stream()
+    test_parser_fault_cold_start()
+    test_parser_fault_post_extraction()
+    test_parser_fault_discriminates_and_resumes()
+    test_parser_fault_sized_group()
+    test_parser_fault_sink_on_parse_one()
+    test_parser_fault_sink_never_raises()
+    test_parser_fault_sink_on_live_stream()
+    test_parser_fault_unexpected_error()
+    test_parser_fault_sink_instance_default()


### PR DESCRIPTION
I'm tagging @SmithSamuelM and @pfeairheller , because I think you're the two most likely to have an opinion about this. But I'd love to hear from anyone else.

There's a comment at src/keri/core/parsing.py:894 that reads `except ExtractionError as ex:  # maybe this needs to be more granular`. This PR adds that feature. If the PR were a line or two, I think it would be a no-brainer, but since it requires some real code additions, that make me ask if it's worth the cost. I need the feature but could leave it in my clone of keripy, permanently diverging in this one way from what keripy provides. Or maybe you'll convince me that the whole feature is wrong-headed... This is why I left the PR in draft state for the moment.

Parser knows exactly why it declined a message and then discards that knowledge. parse(), parseOne() and allParsator() never raise to a caller, and the 4 except pairs they share log the exception and drop it. kering.py defines something like 81 error classes, and the distinctions are real: ShortageError means more bytes may help and ColdStartError means they won't; MissingWitnessSignatureError and LikelyDuplicitousError describe very different states of the world. All of it is available at the moment of failure and gone one frame later.

The parser has already made that coarser judgement. Each of those pairs splits into `except (ColdStartError, ExtractionError)`, which flushes the stream, and `except (ValidationError, Exception)`, which resumes — recoverable against not. That decision doesn't leave the frame either.

I'm building a library that consumes keripy goodness (lots of background that I'll skip), and I need the distinction for two reasons. When a stream fails to establish what it should, I have to decide how much of that failure to impute to which party's reputation, and I have to be able to say what the flaw in the evidence actually was. Right now a truncated stream, a desynced stream, an under-witnessed log, a duplicitous log, and a stream about the wrong identifier all look the same from outside: each establishes less than it should, and parse returns normally in every case. Working out which one happened means reading database residue and guessing at control flow that has already run.

So this doesn't change what parse does. It gives it somewhere to put what it currently only logs. There's an optional faults= argument on the parse entry points, threaded down through the generators, defaulting to a new Parser.faults which itself defaults to None. When nothing is supplied, nothing is collected and no code path changes. Parser is tolerant by design and should stay that way: it's a streaming parser, a live stream legitimately runs short and has to wait for more bytes rather than fail, and anything that made parse raise by default would break every existing consumer.

Each recovered error appends a frozen Fault. It carries a kind, which is the class name of the most specific KeriError in the chain; a disp, which is flush, resume, or group, the disposition the call site had already chosen; an offset, which is a lower bound on how many bytes the call consumed before the fault, and exact for a fixed stream; pre, sn, and said when the message had already been extracted; and the exception itself, with its chain intact and its traceback cleared.

kind walks the chain rather than naming the class the handler caught, because the parser rewraps as it unwinds. A truncated stream arrives at allParsator as an ExtractionError() with no message at all, and only the chain still says ShortageError. The walk follows `__cause__` where the raise was explicit and `__context__` otherwise, since all 4 SizedGroupError raise sites are bare raises inside an except block.

I got this next part wrong in my own first draft, so it's stated in the Fault docstring as plainly as I could manage. A Fault records what the parse loop did, not what became of the message. Kevery escrows an event and then raises, so OutOfOrderError, MissingWitnessSignatureError, MissingDelegationError, and LikelyDuplicitousError all produce a Fault for an event that a later processEscrows() may accept in full. Reading a Fault as "this message was rejected" turns ordinary out-of-order KEL traffic into a hard failure. A Fault isn't duplicity evidence either, since the conflicting event is already preserved in the duplicitous escrow, and "Likely" in LikelyDuplicitousError is there for a reason. This seems to me like the part most worth pushing on if it looks wrong.

disp got a namedtuple codex because it has three values. kind didn't, because pinning a normative name for each of 81 exception classes seems like your call rather than mine. As it stands, kind is documented as keripy's internal taxonomy: not stable across releases, not shared with signify-ts or KERIA, and an unrecognized value to be treated as a fault rather than as no fault. If you'd rather it were normative and cross-implementation, I can do that instead.

*Two things I ran into while reading these paths look like bugs rather than gaps*, and I left both alone because fixing either changes behavior. At parsing.py:1082, self.mucodes.FixBodyGroup raises AttributeError under CESR v1, because MessageUniversalCodex_1_0 defines only NonNativeBodyGroup — native bodies being v2-only. A v1 stream that starts on a stray attachment counter therefore dies with an AttributeError rather than with the ColdStartError two branches below, which seems to be what was intended. And at parsing.py:864, `except (ExtractionError, Exception) as ex: raise ExtractionError from ex` swallows SizedGroupError, whose docstring says the group has already been stripped and so the stream must not be flushed. Rewrapped as a plain ExtractionError it reaches allParsator and flushes the rest of the stream anyway. I can open issues for both if that's useful.

I added a bunch of new tests in tests/core/test_parsing.py, over both CESR v1 and v2 streams, native CESR bodies included. No existing test changed, and all of them pass cleanly.
