### PR TITLE
Backport to v1.2.14: fix: set eid on OOBI processReply when available

### DIFF
--- a/src/keri/app/oobiing.py
+++ b/src/keri/app/oobiing.py
@@ -368,6 +368,10 @@ class Oobiery:
         cid = cider.qb64  # controller authorizing eid at role
         aid = cid  # authorizing attribution id
 
+        # Defaults to controller ID (cid) if eid not present.
+        eider = coring.Prefixer(qb64=data.get("eid", cid))  # raises error if unsupported code
+        eid = eider.qb64  # endpoint eid at role
+
         oobi = data["oobi"]
         url = urlparse(oobi)
         if url.scheme not in ("http", "https"):
@@ -383,7 +387,7 @@ class Oobiery:
         if not accepted:
             raise UnverifiedReplyError(f"Unverified introduction reply. {serder.ked}")
 
-        obr = basing.OobiRecord(cid=cid, date=dt)
+        obr = basing.OobiRecord(cid=eid, date=dt)
         self.hby.db.oobis.put(keys=(oobi,), val=obr)
 
     def scoobiDo(self, tymth=None, tock=0.0, **kwa):

--- a/tests/app/test_oobiing.py
+++ b/tests/app/test_oobiing.py
@@ -141,6 +141,8 @@ def test_introduce(mockHelpingNowUTC):
         watHab = watHby.makeHab(name='wes', isith="1", icount=1, transferable=False)
         assert not watHab.kever.prefixer.transferable
         assert watHab.pre == "BBVDlgWic_rAf-m_v7vz_VvIYAUPErvZgLTfXGNrFRom"
+        endHab = watHby.makeHab(name='web', isith="1", icount=1, transferable=False)
+        assert endHab.pre != watHab.pre
         watKvy = eventing.Kevery(db=watHab.db, lax=False, local=False)
         watPsr = parsing.Parser(kvy=watKvy)
 
@@ -156,37 +158,36 @@ def test_introduce(mockHelpingNowUTC):
         witPsr = parsing.Parser(kvy=witKvy, rvy=rvy)
         assert witHby.db.oobis.cntAll() == 0
 
-        oobi = f"https://localhost:8989/oobi/{watHab.pre}/controller"
+        oobi = f"https://localhost:8989/oobi/{endHab.pre}/controller"
         data = dict(
             cid=watHab.pre,
+            eid=endHab.pre,
             oobi=oobi
         )
 
         msg = watHab.reply(route="/introduce", data=data)
-        assert msg == (b'{"v":"KERI10JSON000127_","t":"rpy","d":"EPEU3V7e2d2mhMWVFDS-oC9z'
-                       b'Q8DX8t6ELkhINIaYGFNZ","dt":"2021-01-01T00:00:00.000000+00:00","r'
-                       b'":"/introduce","a":{"cid":"BBVDlgWic_rAf-m_v7vz_VvIYAUPErvZgLTfX'
-                       b'GNrFRom","oobi":"https://localhost:8989/oobi/BBVDlgWic_rAf-m_v7v'
-                       b'z_VvIYAUPErvZgLTfXGNrFRom/controller"}}-VAi-CABBBVDlgWic_rAf-m_v'
-                       b'7vz_VvIYAUPErvZgLTfXGNrFRom0BBqF8yHDeXpzDUNIOsDBGezNBdgHafmOYbQ7'
-                       b'qw0R5t89FbLA26RwaA3NF9-dU0JpbNuJs7jiEBYbSGeDkbBDDEM')
+        rpy = serdering.SerderKERI(raw=msg)
+        assert rpy.ked["a"] == data
 
         witPsr.parseOne(ims=msg)
         assert witHby.db.oobis.cntAll() == 1
         obr = witHby.db.oobis.get(keys=(oobi,))
+        assert obr.cid == endHab.pre
+
+        # Legacy kli introduce messages omit eid, so fall back to the authorizing cid.
+        legacy_oobi = f"https://localhost:8989/oobi/{watHab.pre}/controller"
+        data = dict(cid=watHab.pre, oobi=legacy_oobi)
+        msg = watHab.reply(route="/introduce", data=data)
+        witPsr.parseOne(ims=msg)
+        assert witHby.db.oobis.cntAll() == 2
+        obr = witHby.db.oobis.get(keys=(legacy_oobi,))
         assert obr.cid == watHab.pre
 
-        # Send one missing fields
-        data = dict(cid=watHab.pre)
-        msg = watHab.reply(route="/introduce", data=data)
-        witPsr.parseOne(ims=msg)
-        assert witHby.db.oobis.cntAll() == 1  # Still one because of the missing 'oobi' field
-
         # Send one bad scheme
-        data = dict(cid=watHab.pre, oobi="ftp://localhost")
+        data = dict(cid=watHab.pre, eid=endHab.pre, oobi="ftp://localhost")
         msg = watHab.reply(route="/introduce", data=data)
         witPsr.parseOne(ims=msg)
-        assert witHby.db.oobis.cntAll() == 1  # Still one because of the missing 'oobi' field
+        assert witHby.db.oobis.cntAll() == 2
 
 
 


### PR DESCRIPTION
Backports just the endpoint ID (eid) correction to reply messages with OOBI URLs in them that are processed by Oobiery.processReply.

Backported from https://github.com/WebOfTrust/keripy/pull/1426 (v1.3.x)