### PR TITLE
fix: preserve group hab rmids across Habery reinitialization

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -336,14 +336,16 @@ class Habery:
             if habord.mid and not habord.sid:
                 hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
                                rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
-                               name=habord.name, pre=pre, temp=self.temp, smids=habord.smids)
+                               name=habord.name, pre=pre, temp=self.temp,
+                               smids=habord.smids, rmids=habord.rmids)
                 groups.append(habord)
             elif habord.sid and not habord.mid:
                 hab = SignifyHab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
                                  rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                                  name=habord.name, pre=habord.sid)
             elif habord.sid and habord.mid:
-                hab = SignifyGroupHab(smids=habord.smids, ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+                hab = SignifyGroupHab(smids=habord.smids, rmids=habord.rmids,
+                                      ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
                                       rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                                       name=habord.name, pre=pre)
                 groups.append(habord)

--- a/tests/app/test_habbing.py
+++ b/tests/app/test_habbing.py
@@ -565,6 +565,61 @@ def test_habery_reinitialization():
     """End Test"""
 
 
+def test_habery_reinitialization_group_rmids():
+    """Test Reinitializing Habery preserves a group hab's rotation member roster
+
+    A group's rotation members (rmids) may be a superset of its current signing
+    members (smids), e.g. one current signer with a next-key commitment spread
+    across three members. loadHabs must pass the stored rmids through to
+    GroupHab, otherwise GroupHab.__init__ defaults rmids to smids and the
+    rotation roster silently collapses on every reinitialization.
+    """
+
+    # keri falls back to ~/.keri when /usr/local/var is not writable, so scrub both
+    for head in ('/usr/local/var/keri', os.path.expanduser('~/.keri')):
+        if os.path.exists(f'{head}/cf/test/grouprmids-test.json'):
+            os.remove(f'{head}/cf/test/grouprmids-test.json')
+        if os.path.exists(f'{head}/db/test/grouprmids-test'):
+            shutil.rmtree(f'{head}/db/test/grouprmids-test')
+        if os.path.exists(f'{head}/ks/test/grouprmids-test'):
+            shutil.rmtree(f'{head}/ks/test/grouprmids-test')
+
+    name = "grouprmids-test"
+
+    with habbing.openHby(name=name, base="test", temp=False, clear=True) as hby:
+        hab1 = hby.makeHab(name="mem1", icount=1)
+        hab2 = hby.makeHab(name="mem2", icount=1)
+        hab3 = hby.makeHab(name="mem3", icount=1)
+
+        smids = [hab1.pre]
+        rmids = [hab1.pre, hab2.pre, hab3.pre]
+        ghab = hby.makeGroupHab(group="the-group", mhab=hab1,
+                                smids=smids, rmids=rmids,
+                                isith='1', nsith='["1/2", "1/2", "1/2"]',
+                                toad=0, wits=[])
+        gpre = ghab.pre
+        assert ghab.smids == smids
+        assert ghab.rmids == rmids
+
+        habord = hby.db.habs.get(keys=(gpre,))
+        assert habord.smids == smids
+        assert habord.rmids == rmids  # roster stored correctly
+
+    with habbing.openHby(name=name, base="test", temp=False) as hby:
+        ghab = hby.habs[gpre]
+        assert isinstance(ghab, habbing.GroupHab)
+        assert ghab.smids == smids
+        assert ghab.rmids == rmids  # roster survives reload, not collapsed to smids
+
+    hby.close(clear=True)
+    hby.cf.close(clear=True)
+    assert not os.path.exists(hby.cf.path)
+    assert not os.path.exists(hby.db.path)
+    assert not os.path.exists(hby.ks.path)
+
+    """End Test"""
+
+
 def test_habery_signatory():
     with habbing.openHby(salt=core.Salter(raw=b'0123456789abcdef').qb64) as hby:
         signer = hby.signator


### PR DESCRIPTION
## Summary

`Habery.loadHabs` constructs `GroupHab` (and `SignifyGroupHab`) passing only `smids=habord.smids` — the stored `rmids` are never passed. `GroupHab.__init__` defaults `rmids` to `smids` when not provided:

```python
self.rmids = rmids or smids
```

so **every Habery reinitialization silently collapses a group's rotation-member roster to its current signing members**, even though the `HabitatRecord` on disk is correct.

## Impact

For any group whose rotation authority is spread wider than its current signing set (e.g. 3 current signers with a 7-member next-key commitment, `nt` weighted across 7), every flow that reads `ghab.rmids` after a restart operates on the wrong member set:

- multisig exn recipient lists gossip proposals only to the collapsed set;
- rotation events built from `ghab.smids`/`ghab.rmids` re-commit a shrunken next-key membership (`n` drops from 7 digests to 3), permanently ejecting the other rotation members if the event completes;
- delegation-approval anchoring rotations (EstOnly delegators) inherit the same collapsed set.

Observed in production: a Root multisig delegator with `k`=3/`n`=7 rendered and proposed with only 3 rotation members after every application start, on every member's machine, while the stored record held all 7 rmids the whole time.

## Fix

Pass `rmids=habord.rmids` through in both `loadHabs` branches (`GroupHab` and `SignifyGroupHab`). A stored `None` behaves exactly as before (defaults to smids).

## Testing

New regression test `test_habery_reinitialization_group_rmids`: builds a group with `rmids ⊃ smids` in a non-temp Habery, reopens it, and asserts the roster survives (fails on the base branch, passes with the fix). `tests/app/test_habbing.py` and `tests/app/test_grouping.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)