### PR TITLE
fix(eventing): escrow duplicitous events in .ldes, not through a removed Baser method

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -5811,7 +5811,7 @@ class Kevery:
         self.db.dtss.put(keys=dgkey, val=Dater())
         self.db.sigs.put(keys=dgkey, vals=sigers)
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
-        self.db.addLde(snKey(serder.preb, serder.sn), serder.saidb)
+        self.db.ldes.add(keys=serder.preb, on=serder.sn, val=serder.saidb)
         # log duplicitous
         logger.debug("Kevery process: escrowed likely duplicitous event=\n%s\n", serder.pretty())
 

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -2050,6 +2050,91 @@ def test_unverified_trans_receipt_escrow():
     """End Test"""
 
 
+def test_likely_duplicitous_escrow():
+    """
+    Test likely duplicitous escrow
+
+    Two validly signed events at one sn that neither supersedes the other must
+    be preserved rather than dropped: duplicity is proven by placing the
+    conflicting events side by side, so the second one is escrowed in .ldes
+    with its body in .evts and its signatures in .sigs, while the KEL keeps
+    the version it accepted first.
+    """
+    salt = Salter(raw=b'0123456789abcdef').qb64  # init wes Salter
+    psr = parsing.Parser(version=Vrsn_1_0)
+
+    # init event DB and keep DB
+    with openDB(name="edy", temp=True) as db, keeping.openKS(name="edy") as ks:
+        # Init key pair manager
+        mgr = keeping.Manager(ks=ks, salt=salt)
+
+        # Init Kevery with event DB
+        kvy = Kevery(db=db)
+
+        verfers, digers = mgr.incept(icount=1, ncount=1, stem='wes', temp=True)
+
+        srdr = incept(keys=[verfer.qb64 for verfer in verfers],
+                      ndigs=[diger.qb64 for diger in digers],
+                      code=MtrDex.Blake3_256, version=Vrsn_1_0, kind=Kinds.json)
+
+        pre = srdr.ked["i"]
+        icpdig = srdr.said
+
+        mgr.move(old=verfers[0].qb64, new=pre)  # move key pair label to prefix
+
+        def signed(srdr):
+            """Serialize srdr with its controller signatures attached"""
+            sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
+            msg = bytearray(srdr.raw)
+            msg.extend(Counter(Codens.ControllerIdxSigs, count=len(sigers),
+                               version=Vrsn_1_0).qb64b)
+            for siger in sigers:
+                msg.extend(siger.qb64b)
+            return msg
+
+        psr.parse(ims=signed(srdr), kvy=kvy)
+        assert pre in kvy.kevers  # inception accepted
+        assert kvy.kevers[pre].sn == 0
+
+        # two interaction events at sn 1, both chaining from the inception and
+        # both validly signed by the keys the inception established. Neither
+        # supersedes the other, since superseding recovery is rot over ixn.
+        this = interact(pre=pre, dig=icpdig, sn=1, data=[dict(fork="this")],
+                        version=Vrsn_1_0, kind=Kinds.json)
+        that = interact(pre=pre, dig=icpdig, sn=1, data=[dict(fork="that")],
+                        version=Vrsn_1_0, kind=Kinds.json)
+        assert this.said != that.said
+
+        psr.parse(ims=signed(this), kvy=kvy)
+        assert kvy.kevers[pre].serder.said == this.said  # first one accepted
+
+        psr.parse(ims=signed(that), kvy=kvy)
+        assert kvy.kevers[pre].serder.said == this.said  # KEL unchanged
+
+        # the conflicting event is escrowed as likely duplicitous, with the
+        # evidence it consists of kept alongside it
+        escrows = db.ldes.get(keys=pre, on=1)
+        assert escrows == [that.said]
+        assert db.evts.get(keys=(pre, that.said)).said == that.said
+        assert len(db.sigs.get(keys=(pre, that.said))) == 1
+
+        # processing the escrow leaves it in place, since nothing has arrived
+        # that could resolve which version the controller stands behind
+        kvy.processEscrowDuplicitous()
+        assert db.ldes.get(keys=pre, on=1) == [that.said]
+        assert kvy.kevers[pre].serder.said == this.said
+
+        # an event already in the KEL is a duplicate rather than duplicitous,
+        # so replaying it adds no escrow entry
+        psr.parse(ims=signed(this), kvy=kvy)
+        assert db.ldes.get(keys=pre, on=1) == [that.said]
+
+    assert not os.path.exists(ks.path)
+    assert not os.path.exists(db.path)
+
+    """End Test"""
+
+
 if __name__ == "__main__":
     test_partial_signed_escrow()
     test_missing_delegator_escrow()
@@ -2062,3 +2147,4 @@ if __name__ == "__main__":
     test_ooes_missing_db_entries_escrow_cleanup()
     test_unverified_receipt_escrow()
     test_unverified_trans_receipt_escrow()
+    test_likely_duplicitous_escrow()


### PR DESCRIPTION
Fixes #1586.

I found this issue while working in some code that consumes keripy. I think it's just caused by a partial edit.

`Kevery.escrowLDEvent` ended with `self.db.addLde(snKey(...), serder.saidb)`, an `IoDupSuber`-era `Baser` method that no longer exists. `Baser`'s escrows moved onto `subing` instances and the sibling escrows moved with them — `escrowOOEvent` writes `self.db.ooes.add(keys=..., on=..., val=...)`, `escrowPWEvent` writes `self.db.pwes.add(...)` — but this call site was left behind.

So every likely-duplicitous event raised `AttributeError` from inside `processEvent`, which `Parser.msgParsator` catches and re-raises as `ValidationError: No kevery to process so dropped msg=…`. The event was discarded: `.ldes` never written, `.evts` and `.sigs` never given the body or its signatures, `processEscrowDuplicitous` left with nothing to iterate.

The consequence is a silent loss of exactly the material duplicity is proven with. Two validly signed conflicting events at one sn leave no trace — the KEL keeps whichever arrived first, arrival order decides which, and a verifier reading `.ldes` sees an empty escrow for a duplicitous identifier. Since `Fault` is explicitly not evidence and points at the duplicitous escrow instead, `.ldes` is the documented place to look.

The fix is one line, mirroring the sibling escrows:

```python
self.db.ldes.add(keys=serder.preb, on=serder.sn, val=serder.saidb)
```

There was no test over the KEL duplicity path, which is how a call to a removed method survived. `test_likely_duplicitous_escrow` covers it: two `ixn` events at one sn, neither superseding the other, asserting the escrow entry, the preserved body and signatures, the unchanged KEL, escrow survival across a `processEscrowDuplicitous` pass, and a plain duplicate adding no entry.