### PR TITLE
feat: tocks from configs, envs superseding file

### DIFF
--- a/scripts/demo/test_scripts.sh
+++ b/scripts/demo/test_scripts.sh
@@ -6,6 +6,19 @@ script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${script_dir}"/demo-scripts.sh
 source "${script_dir}"/basic/script-utils.sh
 
+# Keep tocks at one Doist tick for the script suite, for speed.
+# These overrides supply tocks when later KLI processes
+# open/reopen Haberies without having an external config file.
+export KERI_WITNESS_ESCROW_TOCK=0.03125
+export KERI_INDIRECTOR_ESCROW_TOCK=0.03125
+export KERI_MAILBOX_ESCROW_TOCK=0.03125
+export KERI_POLLER_CONNECT_TOCK=0.03125
+export KERI_REACTOR_ESCROW_TOCK=0.03125
+export KERI_REACTANT_ESCROW_TOCK=0.03125
+export KERI_REGISTRAR_ESCROW_TOCK=0.03125
+export KERI_CREDENTIALER_ESCROW_TOCK=0.03125
+export KERI_COUNSELOR_ESCROW_TOCK=0.03125
+export KERI_ANCHORER_ESCROW_TOCK=0.03125
 # Launch witnesses in background
 kli witness demo &
 wits=$!

--- a/scripts/keri/cf/demo-witness-oobis.json
+++ b/scripts/keri/cf/demo-witness-oobis.json
@@ -4,5 +4,36 @@
     "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
     "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller",
     "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller"
-  ]
+  ],
+  "tocks": {
+    "witnessMsg": 0.0,
+    "witnessEscrow": 0.03125,
+    "witnessCue": 0.0,
+    "indirectorMsg": 0.0,
+    "indirectorCue": 0.0,
+    "indirectorEscrow": 0.03125,
+    "mailboxPoll": 0.0,
+    "mailboxMsg": 0.0,
+    "mailboxEscrow": 0.03125,
+    "pollerEvent": 0.0,
+    "pollerConnect": 0.03125,
+    "receiptIntercept": 0.0,
+    "reactorMsg": 0.0,
+    "reactorCue": 0.0,
+    "reactorEscrow": 0.03125,
+    "reactantMsg": 0.0,
+    "reactantCue": 0.0,
+    "reactantEscrow": 0.03125,
+    "respondant": 0.0,
+    "receiptor": 0.0,
+    "oobi": 0.0,
+    "witnessReceiptor": 0.0,
+    "witnessReceiptorIdle": 1.0,
+    "witnessInquisitor": 0.0,
+    "witnessPublisher": 0.0,
+    "registrarEscrow": 0.03125,
+    "credentialerEscrow": 0.03125,
+    "counselorEscrow": 0.03125,
+    "anchorerEscrow": 0.03125
+  }
 }

--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -14,7 +14,7 @@ from hio.help import decking, Hict
 
 from socket import gaierror
 
-from . import httping, forwarding, tocking
+from . import httping, forwarding
 from .. import help
 from .. import kering
 from .. import core
@@ -45,10 +45,12 @@ class Receiptor(doing.DoDoer):
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.gets = gets if gets is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
+        self.hby = hby
         self.clienter = httping.Clienter()
 
-        doers = [self.clienter, doing.doify(self.witDo), doing.doify(self.gitDo)]
-        self.hby = hby
+        doers = [self.clienter,
+                 doing.doify(self.witDo, tock=hby.tocks["receiptor"]),
+                 doing.doify(self.gitDo, tock=hby.tocks["receiptor"])]
 
         super(Receiptor, self).__init__(doers=doers)
 
@@ -272,10 +274,13 @@ class WitnessReceiptor(doing.DoDoer):
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
         self.auths = auths if auths is not None else dict()
+        self.idleTock = hby.tocks["witnessReceiptorIdle"]
 
-        super(WitnessReceiptor, self).__init__(doers=[doing.doify(self.receiptDo)], **kwa)
+        super(WitnessReceiptor, self).__init__(
+            doers=[doing.doify(self.receiptDo,
+                               tock=hby.tocks["witnessReceiptor"])], **kwa)
 
-    def receiptDo(self, tymth=None, tock=None, **kwa):
+    def receiptDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that sends events to witnesses and propagates receipts.
 
 
@@ -287,8 +292,7 @@ class WitnessReceiptor(doing.DoDoer):
         Pushes the original request to self.cues to signal completion
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessReceiptorTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.msgs:
@@ -334,13 +338,13 @@ class WitnessReceiptor(doing.DoDoer):
                                 witer.msgs.append(bytearray(fmsg))
 
                         witer.msgs.append(bytearray(msg))  # make a copy
-                        _ = (yield self.tock)
+                        _ = (yield tock)
 
                     while True: # wait for all receipts to arrive
                         wigs = hab.db.getWigs(dgkey)
                         if len(wigs) == len(wits):
                             break
-                        _ = yield self.tock
+                        _ = yield tock
 
                 # If we started with all our receipts, exit unless told to force resubmit of all receipts
                 if completed and not self.force:
@@ -378,13 +382,13 @@ class WitnessReceiptor(doing.DoDoer):
                     rctMsg.extend(eventing.messagize(serder=rserder, wigers=wigers))
 
                     witer.msgs.append(rctMsg)
-                    _ = (yield self.tock)
+                    _ = (yield tock)
 
                 while True:
                     done = True
                     for witer in witers:
                         if not witer.idle:
-                            yield 1.0
+                            yield self.idleTock
                             done = False
                             break
                     if done:
@@ -393,9 +397,9 @@ class WitnessReceiptor(doing.DoDoer):
                 self.remove(witers)
 
                 self.cues.push(evt)
-                yield self.tock
+                yield tock
 
-            yield self.tock
+            yield tock
 
 
 class WitnessInquisitor(doing.DoDoer):
@@ -426,9 +430,11 @@ class WitnessInquisitor(doing.DoDoer):
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = decking.Deck()
 
-        super(WitnessInquisitor, self).__init__(doers=[doing.doify(self.msgDo)], **kwa)
+        super(WitnessInquisitor, self).__init__(
+            doers=[doing.doify(self.msgDo,
+                               tock=hby.tocks["witnessInquisitor"])], **kwa)
 
-    def msgDo(self, tymth=None, tock=None, **opts):
+    def msgDo(self, tymth=None, tock=0.0, **opts):
         """
         Doer loop that sends one query to one selected endpoint.
 
@@ -437,12 +443,11 @@ class WitnessInquisitor(doing.DoDoer):
         Pushes the raw sent message to self.sent to signal completion.
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessInquisitorTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while not self.msgs:
-                yield self.tock
+                yield tock
 
             evt = self.msgs.popleft()
             pre = evt["pre"]
@@ -498,11 +503,11 @@ class WitnessInquisitor(doing.DoDoer):
             witer.msgs.append(bytearray(msg))
 
             while not witer.sent:
-                yield self.tock
+                yield tock
 
             self.sent.append(witer.sent.popleft())
 
-            yield self.tock
+            yield tock
 
     def query(self, pre, r="logs", sn='0', fn='0', src=None, hab=None, anchor=None, wits=None, **kwa):
         """Create, sign, and queue a `qry` KEL query request against the attester for the prefix for later sending.
@@ -556,16 +561,17 @@ class WitnessPublisher(doing.DoDoer):
         self.posted = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
-        super(WitnessPublisher, self).__init__(doers=[doing.doify(self.sendDo)], **kwa)
+        super(WitnessPublisher, self).__init__(
+            doers=[doing.doify(self.sendDo,
+                               tock=hby.tocks["witnessPublisher"])], **kwa)
 
-    def sendDo(self, tymth=None, tock=None, **opts):
+    def sendDo(self, tymth=None, tock=0.0, **opts):
         """Doer loop that sends queued messages to each witness.
 
         Pushes the original request to self.cues to signal completion
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessPublisherTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.msgs:
@@ -587,19 +593,19 @@ class WitnessPublisher(doing.DoDoer):
                     witer.msgs.append(bytearray(msg))  # make a copy so everyone munges their own
                     self.extend([witer])
 
-                    _ = (yield self.tock)
+                    _ = (yield tock)
 
                 while witers:
                     witer = witers.pop()
                     while not witer.idle:
-                        _ = (yield self.tock)
+                        _ = (yield tock)
 
                 self.remove(witers)
                 self.cues.push(evt)
 
-                yield self.tock
+                yield tock
 
-            yield self.tock
+            yield tock
 
     def sent(self, said):
         """ Check if message with given SAID was sent

--- a/src/keri/app/delegating.py
+++ b/src/keri/app/delegating.py
@@ -48,7 +48,13 @@ class Anchorer(doing.DoDoer):
         self.proxy = proxy
         self.auths = auths
 
-        super(Anchorer, self).__init__(doers=[self.witq, self.witDoer, self.postman, doing.doify(self.escrowDo)], **kwa)
+        super(Anchorer, self).__init__(
+            doers=[self.witq,
+                   self.witDoer,
+                   self.postman,
+                   doing.doify(self.escrowDo,
+                               tock=hby.tocks["anchorerEscrow"])],
+            **kwa)
 
     def delegation(self, pre, sn=None, proxy=None, auths=None):
         if pre not in self.hby.habs:
@@ -109,7 +115,7 @@ class Anchorer(doing.DoDoer):
         Parameters:
             tymth (function): injected function wrapper closure returned by .tymen() of
                 Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock (float): injected initial tock value.  Default to 1.0 to slow down processing
+            tock (float): injected scheduler cadence
 
         """
         # enter context
@@ -119,7 +125,7 @@ class Anchorer(doing.DoDoer):
 
         while True:
             self.processEscrows()
-            yield 0.5
+            yield tock
 
     def processEscrows(self):
         self.processPartialWitnessEscrow()

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -8,7 +8,6 @@ simple direct mode demo support classes
 import itertools
 from hio.base import doing
 
-from . import tocking
 from .. import help
 from ..core import eventing, routing
 from ..core import parsing
@@ -172,9 +171,9 @@ class Reactor(doing.DoDoer):
         self.exc = exchanger
         self.direct = True if direct else False
         doers = doers if doers is not None else []
-        doers.extend([doing.doify(self.msgDo),
-                      doing.doify(self.escrowDo),
-                      doing.doify(self.cueDo)])
+        doers.extend([doing.doify(self.msgDo, tock=hab.tocks["reactorMsg"]),
+                      doing.doify(self.escrowDo, tock=hab.tocks["reactorEscrow"]),
+                      doing.doify(self.cueDo, tock=hab.tocks["reactorCue"])])
 
         self.kevery = eventing.Kevery(db=self.hab.db,
                                       lax=False,
@@ -208,7 +207,7 @@ class Reactor(doing.DoDoer):
         self.client.wind(tymth)
 
 
-    def msgDo(self, tymth=None, tock=None, **opts):
+    def msgDo(self, tymth=None, tock=0.0, **opts):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -229,8 +228,7 @@ class Reactor(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactorMsgTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         if self.parser.ims:
             logger.info("Client %s received:\n%s\n...\n", self.hab.name, self.parser.ims[:1024])
         parser = self.parser.parsator(local=True)
@@ -239,10 +237,10 @@ class Reactor(doing.DoDoer):
                 next(parser)
             except StopIteration as ex:
                 return ex.value  # should never get here except forced close
-            yield self.tock
+            yield tock
 
 
-    def cueDo(self, tymth=None, tock=None, **opts):
+    def cueDo(self, tymth=None, tock=0.0, **opts):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -262,16 +260,15 @@ class Reactor(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactorCueTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         while True:
             for msg in self.hab.processCuesIter(self.kevery.cues):
                 self.sendMessage(msg, label="chit or receipt")
-                yield self.tock  # throttle just do one cue at a time
-            yield self.tock
+                yield tock  # throttle just do one cue at a time
+            yield tock
         return False  # should never get here except forced close
 
-    def escrowDo(self, tymth=None, tock=None, **opts):
+    def escrowDo(self, tymth=None, tock=0.0, **opts):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -291,13 +288,12 @@ class Reactor(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactorEscrowTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         while True:
             self.kevery.processEscrows()
             if self.tvy is not None:
                 self.tvy.processEscrows()
-            yield self.tock
+            yield tock
         return False  # should never get here except forced close
 
     def sendMessage(self, msg, label=""):
@@ -532,9 +528,9 @@ class Reactant(doing.DoDoer):
         self.remoter = remoter  # use remoter for both rx and tx
 
         doers = doers if doers is not None else []
-        doers.extend([doing.doify(self.msgDo),
-                      doing.doify(self.cueDo),
-                      doing.doify(self.escrowDo)])
+        doers.extend([doing.doify(self.msgDo, tock=hab.tocks["reactantMsg"]),
+                      doing.doify(self.cueDo, tock=hab.tocks["reactantCue"]),
+                      doing.doify(self.escrowDo, tock=hab.tocks["reactantEscrow"])])
 
         #  needs unique kevery with ims per remoter connnection
         rvy = routing.Revery(db=hab.db)
@@ -573,7 +569,7 @@ class Reactant(doing.DoDoer):
         self.remoter.wind(tymth)
 
 
-    def msgDo(self, tymth=None, tock=None, **opts):
+    def msgDo(self, tymth=None, tock=0.0, **opts):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -594,8 +590,7 @@ class Reactant(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactantMsgTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         if self.parser.ims:
             logger.info("Server %s: received:\n%s\n...\n", self.hab.name,
                         self.parser.ims[:1024])
@@ -603,7 +598,7 @@ class Reactant(doing.DoDoer):
         return done  # should nover get here except forced close
 
 
-    def cueDo(self, tymth=None, tock=None, **opts):
+    def cueDo(self, tymth=None, tock=0.0, **opts):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -623,20 +618,19 @@ class Reactant(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactantCueTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         while True:
             for msg in self.hab.processCuesIter(self.kevery.cues):
                 if isinstance(msg, list):
                     msg = bytearray(itertools.chain(*msg))
 
                 self.sendMessage(msg, label="chit or receipt or replay")
-                yield self.tock  # throttle just do one cue at a time
-            yield self.tock
+                yield tock  # throttle just do one cue at a time
+            yield tock
         return False  # should never get here except forced close
 
 
-    def escrowDo(self, tymth=None, tock=None, **opts):
+    def escrowDo(self, tymth=None, tock=0.0, **opts):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -656,13 +650,12 @@ class Reactant(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReactantEscrowTock
-        _ = (yield self.tock)  # enter context
+        _ = (yield tock)  # enter context
         while True:
             self.kevery.processEscrows()
             if self.tevery is not None:
                 self.tevery.processEscrows()
-            yield self.tock
+            yield tock
         return False  # should never get here except forced close
 
     def sendMessage(self, msg, label=""):

--- a/src/keri/app/grouping.py
+++ b/src/keri/app/grouping.py
@@ -30,7 +30,9 @@ class Counselor(doing.DoDoer):
         self.witDoer = agenting.Receiptor(hby=self.hby)
         self.witq = agenting.WitnessInquisitor(hby=hby)
 
-        doers = [self.swain, self.witq, self.witDoer, doing.doify(self.escrowDo)]
+        doers = [self.swain, self.witq, self.witDoer,
+                 doing.doify(self.escrowDo,
+                             tock=hby.tocks["counselorEscrow"])]
 
         super(Counselor, self).__init__(doers=doers, **kwa)
 
@@ -72,7 +74,7 @@ class Counselor(doing.DoDoer):
 
         return True
 
-    def escrowDo(self, tymth, tock=1.0, **kwa):
+    def escrowDo(self, tymth, tock=0.5, **kwa):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:
@@ -91,12 +93,11 @@ class Counselor(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.processEscrows()
-            yield 0.5
+            yield tock
 
     def processEscrows(self):
         self.processPartialSignedEscrow()

--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -13,7 +13,7 @@ from hio.base import doing
 from hio.help import hicting
 
 from keri.peer import exchanging
-from . import keeping, configing
+from . import keeping, configing, tocking
 from .. import help
 from .. import kering
 from .. import core
@@ -147,7 +147,8 @@ class Habery:
     """
 
     def __init__(self, *, name='test', base="", temp=False,
-                 ks=None, db=None, cf=None, clear=False, headDirPath=None, **kwa):
+                 ks=None, db=None, cf=None, tocks=None, clear=False,
+                 headDirPath=None, **kwa):
         """
         Initialize instance.
 
@@ -164,6 +165,7 @@ class Habery:
             ks (Keeper):  keystore lmdb subclass instance
             db (Baser): database lmdb subclass instance
             cf (Configer): config file instance
+            tocks (dict): scheduler configuration; simplifies per-Habery tuning and testing
             clear (bool): True means remove resource directory upon close when
                             reopening
                           False means do not remove directory upon close when
@@ -220,7 +222,6 @@ class Habery:
                                                                temp=self.temp,
                                                                reopen=True,
                                                                clear=clear)
-
         self.mgr = None  # wait to setup until after ks is known to be opened
         self.rtr = routing.Router()
         self.rvy = routing.Revery(db=self.db, rtr=self.rtr)
@@ -237,6 +238,7 @@ class Habery:
         # init setup elseqhere after databases are opened if not below
         self._inits = kwa
         self._inits['temp'] = temp  # add temp for seed from bran tier override
+        self.tocks = tocks  # allow preconfigured tocks
 
         if self.db.opened and self.ks.opened:
             self.setup(**self._inits)  # finish setup later
@@ -334,7 +336,7 @@ class Habery:
 
             # create Hab instance and inject dependencies
             if habord.mid and not habord.sid:
-                hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+                hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, tocks=self.tocks, mgr=self.mgr,
                                rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                                name=habord.name, pre=pre, temp=self.temp, smids=habord.smids)
                 groups.append(habord)
@@ -348,7 +350,7 @@ class Habery:
                                       name=habord.name, pre=pre)
                 groups.append(habord)
             else:
-                hab = Hab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+                hab = Hab(ks=self.ks, db=self.db, cf=self.cf, tocks=self.tocks, mgr=self.mgr,
                           rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                           name=habord.name, pre=pre, temp=self.temp)
 
@@ -393,7 +395,7 @@ class Habery:
             raise kering.ConfigurationError("Hab namespace names are not allowed to contain the '.' character")
 
         cf = cf if cf is not None else self.cf
-        hab = Hab(ks=self.ks, db=self.db, cf=cf, mgr=self.mgr,
+        hab = Hab(ks=self.ks, db=self.db, cf=cf, tocks=self.tocks, mgr=self.mgr,
                   rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                   name=name, ns=ns, temp=self.temp)
 
@@ -465,7 +467,7 @@ class Habery:
         kwa["migers"] = migers
 
         # create group Hab in this Habery
-        hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+        hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, tocks=self.tocks, mgr=self.mgr,
                        rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                        name=group, ns=ns, mhab=mhab, smids=smids, rmids=rmids, temp=self.temp)
 
@@ -512,7 +514,7 @@ class Habery:
                                                     f" next members ={rmids}")
 
         # create group Hab in this Habery
-        hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, mgr=self.mgr,
+        hab = GroupHab(ks=self.ks, db=self.db, cf=self.cf, tocks=self.tocks, mgr=self.mgr,
                        rtr=self.rtr, rvy=self.rvy, kvy=self.kvy, psr=self.psr,
                        name=group, ns=ns, mhab=mhab, smids=smids, rmids=rmids, temp=self.temp)
 
@@ -767,6 +769,13 @@ class Habery:
 
         """
         conf = self.cf.get()
+        cfTocks = None
+        if self.tocks is not None:
+            cfTocks = self.tocks  # allow preconfigured tocks; for testing
+        elif "tocks" in conf:
+            cfTocks = conf["tocks"]
+        self.tocks = tocking.resolveTocks(cfTocks=cfTocks)
+
         if "dt" in conf:  # datetime of config file
             dt = help.fromIso8601(conf["dt"])  # raises error if not convert
             if "iurls" in conf:  # process OOBI URLs
@@ -951,7 +960,7 @@ class BaseHab:
     """
 
     def __init__(self, ks, db, cf, mgr, rtr, rvy, kvy, psr, *,
-                 name='test', ns=None, pre=None, temp=False):
+                 name='test', ns=None, pre=None, temp=False, tocks=None):
         """
         Initialize instance.
 
@@ -977,6 +986,7 @@ class BaseHab:
         self.db = db  # injected
         self.ks = ks  # injected
         self.cf = cf  # injected
+        self.tocks = tocks  # injected
         self.mgr = mgr  # injected
         self.rtr = rtr  # injected
         self.rvy = rvy  # injected

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -19,7 +19,7 @@ from hio.core.tcp import serving
 from hio.help import decking
 
 import keri.app.oobiing
-from . import directing, storing, httping, forwarding, agenting, oobiing, tocking
+from . import directing, storing, httping, forwarding, agenting, oobiing
 from .habbing import GroupHab
 from .. import help, kering
 from ..core import (eventing, parsing, routing, coring, serdering,
@@ -161,7 +161,10 @@ class WitnessStart(doing.DoDoer):
         self.responses = responses if responses is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
 
-        doers = [doing.doify(self.start), doing.doify(self.msgDo), doing.doify(self.escrowDo), doing.doify(self.cueDo)]
+        doers = [doing.doify(self.start, tock=0.0),
+                 doing.doify(self.msgDo, tock=hab.tocks["witnessMsg"]),
+                 doing.doify(self.escrowDo, tock=hab.tocks["witnessEscrow"]),
+                 doing.doify(self.cueDo, tock=hab.tocks["witnessCue"])]
         super().__init__(doers=doers, **opts)
 
     def start(self, tymth=None, tock=0.0, **kwa):
@@ -181,7 +184,7 @@ class WitnessStart(doing.DoDoer):
 
         print("Witness", self.hab.name, ":", self.hab.pre)
 
-    def msgDo(self, tymth=None, tock=None, **kwa):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -195,8 +198,7 @@ class WitnessStart(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessMsgTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         if self.parser.ims:
             logger.debug("Client %s received:\n%s\n...\n", self.kvy, self.parser.ims[:1024])
@@ -206,9 +208,9 @@ class WitnessStart(doing.DoDoer):
                 next(parser)
             except StopIteration as ex:
                 return ex.value  # should never get here except forced close
-            yield self.tock
+            yield tock
 
-    def escrowDo(self, tymth=None, tock=None, **kwa):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery and .tevery escrows.
@@ -222,8 +224,7 @@ class WitnessStart(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessEscrowTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.kvy.processEscrows()
@@ -232,9 +233,9 @@ class WitnessStart(doing.DoDoer):
                 self.tvy.processEscrows()
             self.exc.processEscrow()
 
-            yield self.tock
+            yield tock
 
-    def cueDo(self, tymth=None, tock=None, **kwa):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -253,8 +254,7 @@ class WitnessStart(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.WitnessCueTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.cues:
@@ -264,8 +264,8 @@ class WitnessStart(doing.DoDoer):
                     self.queries.append(cue)
                 else:
                     self.responses.append(cue)
-                yield self.tock
-            yield self.tock
+                yield tock
+            yield tock
 
 class Indirector(doing.DoDoer):
     """
@@ -353,10 +353,10 @@ class Indirector(doing.DoDoer):
                                      framed=True,
                                      kvy=self.kevery)
         doers = doers if doers is not None else []
-        doers.extend([doing.doify(self.msgDo),
-                      doing.doify(self.escrowDo)])
+        doers.extend([doing.doify(self.msgDo, tock=hab.tocks["indirectorMsg"]),
+                      doing.doify(self.escrowDo, tock=hab.tocks["indirectorEscrow"])])
         if self.direct:
-            doers.extend([doing.doify(self.cueDo)])
+            doers.extend([doing.doify(self.cueDo, tock=hab.tocks["indirectorCue"])])
 
         super(Indirector, self).__init__(doers=doers, **kwa)
         if self.tymth:
@@ -370,7 +370,7 @@ class Indirector(doing.DoDoer):
         super(Indirector, self).wind(tymth)
         self.client.wind(tymth)
 
-    def msgDo(self, tymth=None, tock=None, **kwa):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -389,8 +389,7 @@ class Indirector(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.IndirectorMsgTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         if self.parser.ims:
             logger.debug("Client %s received:\n%s\n...\n", self.hab.pre, self.parser.ims[:1024])
@@ -400,9 +399,9 @@ class Indirector(doing.DoDoer):
                 next(parser)
             except StopIteration as ex:
                 return ex.value  # should never get here except forced close
-            yield self.tock
+            yield tock
 
-    def cueDo(self, tymth=None, tock=None, **kwa):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery.cues deque
@@ -421,16 +420,15 @@ class Indirector(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.IndirectorCueTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             for msg in self.hab.processCuesIter(self.kevery.cues):
                 self.sendMessage(msg, label="chit or receipt")
-                yield self.tock  # throttle just do one cue at a time
-            yield self.tock
+                yield tock  # throttle just do one cue at a time
+            yield tock
 
-    def escrowDo(self, tymth=None, tock=None, **kwa):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -449,12 +447,11 @@ class Indirector(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.IndirectorEscrowTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.kevery.processEscrows()
-            yield self.tock
+            yield tock
 
     def sendMessage(self, msg, label=""):
         """
@@ -548,9 +545,9 @@ class MailboxDirector(doing.DoDoer):
         self.ims = ims if ims is not None else bytearray()
 
         doers = []
-        doers.extend([doing.doify(self.pollDo),
-                      doing.doify(self.msgDo),
-                      doing.doify(self.escrowDo)])
+        doers.extend([doing.doify(self.pollDo, tock=hby.tocks["mailboxPoll"]),
+                      doing.doify(self.msgDo, tock=hby.tocks["mailboxMsg"]),
+                      doing.doify(self.escrowDo, tock=hby.tocks["mailboxEscrow"])])
 
         self.rtr = routing.Router()
         self.rvy = rvy if rvy is not None else routing.Revery(db=self.hby.db, rtr=self.rtr, cues=cues,
@@ -590,7 +587,7 @@ class MailboxDirector(doing.DoDoer):
         """
         super(MailboxDirector, self).wind(tymth)
 
-    def pollDo(self, tymth=None, tock=None, **kwa):
+    def pollDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:
            doifiable Doist compatible generator method
@@ -600,14 +597,13 @@ class MailboxDirector(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.MailboxPollTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         habs = list(self.hby.habs.values())
         for hab in habs:
             if hab.accepted:
                 self.addPollers(hab)
-                _ = (yield self.tock)
+                _ = (yield tock)
 
         while True:
             pres = oset(self.hby.habs.keys())
@@ -616,12 +612,12 @@ class MailboxDirector(doing.DoDoer):
                     hab = self.hby.habs[pre]
                     if hab.accepted:
                         self.addPollers(hab=hab)
-                        _ = (yield self.tock)
+                        _ = (yield tock)
 
             for msg in self.processPollIter():
                 self.ims.extend(msg)
-                _ = (yield self.tock)
-            _ = (yield self.tock)
+                _ = (yield tock)
+            _ = (yield tock)
 
     def addPollers(self, hab):
         """ add mailbox pollers for every witness for this prefix identifier
@@ -668,7 +664,7 @@ class MailboxDirector(doing.DoDoer):
             msg = mail.pop(0)
             yield msg
 
-    def msgDo(self, tymth=None, tock=None, **kwa):
+    def msgDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns doifiable Doist compatibile generator method (doer dog) to process
             incoming message stream of .kevery
@@ -687,8 +683,7 @@ class MailboxDirector(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.MailboxMsgTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         parser = self.parser.parsator(local=True)
         while True:
@@ -696,9 +691,9 @@ class MailboxDirector(doing.DoDoer):
                 next(parser)
             except StopIteration as ex:
                 return ex.value  # should never get here except forced close
-            yield self.tock
+            yield tock
 
-    def escrowDo(self, tymth=None, tock=None, **kwa):
+    def escrowDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             .kevery escrows.
@@ -717,8 +712,7 @@ class MailboxDirector(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.MailboxEscrowTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.kvy.processEscrows()
@@ -730,7 +724,7 @@ class MailboxDirector(doing.DoDoer):
             if self.verifier is not None:
                 self.verifier.processEscrows()
 
-            yield self.tock
+            yield tock
 
     @property
     def times(self):
@@ -767,11 +761,14 @@ class Poller(doing.DoDoer):
         self.msgs = None if msgs is not None else decking.Deck()
         self.times = dict()
 
-        doers = [doing.doify(self.eventDo)]
+        # pollerConnect: failure backoff when wit end unavailable, stops rapid retries and logging
+        self.connectTock = hab.tocks["pollerConnect"]
+
+        doers = [doing.doify(self.eventDo, tock=hab.tocks["pollerEvent"])]
 
         super(Poller, self).__init__(doers=doers, **kwa)
 
-    def eventDo(self, tymth=None, tock=None, **kwa):
+    def eventDo(self, tymth=None, tock=0.0, **kwa):
         """
         Returns:
            doifiable Doist compatible generator method
@@ -780,8 +777,7 @@ class Poller(doing.DoDoer):
             add result of doify on this method to doers list
         """
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.PollerEventTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         witrec = self.hab.db.tops.get((self.pre, self.witness))
         if witrec is None:
@@ -792,7 +788,7 @@ class Poller(doing.DoDoer):
                 client, clientDoer = agenting.httpClient(self.hab, self.witness)
             except kering.MissingEntryError as e:
                 traceback.print_exception(e, file=sys.stderr)  # logging
-                yield self.tock
+                yield self.connectTock
                 continue
 
             self.extend([clientDoer])
@@ -813,7 +809,7 @@ class Poller(doing.DoDoer):
             httping.createCESRRequest(msg, client, dest=self.witness)
 
             while client.requests:
-                yield self.tock
+                yield tock
 
             created = helping.nowUTC()
             while True:
@@ -839,13 +835,13 @@ class Poller(doing.DoDoer):
                         continue
 
                     self.msgs.append(msg.encode("utf=8"))
-                    yield self.tock
+                    yield tock
 
                     witrec.topics[tpc] = int(idx)
                     self.times[tpc] = helping.nowUTC()
                     self.hab.db.tops.pin((self.pre, self.witness), witrec)
 
-                yield 0.25
+                yield tock
             yield self.retry / 1000
 
 
@@ -1062,7 +1058,10 @@ class ReceiptEnd(doing.DoDoer):
         self.psr = parsing.Parser(framed=True,
                                   kvy=self.hab.kvy)
 
-        super(ReceiptEnd, self).__init__(doers=[doing.doify(self.interceptDo)])
+        super(ReceiptEnd, self).__init__(
+            doers=[doing.doify(self.interceptDo,
+                               tock=hab.tocks["receiptIntercept"])]
+        )
 
     def on_post(self, req, rep):
         """  Receipt POST endpoint handler
@@ -1169,7 +1168,7 @@ class ReceiptEnd(doing.DoDoer):
         rep.status = falcon.HTTP_200
         rep.data = rct
 
-    def interceptDo(self, tymth=None, tock=None, **kwa):
+    def interceptDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             Kevery and Tevery cues deque
@@ -1179,8 +1178,7 @@ class ReceiptEnd(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.ReceiptInterceptTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.inbound:  # iteratively process each cue in cues
@@ -1197,9 +1195,9 @@ class ReceiptEnd(doing.DoDoer):
                 else:
                     self.outbound.append(cue)
 
-                yield self.tock
+                yield tock
 
-            yield self.tock
+            yield tock
 
 
 class QueryEnd:

--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -301,7 +301,8 @@ class Oobiery:
 
         self.cues = cues if cues is not None else decking.Deck()
         self.clients = dict()
-        self.doers = [self.clienter, doing.doify(self.scoobiDo)]
+        self.doers = [self.clienter,
+                      doing.doify(self.scoobiDo, tock=hby.tocks["oobi"])]
 
     def registerReplyRoutes(self, router):
         """ Register the routes for processing messages embedded in `rpy` event messages
@@ -647,7 +648,8 @@ class Authenticator:
         self.hby = hby
         self.clienter = clienter if clienter is not None else httping.Clienter()
         self.clients = dict()
-        self.doers = [self.clienter, doing.doify(self.authzDo)]
+        self.doers = [self.clienter,
+                      doing.doify(self.authzDo, tock=hby.tocks["oobi"])]
 
     def request(self, wurl, obr):
         client = self.clienter.request("GET", wurl)

--- a/src/keri/app/storing.py
+++ b/src/keri/app/storing.py
@@ -9,7 +9,7 @@ from hio.base import doing
 from hio.help import decking
 from ordered_set import OrderedSet as oset
 
-from . import forwarding, tocking
+from . import forwarding
 from .. import help
 from ..core import coring, serdering
 from ..core.coring import MtrDex
@@ -196,7 +196,9 @@ class Respondant(doing.DoDoer):
         self.mbx = mbx if mbx is not None else Mailboxer(name=self.hby.name)
         self.postman = forwarding.Poster(hby=self.hby, mbx=self.mbx)
 
-        doers = [self.postman, doing.doify(self.responseDo), doing.doify(self.cueDo)]
+        doers = [self.postman,
+                 doing.doify(self.responseDo, tock=hby.tocks["respondant"]),
+                 doing.doify(self.cueDo, tock=hby.tocks["respondant"])]
         super(Respondant, self).__init__(doers=doers, **kwa)
 
     def responseDo(self, tymth=None, tock=0.0, **kwa):
@@ -213,8 +215,7 @@ class Respondant(doing.DoDoer):
 
         # enter context
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.reps:
@@ -241,11 +242,11 @@ class Respondant(doing.DoDoer):
                 logger.debug("exn body=\n%s\n", exn.pretty())
                 self.postman.send(recipient, topic=topic, serder=exn, hab=forwardHab, attachment=eattach)
 
-                yield self.tock  # throttle just do one cue at a time
+                yield tock  # throttle just do one cue at a time
 
-            yield self.tock
+            yield tock
 
-    def cueDo(self, tymth=None, tock=None, **kwa):
+    def cueDo(self, tymth=None, tock=0.0, **kwa):
         """
          Returns doifiable Doist compatibile generator method (doer dog) to process
             Kevery and Tevery cues deque
@@ -255,12 +256,11 @@ class Respondant(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock if tock is not None else tocking.RespondantCueTock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while not self.cues:
-                yield self.tock
+                yield tock
 
             cue = self.cues.pull() # self.cues.popleft()
             cueKin = cue["kin"]  # type or kind of cue
@@ -325,4 +325,4 @@ class Respondant(doing.DoDoer):
             else:
                 self.cues.push(cue)
 
-            yield self.tock
+            yield tock

--- a/src/keri/app/tocking.py
+++ b/src/keri/app/tocking.py
@@ -2,88 +2,287 @@
 """
 keri.app.tocking module
 
-Centralized tock configuration for doer timing control.
+Centralized tock configuration for doer timing control (HIO scheduler tocks).
 Environment variables allow production tuning without code changes.
 
 Tock values control how frequently doer methods execute:
-- 0.0 = run as soon as possible (~31ms doist interval)
+- 0.0 = run on the next scheduler cycle (~31ms doist interval)
 - 1.0 = run once per second
 - Higher values = less frequent execution, lower CPU usage
 
+Defaults keep active message, cue, queue, and network-progress paths on the
+next Doist cycle by using the lowest possible value, 0.0.
+Positive, non-zero defaults are reserved for full escrow scans and
+genuine idle or retry waits so they do not throttle active queue throughput.
+
+These tocks cover operator-meaningful
+ - inbound processing (HTTP/TCP receives)
+ - outbound dispatch (HTTP/TCP client sends)
+ - workflow coordination (other DoDoer coordination)
+ - deferred-state scans (escrows)
+ - maintenance and backoff
 """
+
+import math
 import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .. import kering
+
+@dataclass(frozen=True)
+class Tock:
+    """Environment variable and default for one scheduler cadence."""
+
+    env: str
+    default: float = 0.0
+
+
+@dataclass(frozen=True)
+class TockAlias:
+    """Describe one coarse tock group setting and its config targets."""
+
+    env: str
+    targets: tuple[str, ...]
+
+# Default tock values mapped by config prop name to Tock env key and default
+TOCKS: dict[str, Tock] = {}
+
+# tock subkeys cascading tock to "targets" subkeys, if present
+TOCK_ALIASES: dict[str, TockAlias] = {}
 
 # Witness component tocks (indirecting.py - WitnessStart)
 KERI_WITNESS_MSG_TOCK_KEY = "KERI_WITNESS_MSG_TOCK"
 KERI_WITNESS_ESCROW_TOCK_KEY = "KERI_WITNESS_ESCROW_TOCK"
 KERI_WITNESS_CUE_TOCK_KEY = "KERI_WITNESS_CUE_TOCK"
 
-WitnessMsgTock = float(os.getenv(KERI_WITNESS_MSG_TOCK_KEY, "0.0"))
-WitnessEscrowTock = float(os.getenv(KERI_WITNESS_ESCROW_TOCK_KEY, "1.0"))
-WitnessCueTock = float(os.getenv(KERI_WITNESS_CUE_TOCK_KEY, "0.25"))
+TOCKS["witnessMsg"] = Tock(KERI_WITNESS_MSG_TOCK_KEY, 0.0)
+TOCKS["witnessEscrow"] = Tock(KERI_WITNESS_ESCROW_TOCK_KEY, 1.0)
+TOCKS["witnessCue"] = Tock(KERI_WITNESS_CUE_TOCK_KEY, 0.0)
 
 # Indirector component tocks (indirecting.py - Indirector)
 KERI_INDIRECTOR_MSG_TOCK_KEY = "KERI_INDIRECTOR_MSG_TOCK"
 KERI_INDIRECTOR_CUE_TOCK_KEY = "KERI_INDIRECTOR_CUE_TOCK"
 KERI_INDIRECTOR_ESCROW_TOCK_KEY = "KERI_INDIRECTOR_ESCROW_TOCK"
 
-IndirectorMsgTock = float(os.getenv(KERI_INDIRECTOR_MSG_TOCK_KEY, "0.0"))
-IndirectorCueTock = float(os.getenv(KERI_INDIRECTOR_CUE_TOCK_KEY, "0.25"))
-IndirectorEscrowTock = float(os.getenv(KERI_INDIRECTOR_ESCROW_TOCK_KEY, "1.0"))
+TOCKS["indirectorMsg"] = Tock(KERI_INDIRECTOR_MSG_TOCK_KEY, 0.0)
+TOCKS["indirectorCue"] = Tock(KERI_INDIRECTOR_CUE_TOCK_KEY, 0.0)
+TOCKS["indirectorEscrow"] = Tock(KERI_INDIRECTOR_ESCROW_TOCK_KEY, 1.0)
 
 # MailboxDirector component tocks (indirecting.py - MailboxDirector)
 KERI_MAILBOX_POLL_TOCK_KEY = "KERI_MAILBOX_POLL_TOCK"
 KERI_MAILBOX_MSG_TOCK_KEY = "KERI_MAILBOX_MSG_TOCK"
 KERI_MAILBOX_ESCROW_TOCK_KEY = "KERI_MAILBOX_ESCROW_TOCK"
 
-MailboxPollTock = float(os.getenv(KERI_MAILBOX_POLL_TOCK_KEY, "0.5"))
-MailboxMsgTock = float(os.getenv(KERI_MAILBOX_MSG_TOCK_KEY, "0.0"))
-MailboxEscrowTock = float(os.getenv(KERI_MAILBOX_ESCROW_TOCK_KEY, "1.0"))
+TOCKS["mailboxPoll"] = Tock(KERI_MAILBOX_POLL_TOCK_KEY, 0.0)
+TOCKS["mailboxMsg"] = Tock(KERI_MAILBOX_MSG_TOCK_KEY, 0.0)
+TOCKS["mailboxEscrow"] = Tock(KERI_MAILBOX_ESCROW_TOCK_KEY, 1.0)
 
 # Poller component tocks (indirecting.py - Poller)
 KERI_POLLER_EVENT_TOCK_KEY = "KERI_POLLER_EVENT_TOCK"
+KERI_POLLER_CONNECT_TOCK_KEY = "KERI_POLLER_CONNECT_TOCK"
 
-PollerEventTock = float(os.getenv(KERI_POLLER_EVENT_TOCK_KEY, "0.5"))
+TOCKS["pollerEvent"] = Tock(KERI_POLLER_EVENT_TOCK_KEY, 0.0)
+TOCKS["pollerConnect"] = Tock(KERI_POLLER_CONNECT_TOCK_KEY, 0.5)
 
 # ReceiptEnd component tocks (indirecting.py - ReceiptEnd)
 KERI_RECEIPT_INTERCEPT_TOCK_KEY = "KERI_RECEIPT_INTERCEPT_TOCK"
 
-ReceiptInterceptTock = float(os.getenv(KERI_RECEIPT_INTERCEPT_TOCK_KEY, "0.1"))
+TOCKS["receiptIntercept"] = Tock(KERI_RECEIPT_INTERCEPT_TOCK_KEY, 0.0)
 
 # Reactor component tocks (directing.py - Reactor)
 KERI_REACTOR_MSG_TOCK_KEY = "KERI_REACTOR_MSG_TOCK"
 KERI_REACTOR_CUE_TOCK_KEY = "KERI_REACTOR_CUE_TOCK"
 KERI_REACTOR_ESCROW_TOCK_KEY = "KERI_REACTOR_ESCROW_TOCK"
 
-ReactorMsgTock = float(os.getenv(KERI_REACTOR_MSG_TOCK_KEY, "0.0"))
-ReactorCueTock = float(os.getenv(KERI_REACTOR_CUE_TOCK_KEY, "0.25"))
-ReactorEscrowTock = float(os.getenv(KERI_REACTOR_ESCROW_TOCK_KEY, "1.0"))
+TOCKS["reactorMsg"] = Tock(KERI_REACTOR_MSG_TOCK_KEY, 0.0)
+TOCKS["reactorCue"] = Tock(KERI_REACTOR_CUE_TOCK_KEY, 0.0)
+TOCKS["reactorEscrow"] = Tock(KERI_REACTOR_ESCROW_TOCK_KEY, 1.0)
 
 # Reactant component tocks (directing.py - Reactant)
 KERI_REACTANT_MSG_TOCK_KEY = "KERI_REACTANT_MSG_TOCK"
 KERI_REACTANT_CUE_TOCK_KEY = "KERI_REACTANT_CUE_TOCK"
 KERI_REACTANT_ESCROW_TOCK_KEY = "KERI_REACTANT_ESCROW_TOCK"
 
-ReactantMsgTock = float(os.getenv(KERI_REACTANT_MSG_TOCK_KEY, "0.0"))
-ReactantCueTock = float(os.getenv(KERI_REACTANT_CUE_TOCK_KEY, "0.25"))
-ReactantEscrowTock = float(os.getenv(KERI_REACTANT_ESCROW_TOCK_KEY, "1.0"))
+TOCKS["reactantMsg"] = Tock(KERI_REACTANT_MSG_TOCK_KEY, 0.0)
+TOCKS["reactantCue"] = Tock(KERI_REACTANT_CUE_TOCK_KEY, 0.0)
+TOCKS["reactantEscrow"] = Tock(KERI_REACTANT_ESCROW_TOCK_KEY, 1.0)
 
 # Respondant component tocks (storing.py - Respondant)
 KERI_RESPONDANT_CUE_TOCK_KEY = "KERI_RESPONDANT_CUE_TOCK"
 
-RespondantCueTock = float(os.getenv(KERI_RESPONDANT_CUE_TOCK_KEY, "0.25"))
+TOCKS["respondant"] = Tock(KERI_RESPONDANT_CUE_TOCK_KEY, 0.0)
+
+# Receiptor component tocks (agenting.py - Receiptor)
+KERI_RECEIPTOR_TOCK_KEY = "KERI_RECEIPTOR_TOCK"
+
+TOCKS["receiptor"] = Tock(KERI_RECEIPTOR_TOCK_KEY, 0.0)
+
+# OOBI resolution and authentication (oobiing.py)
+KERI_OOBI_TOCK_KEY = "KERI_OOBI_TOCK"
+
+TOCKS["oobi"] = Tock(KERI_OOBI_TOCK_KEY, 0.0)
 
 # WitnessReceiptor component tocks (agenting.py)
 KERI_WITNESS_RECEIPTOR_TOCK_KEY = "KERI_WITNESS_RECEIPTOR_TOCK"
+KERI_WITNESS_RECEIPTOR_IDLE_TOCK_KEY = "KERI_WITNESS_RECEIPTOR_IDLE_TOCK"
 
-WitnessReceiptorTock = float(os.getenv(KERI_WITNESS_RECEIPTOR_TOCK_KEY, "0.0"))
+TOCKS["witnessReceiptor"] = Tock(KERI_WITNESS_RECEIPTOR_TOCK_KEY, 0.0)
+TOCKS["witnessReceiptorIdle"] = Tock(KERI_WITNESS_RECEIPTOR_IDLE_TOCK_KEY, 1.0)
 
 # WitnessInquisitor component tocks (agenting.py)
 KERI_WITNESS_INQUISITOR_TOCK_KEY = "KERI_WITNESS_INQUISITOR_TOCK"
 
-WitnessInquisitorTock = float(os.getenv(KERI_WITNESS_INQUISITOR_TOCK_KEY, "1.0"))
+TOCKS["witnessInquisitor"] = Tock(KERI_WITNESS_INQUISITOR_TOCK_KEY, 0.0)
 
 # WitnessPublisher component tocks (agenting.py)
 KERI_WITNESS_PUBLISHER_TOCK_KEY = "KERI_WITNESS_PUBLISHER_TOCK"
 
-WitnessPublisherTock = float(os.getenv(KERI_WITNESS_PUBLISHER_TOCK_KEY, "0.25"))
+TOCKS["witnessPublisher"] = Tock(KERI_WITNESS_PUBLISHER_TOCK_KEY, 0.0)
+
+# Registrar and Credentialer tocks, and prior VDR group alias (credentialing.py)
+KERI_VDR_ESCROW_TOCK_KEY = "KERI_VDR_ESCROW_TOCK"
+TOCK_ALIASES["vdrEscrow"] = TockAlias(
+    env=KERI_VDR_ESCROW_TOCK_KEY,
+    targets=("registrarEscrow", "credentialerEscrow"),
+)
+
+KERI_REGISTRAR_ESCROW_TOCK_KEY = "KERI_REGISTRAR_ESCROW_TOCK"
+KERI_CREDENTIALER_ESCROW_TOCK_KEY = "KERI_CREDENTIALER_ESCROW_TOCK"
+
+TOCKS["registrarEscrow"] = Tock(KERI_REGISTRAR_ESCROW_TOCK_KEY, 0.5)
+TOCKS["credentialerEscrow"] = Tock(KERI_CREDENTIALER_ESCROW_TOCK_KEY, 0.5)
+
+# Counselor component tocks (grouping.py)
+KERI_COUNSELOR_ESCROW_TOCK_KEY = "KERI_COUNSELOR_ESCROW_TOCK"
+
+TOCKS["counselorEscrow"] = Tock(KERI_COUNSELOR_ESCROW_TOCK_KEY, 0.5)
+
+# Delegation escrow processing (delegating.py - Anchorer)
+KERI_ANCHORER_ESCROW_TOCK_KEY = "KERI_ANCHORER_ESCROW_TOCK"
+
+TOCKS["anchorerEscrow"] = Tock(KERI_ANCHORER_ESCROW_TOCK_KEY, 0.5)
+
+def _validateTock(value, source):
+    """Return a finite, non-negative float or raise ConfigurationError."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise kering.ConfigurationError(f"Invalid tock for {source}: {value!r}")
+
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0:
+        raise kering.ConfigurationError(f"Invalid tock for {source}: {value!r}")
+
+    return value
+
+
+def _parseEnvTock(value, source):
+    """Parse and validate an environment-variable tock."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise kering.ConfigurationError(f"Invalid tock for {source}: {value!r}")
+
+    try:
+        value = float(value)
+    except ValueError as ex:
+        raise kering.ConfigurationError(
+            f"Invalid tock for {source}: {value!r}"
+        ) from ex
+
+    return _validateTock(value, source)
+
+
+def resolveTocks(cfTocks=None, *, tocks=TOCKS,
+                 aliases=TOCK_ALIASES, environ=None, reserved=("signify",)):
+    """
+    Resolve and validate one scheduler configuration dictionary using the following precedence
+    rule: specific env > coarse env > specific config > coarse config > default.
+
+    Parameters:
+        cfTocks (dict): supplied configured tocks
+        tocks (dict): default tock configuration
+        aliases (dict): configuration target aliases (coarse grained tock definitions)
+        environ (dict): environment variables; defaulted from OS
+        reserved (list): reserved tock config subsections such as for Signify/KERIA tocks
+    """
+
+    cfTocks = {} if cfTocks is None else cfTocks
+    if not isinstance(cfTocks, Mapping):
+        raise kering.ConfigurationError(
+            f"Invalid tocks configuration: expected mapping, got {type(cfTocks).__name__}"
+        )
+
+    environ = os.environ if environ is None else environ
+    if not isinstance(environ, Mapping):
+        raise kering.ConfigurationError("Invalid tock environment mapping")
+
+    # strict - error on unknown tock config props
+    unknown = sorted(
+        key for key in cfTocks
+        if key not in tocks
+        and key not in aliases
+        and key not in reserved
+    )
+    if unknown:
+        raise kering.ConfigurationError(
+            f"Unknown tock configuration key(s): {', '.join(unknown)}"
+        )
+
+    # Validate supplied values before applying precedence, skipping reserved keys.
+    # Invalid values error even if valid coarse grained overrides are present.
+    validTocks = {}
+    for tockName, value in cfTocks.items():
+        if tockName in tocks:
+            validTocks[tockName] = _validateTock(value, f"tocks.{tockName}")
+        elif tockName in aliases:
+            validTocks[tockName] = _validateTock(value, f"tocks.{tockName}")
+
+    # read any tocks from environment vars, including supported group aliases
+    validEnvs = {}
+    for tockVals in tocks.values():
+        if tockVals.env in environ:
+            validEnvs[tockVals.env] = _parseEnvTock(
+                environ[tockVals.env], tockVals.env
+            )
+    for alias in aliases.values():
+        if alias.env in environ:
+            validEnvs[alias.env] = _parseEnvTock(
+                environ[alias.env], alias.env
+            )
+
+    # tock resolution precedence is:
+    # specific env > coarse env > specific config > coarse config > default
+    resolved = {}
+    # iterate over flat fine-grained tocks dict
+    for tockName, tockVals in tocks.items():
+        # specific env
+        if tockVals.env in validEnvs:
+            value = validEnvs[tockVals.env]
+        else:
+            value = None
+            # coarse env: alias env present means set target vals
+            for aliasVals in aliases.values():
+                if tockName in aliasVals.targets and aliasVals.env in validEnvs:
+                    value = validEnvs[aliasVals.env]
+                    break
+
+            # specific config: pull resolved value straight from config
+            if value is None and tockName in validTocks:
+                value = validTocks[tockName]
+
+            # coarse config: fallback set by coarse alias if specific config hasn't set it
+            if value is None:
+                for aliasName, aliasVals in aliases.items():
+                    if tockName in aliasVals.targets and aliasName in validTocks:
+                        value = validTocks[aliasName]
+                        break
+
+            # default - from above or caller supplied defaults
+            if value is None:
+                value = _validateTock(
+                    tockVals.default, f"default for tocks.{tockName}"
+                )
+
+        resolved[tockName] = value
+
+    return resolved

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -496,7 +496,9 @@ class Registrar(doing.DoDoer):
         self.witDoer = agenting.WitnessReceiptor(hby=self.hby)
         self.witPub = agenting.WitnessPublisher(hby=self.hby)
 
-        doers = [self.witDoer, self.witPub, doing.doify(self.escrowDo)]
+        doers = [self.witDoer, self.witPub,
+                 doing.doify(self.escrowDo,
+                             tock=hby.tocks["registrarEscrow"])]
 
         super(Registrar, self).__init__(doers=doers)
 
@@ -651,7 +653,7 @@ class Registrar(doing.DoDoer):
         said = self.rgy.reger.ctel.get(keys=(pre, seqner.qb64))
         return said is not None and self.witPub.sent(said=pre)
 
-    def escrowDo(self, tymth, tock=1.0, **kwa):
+    def escrowDo(self, tymth, tock=0.5, **kwa):
         """ Process escrows of group multisig identifiers waiting to be compeleted.
 
         Steps involve:
@@ -670,12 +672,11 @@ class Registrar(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.processEscrows()
-            yield 0.5
+            yield tock
 
     def processEscrows(self):
         """
@@ -769,7 +770,8 @@ class Credentialer(doing.DoDoer):
         self.rgy = rgy
         self.registrar = registrar
         self.verifier = verifier
-        doers = [doing.doify(self.escrowDo)]
+        doers = [doing.doify(self.escrowDo,
+                             tock=hby.tocks["credentialerEscrow"])]
 
         super(Credentialer, self).__init__(doers=doers)
 
@@ -877,7 +879,7 @@ class Credentialer(doing.DoDoer):
     def complete(self, said):
         return self.rgy.reger.ccrd.get(keys=(said,)) is not None
 
-    def escrowDo(self, tymth, tock=1.0, **kwa):
+    def escrowDo(self, tymth, tock=0.5, **kwa):
         """ Process escrows of group multisig identifiers waiting to be completed.
 
         Steps involve:
@@ -896,12 +898,11 @@ class Credentialer(doing.DoDoer):
         """
         # enter context
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.processEscrows()
-            yield 0.5
+            yield tock
 
     def processEscrows(self):
         """

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -16,34 +16,35 @@ from keri.db import basing, dbing
 from keri.vdr import eventing, viring
 
 
-def test_receiptor_cadences_are_generator_local():
-    receiptor = agenting.Receiptor(hby=object())
-    seen = []
+def test_receiptor_tocks_are_generator_local():
+    with habbing.openHby(name="receiptor-generator-tocks", temp=True) as hby:
+        receiptor = agenting.Receiptor(hby=hby)
+        seen = []
 
-    def receipt(pre, sn=None, auths=None, tock=0.0):
-        seen.append(("receipt", tock))
-        yield tock
+        def receipt(pre, sn=None, auths=None, tock=0.0):
+            seen.append(("receipt", tock))
+            yield tock
 
-    def get(pre, sn=None, tock=0.0):
-        seen.append(("get", tock))
-        yield tock
+        def get(pre, sn=None, tock=0.0):
+            seen.append(("get", tock))
+            yield tock
 
-    receiptor.receipt = receipt
-    receiptor.get = get
-    receiptor.msgs.append({"pre": "witness"})
-    receiptor.gets.append({"pre": "query"})
+        receiptor.receipt = receipt
+        receiptor.get = get
+        receiptor.msgs.append({"pre": "witness"})
+        receiptor.gets.append({"pre": "query"})
 
-    witness = receiptor.witDo(tymth=lambda: 0.0, tock=0.011)
-    query = receiptor.gitDo(tymth=lambda: 0.0, tock=0.013)
+        witness = receiptor.witDo(tymth=lambda: 0.0, tock=0.011)
+        query = receiptor.gitDo(tymth=lambda: 0.0, tock=0.013)
 
-    assert next(witness) == 0.011
-    assert next(query) == 0.013
-    assert next(witness) == 0.011
-    assert next(query) == 0.013
-    assert seen == [("receipt", 0.011), ("get", 0.013)]
+        assert next(witness) == 0.011
+        assert next(query) == 0.013
+        assert next(witness) == 0.011
+        assert next(query) == 0.013
+        assert seen == [("receipt", 0.011), ("get", 0.013)]
 
-    witness.close()
-    query.close()
+        witness.close()
+        query.close()
 
 
 def test_witness_receiptor(seeder):

--- a/tests/app/test_delegating.py
+++ b/tests/app/test_delegating.py
@@ -19,7 +19,9 @@ from keri.db import dbing
 def test_anchorer(seeder):
     with habbing.openHby(name="wes", salt=core.Salter(raw=b'wess-the-witness').qb64) as wesHby, \
             habbing.openHby(name="pal", salt=core.Salter(raw=b'0123456789abcdef').qb64) as palHby, \
-            habbing.openHby(name="del", salt=core.Salter(raw=b'0123456789ghijkl').qb64) as delHby:
+            habbing.openHby(name="del",
+                            salt=core.Salter(raw=b'0123456789ghijkl').qb64,
+                            tocks={"anchorerEscrow": 0.0}) as delHby:
 
         wesDoers = indirecting.setupWitness(alias="wes", hby=wesHby, tcpPort=5634, httpPort=5644)
         witDoer = agenting.Receiptor(hby=palHby)

--- a/tests/app/test_tocking.py
+++ b/tests/app/test_tocking.py
@@ -1,258 +1,212 @@
 # -*- encoding: utf-8 -*-
-"""
-tests.app.test_tocking module
-
-Tests for centralized tock configuration.
-"""
-import os
-import importlib
+"""Tests for centralized scheduler tock configuration."""
 
 import pytest
 
+from hio.base import doing
 
-def test_tocking_defaults():
-    """
-    Test default tock values when no environment variables are set
-    """
-    # Clear any existing env vars that might affect the test
-    env_keys = [
-        "KERI_WITNESS_MSG_TOCK",
-        "KERI_WITNESS_ESCROW_TOCK",
-        "KERI_WITNESS_CUE_TOCK",
-        "KERI_INDIRECTOR_MSG_TOCK",
-        "KERI_INDIRECTOR_CUE_TOCK",
-        "KERI_INDIRECTOR_ESCROW_TOCK",
-        "KERI_MAILBOX_POLL_TOCK",
-        "KERI_MAILBOX_MSG_TOCK",
-        "KERI_MAILBOX_ESCROW_TOCK",
-        "KERI_POLLER_EVENT_TOCK",
-        "KERI_RECEIPT_INTERCEPT_TOCK",
-        "KERI_REACTOR_MSG_TOCK",
-        "KERI_REACTOR_CUE_TOCK",
-        "KERI_REACTOR_ESCROW_TOCK",
-        "KERI_REACTANT_MSG_TOCK",
-        "KERI_REACTANT_CUE_TOCK",
-        "KERI_REACTANT_ESCROW_TOCK",
-        "KERI_RESPONDANT_CUE_TOCK",
-        "KERI_WITNESS_RECEIPTOR_TOCK",
-        "KERI_WITNESS_INQUISITOR_TOCK",
-        "KERI_WITNESS_PUBLISHER_TOCK",
-    ]
-
-    # Save and clear existing env vars
-    saved_env = {}
-    for key in env_keys:
-        if key in os.environ:
-            saved_env[key] = os.environ.pop(key)
-
-    try:
-        # Reload module to pick up cleared env vars
-        from keri.app import tocking
-        importlib.reload(tocking)
-
-        # Witness component tocks
-        assert tocking.WitnessMsgTock == 0.0
-        assert tocking.WitnessEscrowTock == 1.0
-        assert tocking.WitnessCueTock == 0.25
-
-        # Indirector component tocks
-        assert tocking.IndirectorMsgTock == 0.0
-        assert tocking.IndirectorCueTock == 0.25
-        assert tocking.IndirectorEscrowTock == 1.0
-
-        # MailboxDirector component tocks
-        assert tocking.MailboxPollTock == 0.5
-        assert tocking.MailboxMsgTock == 0.0
-        assert tocking.MailboxEscrowTock == 1.0
-
-        # Poller component tocks
-        assert tocking.PollerEventTock == 0.5
-
-        # ReceiptEnd component tocks
-        assert tocking.ReceiptInterceptTock == 0.1
-
-        # Reactor component tocks
-        assert tocking.ReactorMsgTock == 0.0
-        assert tocking.ReactorCueTock == 0.25
-        assert tocking.ReactorEscrowTock == 1.0
-
-        # Reactant component tocks
-        assert tocking.ReactantMsgTock == 0.0
-        assert tocking.ReactantCueTock == 0.25
-        assert tocking.ReactantEscrowTock == 1.0
-
-        # Respondant component tocks
-        assert tocking.RespondantCueTock == 0.25
-
-        # WitnessReceiptor component tocks
-        assert tocking.WitnessReceiptorTock == 0.0
-
-        # WitnessInquisitor component tocks
-        assert tocking.WitnessInquisitorTock == 1.0
-
-        # WitnessPublisher component tocks
-        assert tocking.WitnessPublisherTock == 0.25
-
-    finally:
-        # Restore saved env vars
-        for key, value in saved_env.items():
-            os.environ[key] = value
-        # Reload to restore original state
-        importlib.reload(tocking)
-
-    """Done Test"""
+from keri import kering
+from keri.app import configing, habbing, tocking
 
 
-def test_tocking_env_override():
-    """
-    Test that environment variables properly override default tock values
-    """
-    # Save existing env vars
-    env_overrides = {
-        "KERI_WITNESS_MSG_TOCK": "2.5",
-        "KERI_WITNESS_ESCROW_TOCK": "3.0",
-        "KERI_WITNESS_CUE_TOCK": "0.5",
-        "KERI_INDIRECTOR_MSG_TOCK": "1.0",
-        "KERI_INDIRECTOR_CUE_TOCK": "0.75",
-        "KERI_INDIRECTOR_ESCROW_TOCK": "2.0",
-        "KERI_MAILBOX_POLL_TOCK": "1.5",
-        "KERI_MAILBOX_MSG_TOCK": "0.1",
-        "KERI_MAILBOX_ESCROW_TOCK": "2.5",
-        "KERI_POLLER_EVENT_TOCK": "1.0",
-        "KERI_RECEIPT_INTERCEPT_TOCK": "0.5",
-        "KERI_REACTOR_MSG_TOCK": "0.5",
-        "KERI_REACTOR_CUE_TOCK": "0.5",
-        "KERI_REACTOR_ESCROW_TOCK": "2.0",
-        "KERI_REACTANT_MSG_TOCK": "0.5",
-        "KERI_REACTANT_CUE_TOCK": "0.5",
-        "KERI_REACTANT_ESCROW_TOCK": "2.0",
-        "KERI_RESPONDANT_CUE_TOCK": "0.5",
-        "KERI_WITNESS_RECEIPTOR_TOCK": "0.5",
-        "KERI_WITNESS_INQUISITOR_TOCK": "2.0",
-        "KERI_WITNESS_PUBLISHER_TOCK": "0.5",
+def test_tocking_defaults_are_effective_runtime_defaults():
+    tocks = tocking.resolveTocks(environ={})
+
+    assert isinstance(tocks, dict)
+    assert len(tocks) == 29
+    assert set(tocks) == set(tocking.TOCKS)
+    assert set(tocking.TOCK_ALIASES) == {"vdrEscrow"}
+    nonzero_defaults = {
+        "witnessEscrow": 1.0,
+        "indirectorEscrow": 1.0,
+        "mailboxEscrow": 1.0,
+        "pollerConnect": 0.5,
+        "reactorEscrow": 1.0,
+        "reactantEscrow": 1.0,
+        "witnessReceiptorIdle": 1.0,
+        "registrarEscrow": 0.5,
+        "credentialerEscrow": 0.5,
+        "counselorEscrow": 0.5,
+        "anchorerEscrow": 0.5,
+    }
+    assert {key: tocks[key] for key in nonzero_defaults} == nonzero_defaults
+
+    zero_defaults = set(tocks) - set(nonzero_defaults)
+    assert all(tocks[key] == 0.0 for key in zero_defaults)
+
+
+def test_tocking_specific_config_precedes_coarse_config():
+    tocks = tocking.resolveTocks(
+        {
+            "pollerEvent": 0.4,
+            "pollerConnect": 0.125,
+            "vdrEscrow": 0.6,
+            "registrarEscrow": 0.2,
+        },
+        environ={},
+    )
+
+    assert tocks["pollerEvent"] == 0.4
+    assert tocks["pollerConnect"] == 0.125
+
+    # cascaded from vdrEscrow
+    assert tocks["credentialerEscrow"] == 0.6
+    # specific config override
+    assert tocks["registrarEscrow"] == 0.2
+
+
+def test_tocking_environment_precedes_config_and_coarse_environment():
+    tocks = tocking.resolveTocks(
+        {
+            "pollerEvent": 0.9,
+            "pollerConnect": 0.8,
+            "registrarEscrow": 0.7,
+            "credentialerEscrow": 0.6,
+        },
+        environ={
+            "KERI_POLLER_EVENT_TOCK": "0.5",
+            "KERI_POLLER_CONNECT_TOCK": "0.25",
+            "KERI_VDR_ESCROW_TOCK": "0.4",
+            "KERI_REGISTRAR_ESCROW_TOCK": "0.125",
+        },
+    )
+
+    assert tocks["pollerEvent"] == 0.5
+    assert tocks["pollerConnect"] == 0.25
+    assert tocks["registrarEscrow"] == 0.125
+    assert tocks["credentialerEscrow"] == 0.4
+
+
+def test_every_tock_has_an_environment_override():
+    # return dict with all tocks set to values like 0.001, 0.002, and so forth
+    expected = {
+        key: (idx + 1) / 1000
+        for idx, key in enumerate(tocking.TOCKS)
+    }
+    # set tock associated environment vars to expected values set above
+    environ = {
+        tocking.TOCKS[key].env: str(value)
+        for key, value in expected.items()
     }
 
-    # Save and set env vars
-    saved_env = {}
-    for key, value in env_overrides.items():
-        if key in os.environ:
-            saved_env[key] = os.environ[key]
-        os.environ[key] = value
-
-    try:
-        # Reload module to pick up new env vars
-        from keri.app import tocking
-        importlib.reload(tocking)
-
-        # Witness component tocks
-        assert tocking.WitnessMsgTock == 2.5
-        assert tocking.WitnessEscrowTock == 3.0
-        assert tocking.WitnessCueTock == 0.5
-
-        # Indirector component tocks
-        assert tocking.IndirectorMsgTock == 1.0
-        assert tocking.IndirectorCueTock == 0.75
-        assert tocking.IndirectorEscrowTock == 2.0
-
-        # MailboxDirector component tocks
-        assert tocking.MailboxPollTock == 1.5
-        assert tocking.MailboxMsgTock == 0.1
-        assert tocking.MailboxEscrowTock == 2.5
-
-        # Poller component tocks
-        assert tocking.PollerEventTock == 1.0
-
-        # ReceiptEnd component tocks
-        assert tocking.ReceiptInterceptTock == 0.5
-
-        # Reactor component tocks
-        assert tocking.ReactorMsgTock == 0.5
-        assert tocking.ReactorCueTock == 0.5
-        assert tocking.ReactorEscrowTock == 2.0
-
-        # Reactant component tocks
-        assert tocking.ReactantMsgTock == 0.5
-        assert tocking.ReactantCueTock == 0.5
-        assert tocking.ReactantEscrowTock == 2.0
-
-        # Respondant component tocks
-        assert tocking.RespondantCueTock == 0.5
-
-        # WitnessReceiptor component tocks
-        assert tocking.WitnessReceiptorTock == 0.5
-
-        # WitnessInquisitor component tocks
-        assert tocking.WitnessInquisitorTock == 2.0
-
-        # WitnessPublisher component tocks
-        assert tocking.WitnessPublisherTock == 0.5
-
-    finally:
-        # Restore or remove env vars
-        for key in env_overrides:
-            if key in saved_env:
-                os.environ[key] = saved_env[key]
-            else:
-                os.environ.pop(key, None)
-        # Reload to restore original state
-        importlib.reload(tocking)
-
-    """Done Test"""
+    # verify that tock resolution from environment uses highest precedence for env vars
+    assert tocking.resolveTocks(environ=environ) == expected
 
 
-def test_tocking_keys():
-    """
-    Test that environment variable keys are correctly defined
-    """
-    from keri.app import tocking
-
-    # Witness component keys
-    assert tocking.KERI_WITNESS_MSG_TOCK_KEY == "KERI_WITNESS_MSG_TOCK"
-    assert tocking.KERI_WITNESS_ESCROW_TOCK_KEY == "KERI_WITNESS_ESCROW_TOCK"
-    assert tocking.KERI_WITNESS_CUE_TOCK_KEY == "KERI_WITNESS_CUE_TOCK"
-
-    # Indirector component keys
-    assert tocking.KERI_INDIRECTOR_MSG_TOCK_KEY == "KERI_INDIRECTOR_MSG_TOCK"
-    assert tocking.KERI_INDIRECTOR_CUE_TOCK_KEY == "KERI_INDIRECTOR_CUE_TOCK"
-    assert tocking.KERI_INDIRECTOR_ESCROW_TOCK_KEY == "KERI_INDIRECTOR_ESCROW_TOCK"
-
-    # MailboxDirector component keys
-    assert tocking.KERI_MAILBOX_POLL_TOCK_KEY == "KERI_MAILBOX_POLL_TOCK"
-    assert tocking.KERI_MAILBOX_MSG_TOCK_KEY == "KERI_MAILBOX_MSG_TOCK"
-    assert tocking.KERI_MAILBOX_ESCROW_TOCK_KEY == "KERI_MAILBOX_ESCROW_TOCK"
-
-    # Poller component keys
-    assert tocking.KERI_POLLER_EVENT_TOCK_KEY == "KERI_POLLER_EVENT_TOCK"
-
-    # ReceiptEnd component keys
-    assert tocking.KERI_RECEIPT_INTERCEPT_TOCK_KEY == "KERI_RECEIPT_INTERCEPT_TOCK"
-
-    # Reactor component keys
-    assert tocking.KERI_REACTOR_MSG_TOCK_KEY == "KERI_REACTOR_MSG_TOCK"
-    assert tocking.KERI_REACTOR_CUE_TOCK_KEY == "KERI_REACTOR_CUE_TOCK"
-    assert tocking.KERI_REACTOR_ESCROW_TOCK_KEY == "KERI_REACTOR_ESCROW_TOCK"
-
-    # Reactant component keys
-    assert tocking.KERI_REACTANT_MSG_TOCK_KEY == "KERI_REACTANT_MSG_TOCK"
-    assert tocking.KERI_REACTANT_CUE_TOCK_KEY == "KERI_REACTANT_CUE_TOCK"
-    assert tocking.KERI_REACTANT_ESCROW_TOCK_KEY == "KERI_REACTANT_ESCROW_TOCK"
-
-    # Respondant component keys
-    assert tocking.KERI_RESPONDANT_CUE_TOCK_KEY == "KERI_RESPONDANT_CUE_TOCK"
-
-    # WitnessReceiptor component keys
-    assert tocking.KERI_WITNESS_RECEIPTOR_TOCK_KEY == "KERI_WITNESS_RECEIPTOR_TOCK"
-
-    # WitnessInquisitor component keys
-    assert tocking.KERI_WITNESS_INQUISITOR_TOCK_KEY == "KERI_WITNESS_INQUISITOR_TOCK"
-
-    # WitnessPublisher component keys
-    assert tocking.KERI_WITNESS_PUBLISHER_TOCK_KEY == "KERI_WITNESS_PUBLISHER_TOCK"
-
-    """Done Test"""
+# Tocks must be finite, non-negative numeric values; booleans are not numeric here.
+@pytest.mark.parametrize("value", [
+    True,
+    False,
+    None,
+    "",
+    "0.25",
+    -0.1,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+])
+def test_tocking_rejects_invalid_config_values(value):
+    with pytest.raises(kering.ConfigurationError, match="tocks.witnessMsg"):
+        tocking.resolveTocks({"witnessMsg": value}, environ={})
 
 
-if __name__ == "__main__":
-    test_tocking_defaults()
-    test_tocking_env_override()
-    test_tocking_keys()
+# Invalid env var values should not be allowed either
+@pytest.mark.parametrize("value", [
+    True,
+    "",
+    "not-a-number",
+    "-0.1",
+    "nan",
+    "NaN",
+    "inf",
+    "+inf",
+    "-inf",
+])
+def test_tocking_rejects_invalid_environment_values(value):
+    with pytest.raises(kering.ConfigurationError,
+                       match="KERI_WITNESS_MSG_TOCK"):
+        tocking.resolveTocks(
+            environ={"KERI_WITNESS_MSG_TOCK": value}
+        )
+
+
+def test_tocking_rejects_invalid_config_even_when_environment_shadows_it():
+    with pytest.raises(kering.ConfigurationError, match="tocks.witnessMsg"):
+        tocking.resolveTocks(
+            {"witnessMsg": float("nan")},
+            environ={"KERI_WITNESS_MSG_TOCK": "0.25"},
+        )
+
+
+def test_tocking_rejects_invalid_coarse_environment_when_specifics_shadow_it():
+    with pytest.raises(kering.ConfigurationError,
+                       match="KERI_VDR_ESCROW_TOCK"):
+        tocking.resolveTocks(
+            environ={
+                "KERI_VDR_ESCROW_TOCK": "not-a-number",
+                "KERI_REGISTRAR_ESCROW_TOCK": "0.1",
+                "KERI_CREDENTIALER_ESCROW_TOCK": "0.2",
+            }
+        )
+
+
+def test_tocking_accepts_zero_and_sub_hio_tick_values():
+    tocks = tocking.resolveTocks(
+        {"witnessMsg": 0.0, "counselorEscrow": 0.001},
+        environ={"KERI_REGISTRAR_ESCROW_TOCK": "0"},
+    )
+
+    assert tocks["witnessMsg"] == 0.0
+    assert tocks["counselorEscrow"] == 0.001
+    assert tocks["registrarEscrow"] == 0.0
+
+
+def test_tocking_rejects_unknown_keys_but_reserves_signify():
+    tocks = tocking.resolveTocks({"signify": {"escrower": 1.0}}, environ={})
+    assert tocks["witnessMsg"] == 0.0
+
+    with pytest.raises(kering.ConfigurationError, match="unknownTock"):
+        tocking.resolveTocks({"unknownTock": 1.0}, environ={})
+
+
+def test_tocking_supports_caller_owned_registry():
+    specs = {
+        "worker": tocking.Tock(env="KERIA_WORKER_TOCK", default=0.0)
+    }
+
+    tocks = tocking.resolveTocks(
+        {"worker": 1.0},
+        tocks=specs,
+        aliases={},
+        environ={"KERIA_WORKER_TOCK": "0.125"},
+        reserved=(),
+    )
+    assert tocks == {"worker": 0.125}
+
+
+def test_habery_resolves_config_and_shares_tocks_with_hab():
+    with configing.openCF(name="tocks", temp=True) as cf:
+        cf.put({"tocks": {"witnessMsg": 0.007}})
+        with habbing.openHby(name="tocks", temp=True, cf=cf) as hby:
+            hab = hby.makeHab(name="tocks")
+            assert hby.tocks["witnessMsg"] == 0.007
+            assert hab.tocks is hby.tocks
+
+
+def test_doify_delivers_resolved_nonzero_and_zero_tocks():
+    seen = []
+
+    def sampleDo(tymth=None, tock=0.0, **kwa):
+        seen.append(tock)
+        yield tock
+
+    configured = tocking.resolveTocks(
+        {"witnessMsg": 0.007}, environ={}
+    )
+    nonzero = doing.doify(sampleDo, tock=configured["witnessMsg"])
+    zero = doing.doify(sampleDo, tock=0.0)
+
+    doist = doing.Doist(tock=0.03125, limit=0.1)
+    doist.do(doers=[nonzero, zero])
+
+    assert seen == [0.007, 0.0]


### PR DESCRIPTION
### Problem

Tock configurability for performance tuning. 
Prior to this PR, tocks were inconsistently applied and did not support config file tock definition.

### Solution

Tocks are configurable with both config files and environment variables using the following precedence rule:
`specific env > coarse env > specific config > coarse config > default`

#### Tock Precedence 

This means tocks are read in order from env vars first, then config file, and then default config in the module. 

The superseding hierarchy for tock config comes with a concrete `Tock` and `TockAlias` type where the valid env var names and defaults are defined. 

#### Tock config on Habery and Hab

Another key point in this tock design is that it moves tock config to the `Habery` and subsequent `Hab` for simplicity. This was a natural, convenient place to pass tocks through to Doers and allows simple, Habery/Hab based testing of a given set of tock config for multiple Habery/Hab instances in a single test.

#### Coarse env and config tock support

The "coarse env" and "coarse config" options provide both backwards compatibility with existing coarse-grained env vars while also allowing setting multiple tocks with one var.
