### PR TITLE
Fix small klass -> klas typo

### DIFF
--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -1163,7 +1163,7 @@ class Baser(dbing.LMDBer):
         # TODO: clean
         self.epath = subing.IoSetSuber(db=self, subkey=".epath")
 
-        self.essrs = subing.CesrIoSetSuber(db=self, subkey=".essrs", klass=coring.Texter)
+        self.essrs = subing.CesrIoSetSuber(db=self, subkey=".essrs", klas=coring.Texter)
 
         # accepted signed 12-word challenge response exn messages keys by prefix of signer
         # TODO: clean


### PR DESCRIPTION
Supersedes #1538, which GitHub closed when its `v1.3.5` base branch was deleted. This branch is rebased onto `v1.3.6`.

Looks like there was an accidental `s` character included in the ESSR database keyword when it was added. Using `klas=coring.Texter` ensures ESSR values deserialize as `Texter` rather than falling back to `Matter`.

Prior approved review context remains on #1538.

Validation: `tests/peer/test_exchanging.py::test_essrs` passes, and `git diff --check` is clean.
