### PR TITLE
Backport to v1.2.14: feat: Switched internal receipting mechanism of Registrar to use Receiptor

### DIFF
--- a/src/keri/app/cli/commands/witness/demo.py
+++ b/src/keri/app/cli/commands/witness/demo.py
@@ -22,6 +22,8 @@ from keri.core import Salter
 parser = argparse.ArgumentParser(description="Run a demo collection of witnesses")
 parser.add_argument("--loglevel", action="store", required=False, default=os.getenv("KERI_LOG_LEVEL", "CRITICAL"),
                     help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
+parser.add_argument('--base', '-b', help='additional optional prefix to file location of KERI keystore',
+                    required=False, default="")
 parser.set_defaults(handler=lambda args: demo(args))
 
 
@@ -47,12 +49,12 @@ def demo(args):
     wubcf = configing.Configer(name="wub", headDirPath="scripts", temp=False, reopen=True, clear=False)
     wyzcf = configing.Configer(name="wyz", headDirPath="scripts", temp=False, reopen=True, clear=False)
 
-    wanHby = habbing.Habery(name="wan", salt=Salter(raw=b'wann-the-witness').qb64, temp=False, cf=wancf)
-    wilHby = habbing.Habery(name="wil", salt=Salter(raw=b'will-the-witness').qb64, temp=False, cf=wilcf)
-    wesHby = habbing.Habery(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=False, cf=wescf)
-    witHby = habbing.Habery(name="wit", salt=Salter(raw=b'witn-the-witness').qb64, temp=False, cf=witcf)
-    wubHby = habbing.Habery(name="wub", salt=Salter(raw=b'wubl-the-witness').qb64, temp=False, cf=wubcf)
-    wyzHby = habbing.Habery(name="wyz", salt=Salter(raw=b'wyzs-the-witness').qb64, temp=False, cf=wyzcf)
+    wanHby = habbing.Habery(name="wan", salt=Salter(raw=b'wann-the-witness').qb64, temp=False, cf=wancf, base=args.base)
+    wilHby = habbing.Habery(name="wil", salt=Salter(raw=b'will-the-witness').qb64, temp=False, cf=wilcf, base=args.base)
+    wesHby = habbing.Habery(name="wes", salt=Salter(raw=b'wess-the-witness').qb64, temp=False, cf=wescf, base=args.base)
+    witHby = habbing.Habery(name="wit", salt=Salter(raw=b'witn-the-witness').qb64, temp=False, cf=witcf, base=args.base)
+    wubHby = habbing.Habery(name="wub", salt=Salter(raw=b'wubl-the-witness').qb64, temp=False, cf=wubcf, base=args.base)
+    wyzHby = habbing.Habery(name="wyz", salt=Salter(raw=b'wyzs-the-witness').qb64, temp=False, cf=wyzcf, base=args.base)
 
     doers = [InitDoer(wan=wanHby, wil=wilHby, wes=wesHby, wit=witHby, wub=wubHby, wyz=wyzHby)]
 

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -493,10 +493,10 @@ class Registrar(doing.DoDoer):
         self.hby = hby
         self.rgy = rgy
         self.counselor = counselor
-        self.witDoer = agenting.WitnessReceiptor(hby=self.hby)
+        self.receiptor = agenting.Receiptor(hby=self.hby)
         self.witPub = agenting.WitnessPublisher(hby=self.hby)
 
-        doers = [self.witDoer, self.witPub, doing.doify(self.escrowDo)]
+        doers = [self.receiptor, self.witPub, doing.doify(self.escrowDo)]
 
         super(Registrar, self).__init__(doers=doers)
 
@@ -524,7 +524,7 @@ class Registrar(doing.DoDoer):
                                saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=anc.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=anc.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(registry.regk, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
@@ -564,7 +564,7 @@ class Registrar(doing.DoDoer):
             registry.anchorMsg(pre=vcid, regd=iserder.said, seqner=seqner, saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
@@ -604,7 +604,7 @@ class Registrar(doing.DoDoer):
             registry.anchorMsg(pre=vcid, regd=rserder.said, seqner=seqner, saider=saider)
 
             print("Waiting for TEL event witness receipts")
-            self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
+            self.receiptor.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
             return vcid, rseq.sn
@@ -703,7 +703,7 @@ class Registrar(doing.DoDoer):
                 if len(wigs) == len(kever.wits):  # We have all of them, this event is finished
                     hab = self.hby.habs[prefixer.qb64]
                     witnessed = False
-                    for cue in self.witDoer.cues:
+                    for cue in self.receiptor.cues:
                         if cue["pre"] == hab.pre and cue["sn"] == seqner.sn:
                             witnessed = True
 


### PR DESCRIPTION
### Includes

Backports the v1.3.3 change of https://github.com/WebOfTrust/keripy/pull/1166 changing WitnessReceiptor to Receiptor for witness receipts. This uses the HTTP API for receipts and does not require witnesses to also behave as mailboxes.


### Excludes

Does not backport the `kli vc import` command.