### PR TITLE
chore(ci): move workflow actions off deprecated Node runtimes

### DIFF
--- a/.github/workflows/publish-keripy.yml
+++ b/.github/workflows/publish-keripy.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: gleif/keri
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: images/keripy.dockerfile

--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -19,9 +19,9 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.12.6+
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.12.6'
 
@@ -62,9 +62,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.12.6+
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.12.6'
       - name: Install dependencies
@@ -76,16 +76,16 @@ jobs:
         run: |
           pytest --cov=./ --cov-report=xml
       - name: Upload
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.12.6+
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '>=3.12.6'
       - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.cache.outputs.GITHUB_REPOSITORY_NAME }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set outputs
         id: cache
         run: |
@@ -122,7 +122,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: interop
         run: |
           echo ${{ secrets.CR_PAT }} | docker login ghcr.io --username ${{ secrets.CR_USER }} --password-stdin


### PR DESCRIPTION
@pfeairheller Here's the trivial GHA PR I said I'd give you.

Every pinned action in this branch ran on node12, node16 or node20, all of which GitHub has deprecated, so each workflow run logged a deprecation warning.

actions/checkout v3 and v4 -> v6, actions/setup-python v2 and v5 -> v6, codecov/codecov-action v4 -> v5, and in the docker publish workflow docker/login-action v2 -> v4, docker/metadata-action v4 -> v6, and docker/build-push-action v3 -> v7. Each target is the version that first leaves the deprecated runtime, except checkout, where v5 would be enough but v6 keeps this branch on the same pin as the equivalent change on main.

The inputs in use are unchanged across all six bumps, and the '>=3.12.6' range the coverage and scripts jobs pass to setup-python resolves the same way under v6 as it did under v2.

The docker bumps are the least verifiable here, since publish-keripy.yml runs only on workflow_dispatch and no CI job exercises it.

Backport of the change proposed for main in WebOfTrust/keripy#1582. Refs WebOfTrust/keripy#1581