### PR TITLE
fix: make witness transmission teardown deterministic

### DIFF
--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -8,7 +8,7 @@ simple direct mode demo support classes
 import itertools
 from hio.base import doing
 
-from .. import help
+from .. import help, kering
 from ..core import eventing, routing
 from ..core import parsing
 from ..vdr.eventing import Tevery
@@ -305,83 +305,58 @@ class Reactor(doing.DoDoer):
 
 
 class Directant(doing.DoDoer):
-    """
-    Directant class with TCP Server.
-    Responds to initiated connections from a remote Director by creating and
-    running a Reactant per connection. Each Reactant has TCP remoter.
+    """Supervise inbound direct-mode TCP connections with one Reactant each.
 
-    Directant Subclass of DoDoer with doers list from do generator methods:
+    Directant owns every accepted raw-TCP ``Remoter`` and its corresponding
+    ``Reactant``. HIO ``cutoff`` means only that receive is closed, so it is a
+    transition into draining rather than permission to discard accepted input
+    or generated responses. HIO ``txCutoff`` independently reports that sending
+    has become terminal.
+
+    During draining, Directant waits for the active parser to end or fail,
+    response production to settle, and ``txbs`` to empty. Terminal ``txCutoff``
+    or an absolute, non-refreshing deadline may end draining as an explicit
+    failure; the parser, producer, and unsent-output state is logged before
+    removal.
+    These are local lifecycle facts and do not prove remote processing or
+    durable storage.
+
+    Doer generator methods:
         .serviceDo
 
-    Enables continuous scheduling of doers (do generator instances or functions)
-
-    Implements Doist like functionality to allow nested scheduling of doers.
-    Each DoDoer runs a list of doers like a Doist but using the tyme from its
-       injected tymist as injected by its parent DoDoer or Doist.
-
-    Scheduling hierarchy: Doist->DoDoer...->DoDoer->Doers
-
-    Inherited Attributes:
-        .done is Boolean completion state:
-            True means completed
-            Otherwise incomplete. Incompletion maybe due to close or abort.
-        .opts is dict of injected options for its generator .do
-        .doers is list of Doers or Doer like generator functions
-
     Attributes:
-        .hab is Habitat instance of local controller's context
-        .server is TCP client instance. Assumes operated by another doer.
-        .rants is dict of Reactants indexed by connection address
-
-    Inherited Properties:
-        .tyme is float relative cycle time of associated Tymist .tyme obtained
-            via injected .tymth function wrapper closure.
-        .tymth is function wrapper closure returned by Tymist .tymeth() method.
-            When .tymth is called it returns associated Tymist .tyme.
-            .tymth provides injected dependency on Tymist tyme base.
-        .tock is desired time in seconds between runs or until next run,
-                 non negative, zero means run asap
-
-    Properties:
-
-    Inherited Methods:
-        .wind  injects ._tymth dependency from associated Tymist to get its .tyme
-        .__call__ makes instance callable
-            Appears as generator function that returns generator
-        .do is generator method that returns generator
-        .enter is enter context action method
-        .recur is recur context action method or generator method
-        .clean is clean context action method
-        .exit is exit context method
-        .close is close context method
-        .abort is abort context method
-
-    Methods:
-
-    Hidden:
-       ._tymth is injected function wrapper closure returned by .tymen() of
-            associated Tymist instance that returns Tymist .tyme. when called.
-       ._tock is hidden attribute for .tock property
+        hab: Local habitat whose database and routing context process messages.
+        server: TCP server containing active Remoters in ``server.ixes``.
+        rants: Reactants indexed by their Remoter connection addresses.
+        drainTymeout: Positive whole-drain deadline duration in seconds.
+        drainStops: Absolute, non-refreshing stop tyme for each draining Remoter.
     """
 
-    def __init__(self, hab, server, verifier=None, exchanger=None, doers=None, **kwa):
-        """
-        Initialize instance.
+    DrainTymeout = 30.0  # force TCP teardown, bounding txbs drain after peer/local EOF
 
-        Inherited Parameters:
-            tymist is  Tymist instance
-            tock is float seconds initial value of .tock
+    def __init__(self, hab, server, verifier=None, exchanger=None, doers=None,
+                 drainTymeout=None, **kwa):
+        """Initialize the supervisor for an existing raw-TCP server.
 
         Parameters:
-            db is database instance of local controller's context
-            verifier (optional) is Verifier instance of local controller's TEL context
-            server is TCP Server instance
+            hab: Local habitat used to construct per-connection Reactants.
+            server: TCP server whose accepted Remoters are supervised.
+            verifier: Optional TEL verifier supplied to each Reactant.
+            exchanger: Optional EXN exchanger supplied to each Reactant.
+            doers: Additional doers to run alongside ``serviceDo``.
+            drainTymeout: Positive whole-drain deadline in seconds. Defaults to
+                ``DrainTymeout`` and is independent of the Remoter idle timer.
         """
         self.hab = hab
         self.verifier = verifier
         self.exchanger = exchanger
         self.server = server  # use server for cx
         self.rants = dict()
+        self.drainTymeout = (float(drainTymeout) if drainTymeout is not None
+                             else self.DrainTymeout)
+        if not 0.0 < self.drainTymeout < float("inf"):
+            raise ValueError("drainTymeout must be finite and positive")
+        self.drainStops = dict()
         doers = doers if doers is not None else []
         doers.extend([doing.doify(self.serviceDo)])
         super(Directant, self).__init__(doers=doers, **kwa)
@@ -389,143 +364,175 @@ class Directant(doing.DoDoer):
             self.server.wind(self.tymth)
 
     def wind(self, tymth):
-        """
-        Inject new tymist.tymth as new ._tymth. Changes tymist.tyme base.
-        Updates winds .tymer .tymth
+        """Propagate a scheduler time base to this doer and its TCP server.
+
+        Parameters:
+            tymth: Callable returning the scheduler's current time.
         """
         super(Directant, self).wind(tymth)
         self.server.wind(tymth)
 
-
     def serviceDo(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns doifiable Doist compatibile generator method (doer dog) to service
-            connections on .server. Creates remoter and rant (Reactant) for each
-            open connection and adds rant to running doers.
+        """Create, retain, drain, and remove per-connection Reactants.
 
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
+        Each recurrence inspects the server's active Remoters. Peer receive EOF
+        enters draining immediately. A transmit-only failure or expired idle
+        timer first services bytes already waiting at the socket and then calls
+        ``shutdownReceive()``; directional HIO keeps ordinary sends enabled.
 
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
+        The first draining transition records one absolute deadline. Buffered
+        input gets a Reactant even when receive closed before construction.
+        Connections remain scheduled until ingress and response production
+        settle and either ``txbs`` empties or ``txCutoff`` makes sending
+        terminal. The whole-drain deadline bounds parser, producer, and egress
+        work and logs their remaining state before forced removal.
 
+        A receive-closed Remoter with no parser work still waits for any queued
+        ``txbs`` to drain, become terminal, or reach the same deadline.
 
-        Usage:
-            add result of doify on this method to doers list
+        Yields:
+            Once per connection-supervision recurrence.
         """
         yield  # enter context
         while True:
             for ca, ix in list(self.server.ixes.items()):
-                if ix.cutoff:
-                    self.closeConnection(ca)
-                    continue
+                if not ix.cutoff:
+                    if ix.txCutoff:
+                        # Sending is terminal. Accept any bytes already waiting
+                        # at the socket before closing the receive direction.
+                        ix.serviceReceives()
+                        ix.shutdownReceive()
+                    elif ix.tymeout > 0.0 and ix.tymer.expired:
+                        # Receive once before enforcing inactivity so bytes at
+                        # the boundary may refresh the Remoter timer.
+                        ix.serviceReceives()
+                        if not ix.cutoff and ix.tymer.expired:
+                            ix.shutdownReceive()
+
+                if ix.cutoff and ca not in self.drainStops:
+                    self.drainStops[ca] = self.tyme + self.drainTymeout
 
                 if ca not in self.rants:  # create Reactant and extend doers with it
+                    if ix.cutoff and not ix.rxbs:
+                        if not ix.txbs:
+                            self.closeConnection(ca)
+                        elif ix.txCutoff:
+                            self._logDrainFailure(ca=ca, ix=ix,
+                                                  reason="transmit cutoff")
+                            self.closeConnection(ca)
+                        elif self.tyme >= self.drainStops[ca]:
+                            self._logDrainFailure(ca=ca, ix=ix,
+                                                  reason="drain deadline expired")
+                            self.closeConnection(ca)
+                        continue
+
                     rant = Reactant(tymth=self.tymth, hab=self.hab, verifier=self.verifier,
                                     exchanger=self.exchanger, remoter=ix)
                     self.rants[ca] = rant
                     # add Reactant (rant) doer to running doers
                     self.extend(doers=[rant])  # open and run rant as doer
 
-                if ix.tymeout > 0.0 and ix.tymer.expired:
-                    self.closeConnection(ca)  # also removes rant
+                if ix.cutoff:
+                    rant = self.rants[ca]
+                    rxSettled = rant.rxDrained or rant.rxFailed
+                    outputDrained = rant.responseSettled and not ix.txbs
+                    deadlineExpired = self.tyme >= self.drainStops[ca]
+
+                    if rxSettled and outputDrained:
+                        self.closeConnection(ca)
+                    elif rxSettled and ix.txCutoff:
+                        self._logDrainFailure(ca=ca, ix=ix, rant=rant,
+                                              reason="transmit cutoff")
+                        self.closeConnection(ca)
+                    elif deadlineExpired:
+                        self._logDrainFailure(ca=ca, ix=ix, rant=rant,
+                                              reason="drain deadline expired")
+                        self.closeConnection(ca)
 
             yield
 
-    def closeConnection(self, ca):
+    @staticmethod
+    def _logDrainFailure(ca, ix, reason, rant=None):
+        """Log application and transport work abandoned by terminal close.
+
+        Parameters:
+            ca: Connection address used by ``server.ixes``.
+            ix: Remoter whose accepted or queued bytes are being abandoned.
+            reason: Stable human-readable terminal close reason.
+            rant: Optional Reactant containing parser and producer state.
         """
-        Close and remove connection given by ca and remove associated rant at ca.
+        logger.error("Closing direct connection %s after %s; "
+                     "rxbs=%d, messageInProgress=%s, responseSettled=%s, "
+                     "txbs=%d, txCutoff=%s",
+                     ca,
+                     reason,
+                     len(ix.rxbs),
+                     rant.messageInProgress if rant is not None else False,
+                     rant.responseSettled if rant is not None else True,
+                     len(ix.txbs),
+                     ix.txCutoff)
+
+    def closeConnection(self, ca):
+        """Remove a settled or explicitly failed Remoter and its Reactant.
+
+        ``serviceDo`` calls this after successful ingress/producer/egress
+        settlement, terminal transmit failure, or whole-drain deadline expiry.
+        It never performs an opportunistic final send; recurrent send service
+        belongs to the server doer before this terminal removal.
+
+        Parameters:
+            ca: Connection address used by ``server.ixes``, ``rants``, and
+                ``drainStops``.
         """
         if ca in self.server.ixes:  # remoter still there
-            self.server.ixes[ca].serviceSends()  # send final bytes to socket
-        self.server.removeIx(ca)
+            self.server.removeIx(ca)
         if ca in self.rants:  # remove rant (Reactant) if any
             self.remove([self.rants[ca]])  # close and remove rant from doers list
             del self.rants[ca]
+        self.drainStops.pop(ca, None)
 
 
 class Reactant(doing.DoDoer):
-    """
-    Reactant Subclass of DoDoer with doers list from do generator methods:
-        .msgDo, .cueDo, and .escrowDo.
-    Enables continuous scheduling of doers (do generator instances or functions)
+    """Process one accepted direct-mode TCP connection.
 
-    Implements Doist like functionality to allow nested scheduling of doers.
-    Each DoDoer runs a list of doers like a Doist but using the tyme from its
-       injected tymist as injected by its parent DoDoer or Doist.
+    Each Reactant binds a per-connection Parser to KEL, optional TEL, EXN, and
+    reply handlers. The Parser consumes the same mutable byte buffer exposed as
+    both ``remoter.rxbs`` and ``parser.ims``. ``msgDo`` dispatches inbound CESR
+    messages, ``cueDo`` queues protocol responses on the same Remoter, and
+    ``escrowDo`` advances deferred event processing. Directant owns the
+    Reactant's lifetime.
 
-    Scheduling hierarchy: Doist->DoDoer...->DoDoer->Doers
+    ``messageInProgress`` distinguishes a true empty message boundary from a
+    parser that has consumed bytes but still needs a body or attachments.
+    ``responseSettled`` combines queued cues with the active cue iterator so a
+    temporary empty cue deque cannot look settled between response fragments.
 
     Attributes:
-        .hab is Habitat instance of local controller's context
-        .kevery is Kevery instance
-        .remoter is TCP Remoter instance for connection from remote TCP client.
-
-    Inherited Attributes:
-        .done is Boolean completion state:
-            True means completed
-            Otherwise incomplete. Incompletion maybe due to close or abort.
-        .opts is dict of injected options for its generator .do
-        .doers is list of Doers or Doer like generator functions
-
-
-    Inherited Properties:
-        .tyme is float relative cycle time of associated Tymist .tyme obtained
-            via injected .tymth function wrapper closure.
-        .tymth is function wrapper closure returned by Tymist .tymeth() method.
-            When .tymth is called it returns associated Tymist .tyme.
-            .tymth provides injected dependency on Tymist tyme base.
-        .tock is float, desired time in seconds between runs or until next run,
-                 non negative, zero means run asap
-
-    Properties:
-
-    Inherited Methods:
-        .wind  injects ._tymth dependency from associated Tymist to get its .tyme
-        .__call__ makes instance callable
-            Appears as generator function that returns generator
-        .do is generator method that returns generator
-        .enter is enter context action method
-        .recur is recur context action method or generator method
-        .clean is clean context action method
-        .exit is exit context method
-        .close is close context method
-        .abort is abort context method
-
-    Overidden Methods:
-
-    Hidden:
-       ._tymth is injected function wrapper closure returned by .tymen() of
-            associated Tymist instance that returns Tymist .tyme. when called.
-       ._tock is hidden attribute for .tock property
-
+        hab: Local habitat providing the database and protocol context.
+        remoter: TCP connection used for both inbound and outbound bytes.
+        parser: Per-connection CESR parser backed by ``remoter.rxbs``.
+        messageInProgress: Whether one CESR message awaits completion.
+        cueInProgress: Whether a popped cue may still generate more output.
+        rxError: Terminal error for incomplete input at receive cutoff.
     """
 
     def __init__(self, hab, remoter, verifier=None, exchanger=None, doers=None, **kwa):
-        """
-        Initialize instance.
-
-        Inherited Parameters:
-            tymist is  Tymist instance
-            tock is float seconds initial value of .tock
-            doers is list of doers (do generator instancs or functions)
+        """Initialize protocol handlers for one accepted TCP connection.
 
         Parameters:
-            hby is Habitat instance of local controller's context
-            verifier is Verifier instance of local controller's TEL context
-            remoter is TCP Remoter instance
-            doers is list of doers (do generator instances, functions or methods)
-
+            hab: Local habitat whose database receives parsed protocol state.
+            remoter: Accepted TCP Remoter supplying the shared receive buffer.
+            verifier: Optional TEL verifier used to construct a Tevery.
+            exchanger: Optional EXN exchanger registered with the Parser.
+            doers: Additional doers to run with message, cue, and escrow work.
         """
         self.hab = hab
         self.verifier = verifier
         self.exchanger = exchanger
         self.remoter = remoter  # use remoter for both rx and tx
+        self.messageInProgress = False
+        self.cueInProgress = False
+        self.rxError = None
 
         doers = doers if doers is not None else []
         doers.extend([doing.doify(self.msgDo, tock=hab.tocks["reactantMsg"]),
@@ -561,93 +568,126 @@ class Reactant(doing.DoDoer):
             self.remoter.wind(self.tymth)
 
     def wind(self, tymth):
-        """
-        Inject new tymist.tymth as new ._tymth. Changes tymist.tyme base.
-        Updates winds .tymer .tymth
+        """Propagate a scheduler time base to this doer and its Remoter.
+
+        Parameters:
+            tymth: Callable returning the scheduler's current time.
         """
         super(Reactant, self).wind(tymth)
         self.remoter.wind(tymth)
 
-
     def msgDo(self, tymth=None, tock=0.0, **opts):
-        """
-        Returns doifiable Doist compatibile generator method (doer dog) to process
-            incoming message stream of .kevery
+        """Incrementally parse and dispatch complete inbound CESR messages.
 
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
+        Parsing starts only after the first byte arrives. A local
+        ``onceParsator`` then runs until one complete message and its attachments
+        have been dispatched. Normal iterator completion marks a message
+        boundary; a yield means the parser needs more bytes.
 
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
+        ``messageInProgress`` remains true during that wait, so destructively
+        consumed input and an empty ``parser.ims`` cannot be mistaken for drain.
+        If receive has closed when the parser yields, the active message fails
+        with ``ShortageError`` reporting the remaining buffered byte count
+        before the unusable remainder is cleared.
 
+        Complete buffered successors continue one message per recurrence until
+        ``rxDrained`` reaches a successful empty boundary.
 
-        Usage:
-            add result of doify on this method to doers list
-        """
-        self.wind(tymth)
-        _ = (yield tock)  # enter context
-        if self.parser.ims:
-            logger.info("Server %s: received:\n%s\n...\n", self.hab.name,
-                        self.parser.ims[:1024])
-        done = yield from self.parser.parsator(local=True)  # process messages continuously
-        return done  # should nover get here except forced close
-
-
-    def cueDo(self, tymth=None, tock=0.0, **opts):
-        """
-         Returns doifiable Doist compatibile generator method (doer dog) to process
-            .kevery.cues deque
-
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
-
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
-
-        Usage:
-            add result of doify on this method to doers list
+        Yields:
+            The configured ``tock`` while idle and after each parser step.
         """
         self.wind(tymth)
         _ = (yield tock)  # enter context
         while True:
-            for msg in self.hab.processCuesIter(self.kevery.cues):
-                if isinstance(msg, list):
-                    msg = bytearray(itertools.chain(*msg))
+            while not self.parser.ims:
+                yield tock
 
-                self.sendMessage(msg, label="chit or receipt or replay")
-                yield tock  # throttle just do one cue at a time
+            logger.info("Server %s: received:\n%s\n...\n", self.hab.name,
+                        self.parser.ims[:1024])
+            messageParser = self.parser.onceParsator(local=True)
+            self.messageInProgress = True
+            try:
+                while True:
+                    try:
+                        next(messageParser)
+                    except StopIteration:
+                        break
+
+                    if self.remoter.cutoff:
+                        remaining = len(self.parser.ims)
+                        self.rxError = kering.ShortageError(
+                            f"incomplete CESR message at EOF from "
+                            f"{self.remoter.ca}; {remaining} buffered bytes remain")
+                        del self.parser.ims[:]
+                        logger.error(str(self.rxError))
+                        break
+
+                    yield tock
+            finally:
+                messageParser.close()
+                self.messageInProgress = False
+
+            yield tock
+
+    @property
+    def rxDrained(self):
+        """Whether parsing is at a successful empty message boundary.
+
+        True requires no receiver error, no message in progress, and no bytes
+        in ``parser.ims``. Directant treats this as terminal only after receive
+        closure; an open idle connection may receive more.
+        """
+        return self.rxError is None and not self.messageInProgress and not self.parser.ims
+
+    @property
+    def rxFailed(self):
+        """Whether receive closure exposed an incomplete CESR message."""
+        return self.rxError is not None
+
+    @property
+    def responseSettled(self):
+        """Whether queued and active response production is locally settled."""
+        return not self.cueInProgress and not self.kevery.cues
+
+    def cueDo(self, tymth=None, tock=0.0, **opts):
+        """Generate and queue protocol responses from Kevery cues.
+
+        ``hab.processCuesIter`` may produce one or more messages for a cue.
+        ``cueInProgress`` remains true across every yielded response so
+        ``responseSettled`` stays false after the cue has been popped.
+        Fragment lists are flattened before each response is queued, and one
+        scheduler yield follows every response.
+
+        Queueing bytes on the Remoter proves neither transport delivery nor peer
+        processing.
+
+        Yields:
+            The configured ``tock`` after each response and while no cues exist.
+        """
+        self.wind(tymth)
+        _ = (yield tock)  # enter context
+        while True:
+            self.cueInProgress = bool(self.kevery.cues)
+            try:
+                for msg in self.hab.processCuesIter(self.kevery.cues):
+                    if isinstance(msg, list):
+                        msg = bytearray(itertools.chain(*msg))
+
+                    self.sendMessage(msg, label="chit or receipt or replay")
+                    yield tock  # throttle just do one cue at a time
+            finally:
+                self.cueInProgress = False
             yield tock
         return False  # should never get here except forced close
 
-
     def escrowDo(self, tymth=None, tock=0.0, **opts):
-        """
-         Returns doifiable Doist compatibile generator method (doer dog) to process
-            .kevery escrows.
+        """Advance deferred KEL and optional TEL processing once per recurrence.
 
-        Doist Injected Attributes:
-            g.tock = tock  # default tock attributes
-            g.done = None  # default done state
-            g.opts
+        Escrow processing may unblock protocol validation, but it does not define
+        the receiver-drain boundary and does not control connection teardown.
 
-        Parameters:
-            tymth is injected function wrapper closure returned by .tymen() of
-                Tymist instance. Calling tymth() returns associated Tymist .tyme.
-            tock is injected initial tock value
-            opts is dict of injected optional additional parameters
-
-        Usage:
-            add result of doify on this method to doers list
+        Yields:
+            The configured ``tock`` after each escrow-processing pass.
         """
         self.wind(tymth)
         _ = (yield tock)  # enter context
@@ -659,8 +699,14 @@ class Reactant(doing.DoDoer):
         return False  # should never get here except forced close
 
     def sendMessage(self, msg, label=""):
-        """
-        Sends message msg and loggers label if any
+        """Queue response bytes on the Remoter and log the local operation.
+
+        Returning means only that bytes entered the local transport buffer; it
+        is not acknowledgement of transport drain or peer processing.
+
+        Parameters:
+            msg: Bytes to queue on the connection.
+            label: Optional description included in the log entry.
         """
         self.remoter.tx(msg)  # send to remote
         logger.info("Server %s: sent %s:\n%d\n\n", self.hab.name,

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -6,17 +6,68 @@ tests.db.dbing module
 
 import logging
 import os
+import socket
+
+import pytest
 
 from hio.base import doing
 from hio.core.tcp import clienting, serving
 
 from keri import help  # logger support
-from keri import core
-from keri.core import eventing, coring
+from keri import core, kering
+from keri.core import eventing, coring, serdering
 
 from keri.app import habbing, directing
 
 from keri.demo import demoing
+
+
+@pytest.fixture()
+def directHabs():
+    """Provide temporary sender and receiver habitats for direct-mode tests."""
+    with habbing.openHab(name="alice-directing", temp=True) as (_, alice), \
+            habbing.openHab(name="bob-directing", temp=True) as (_, bob):
+        yield alice, bob
+
+
+def makeRemoter(ims=b"", *, cutoff=False, cs=None, tymeout=None):
+    """Create a synthetic Remoter with optional socket and buffered input."""
+    remoter = serving.Remoter(
+        ha=("127.0.0.1", 5632),
+        ca=("127.0.0.1", 5633),
+        cs=cs,
+        tymeout=tymeout,
+    )
+    remoter.rxbs.extend(ims)
+    remoter.cutoff = cutoff
+    return remoter
+
+
+def drainSocket(sock):
+    """Return all currently readable bytes without blocking."""
+    sock.setblocking(False)
+    received = bytearray()
+    while True:
+        try:
+            data = sock.recv(4096)
+        except BlockingIOError:
+            break
+        if not data:
+            break
+        received.extend(data)
+    return bytes(received)
+
+
+def recurUntil(doist, condition, message):
+    """Recur a bounded Doist until condition is true or its limit expires."""
+    if doist.limit is None or doist.limit <= 0.0:
+        raise ValueError("recur_until requires a positive Doist limit")
+
+    stop = doist.tyme + doist.limit
+    while not condition():
+        if doist.tyme >= stop:
+            raise AssertionError(message)
+        doist.recur()
 
 
 def test_directing_basic():
@@ -158,6 +209,336 @@ def test_directing_basic():
 
     help.ogler.resetLevel(level=help.ogler.level)
     """End Test"""
+
+
+def test_reactant_drains_complete_messages_after_receive_cutoff(directHabs):
+    alice, bob = directHabs
+
+    first = alice.makeOwnEvent(sn=0)
+    alice.interact()
+    second = alice.makeOwnEvent(sn=1)
+
+    remoter = makeRemoter(first + second, cutoff=True)
+    reactant = directing.Reactant(hab=bob, remoter=remoter)
+    dog = reactant.msgDo(tymth=lambda: 0.0, tock=0.0)
+
+    assert next(dog) == 0.0  # Prime msgDo at its enter-context yield.
+
+    assert next(dog) == 0.0  # Parse and dispatch the first buffered message.
+    assert not reactant.messageInProgress
+    assert not reactant.rxDrained  # The buffered successor still prevents drain.
+    assert reactant.kevery.kevers[alice.pre].sn == 0
+
+    assert next(dog) == 0.0  # Parse and dispatch the second buffered message.
+    assert not reactant.messageInProgress
+    assert reactant.rxDrained  # Both complete messages reached a safe EOF boundary.
+    assert not reactant.rxFailed
+    assert reactant.kevery.kevers[alice.pre].sn == 1
+    dog.close()
+
+
+def test_reactant_rejects_incomplete_message_at_receive_cutoff(directHabs):
+    alice, bob = directHabs
+
+    message = alice.makeOwnEvent(sn=0)
+    bodySize = serdering.SerderKERI(raw=message).size
+
+    # Exercise shortages in the body, at its boundary, and in attachments.
+    for cut in (10, bodySize, len(message) - 1):
+        remoter = makeRemoter(message[:cut], cutoff=True)
+        reactant = directing.Reactant(hab=bob, remoter=remoter)
+        dog = reactant.msgDo(tymth=lambda: 0.0, tock=0.0)
+
+        assert next(dog) == 0.0  # Prime msgDo at its enter-context yield.
+        assert next(dog) == 0.0  # Turn the parser shortage at EOF into failure.
+        assert not reactant.messageInProgress
+        assert not reactant.rxDrained
+        assert reactant.rxFailed  # Incomplete EOF is terminal, never a clean drain.
+        assert isinstance(reactant.rxError, kering.ShortageError)
+        assert "buffered bytes remain" in str(reactant.rxError)
+        assert not remoter.rxbs  # Discard the unusable suffix after recording failure.
+        dog.close()
+
+
+def test_directant_drains_response_after_peer_half_close(directHabs):
+    alice, bob = directHabs
+    remoterSocket, peerSocket = socket.socketpair()
+    remoter = makeRemoter(cs=remoterSocket, tymeout=1.0)
+    ca = remoter.ca
+
+    server = serving.Server(host="127.0.0.1", port=0, tymeout=1.0)
+    directant = directing.Directant(hab=bob, server=server)
+    serverDoer = serving.ServerDoer(server=server)
+    doist = doing.Doist(tock=0.03125, limit=1.0,
+                        doers=[directant, serverDoer])
+    doist.enter()
+    remoter.wind(doist.tymen())
+    server.ixes[ca] = remoter
+
+    try:
+        peerSocket.sendall(alice.makeOwnEvent(sn=0))
+        peerSocket.shutdown(socket.SHUT_WR)  # Send EOF but keep response reads open.
+
+        # Parse the request, drain its receipt, and then remove the connection.
+        recurUntil(
+            doist,
+            condition=lambda: ca not in server.ixes,
+            message="peer-half-closed connection did not drain its response",
+        )
+
+        assert alice.pre in bob.kevers  # should have processed request before close
+        assert b'"t":"rct"' in drainSocket(peerSocket)  # should have received receipt response
+        assert not remoter.txbs  # should have drained the local response buffer
+        assert ca not in directant.rants
+    finally:
+        doist.exit()
+        peerSocket.close()
+
+
+def test_directant_closes_receive_cutoff_without_buffered_input(directHabs):
+    _, bob = directHabs
+
+    remoter = makeRemoter(cutoff=True)
+    ca = remoter.ca
+    server = serving.Server()
+    server.ixes[ca] = remoter
+    directant = directing.Directant(hab=bob, server=server)
+    directant.wind(lambda: 0.0)
+    dog = directant.serviceDo(tymth=lambda: 0.0, tock=0.0)
+
+    next(dog)  # Prime serviceDo at its enter-context yield.
+    next(dog)  # Close the cutoff Remoter because it has no work to drain.
+    assert ca not in server.ixes
+    assert ca not in directant.rants
+    assert ca not in directant.drainStops  # should remove deadline bookkeeping
+
+    dog.close()
+    server.close()
+
+
+def test_directant_waits_for_all_output_from_one_cue(
+        directHabs, monkeypatch):
+    _, bob = directHabs
+    remoterSocket, peerSocket = socket.socketpair()
+    remoter = makeRemoter(cs=remoterSocket, tymeout=1.0)
+    ca = remoter.ca
+
+    server = serving.Server(host="127.0.0.1", port=0, tymeout=1.0)
+    directant = directing.Directant(hab=bob, server=server)
+    serverDoer = serving.ServerDoer(server=server)
+    doist = doing.Doist(tock=0.03125, limit=1.0,
+                        doers=[directant, serverDoer])
+    doist.enter()
+    remoter.wind(doist.tymen())
+    server.ixes[ca] = remoter
+
+    try:
+        # Create the Reactant before injecting its multi-response cue.
+        doist.recur()
+        rant = directant.rants[ca]
+
+        # Keep one cue active across two response-producing iterator yields.
+        def process_cue(cues):
+            assert cues.pull() == {"kin": "multi"}
+            yield b"first response"
+            yield b"second response"
+
+        # Mock Hab.processCuesIter wit ha fake, two message response to the single input cue
+        monkeypatch.setattr(bob, "processCuesIter", process_cue)
+        rant.kevery.cues.append({"kin": "multi"})
+        assert not rant.responseSettled
+        remoter.cutoff = True  # Immediate peer EOF (half close) -> server msgs must send to peer
+
+        # Send and drain the first response while the cue iterator stays active.
+        doist.recur()
+        assert ca in server.ixes
+        assert not rant.responseSettled  # Popped cue may still yield another response.
+        assert not rant.kevery.cues  # Cue deque alone now appears settled.
+        assert not remoter.txbs  # First response drained before the second is produced.
+
+        # Send and drain the second response before the iterator can settle.
+        doist.recur()
+        assert ca in server.ixes
+        assert not rant.responseSettled  # Iterator has not resumed to completion yet.
+        assert not remoter.txbs
+
+        # Let the cue iterator settle before Directant removes the connection.
+        recurUntil(
+            doist,
+            condition=lambda: ca not in server.ixes,
+            message="connection closed before all cue output drained",
+        )
+
+        assert drainSocket(peerSocket) == b"first responsesecond response"  # both must arrive before close
+        assert ca not in directant.rants
+    finally:
+        doist.exit()
+        peerSocket.close()
+
+
+def test_directant_requires_finite_positive_drain_timeout(directHabs):
+    _, bob = directHabs
+    server = serving.Server()
+
+    # A bounded drain deadline must be positive and finite.
+    for drainTymeout in (0.0, -1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            directing.Directant(hab=bob, server=server,
+                                drainTymeout=drainTymeout)
+
+    server.close()
+
+
+def test_directant_timeout_services_boundary_input_before_drain(directHabs):
+    alice, bob = directHabs
+    message = alice.makeOwnEvent(sn=0)
+    split = len(message) // 2
+
+    remoterSocket, peerSocket = socket.socketpair()
+    remoter = makeRemoter(message[:split], cs=remoterSocket,
+                          tymeout=0.0625)  # two hio ticks timeout
+    ca = remoter.ca
+
+    server = serving.Server(host="127.0.0.1", port=0, tymeout=0.0625)
+    directant = directing.Directant(hab=bob, server=server)
+    serverDoer = serving.ServerDoer(server=server)
+    doist = doing.Doist(tock=0.03125, limit=1.0,
+                        doers=[directant, serverDoer])
+    doist.enter()
+    remoter.wind(doist.tymen())
+    server.ixes[ca] = remoter
+
+    try:
+        # First recurrence creates the Reactant.
+        doist.recur()  # time accumulated = 1 tick or 0.03125
+        assert ca in directant.rants
+        rant = directant.rants[ca]
+
+        # Second recurrence advances its parser to wait at the idle boundary.
+        doist.recur()  # time accumulated = 2 ticks or 0.0625 - timeout/expiry occurs
+        assert remoter.tymer.expired  # Establish that final receive runs at expiry.
+        assert rant.messageInProgress
+
+        # Final receive refreshes HIO's timer instead of closing at the boundary.
+        peerSocket.sendall(message[split:])
+        doist.recur()
+        assert not remoter.cutoff  # Boundary input refreshed the timer before shutdown.
+
+        recurUntil(
+            doist,
+            condition=lambda: ca not in server.ixes,
+            message="timed-out connection did not finish draining",
+        )
+
+        assert alice.pre in bob.kevers  # should have completed the split request
+        assert rant.rxDrained
+        assert not rant.rxFailed
+        assert b'"t":"rct"' in drainSocket(peerSocket)  # should have drained its receipt
+        assert not remoter.txbs
+        assert ca not in directant.rants
+    finally:
+        doist.exit()
+        peerSocket.close()
+
+
+def test_directant_tx_cutoff_accounts_for_unsent_response(
+        directHabs, monkeypatch):
+    alice, bob = directHabs
+    remoterSocket, peerSocket = socket.socketpair()
+    remoter = makeRemoter(cs=remoterSocket, tymeout=1.0)
+    remoter.txCutoff = True  # Send is terminal; receive still needs final service.
+    ca = remoter.ca
+
+    server = serving.Server()
+    server.ixes[ca] = remoter
+    directant = directing.Directant(hab=bob, server=server,
+                                    drainTymeout=0.25)
+    # Directant must consume socket input and account for its unsendable receipt.
+    doist = doing.Doist(tock=0.03125, limit=1.0, doers=[directant])
+    doist.enter()
+    errors = []
+    monkeypatch.setattr(directing.logger, "error",
+                        lambda msg, *args: errors.append(msg % args))
+
+    try:
+        # Leave input in the kernel buffer for Directant's txCutoff receive pass.
+        peerSocket.sendall(alice.makeOwnEvent(sn=0))
+        assert not remoter.cutoff
+        assert not remoter.rxbs
+
+        recurUntil(
+            doist,
+            condition=lambda: ca not in server.ixes,
+            message="transmit-cutoff connection did not terminate",
+        )
+
+        assert alice.pre in bob.kevers  # Final receive must still process the request.
+        assert remoter.txbs  # Receipt remains queued because send is terminal.
+        assert any("after transmit cutoff" in error for error in errors)  # expose terminal reason
+        assert any(f"txbs={len(remoter.txbs)}" in error for error in errors)  # account for unsent bytes
+        assert ca not in directant.rants
+    finally:
+        doist.exit()
+        server.close()
+        peerSocket.close()
+
+
+def test_directant_response_drain_stops_at_absolute_deadline(
+        directHabs, monkeypatch):
+    alice, bob = directHabs
+    remoterSocket, peerSocket = socket.socketpair()
+    remoter = makeRemoter(alice.makeOwnEvent(sn=0), cutoff=True,
+                          cs=remoterSocket, tymeout=1.0)
+
+    # Simulate one-byte writes that continually refresh HIO's idle timer.
+    def serviceOneByteAndRefreshTimer():
+        if remoter.txbs:
+            del remoter.txbs[:1]
+            remoter.refresh()
+
+    monkeypatch.setattr(remoter, "serviceSends",
+                        serviceOneByteAndRefreshTimer)
+    ca = remoter.ca
+
+    server = serving.Server(host="127.0.0.1", port=0, tymeout=1.0)
+    directant = directing.Directant(hab=bob, server=server,
+                                    drainTymeout=0.125)
+    serverDoer = serving.ServerDoer(server=server)
+    doist = doing.Doist(tock=0.03125, limit=1.0,
+                        doers=[directant, serverDoer])
+    doist.enter()
+    remoter.wind(doist.tymen())
+    server.ixes[ca] = remoter
+    errors = []
+    monkeypatch.setattr(directing.logger, "error",
+                        lambda msg, *args: errors.append(msg % args))
+
+    try:
+        # First recurrence fixes Directant's non-refreshing drain deadline.
+        doist.recur()
+        drainStop = directant.drainStops[ca]
+        transportRemaining = remoter.tymer.remaining
+
+        # Second recurrence advances output and refreshes only HIO's timer.
+        doist.recur()
+        assert directant.drainStops[ca] == drainStop  # Partial sends cannot extend drain.
+        assert remoter.tymer.remaining > transportRemaining  # HIO timer did refresh.
+
+        recurUntil(
+            doist,
+            condition=lambda: ca not in server.ixes,
+            message="blocked response did not reach its drain deadline",
+        )
+
+        assert alice.pre in bob.kevers
+        assert remoter.txbs  # Absolute deadline wins before the trickle can drain output.
+        assert any("after drain deadline expired" in error for error in errors)  # expose deadline reason
+        assert any(f"txbs={len(remoter.txbs)}" in error for error in errors)
+        assert any("txCutoff=False" in error for error in errors)
+        assert ca not in directant.rants
+    finally:
+        doist.exit()
+        peerSocket.close()
 
 
 def test_runcontroller_demo():


### PR DESCRIPTION
## Summary

Treat inbound direct-mode TCP receive cutoff as the start of a bounded drain instead of immediate teardown.

- Keep Reactant alive until buffered CESR input is parsed or fails at EOF.
- Wait for response production to settle and HIO txbs to empty.
- End failed drains on HIO txCutoff or one absolute drain deadline.
- Cover EOF, incomplete and multiple messages, multi-response cues, idle boundaries, deadlines, and terminal transmit failure.

## Scope

Limited to src/keri/app/directing.py and tests/app/test_directing.py. Sender-side delivery results and other transport follow-ups remain separate.

## Validation

./venv/bin/python -m pytest -q tests/app/test_directing.py — 11 passed.