### PR TITLE
Backport to v1.2.14: fix: full size of 1AAE should be 156, not 56

### DIFF
--- a/src/keri/core/coring.py
+++ b/src/keri/core/coring.py
@@ -804,7 +804,7 @@ class Matter:
         '1AAB': Sizage(hs=4, ss=0, xs=0, fs=48, ls=0),
         '1AAC': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
         '1AAD': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
-        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=56, ls=0),
+        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=156, ls=0),
         '1AAF': Sizage(hs=4, ss=4, xs=0, fs=8, ls=0),
         '1AAG': Sizage(hs=4, ss=0, xs=0, fs=36, ls=0),
         '1AAH': Sizage(hs=4, ss=0, xs=0, fs=100, ls=0),

--- a/tests/core/test_coring.py
+++ b/tests/core/test_coring.py
@@ -460,7 +460,7 @@ def test_matter_class():
         '1AAB': Sizage(hs=4, ss=0, xs=0, fs=48, ls=0),
         '1AAC': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
         '1AAD': Sizage(hs=4, ss=0, xs=0, fs=80, ls=0),
-        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=56, ls=0),
+        '1AAE': Sizage(hs=4, ss=0, xs=0, fs=156, ls=0),
         '1AAF': Sizage(hs=4, ss=4, xs=0, fs=8, ls=0),
         '1AAG': Sizage(hs=4, ss=0, xs=0, fs=36, ls=0),
         '1AAH': Sizage(hs=4, ss=0, xs=0, fs=100, ls=0),
@@ -514,6 +514,14 @@ def test_matter_class():
     assert Matter.Sizes['A'].xs == 0  # xtra size
     assert Matter.Sizes['A'].fs == 44  # full size
     assert Matter.Sizes['A'].ls == 0  # lead size
+
+    raw = bytes(range(114))
+    matter = Matter(raw=raw, code=MtrDex.Ed448_Sig)
+    assert len(matter.qb64) == 156
+
+    matter = Matter(qb64=matter.qb64)
+    assert matter.code == MtrDex.Ed448_Sig
+    assert matter.raw == raw
 
 
     #  verify all Codes


### PR DESCRIPTION
Backports to `v1.2.14` from `main` Daniel's fix to the CESR code table for an Ed448 signature. 
Reference PR: https://github.com/WebOfTrust/keripy/pull/893

Rationale (copied):

An Ed448 signature is 114 bytes (binary). When serialized as CESR, there's a 4/3 increase in size, and a prefix. The correct size of this primitive in CESR is 156 bytes, which is what the spec claims, not 56 bytes as currently shown in the Matter class in keripy.

Fixes #892 