### PR TITLE
Fix scheduler tock boundaries

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -684,7 +684,13 @@ class TCPMessenger(doing.DoDoer):
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
         """Doer loop that parses inbound TCP messages into the Kevery."""
-        yield from self.parser.parsator(local=True)  # process messages continuously
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value
+            yield tock
 
     @property
     def idle(self):
@@ -757,7 +763,13 @@ class TCPStreamMessenger(doing.DoDoer):
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
         """Doer loop that parses inbound TCP messages into the Kevery."""
-        yield from self.parser.parsator(local=True)  # process messages continuously
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value
+            yield tock
 
     @property
     def idle(self):

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -233,8 +233,13 @@ class Reactor(doing.DoDoer):
         _ = (yield self.tock)  # enter context
         if self.parser.ims:
             logger.info("Client %s received:\n%s\n...\n", self.hab.name, self.parser.ims[:1024])
-        done = yield from self.parser.parsator(local=True)  # process messages continuously
-        return done  # should nover get here except forced close
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value  # should never get here except forced close
+            yield self.tock
 
 
     def cueDo(self, tymth=None, tock=None, **opts):

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -201,8 +201,13 @@ class WitnessStart(doing.DoDoer):
 
         if self.parser.ims:
             logger.debug("Client %s received:\n%s\n...\n", self.kvy, self.parser.ims[:1024])
-        done = yield from self.parser.parsator(local=True)  # process messages continuously
-        return done  # should nover get here except forced close
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value  # should never get here except forced close
+            yield self.tock
 
     def escrowDo(self, tymth=None, tock=None, **kwa):
         """
@@ -390,8 +395,13 @@ class Indirector(doing.DoDoer):
 
         if self.parser.ims:
             logger.debug("Client %s received:\n%s\n...\n", self.hab.pre, self.parser.ims[:1024])
-        done = yield from self.parser.parsator(local=True)  # process messages continuously
-        return done  # should nover get here except forced close
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value  # should never get here except forced close
+            yield self.tock
 
     def cueDo(self, tymth=None, tock=None, **kwa):
         """
@@ -681,8 +691,13 @@ class MailboxDirector(doing.DoDoer):
         self.tock = tock if tock is not None else tocking.MailboxMsgTock
         _ = (yield self.tock)
 
-        done = yield from self.parser.parsator(local=True)  # process messages continuously
-        return done  # should nover get here except forced close
+        parser = self.parser.parsator(local=True)
+        while True:
+            try:
+                next(parser)
+            except StopIteration as ex:
+                return ex.value  # should never get here except forced close
+            yield self.tock
 
     def escrowDo(self, tymth=None, tock=None, **kwa):
         """

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -22,6 +22,30 @@ from keri.metric import EscrowEnd
 from keri.vdr import viring
 
 
+def test_witness_message_tock_continues_after_initial_entry():
+    class Parser:
+        ims = bytearray()
+
+        @staticmethod
+        def parsator(local=False):
+            assert local is True
+            yield
+            yield
+            return "complete"
+
+    witness = object.__new__(indirecting.WitnessStart)
+    witness.parser = Parser()
+    witness.wind = lambda tymth: None
+
+    dog = witness.msgDo(tymth=lambda: 0.0, tock=0.007)
+    assert next(dog) == 0.007
+    assert next(dog) == 0.007
+    assert next(dog) == 0.007
+    with pytest.raises(StopIteration) as ex:
+        next(dog)
+    assert ex.value.value == "complete"
+
+
 def test_mailbox_iter():
     pre = "EA3mbE6upuYnFlx68GmLYCQd7cCcwG_AtHM6dW_GT068"
     mbx = storing.Mailboxer(temp=True)


### PR DESCRIPTION
## Summary

- `yield` the tock set in the outer DoDoer's constructor after each parser iteration rather than delegate yields to the parser with `yield from`
- step through parser yields explicitly while incrementally yielding the owning DoDoer's tock
- preserve parser completion values (`ex.value`) and existing tock defaults

## Why

Delegating with `yield from parsator(...)` exposes the parser's own yields directly to HIO. This means the initial tock set only affects initial yield but not later yields driven by parser shortages.

Changing to adding a yield after the parser iteratest keeps a consistent scheduling boundary with initial tock set by the Doer/task that owns the operation. Parsing behavior is unchanged; the owning Doer/task now consistently controls when its parser is scheduled again rather than inadvertently delegating that to whatever is yielded from the Parser.
