### PR TITLE
Backport to v1.2.14: Missing sn in CloneCreds after fix in PR #682

### DIFF
--- a/src/keri/vdr/viring.py
+++ b/src/keri/vdr/viring.py
@@ -420,11 +420,21 @@ class Reger(dbing.LMDBer):
             atc = bytearray(signing.serialize(creder, prefixer, seqner, saider))
             del atc[0:creder.size]
 
-            iss = bytearray(self.cloneTvtAt(creder.said))
+            regk = creder.regi
+            status = self.tevers[regk].vcState(saider.qb64)
+            schemer = db.schema.get(creder.schema)
+            revoked = status.et in (coring.Ilks.rev, coring.Ilks.brv)
+
+            iss = bytearray(self.cloneTvtAt(creder.said, sn=0))
             iserder = serdering.SerderKERI(raw=iss)
             issatc = bytes(iss[iserder.size:])
-
             del iss[0:iserder.size]
+
+            if revoked:
+                rev = bytearray(self.cloneTvtAt(creder.said, sn=1))
+                rserder = serdering.SerderKERI(raw=rev)
+                revatc = bytes(rev[rserder.size:])
+                del rev[0:rserder.size]
 
             chainSaids = []
             for k, p in (creder.edge.items() if creder.edge is not None else {}):
@@ -437,15 +447,13 @@ class Reger(dbing.LMDBer):
                 chainSaids.append(coring.Saider(qb64=p["n"]))
             chains = self.cloneCreds(chainSaids, db)
 
-            regk = creder.regi
-            status = self.tevers[regk].vcState(saider.qb64)
-            schemer = db.schema.get(creder.schema)
-
             cred = dict(
                 sad=creder.sad,
                 atc=atc.decode("utf-8"),
                 iss=iserder.sad,
                 issatc=issatc.decode("utf-8"),
+                rev=rserder.sad if revoked else None,
+                revatc=revatc.decode("utf-8") if revoked else None,
                 pre=creder.issuer,
                 schema=schemer.sed,
                 chains=chains,
@@ -470,6 +478,21 @@ class Reger(dbing.LMDBer):
                 ancatc = bytes(anc[aserder.size:])
                 cred['anc'] = aserder.sad
                 cred['ancatc'] = ancatc.decode("utf-8"),
+
+            if revoked:
+                ctr = core.Counter(qb64b=rev, strip=True, gvrsn=kering.Vrsn_1_0)
+                if ctr.code == counting.CtrDex_1_0.AttachmentGroup:
+                    ctr = core.Counter(qb64b=rev, strip=True, gvrsn=kering.Vrsn_1_0)
+
+                if ctr.code == counting.CtrDex_1_0.SealSourceCouples:
+                    coring.Seqner(qb64b=rev, strip=True)
+                    saider = coring.Saider(qb64b=rev)
+
+                    anc = db.cloneEvtMsg(pre=creder.issuer, fn=0, dig=saider.qb64b)
+                    aserder = serdering.SerderKERI(raw=anc)
+                    ancatc = bytes(anc[aserder.size:])
+                    cred['revanc'] = aserder.sad
+                    cred['revancatc'] = ancatc.decode("utf-8")
 
             creds.append(cred)
 

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -112,8 +112,10 @@ def test_verifier(seeder):
         # also try it via the cloneCreds function
         creds = regery.reger.cloneCreds(saids=saider, db=hab.db)
 
-        for idx, cred in enumerate(creds):
+        for cred in creds:
             assert dcre.sad == cred["sad"]
+            assert cred["rev"] is None
+            assert cred["revatc"] is None
 
         with pytest.raises(kering.MissingEntryError):
             regery.reger.cloneCred(said="nonexistantsaid")
@@ -658,5 +660,16 @@ def test_verifier_chained_credential(seeder):
         with pytest.raises(kering.RevokedChainError):
             vicverfer.processCredential(vLeiCreder, prefixer=ian.kever.prefixer, seqner=seqner,
                                         saider=coring.Saider(qb64=ian.kever.serder.said))
+
+        creds = ronreg.reger.cloneCreds(saids=[coring.Saider(qb64=creder.said)], db=ronHby.db)
+        for cred in creds:
+            assert cred["status"]["et"] == "rev"
+            assert cred["rev"] is not None
+            assert cred["rev"]["i"] == creder.said
+            assert isinstance(cred["revatc"], str)
+            assert cred["revanc"] is not None
+            assert cred["revanc"]["s"] == "3"
+            assert cred["revanc"]["a"][0]["s"] == "1"
+            assert isinstance(cred["revancatc"], str)
 
     """End Test"""


### PR DESCRIPTION
Adds revoked ACDC support in cloneCreds. This backports Rodo's 2024 change in https://github.com/WebOfTrust/keripy/pull/854 from `main` to `v1.2.14`