### PR TITLE
Backport to v1.2.14: fix: make sure that ESSR attachments survive an escrowed event

### DIFF
--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -87,7 +87,7 @@ class Exchanger:
                     raise MissingSignatureError(msg)
 
                 if prefixer.qb64 not in self.kevers or self.kevers[prefixer.qb64].sn < seqner.sn:
-                    if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
+                    if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed, essrs=essrs):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                     msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
                     logger.info(msg)
@@ -99,7 +99,7 @@ class Exchanger:
                 _, indices = eventing.verifySigs(serder.raw, sigers, verfers)
 
                 if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
-                    if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed):
+                    if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=pathed, essrs=essrs):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=seqner.snh)))
                     msg = (f"Not enough signatures in idx={indices} route={route} "
                            f"for evt = {serder.said} recipient={serder.ked.get('rp', '')}")
@@ -123,7 +123,7 @@ class Exchanger:
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
         else:
-            self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed)
+            self.escrowPSEvent(serder=serder, tsgs=[], pathed=pathed, essrs=essrs)
             msg = (
                 f"Failure satisfying exn, no cigs or sigs for evt = {serder.said} "
                 f"on route {route} recipient = {serder.ked.get('rp', '')}")
@@ -184,13 +184,14 @@ class Exchanger:
         """
         self.processEscrowPartialSigned()
 
-    def escrowPSEvent(self, serder, tsgs, pathed):
+    def escrowPSEvent(self, serder, tsgs, pathed, essrs=None):
         """ Escrow event that does not have enough signatures.
 
         Parameters:
             serder (Serder): instance of event
             tsgs (list): quadlet of prefixer seqner, saider, sigers
             pathed (list): list of bytes of attached paths
+            essrs (list): Texter instances containing encrypted payloads
 
         """
         dig = serder.said
@@ -198,6 +199,9 @@ class Exchanger:
             quadkeys = (serder.said, prefixer.qb64, f"{seqner.sn:032x}", ssaider.qb64)
             for siger in sigers:
                 self.hby.db.esigs.add(keys=quadkeys, val=siger)
+
+        for texter in essrs or []:
+            self.hby.db.essrs.add(keys=(dig,), val=texter)
 
         self.hby.db.epsd.put(keys=(dig,), val=coring.Dater())
         self.hby.db.epath.pin(keys=(dig,), vals=[bytes(p) for p in pathed])
@@ -255,6 +259,7 @@ class Exchanger:
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)
                 self.hby.db.esigs.rem(dig)
+                self.hby.db.essrs.rem(dig)
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.exception("Exchanger: partially signed unescrowed: %s", ex.args[0])
                 else:

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -213,6 +213,48 @@ def test_essrs():
         assert recHby.db.exns.get(keys=(essr.said,)) is None
 
 
+def test_essr_survives_escrow_and_exchanger_restart():
+    with habbing.openHab(name="essr-sid", base="test", salt=b'0123456789abcdef') as (hby, hab), \
+            habbing.openHab(name="essr-rec", base="test", salt=b'0123456789abcdef') as (recHby, recHab):
+        msg = "This encrypted payload must survive escrow"
+        pubkey = pysodium.crypto_sign_pk_to_box_pk(recHab.kever.verfers[0].raw)
+        raw = pysodium.crypto_box_seal(msg.encode("utf-8"), pubkey)
+        texter = coring.Texter(raw=raw)
+        diger = coring.Diger(ser=raw, code=MtrDex.Blake3_256)
+        essr, _ = exchanging.exchange(
+            route="/essr/req",
+            sender=hab.pre,
+            diger=diger,
+            modifiers=dict(src=hab.pre, dest=recHab.pre),
+        )
+        ims = hab.endorse(serder=essr, pipelined=False)
+        ims.extend(core.Counter(core.Codens.ESSRPayloadGroup, count=1,
+                                gvrsn=kering.Vrsn_1_0).qb64b)
+        ims.extend(texter.qb64b)
+
+        exc = exchanging.Exchanger(hby=recHby, handlers=[])
+        parsing.Parser().parse(ims=ims, kvy=recHby.kvy, exc=exc,
+                               gvrsn=kering.Vrsn_1_0)
+
+        assert recHby.db.epse.get(keys=(essr.said,)) is not None
+        escrowed = recHby.db.essrs.get(keys=(essr.said,))
+        assert len(escrowed) == 1
+        assert escrowed[0].raw == texter.raw
+
+        # A replacement Exchanger, such as after a process restart, must reconstruct
+        # and complete the ESSR escrow from DB state only, and not rely on original
+        # Exchanger instance-local state.
+        restarted = exchanging.Exchanger(hby=recHby, handlers=[])
+        parsing.Parser().parse(ims=hab.makeOwnInception(), kvy=recHby.kvy)
+        restarted.processEscrowPartialSigned()
+
+        assert recHby.db.epse.get(keys=(essr.said,)) is None
+        assert recHby.db.exns.get(keys=(essr.said,)) is not None
+        saved = recHby.db.essrs.get(keys=(essr.said,))
+        assert len(saved) == 1
+        assert recHab.decrypt(ser=saved[0].raw).decode("utf-8") == msg
+
+
 def test_exchanger():
     with habbing.openHab(name="sid", base="test", salt=b'0123456789abcdef') as (hby, hab), \
             habbing.openHab(name="rec", base="test", salt=b'0123456789abcdef') as (recHby, recHab):


### PR DESCRIPTION
### Included

Backports a subset of https://github.com/WebOfTrust/keripy/pull/1039 to v1.2.14: just the portion that saves ESSR attachments during `escrowPSEvent` so that ESSR attachments survive escrow of an event with ESSR attachments.


### Excluded

I did not backport the bug fix to ensure one `Exchanger` does not poach another `Exchanger`'s escrowed events because this solution introduces a new bug that indefinitely skips pre-restart escrowed events in the Exchanger partial signature EXN escrow (`epse`), so we can't use this part of #1039 until we come up with a way to handle this condition.