### PR TITLE
chore(ci): move workflow actions off deprecated Node runtimes

### DIFF
--- a/.github/workflows/publish-keripy.yml
+++ b/.github/workflows/publish-keripy.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: gleif/keri
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: images/keripy.dockerfile

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -14,9 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - name: Install dependencies
@@ -51,9 +51,9 @@ jobs:
     name: ${{ matrix.job_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
@@ -95,9 +95,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
         run: |
           pytest --cov=./ --cov-report=xml
       - name: Upload
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -117,9 +117,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - name: Install dependencies
@@ -134,9 +134,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - name: Install keripy (required for autodoc imports)
@@ -168,7 +168,7 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.cache.outputs.GITHUB_REPOSITORY_NAME }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set outputs
         id: cache
         run: |
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: interop
         run: |
           echo ${{ secrets.CR_PAT }} | docker login ghcr.io --username ${{ secrets.CR_USER }} --password-stdin

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         runtime: [chrome, firefox, node]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - uses: pyodide/pyodide-actions/install-browser@v2


### PR DESCRIPTION
Closes #1581.

While working in a layer of code that has a keripy dependency, I noticed that we have deprecated github actions that use old versions of node.js.

Every pinned action except the two composite pyodide ones was on node16 or node20, so each workflow run logged a deprecation warning. This moves them: `actions/checkout` from v3 and v4 to v6, `actions/setup-python` from v5 to v6, `codecov/codecov-action` from v4 to v5, and in the docker publish workflow `docker/login-action` v2 to v4, `docker/metadata-action` v4 to v6, and `docker/build-push-action` v3 to v7.

Each target is the first version that leaves the deprecated runtime, with one exception. For checkout, v5 would be enough, but `spec-examples-drift.yml` already pins v6, so v6 puts the whole repo on one version instead of two. I confirmed each target's runtime by reading `using:` out of its `action.yml` at that tag rather than going by release notes.

No inputs changed across any of the six bumps, and the ones actually in use here still exist in the target versions.

The part I can't demonstrate is the docker workflow. `publish-keripy.yml` triggers only on `workflow_dispatch`, so no CI job touches it, and those three are also the largest jumps. Someone with the Docker Hub secrets should dispatch it once before relying on it.

CI on this PR is likely to sit queued or fail in job setup for reasons unrelated to the change. GitHub declared a major Actions outage at 15:22Z today, and jobs are currently dying at "Failed to resolve action download info" before checkout.
