### PR TITLE
Keep service tocks generator-local

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -52,7 +52,7 @@ class Receiptor(doing.DoDoer):
 
         super(Receiptor, self).__init__(doers=doers)
 
-    def receipt(self, pre, sn=None, auths=None):
+    def receipt(self, pre, sn=None, auths=None, tock=0.0):
         """Yield while witnessing an event and returning witness receipt couples.
 
         Sends the event to all witnesses, optionally catches new witnesses up,
@@ -84,7 +84,7 @@ class Receiptor(doing.DoDoer):
         if ser.ked['t'] in (coring.Ilks.rot, coring.Ilks.drt,):
             adds = ser.ked["ba"]
             for wit in adds:
-                yield from self.catchup(ser.pre, wit)
+                yield from self.catchup(ser.pre, wit, tock=tock)
 
         clients = dict()
         doers = []
@@ -105,7 +105,7 @@ class Receiptor(doing.DoDoer):
 
             httping.streamCESRRequests(client=client, dest=wit, ims=bytearray(msg), path="receipts", headers=headers)
             while not client.responses:
-                yield self.tock
+                yield tock
 
             rep = client.respond()
             if rep.status == 200:
@@ -144,13 +144,13 @@ class Receiptor(doing.DoDoer):
 
             sent = httping.streamCESRRequests(client=client, dest=wit, ims=bytearray(msg))
             while len(client.responses) < sent:
-                yield self.tock
+                yield tock
 
         self.remove(doers)
 
         return rcts.keys()
 
-    def get(self, pre, sn=None):
+    def get(self, pre, sn=None, tock=0.0):
         """Yield while querying a witness for receipts of an event identified by pre and sn.
 
         Picks one witness and issues GET /receipts?pre=&sn=. Parses any
@@ -179,7 +179,7 @@ class Receiptor(doing.DoDoer):
 
         client = self.clienter.request("GET", url)
         while not client.responses:
-            yield self.tock
+            yield tock
 
         rep = client.respond()
         if rep.status == 200:
@@ -189,7 +189,7 @@ class Receiptor(doing.DoDoer):
         self.clienter.remove(client)
         return rep.status == 200
 
-    def catchup(self, pre, wit):
+    def catchup(self, pre, wit, tock=0.0):
         """
         Yield while replaying the full KEL for `pre` to the witness.
         When adding a new Witness, use this method to catch the witness up to the current state of the KEL
@@ -209,15 +209,14 @@ class Receiptor(doing.DoDoer):
         for fmsg in hab.db.clonePreIter(pre=pre):
             httping.streamCESRRequests(client=client, dest=wit, ims=bytearray(fmsg))
             while not client.responses:
-                yield self.tock
+                yield tock
 
         self.remove([clientDoer])
 
     def witDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that drains `msgs` and runs witness receipt flow."""
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.msgs:
@@ -226,16 +225,15 @@ class Receiptor(doing.DoDoer):
                 sn = msg["sn"] if "sn" in msg else None
                 auths = msg["auths"] if "auths" in msg else None
 
-                yield from self.receipt(pre, sn, auths)
+                yield from self.receipt(pre, sn, auths, tock=tock)
                 self.cues.push(msg)
 
-            yield self.tock
+            yield tock
 
     def gitDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that drains `gets` and runs witness receipt queries."""
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.gets:
@@ -243,9 +241,9 @@ class Receiptor(doing.DoDoer):
                 pre = msg["pre"]
                 sn = msg["sn"] if "sn" in msg else None
 
-                yield from self.get(pre, sn)
+                yield from self.get(pre, sn, tock=tock)
 
-            yield self.tock
+            yield tock
 
 
 class WitnessReceiptor(doing.DoDoer):
@@ -652,8 +650,7 @@ class TCPMessenger(doing.DoDoer):
     def receiptDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that sends queued messages over TCP."""
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         up = urlparse(self.url)
         if up.scheme != kering.Schemes.tcp:
@@ -669,7 +666,7 @@ class TCPMessenger(doing.DoDoer):
 
         while True:
             while not self.msgs:
-                yield self.tock
+                yield tock
 
             msg = self.msgs.popleft()
             self.posted += 1
@@ -677,10 +674,10 @@ class TCPMessenger(doing.DoDoer):
             client.tx(msg)  # send to connected remote
 
             while client.txbs:
-                yield self.tock
+                yield tock
 
             self.sent.append(msg)
-            yield self.tock
+            yield tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
         """Doer loop that parses inbound TCP messages into the Kevery."""
@@ -725,8 +722,7 @@ class TCPStreamMessenger(doing.DoDoer):
         Pushes the original request to self.sent to signal completion
         """
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         up = urlparse(self.url)
         if up.scheme != kering.Schemes.tcp:
@@ -742,7 +738,7 @@ class TCPStreamMessenger(doing.DoDoer):
 
         while True:
             while not self.msgs:
-                yield self.tock
+                yield tock
 
             msg = self.msgs.popleft()
             self.posted += 1
@@ -750,10 +746,10 @@ class TCPStreamMessenger(doing.DoDoer):
             client.tx(msg)  # send to connected remote
 
             while client.txbs:
-                yield self.tock
+                yield tock
 
             self.sent.append(msg)
-            yield self.tock
+            yield tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
         """Doer loop that parses inbound TCP messages into the Kevery."""
@@ -802,12 +798,11 @@ class HTTPMessenger(doing.DoDoer):
     def msgDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that sends queued messages over HTTP."""
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while not self.msgs:
-                yield self.tock
+                yield tock
 
             msg = self.msgs.popleft()
             headers = dict()
@@ -816,15 +811,14 @@ class HTTPMessenger(doing.DoDoer):
 
             self.posted += httping.streamCESRRequests(client=self.client, dest=self.wit, ims=msg, headers=headers)
             while self.client.requests:
-                yield self.tock
+                yield tock
 
-            yield self.tock
+            yield tock
 
     def responseDo(self, tymth=None, tock=0.0, **kwa):
         """Doer loop that processes HTTP responses from the client and adds them into `sent` cues."""
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.client.responses:

--- a/src/keri/app/forwarding.py
+++ b/src/keri/app/forwarding.py
@@ -35,8 +35,9 @@ class Poster(doing.DoDoer):
         self.mbx = mbx
         self.evts = evts if evts is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
+        self.deliverTock = 0.0
 
-        doers = [doing.doify(self.deliverDo)]
+        doers = [doing.doify(self.deliverDo, tock=self.deliverTock)]
         super(Poster, self).__init__(doers=doers, **kwa)
 
     def deliverDo(self, tymth=None, tock=0.0, **kwa):
@@ -52,8 +53,7 @@ class Poster(doing.DoDoer):
 
         # enter context
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             while self.evts:
@@ -77,13 +77,17 @@ class Poster(doing.DoDoer):
                         for role in (Roles.controller, Roles.agent, Roles.mailbox):
                             if role in ends:
                                 if role == Roles.mailbox:
-                                    yield from self.forward(hab, ends[role], recp=recp, serder=srdr, atc=atc, topic=tpc)
+                                    yield from self.forward(hab, ends[role], recp=recp, serder=srdr,
+                                                            atc=atc, topic=tpc, tock=tock)
                                 else:
-                                    yield from self.sendDirect(hab, ends[role], serder=srdr, atc=atc)
+                                    yield from self.sendDirect(hab, ends[role], serder=srdr,
+                                                               atc=atc, tock=tock)
 
                     # otherwise send to one witness
                     elif Roles.witness in ends:
-                        yield from self.forwardToWitness(hab, ends[Roles.witness], recp=recp, serder=srdr, atc=atc, topic=tpc)
+                        yield from self.forwardToWitness(hab, ends[Roles.witness], recp=recp,
+                                                         serder=srdr, atc=atc, topic=tpc,
+                                                         tock=tock)
                     else:
                         logger.info(f"No end roles for {recp} to send evt={srdr.said}")
                         continue
@@ -94,9 +98,9 @@ class Poster(doing.DoDoer):
 
                 self.cues.append(dict(dest=recp, topic=tpc, said=srdr.said))
 
-                yield self.tock
+                yield tock
 
-            yield self.tock
+            yield tock
 
     def send(self, dest, topic, serder, src=None, hab=None, attachment=None):
         """
@@ -135,8 +139,9 @@ class Poster(doing.DoDoer):
 
         return False
 
-    def sendEventToDelegator(self, sender, hab, fn=0):
+    def sendEventToDelegator(self, sender, hab, fn=0, tock=None):
         """ Returns generator for sending event and waiting until send is complete """
+        tock = self.deliverTock if tock is None else tock
         # Send KEL event for processing
         icp = self.hby.db.cloneEvtMsg(pre=hab.pre, fn=fn, dig=hab.kever.serder.saidb)
         ser = serdering.SerderKERI(raw=icp)
@@ -150,9 +155,10 @@ class Poster(doing.DoDoer):
                     break
                 else:
                     self.cues.append(cue)
-            yield self.tock
+            yield tock
 
-    def sendDirect(self, hab, ends, serder, atc):
+    def sendDirect(self, hab, ends, serder, atc, tock=None):
+        tock = self.deliverTock if tock is None else tock
         for ctrl, locs in ends.items():
             witer = agenting.messengerFrom(hab=hab, pre=ctrl, urls=locs)
 
@@ -164,11 +170,12 @@ class Poster(doing.DoDoer):
             self.extend([witer])
 
             while not witer.idle:
-                _ = (yield self.tock)
+                _ = (yield tock)
 
             self.remove([witer])
 
-    def forward(self, hab, ends, recp, serder, atc, topic):
+    def forward(self, hab, ends, recp, serder, atc, topic, tock=None):
+        tock = self.deliverTock if tock is None else tock
         # If we are one of the mailboxes, just store locally in mailbox
         owits = oset(ends.keys())
         if self.mbx and owits.intersection(hab.prefixes):
@@ -199,9 +206,10 @@ class Poster(doing.DoDoer):
         self.extend([witer])
 
         while not witer.idle:
-            _ = (yield self.tock)
+            _ = (yield tock)
 
-    def forwardToWitness(self, hab, ends, recp, serder, atc, topic):
+    def forwardToWitness(self, hab, ends, recp, serder, atc, topic, tock=None):
+        tock = self.deliverTock if tock is None else tock
         # If we are one of the mailboxes, just store locally in mailbox
         owits = oset(ends.keys())
         if self.mbx and owits.intersection(hab.prefixes):
@@ -232,7 +240,7 @@ class Poster(doing.DoDoer):
         self.extend([witer])
 
         while not witer.idle:
-            _ = (yield self.tock)
+            _ = (yield tock)
 
 
 class StreamPoster:

--- a/src/keri/app/httping.py
+++ b/src/keri/app/httping.py
@@ -271,8 +271,7 @@ class Clienter(doing.DoDoer):
 
         """
         self.wind(tymth)
-        self.tock = tock
-        yield self.tock
+        yield tock
 
         while True:
             toRemove = []
@@ -282,10 +281,9 @@ class Clienter(doing.DoDoer):
                     if (now - dt) > datetime.timedelta(seconds=self.TimeoutClient):
                         toRemove.append(client)
 
-                yield self.tock
+                yield tock
 
             for client in toRemove:
                 self.remove(client)
 
-            yield self.tock
-
+            yield tock

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -174,11 +174,10 @@ class WitnessStart(doing.DoDoer):
 
         """
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while not self.hab.inited:
-            yield self.tock
+            yield tock
 
         print("Witness", self.hab.name, ":", self.hab.pre)
 

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -144,12 +144,11 @@ class RegeryDoer(doing.Doer):
 
         """
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:
             self.rgy.processEscrows()
-            yield self.tock
+            yield tock
 
 
 class BaseRegistry:

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -16,6 +16,36 @@ from keri.db import basing, dbing
 from keri.vdr import eventing, viring
 
 
+def test_receiptor_cadences_are_generator_local():
+    receiptor = agenting.Receiptor(hby=object())
+    seen = []
+
+    def receipt(pre, sn=None, auths=None, tock=0.0):
+        seen.append(("receipt", tock))
+        yield tock
+
+    def get(pre, sn=None, tock=0.0):
+        seen.append(("get", tock))
+        yield tock
+
+    receiptor.receipt = receipt
+    receiptor.get = get
+    receiptor.msgs.append({"pre": "witness"})
+    receiptor.gets.append({"pre": "query"})
+
+    witness = receiptor.witDo(tymth=lambda: 0.0, tock=0.011)
+    query = receiptor.gitDo(tymth=lambda: 0.0, tock=0.013)
+
+    assert next(witness) == 0.011
+    assert next(query) == 0.013
+    assert next(witness) == 0.011
+    assert next(query) == 0.013
+    assert seen == [("receipt", 0.011), ("get", 0.013)]
+
+    witness.close()
+    query.close()
+
+
 def test_witness_receiptor(seeder):
     with habbing.openHby(name="wan", salt=core.Salter(raw=b'wann-the-witness').qb64) as wanHby, \
             habbing.openHby(name="wil", salt=core.Salter(raw=b'will-the-witness').qb64) as wilHby, \


### PR DESCRIPTION
## Summary

- keep injected HIO tocks local to each service generator
- pass Receiptor and Poster tocks through their nested helper generators
- preserve every existing `0.0` default

## Why

This one was needed because doing.doify overwrites the tock arg with 0.0 when it is called, effectively ignoring any self.tock set from the outer DoDoer, so changing from self.tock to the function argument tock gives consistent behavior.

An injected `tock` belongs to one generator invocation. Storing it on a shared DoDoer makes scheduling depend on execution order: a sibling loop can overwrite the value while another loop or helper is still using it.

The practical case is Receiptor, whose witness and query loops can run interleaved. This change removes that hidden communication channel and lets each operation carry its own tock cadence without adding configuration or changing default scheduling.

