### PR TITLE
Backport to v1.2.14: feat: Add query endpoints to witnesses

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -4,8 +4,9 @@ KERI
 keri.app.agenting module
 
 """
+import json
 import random
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlencode, urlparse, urljoin
 
 from hio.base import doing
 from hio.core import http
@@ -177,7 +178,8 @@ class Receiptor(doing.DoDoer):
         base = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
         url = urljoin(base, f"/receipts?pre={pre}&sn={sn}")
 
-        client = self.clienter.request("GET", url)
+        headers = Hict([(httping.CESR_DESTINATION_HEADER, wit)])
+        client = self.clienter.request("GET", url, headers=headers)
         while not client.responses:
             yield tock
 
@@ -185,6 +187,99 @@ class Receiptor(doing.DoDoer):
         if rep.status == 200:
             rct = bytearray(rep.body)
             hab.psr.parseOne(bytearray(rct))
+
+        self.clienter.remove(client)
+        return rep.status == 200
+
+    def ksn(self, pre, wit, src, tock=0.0):
+        """Yield while querying a witness for the key state of an identifier.
+
+        Parameters:
+            pre (str): qb64 identifier whose key state is requested.
+            wit (str): qb64 witness identifier to query.
+            src (str): qb64 local identifier issuing the query.
+
+        Returns:
+            bool: True if the witness returned HTTP 200.
+        """
+        if src not in self.hby.prefixes:
+            raise kering.MissingEntryError(f"{pre} not a valid AID")
+
+        hab = self.hby.habs[src]
+        kever = hab.kevers[pre]
+
+        if wit not in kever.wits:
+            return
+
+        urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) or \
+            hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+        if not urls:
+            raise kering.MissingEntryError(f"unable to query witness {wit}, no http endpoint")
+
+        base = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
+        url = urljoin(base, f"/ksn?pre={pre}&src={src}")
+        headers = Hict([(httping.CESR_DESTINATION_HEADER, wit)])
+
+        client = self.clienter.request("GET", url, headers=headers)
+        while not client.responses:
+            yield tock
+
+        rep = client.respond()
+        if rep.status == 200:
+            hab.psr.parseOne(bytearray(rep.body))
+
+        self.clienter.remove(client)
+        return rep.status == 200
+
+    def logs(self, pre, wit, src, sn=None, fn=None, anchor=None, tock=0.0):
+        """Yield while retrieving an identifier's event log from a witness.
+
+        Parameters:
+            pre (str): qb64 identifier whose event log is requested.
+            wit (str): qb64 witness identifier to query.
+            src (str): qb64 local identifier issuing the query.
+            sn (int | None): optional minimum witnessed sequence number.
+            fn (int | None): optional first ordinal for the cloned log.
+            anchor (dict | None): optional event seal with `i`, `s`, and `d` fields.
+
+        Returns:
+            bool: True if the witness returned HTTP 200.
+        """
+        if src not in self.hby.prefixes:
+            raise kering.MissingEntryError(f"{pre} not a valid AID")
+
+        hab = self.hby.habs[src]
+        kever = hab.kevers[pre]
+
+        if wit not in kever.wits:
+            return
+
+        urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) or \
+            hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+        if not urls:
+            raise kering.MissingEntryError(f"unable to query witness {wit}, no http endpoint")
+
+        params = {"pre": pre}
+        if sn is not None:
+            params["s"] = f"{sn:X}"
+        if fn is not None:
+            params["fn"] = f"{fn:X}"
+        if anchor is not None:
+            params["a"] = json.dumps(anchor, separators=(",", ":"))
+
+        base = urls[kering.Schemes.http] if kering.Schemes.http in urls else urls[kering.Schemes.https]
+        url = urljoin(base, f"/log?{urlencode(params)}")
+        headers = Hict([(httping.CESR_DESTINATION_HEADER, wit)])
+
+        client = self.clienter.request("GET", url, headers=headers)
+        while not client.responses:
+            yield tock
+
+        rep = client.respond()
+        if rep.status == 200:
+            hab.psr.parse(bytearray(rep.body))
+        else:
+            logger.info(f"Failed to retrieve log from {wit}: {rep.status} {rep.body}")
 
         self.clienter.remove(client)
         return rep.status == 200

--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -6,6 +6,7 @@ keri.app.indirecting module
 simple indirect mode demo support classes
 """
 import datetime
+import json
 
 import falcon
 import time
@@ -21,7 +22,7 @@ from hio.help import decking
 import keri.app.oobiing
 from . import directing, storing, httping, forwarding, agenting, oobiing, tocking
 from .habbing import GroupHab
-from .. import help, kering
+from .. import help, kering, core
 from ..core import (eventing, parsing, routing, coring, serdering,
                     Counter, Codens)
 from ..core.coring import Ilks
@@ -93,6 +94,10 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     app.add_route("/query", queryEnd)
     metricsEnd = EscrowEnd(hby=hby, reger=reger)
     app.add_route("/metrics", metricsEnd)
+    ksnEnd = KeyStateEnd(hab=hab)
+    app.add_route("/ksn", ksnEnd)
+    klogEnd = KeyLogEnd(hab=hab)
+    app.add_route("/log", klogEnd)
 
     server = createHttpServer(host, httpPort, app, keypath, certpath, cafilepath)
     if not server.reopen():
@@ -1301,3 +1306,114 @@ class QueryEnd:
             rep.set_header('Content-Type', "application/json")
             rep.text = "unkown query type."
             rep.status = falcon.HTTP_400
+
+
+class KeyStateEnd:
+    """HTTP endpoint that returns a witness-endorsed key state notice."""
+
+    def __init__(self, hab):
+        self.hab = hab
+
+    def on_get(self, req, rep):
+        """Handle a key state query for the requested identifier prefix."""
+        pre = req.get_param("pre")
+
+        if pre not in self.hab.kevers:
+            msg = f"Query not found error on event pre={pre}"
+            logger.debug(msg)
+            raise falcon.HTTPNotFound(title="AID not found", description=msg)
+
+        kever = self.hab.kevers[pre]
+
+        # Only advertise key state whose witness threshold has been satisfied.
+        wigs = self.hab.db.getWigs(dbing.dgKey(pre, kever.serder.saidb))
+        wigers = [core.Siger(qb64b=bytes(wig)) for wig in wigs]
+        if len(wigers) < kever.toader.num:
+            msg = f"Witness receipts not found error on event pre={pre}"
+            logger.debug(msg)
+            raise falcon.HTTPNotFound(title="Witness receipts not found", description=msg)
+
+        rserder = eventing.reply(route=f"/ksn/{self.hab.pre}", data=kever.state()._asdict())
+        rep.set_header("Content-Type", "application/cesr")
+        rep.status = falcon.HTTP_200
+        rep.data = bytes(self.hab.endorse(rserder))
+
+
+class KeyLogEnd:
+    """HTTP endpoint that returns a cloned key event log."""
+
+    def __init__(self, hab):
+        self.hab = hab
+
+    def on_get(self, req, rep):
+        """Handle an event log query for the requested identifier prefix."""
+        pre = req.get_param("pre")
+        anchor = req.get_param("a", None)
+        if anchor is not None:
+            try:
+                anchor = json.loads(anchor)
+            except json.JSONDecodeError as ex:
+                raise falcon.HTTPBadRequest(
+                    title="Invalid anchor",
+                    description="'a' query param must be a JSON event seal",
+                ) from ex
+
+            fields = eventing.SealEvent._fields
+            # Data validation on anchor
+            if not isinstance(anchor, dict) or set(anchor) != set(fields) or \
+                    any(not isinstance(anchor.get(field), str) or not anchor[field] for field in fields):
+                raise falcon.HTTPBadRequest(
+                    title="Invalid anchor",
+                    description="'a' query param must contain exactly the non-empty string fields i, s, and d",
+                )
+
+            # Normalize field order for fetchAllSealingEventByEventSeal's SealEvent conversion.
+            anchor = {field: anchor[field] for field in fields}
+            try:
+                coring.Prefixer(qb64=anchor["i"])
+                coring.Seqner(snh=anchor["s"])
+                coring.Saider(qb64=anchor["d"])
+            except (ValueError, kering.KeriError) as ex:
+                raise falcon.HTTPBadRequest(
+                    title="Invalid anchor",
+                    description="'a' query param contains an invalid event seal",
+                ) from ex
+
+        sn = req.get_param("s", None)
+        sn = int(sn, 16) if sn else None
+        fn = req.get_param("fn", None)
+        fn = int(fn, 16) if fn else 0
+
+        if pre not in self.hab.kevers:
+            msg = f"Query not found error on pre={pre}"
+            logger.debug(msg)
+            raise falcon.HTTPNotFound(title="AID not found", description=msg)
+
+        kever = self.hab.kevers[pre]
+        if anchor:
+            if not self.hab.db.fetchAllSealingEventByEventSeal(pre=pre, seal=anchor):
+                msg = f"Query not found error on pre={pre} and anchor={anchor}"
+                logger.debug(msg)
+                raise falcon.HTTPNotFound(title="AID not found", description=msg)
+        elif sn is not None:
+            if kever.sner.num < sn or not self.hab.db.fullyWitnessed(kever.serder):
+                msg = f"Query not found error on pre={pre} and sn={sn}"
+                logger.debug(msg)
+                raise falcon.HTTPNotFound(title="AID not found", description=msg)
+
+        msgs = bytearray()
+        for msg in self.hab.db.clonePreIter(pre=pre, fn=fn):
+            msgs.extend(msg)
+
+        if kever.delpre:
+            for msg in self.hab.db.clonePreIter(pre=kever.delpre, fn=0):
+                msgs.extend(msg)
+
+        if not msgs:
+            msg = f"No events found on pre={pre}"
+            logger.debug(msg)
+            raise falcon.HTTPNotFound(title="AID not found", description=msg)
+
+        rep.set_header("Content-Type", "application/cesr")
+        rep.status = falcon.HTTP_200
+        rep.data = bytes(msgs)

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4721,7 +4721,7 @@ class Kevery:
                     aid not in baks and \
                     aid not in wats:
                 raise kering.UntrustedKeyStateSource("key state notice for {} from untrusted source {} "
-                                                     .format(ksr.pre, aid))
+                                                     .format(ksr.i, aid))
 
         if ksr.i in self.kevers:
             kever = self.kevers[ksr.i]

--- a/tests/app/test_indirecting.py
+++ b/tests/app/test_indirecting.py
@@ -199,6 +199,8 @@ def test_wit_query_ends(seeder):
         app = falcon.App()
         query_endpoint = indirecting.QueryEnd(wesHab, reger=wesReger)
         app.add_route("/query", query_endpoint)
+        app.add_route("/ksn", indirecting.KeyStateEnd(wesHab))
+        app.add_route("/log", indirecting.KeyLogEnd(wesHab))
         
         wesClient = testing.TestClient(app)
 
@@ -206,7 +208,8 @@ def test_wit_query_ends(seeder):
             wesHab=wesHab,
             palHby=palHby,
             witDoer=witDoer,
-            wesClient=wesClient
+            wesClient=wesClient,
+            done=decking.Deck(),
         )
 
         doers = wesDoers + [witDoer, doing.doify(wit_querier_test_do, **opts)]
@@ -218,11 +221,11 @@ def test_wit_query_ends(seeder):
 
         tymer = tyming.Tymer(tymth=doist.tymen(), duration=doist.limit)
 
-        while not tymer.expired:
+        while not opts["done"] and not tymer.expired:
             doist.recur()
             time.sleep(doist.tock)
-        # doist.do(doers=doers)
 
+        assert opts["done"]
         assert doist.limit == limit
 
         doist.exit()
@@ -246,6 +249,36 @@ def wit_querier_test_do(tymth=None, tock=0.0, **opts):
 
     witDoer.cues.popleft()
     msg = next(wesHab.db.clonePreIter(pre=palHab.pre))
+
+    # Exercise the routes registered by setupWitness through the Receiptor API.
+    assert (yield from witDoer.get(pre=palHab.pre, tock=tock)) is True
+    assert (yield from witDoer.ksn(pre=palHab.pre, wit=wesHab.pre,
+                                  src=palHab.pre, tock=tock)) is True
+    assert (yield from witDoer.logs(pre=palHab.pre, wit=wesHab.pre,
+                                   src=palHab.pre, tock=tock)) is True
+
+    # Test a fully witnessed key state notice.
+    res = wesClient.simulate_get("/ksn", params={"pre": palHab.pre})
+    assert res.status_code == 200
+    assert res.headers["Content-Type"] == "application/cesr"
+    ksn = core.serdering.SerderKERI(raw=res.content)
+    assert ksn.ked["r"] == f"/ksn/{wesHab.pre}"
+    assert ksn.ked["a"]["i"] == palHab.pre
+
+    res = wesClient.simulate_get("/ksn", params={"pre": "unknown"})
+    assert res.status_code == 404
+
+    # Test full-log retrieval and sequence-number availability checks.
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre})
+    assert res.status_code == 200
+    assert res.headers["Content-Type"] == "application/cesr"
+    assert bytearray(res.content) == bytearray(msg)
+
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre, "s": "1"})
+    assert res.status_code == 404
+
+    res = wesClient.simulate_get("/log", params={"pre": "unknown"})
+    assert res.status_code == 404
 
     # Test valid KEL query with 'pre'
     res = wesClient.simulate_get("/query", params={"typ": "kel", "pre": palHab.pre})
@@ -291,6 +324,33 @@ def wit_querier_test_do(tymth=None, tock=0.0, **opts):
     assert res.status_code == 400
     assert res.headers['Content-Type'] == "application/json"
     assert "unkown query type" in res.text
+
+    # Anchor queries require a JSON-encoded SealEvent and a fully witnessed sealing event.
+    anchor = dict(i=palHab.pre, s=f"{palHab.kever.sn:x}", d=palHab.kever.serder.said)
+    palHab.interact(data=[anchor])
+    witDoer.msgs.append(dict(pre=palHab.pre))
+    while not witDoer.cues:
+        yield tock
+    witDoer.cues.popleft()
+
+    assert (yield from witDoer.logs(pre=palHab.pre, wit=wesHab.pre,
+                                   src=palHab.pre, anchor=anchor, tock=tock)) is True
+
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre, "a": json.dumps(anchor)})
+    assert res.status_code == 200
+
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre, "a": "not-json"})
+    assert res.status_code == 400
+
+    invalid = dict(i=palHab.pre, s="0")
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre, "a": json.dumps(invalid)})
+    assert res.status_code == 400
+
+    invalid = dict(i="invalid", s="0", d=palHab.kever.serder.said)
+    res = wesClient.simulate_get("/log", params={"pre": palHab.pre, "a": json.dumps(invalid)})
+    assert res.status_code == 400
+
+    opts["done"].append(True)
 
 def test_wit_allowlist(seeder):
     with habbing.openHby(name="wes", salt=core.Salter(raw=b'wess-the-witness').qb64) as wesHby, \

--- a/tests/core/test_eventing.py
+++ b/tests/core/test_eventing.py
@@ -1800,6 +1800,29 @@ def test_state(mockHelpingNowUTC):
     """Done Test"""
 
 
+def test_untrusted_key_state_notice_reports_subject(mockHelpingNowUTC):
+    subject = "DN6WBhWqp6wC08no2iWhgFYTaUgrasnqz6llSvWQTWZN"
+    source = "DMrwi0a-Zblpqe5Hg7w7iz9JCKnMgWKu_W9w4aNUL64y"
+    ksr = basing.KeyStateRecord(
+        vn=[1, 0],
+        i=subject,
+        dt=helping.nowIso8601(),
+    )
+    rpy = eventing.reply(route=f"/ksn/{subject}", data=ksr._asdict())
+
+    with openDB(name="ksn-report") as db:
+        kvy = Kevery(db=db, lax=False)
+        with pytest.raises(kering.UntrustedKeyStateSource) as ex:
+            kvy.processReplyKeyStateNotice(
+                serder=rpy,
+                saider=coring.Saider(qb64=rpy.said),
+                route=rpy.ked["r"],
+                aid=source,
+            )
+
+    assert subject in str(ex.value)
+
+
 def test_messagize():
     """
     Test messagize utility function


### PR DESCRIPTION
Backports just the subset of https://github.com/WebOfTrust/keripy/pull/1426 to v1.2.14 that adds /ksn and /logs to witnesses