### PR TITLE
Backport to v1.2.14: fix: elide IPEX notifications for local IPEX initiator

### DIFF
--- a/src/keri/vc/protocoling.py
+++ b/src/keri/vc/protocoling.py
@@ -127,7 +127,8 @@ class IpexHandler:
             m=attrs["m"]
         )
 
-        self.notifier.add(attrs=data)
+        if serder.ked.get("i", "") not in self.hby.habs:
+            self.notifier.add(attrs=data)
 
 
 def ipexApplyExn(hab, recp, message, schema, attrs):

--- a/tests/vc/test_protocoling.py
+++ b/tests/vc/test_protocoling.py
@@ -15,6 +15,40 @@ from keri.vdr import credentialing, verifying
 from keri.app import habbing, notifying
 
 
+def test_ipex_notifications_only_for_remote_senders():
+    with habbing.openHab(name="local", base="test", salt=b"0123456789abcdef") as (hby, hab), \
+            habbing.openHab(name="remote", base="test", salt=b"abcdef0123456789") as (_, remote):
+        notifier = notifying.Notifier(hby=hby)
+        handler = protocoling.IpexHandler(resource="/ipex/apply", hby=hby, notifier=notifier)
+
+        local, _ = protocoling.ipexApplyExn(
+            hab=hab,
+            recp=remote.pre,
+            message="locally initiated",
+            schema="schema",
+            attrs={},
+        )
+        handler.handle(serder=local)
+        assert notifier.getNotes() == []
+
+        incoming, _ = protocoling.ipexApplyExn(
+            hab=remote,
+            recp=hab.pre,
+            message="received remotely",
+            schema="schema",
+            attrs={},
+        )
+        handler.handle(serder=incoming)
+
+        notes = notifier.getNotes()
+        assert len(notes) == 1
+        assert notes[0].attrs == {
+            "r": "/exn/ipex/apply",
+            "d": incoming.said,
+            "m": "received remotely",
+        }
+
+
 def test_ipex(seeder, mockCoringRandomNonce, mockHelpingNowIso8601, mockHelpingNowUTC):
     """ Test IPEX exchange protocol """
 


### PR DESCRIPTION
Initiators of IPEX operations do not need to get a notification for an event they initiated. This backports the IPEX subset of Phil's work in https://github.com/WebOfTrust/keripy/pull/1426 to v1.2.14.

It's a two line fix and then a test.