### PR TITLE
Clean up Signaler tocks (code) and clarify scheduling ownership (docs)

### DIFF
--- a/src/keri/app/notifying.py
+++ b/src/keri/app/notifying.py
@@ -375,6 +375,9 @@ class Notifier:
 
     The notifications are not just signals to reload data and not persistent messages that can be reread
 
+    Notifier exposes its Signaler for the process-level scheduler to own. It
+    does not schedule the Signaler itself.
+
     """
 
     def __init__(self, hby, signaler=None, noter=None):
@@ -383,7 +386,8 @@ class Notifier:
         Parameters:
             hby (Habery): habery database environment with Signator
             noter (Noter): database
-            signaler (Signaler): signaler for sending signals to controller that new data is available
+            signaler (Signaler): caller-owned shared signaler; when omitted,
+                create one for the caller to schedule
 
         """
         self.hby = hby

--- a/src/keri/app/signaling.py
+++ b/src/keri/app/signaling.py
@@ -92,6 +92,10 @@ class Signaler(doing.DoDoer):
 
     The signals are just pings to reload data and not persistent messages that can be reread
 
+    The process-level scheduler owns this DoDoer. Consumers such as Notifier
+    and request handlers share the same Signaler instance but do not schedule
+    it independently.
+
     """
 
     SignalTimeout = datetime.timedelta(minutes=10)
@@ -142,8 +146,7 @@ class Signaler(doing.DoDoer):
 
         """
         self.wind(tymth)
-        self.tock = tock
-        _ = (yield self.tock)
+        _ = (yield tock)
 
         while True:  # loop checking for expired messages
             now = helping.nowUTC()
@@ -151,12 +154,12 @@ class Signaler(doing.DoDoer):
             for sig in self.signals:
                 if now - helping.fromIso8601(sig.dt) > self.SignalTimeout:  # Expire messages that are too old
                     toRemove.append(sig)
-                yield self.tock
+                yield tock
 
             for sig in toRemove:
                 self.signals.remove(sig)
 
-            yield self.tock
+            yield tock
 
 
 def loadEnds(app, *, signals=None):

--- a/tests/app/test_notifying.py
+++ b/tests/app/test_notifying.py
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from keri.app import notifying, habbing
+from keri.app import habbing, notifying, signaling
 from keri.app.notifying import Noter, KERINoterMapSizeKey
 from keri.core import coring
 from keri.db import dbing
@@ -225,6 +225,17 @@ def test_notifier(mockHelpingNowUTC):
 
     assert notifier.mar(note.rid) is False
     assert notifier.rem(note.rid) is True
+
+
+def test_notifier_exposes_caller_owned_signaler():
+    with habbing.openHby(name="notifier-signaler", temp=True) as hby:
+        signaler = signaling.Signaler()
+        notifier = notifying.Notifier(hby=hby, signaler=signaler)
+        try:
+            assert notifier.signaler is signaler
+        finally:
+            notifier.noter.close(clear=True)
+
 
 def test_noter_db_size_set_from_env_var():
     # Clear environment before test


### PR DESCRIPTION
## Summary

- define the process root as the sole scheduler owner of a shared Signaler
- document Notifier as a sharing boundary, not a scheduler owner
- keep expiration cadence local to `expireDo`

## Why

Notifier does not and should not control Signaler tocks. The context creating the Signaler should set those tocks when scheduling it, and pass them in as a `tock` arg whether in a `doify` call or as a constructor arg.

Notifier creates or accepts the Signaler used by notification and request handlers, but does not own its scheduler lifecycle. That ambiguity allows two failure modes: scheduling the same mutable DoDoer more than once, or never scheduling it and leaving signal expiration inactive.

KERIpy does not own the non-KLI application roots, so this PR establishes the contract without pretending to activate downstream services. KERIA and other applications must add `notifier.signaler` to their process root exactly once.
