### PR TITLE
fix: leader election for SignifyGroupHabs

### DIFF
--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -303,7 +303,7 @@ class Exchanger:
             bool: True means hab is the lead
 
         """
-        if not isinstance(hab, habbing.GroupHab):
+        if not isinstance(hab, (habbing.GroupHab, habbing.SignifyGroupHab)):
             return True
 
         keys = [verfer.qb64 for verfer in hab.kever.verfers]

--- a/tests/app/signifying.py
+++ b/tests/app/signifying.py
@@ -1,0 +1,144 @@
+# -*- encoding: utf-8 -*-
+"""Test support for externally controlled Signify habitats."""
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+from keri import core
+from keri.app import habbing, keeping
+from keri.core import coring, eventing
+
+
+@dataclass(frozen=True)
+class SignifyMemberFixture:
+    """One externally controlled Signify member and its signing state."""
+
+    hab: habbing.SignifyHab
+    signer: core.Signer
+    next_diger: core.Diger
+
+    def sign(self, signing_index: int, raw: bytes) -> core.Siger:
+        """Sign raw bytes at this member's position in the group key list."""
+        return self.signer.sign(ser=raw, index=signing_index)
+
+
+@dataclass(frozen=True)
+class SignifyGroupFixture:
+    """A real Signify group backed by externally held member signers."""
+
+    hby: habbing.Habery
+    group: habbing.SignifyGroupHab
+    members: tuple[SignifyMemberFixture, ...]
+
+    def sign(self, signing_index: int, raw: bytes) -> core.Siger:
+        """Sign with the member occupying signing_index in the group."""
+        member = self.members[signing_index]
+        return member.sign(signing_index=signing_index, raw=raw)
+
+
+def makeSignifyMember(
+    *,
+    hby: habbing.Habery,
+    creator: keeping.SaltyCreator,
+    name: str,
+    member_index: int,
+) -> SignifyMemberFixture:
+    """Create one externally signed Signify member habitat.
+
+    member_index selects a distinct salty key derivation path. The caller later
+    places the returned fixture into the group member tuple, whose order defines
+    group signing indexes.
+    """
+    signer = creator.create(pidx=member_index, ridx=0, kidx=0, temp=True).pop()
+    next_signer = creator.create(pidx=member_index, ridx=1, kidx=1, temp=True).pop()
+    next_diger = coring.Diger(ser=next_signer.verfer.qb64b)
+    inception = eventing.incept(
+        keys=[signer.verfer.qb64],
+        isith="1",
+        nsith="1",
+        ndigs=[next_diger.qb64],
+        code=coring.MtrDex.Blake3_256,
+        toad=0,
+    )
+    hab = hby.makeSignifyHab(
+        name=name,
+        serder=inception,
+        sigers=[signer.sign(ser=inception.raw, index=0)],
+    )
+    return SignifyMemberFixture(hab=hab, signer=signer, next_diger=next_diger)
+
+
+def makeSignifyGroupHab(
+    *,
+    hby: habbing.Habery,
+    name: str,
+    members: tuple[SignifyMemberFixture, ...],
+    mhabIdx: int,
+) -> habbing.SignifyGroupHab:
+    """Create one 2-of-3 Signify group from prepared members.
+
+    members defines the group key and signing-index order. mhabIdx selects which
+    member habitat becomes group.mhab, representing the local member whose
+    leadership is evaluated.
+    """
+    group_keys = [member.signer.verfer.qb64 for member in members]
+    next_digests = [member.next_diger.qb64 for member in members]
+    member_ids = [member.hab.pre for member in members]
+    local_member = members[mhabIdx]
+
+    inception = eventing.incept(
+        keys=group_keys,
+        isith="2",
+        nsith="2",
+        ndigs=next_digests,
+        code=coring.MtrDex.Blake3_256,
+        toad=0,
+    )
+    sigers = [
+        member.sign(signing_index=signing_index, raw=inception.raw)
+        for signing_index, member in enumerate(members)
+    ]
+    return hby.makeSignifyGroupHab(
+        name=name,
+        mhab=local_member.hab,
+        smids=member_ids,
+        rmids=member_ids,
+        serder=inception,
+        sigers=sigers,
+    )
+
+
+@contextmanager
+def openSignifyGroup(
+    *,
+    name: str = "signify-group",
+    mhabIdx: int = 0,
+    salt: bytes = b"0123456789abcdef",
+) -> Iterator[SignifyGroupFixture]:
+    """Open a real three-member Signify group for tests.
+
+    Members are created in group signing-index order. mhabIdx selects
+    the member represented locally by the returned group's mhab.
+    """
+    salter = core.Salter(raw=salt)
+    creator = keeping.SaltyCreator(salt=salter.qb64, tier=coring.Tiers.low)
+
+    with habbing.openHby(name=name, temp=True) as hby:
+        # Tuple position becomes the member's group signing index.
+        members = tuple(
+            makeSignifyMember(
+                hby=hby,
+                creator=creator,
+                name=f"{name}-member-{member_index}",
+                member_index=member_index,
+            )
+            for member_index in range(3)
+        )
+        group = makeSignifyGroupHab(
+            hby=hby,
+            name=f"{name}-group",
+            members=members,
+            mhabIdx=mhabIdx,
+        )
+        yield SignifyGroupFixture(hby=hby, group=group, members=members)

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -3,6 +3,8 @@
 tests.peer.test_exchanging module
 
 """
+from contextlib import contextmanager
+
 import pysodium
 import pytest
 
@@ -14,6 +16,118 @@ from keri.app import habbing, forwarding, storing, signing
 
 from keri.peer import exchanging
 from keri.vdr.eventing import incept
+
+from tests.app import openMultiSig
+from tests.app import signifying
+
+
+def _logGroupSigs(exchanger, group, serder, sigers):
+    """Store group signatures through Exchanger's normal persistence path."""
+    exchanger.logEvent(
+        serder=serder,
+        tsgs=[
+            (
+                coring.Prefixer(qb64=group.pre),
+                coring.Seqner(sn=group.kever.sn),
+                coring.Saider(qb64=group.kever.serder.said),
+                sigers,
+            )
+        ],
+    )
+
+
+def _assertLeadElectionContract(exchanger, group, sign):
+    """Verify fallback, no-signature, elected, and superseded outcomes."""
+    lowerSigIdx = 0
+    localSigIdx = 1
+    higherSigIdx = 2
+
+    # A non-group habitat sends without participating in group election.
+    nonGroupExn, _ = exchanging.exchange(
+        route="/test/lead",
+        sender=group.mhab.pre,
+        payload={"case": "non-group"},
+    )
+    assert exchanger.lead(group.mhab, nonGroupExn.said) is True
+
+    # A group cannot elect a sender before indexed signatures are stored.
+    noSigExn, _ = exchanging.exchange(
+        route="/test/lead",
+        sender=group.pre,
+        payload={"case": "no-signatures"},
+    )
+    assert exchanger.lead(group, noSigExn.said) is False
+
+    regularGroupExn, _ = exchanging.exchange(
+        route="/test/lead",
+        sender=group.pre,
+        payload={"case": "group-election"},
+    )
+
+    # Both fixtures make index 1 local. Of indexes 2 and 1, local is lowest.
+    _logGroupSigs(
+        exchanger=exchanger,
+        group=group,
+        serder=regularGroupExn,
+        sigers=[
+            sign(signing_index=higherSigIdx, raw=regularGroupExn.raw),
+            sign(signing_index=localSigIdx, raw=regularGroupExn.raw),
+        ],
+    )
+    assert exchanger.lead(group, regularGroupExn.said) is True
+
+    # Adding index 0 supersedes local index 1, so the local member steps aside.
+    _logGroupSigs(
+        exchanger=exchanger,
+        group=group,
+        serder=regularGroupExn,
+        sigers=[sign(signing_index=lowerSigIdx, raw=regularGroupExn.raw)],
+    )
+    assert exchanger.lead(group, regularGroupExn.said) is False
+
+
+@contextmanager
+def _groupElection():
+    """Adapt a local GroupHab member at signing index 1 for election tests."""
+    # Index 1 leads when signatures 2 and 1 exist, then loses when 0 arrives.
+    with openMultiSig(prefix="exchange-lead") as (
+        (_, ghab1),
+        (hby2, ghab2),
+        (_, ghab3),
+    ):
+        localHby = hby2
+        localGhab = ghab2
+        signingGhabs = (ghab1, ghab2, ghab3)
+
+        def sign(signing_index: int, raw: bytes) -> core.Siger:
+            signingGhab = signingGhabs[signing_index]
+            sigers = signingGhab.sign(raw)
+            return sigers[0]
+
+        yield localHby, localGhab, sign
+
+
+@contextmanager
+def _signifyGroupElection():
+    """Adapt a local Signify member at signing index 1 for election tests."""
+    with signifying.openSignifyGroup(
+        name="signify-lead", mhabIdx=1
+    ) as signifyGroup:
+        yield signifyGroup.hby, signifyGroup.group, signifyGroup.sign
+
+
+@pytest.mark.parametrize(
+    "openElection",
+    (_groupElection, _signifyGroupElection),
+    ids=("group", "signify-group"),
+)
+def test_exchanger_lead_election(openElection):
+    """Real group habitats follow the same lowest-signature-index election, both GroupHab and SignifyGroupHab"""
+    with openElection() as (hby, group, sign):
+        exchanger = exchanging.Exchanger(hby=hby, handlers=[])
+        _assertLeadElectionContract(
+            exchanger=exchanger, group=group, sign=sign
+        )
 
 
 def test_nesting():


### PR DESCRIPTION
And added some test fixtures for both group leader election and Signify testing

Prior to this PR leader election was broken for SignifyGroupHab instances.