### PR TITLE
feat(kering): give a broken prior-event digest its own error class

### DIFF
--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -16,7 +16,8 @@ from ..kering import (MissingEntryError, UntrustedKeyStateSource,
                       ValidationError, MissingSignatureError,
                       MissingWitnessSignatureError, UnverifiedReplyError,
                       MissingDelegationError, OutOfOrderError,
-                      LikelyDuplicitousError, UnverifiedWitnessReceiptError,
+                      LikelyDuplicitousError, MisdigestError,
+                      UnverifiedWitnessReceiptError,
                       UnverifiedReceiptError, UnverifiedTransferableReceiptError,
                       QueryNotFoundError, MisfitEventSourceError,
                       MissingDelegableApprovalError, Version, Versionage,
@@ -2547,7 +2548,7 @@ class Kever:
                                       "= {}.".format(sner.num, self.sner.num + 1, ked))
 
             if not self.serder.compare(said=ked["p"]):  # prior event dig not match
-                raise ValidationError("Mismatch event dig = {} with state dig"
+                raise MisdigestError("Mismatch event dig = {} with state dig"
                                       " = {} for evt = {}.".format(ked["p"],
                                                                    self.serder.said,
                                                                    ked))
@@ -2641,7 +2642,7 @@ class Kever:
                     raise ValidationError("Invalid recovery attempt: "
                                           " Bad dig = {}.".format(pdig))
                 if not pserder.compare(said=prior):  # bad recovery event
-                    raise ValidationError("Invalid recovery attempt:"
+                    raise MisdigestError("Invalid recovery attempt:"
                                           "Mismatch recovery event prior dig"
                                           "= {} with dig = {} of event sn = {}"
                                           " evt = {}.".format(prior,
@@ -2651,7 +2652,7 @@ class Kever:
 
         else:  # sn == self.sn + 1   new non-recovery event
             if not self.serder.compare(said=prior):  # prior event dig not match
-                raise ValidationError("Mismatch event dig = {} with"
+                raise MisdigestError("Mismatch event dig = {} with"
                                       " state dig = {} for evt = {}."
                                       "".format(prior, self.serder.said, ked))
 
@@ -5811,7 +5812,7 @@ class Kevery:
         self.db.dtss.put(keys=dgkey, val=Dater())
         self.db.sigs.put(keys=dgkey, vals=sigers)
         self.db.evts.put(keys=(serder.preb, serder.saidb), val=serder)
-        self.db.addLde(snKey(serder.preb, serder.sn), serder.saidb)
+        self.db.ldes.add(keys=serder.preb, on=serder.sn, val=serder.saidb)
         # log duplicitous
         logger.debug("Kevery process: escrowed likely duplicitous event=\n%s\n", serder.pretty())
 

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -691,6 +691,20 @@ class LikelyDuplicitousError(ValidationError):
     """
 
 
+class MisdigestError(ValidationError):
+    """
+    Error event's prior event digest does not match the digest of the event it
+    claims to follow, so the backward hash chain is broken at this event.
+
+    Distinct from OutOfOrderError, where the prior event is merely absent and
+    may still arrive: a mismatched prior digest is decided against events
+    already in hand, so no later arrival resolves it.
+
+    Usage:
+        raise MisdigestError("error message")
+    """
+
+
 class UnverifiedWitnessReceiptError(ValidationError):
     """
     Error witness receipt is unverfied  event not yet in database

--- a/tests/core/test_escrow.py
+++ b/tests/core/test_escrow.py
@@ -12,7 +12,7 @@ import pytest
 from hio.help import ogler
 
 from keri import Vrsn_1_0
-from keri.kering import MisfitEventSourceError, Kinds
+from keri.kering import MisfitEventSourceError, Kinds, MisdigestError
 
 from keri.core import (Seqner, Counter, Salter, Saider, Prefixer,
                        Number, Diger, Kevery, eventing, parsing,
@@ -2050,6 +2050,60 @@ def test_unverified_trans_receipt_escrow():
     """End Test"""
 
 
+def test_broken_prior_digest_is_its_own_error():
+    """
+    Test that a mismatched prior event digest raises MisdigestError
+
+    A broken backward hash chain is decided against events already in hand, so
+    unlike OutOfOrderError no later arrival resolves it. Its own class is what
+    lets an embedder tell the two apart without reading message prose.
+    """
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    psr = parsing.Parser(version=Vrsn_1_0)
+
+    with openDB(name="edy", temp=True) as db, keeping.openKS(name="edy") as ks:
+        mgr = keeping.Manager(ks=ks, salt=salt)
+        kvy = Kevery(db=db)
+
+        verfers, digers = mgr.incept(icount=1, ncount=1, stem='wes', temp=True)
+        srdr = incept(keys=[verfer.qb64 for verfer in verfers],
+                      ndigs=[diger.qb64 for diger in digers],
+                      code=MtrDex.Blake3_256, version=Vrsn_1_0, kind=Kinds.json)
+        pre = srdr.ked["i"]
+        icpdig = srdr.said
+        mgr.move(old=verfers[0].qb64, new=pre)
+
+        def signed(srdr):
+            sigers = mgr.sign(ser=srdr.raw, verfers=verfers)
+            msg = bytearray(srdr.raw)
+            msg.extend(Counter(Codens.ControllerIdxSigs, count=len(sigers),
+                               version=Vrsn_1_0).qb64b)
+            for siger in sigers:
+                msg.extend(siger.qb64b)
+            return msg
+
+        psr.parse(ims=signed(srdr), kvy=kvy)
+        assert kvy.kevers[pre].sn == 0
+
+        # an interaction at the right sn, validly signed, chaining from nothing
+        astray = interact(pre=pre, dig="E" + "A" * 43, sn=1, data=[],
+                          version=Vrsn_1_0, kind=Kinds.json)
+        with pytest.raises(MisdigestError):
+            kvy.processEvent(serder=astray,
+                             sigers=mgr.sign(ser=astray.raw, verfers=verfers))
+
+        assert kvy.kevers[pre].sn == 0  # nothing accepted
+        assert not db.ooes.get(keys=pre, on=1)  # and nothing escrowed to await
+
+        # the same event chaining correctly is accepted, so the fixture is honest
+        proper = interact(pre=pre, dig=icpdig, sn=1, data=[],
+                          version=Vrsn_1_0, kind=Kinds.json)
+        psr.parse(ims=signed(proper), kvy=kvy)
+        assert kvy.kevers[pre].sn == 1
+
+    """End Test"""
+
+
 if __name__ == "__main__":
     test_partial_signed_escrow()
     test_missing_delegator_escrow()
@@ -2062,3 +2116,4 @@ if __name__ == "__main__":
     test_ooes_missing_db_entries_escrow_cleanup()
     test_unverified_receipt_escrow()
     test_unverified_trans_receipt_escrow()
+    test_broken_prior_digest_is_its_own_error()


### PR DESCRIPTION
I raised this PR because some work I was doing in a library that consumes keripy needed to consume parsing with more granular status. The community may not want it.

A mismatched prior event digest raises bare `ValidationError` — the same class as a dozen unrelated conditions, among them "no verified signatures", an invalid `sith`, a rotation on a nontransferable prefix, and a failed recovery attempt. An embedder that wants to report *why* a key history could not be established therefore cannot tell a broken backward hash chain from an unauthentic signature except by reading the message prose.

Making a distinction seems valuable to me because these failures differ in kind, not merely in detail:

- a broken chain is decided against events already in hand, so unlike `OutOfOrderError` no later arrival resolves it;
- and unlike a signature failure it says nothing about the keys.

`MisdigestError` subclasses `ValidationError`, so every existing handler catches it unchanged and nothing reading `.kind` for the old value loses anything it was entitled to rely on. It is raised at the three sites that compare a prior digest: the interaction path in `Kever.validateSN`'s caller, the rotation path, and the recovery prior-digest check.

The `test_broken_prior_digest_is_its_own_error` proves that the offending event is neither accepted nor escrowed to await a predecessor — so the new class is not merely cosmetic, and the test would fail if the condition were ever folded into out-of-order handling.
