### PR TITLE
feat: upgrade to Hio 0.7.19 and Python 3.14.0

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -24,10 +24,10 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install libsodium
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: 3.12.2
+          python-version: 3.14.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: 3.12.2
+          python-version: 3.14.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.12.2
+      - name: Set up Python 3.14.6
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: 3.12.2
+          python-version: 3.14.6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - libsodium23
   tools:
-    python: "3.12.1"
+    python: "3.14"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We use `--pull=never` to ensure that docker does not implicitly pull a remote im
 ### Dependencies
 #### Binaries
 
-python 3.12.1+
+python 3.14.0+
 libsodium 1.0.18+
 
 
@@ -66,7 +66,7 @@ $ pip3 install -U cbor2
 ## Development
 
 ### Setup
-* Ensure Python 3.12.1 is present along with venv and dev header files;
+* Ensure Python 3.14.0 is present along with venv and dev header files;
 * Setup virtual environment: `python3 -m venv keripy`
 * Activate virtual environment: `source keripy/bin/activate`
 * Setup dependencies: `pip install -r requirements.txt`

--- a/images/keripy.dockerfile
+++ b/images/keripy.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=python:3.12.3-alpine3.20
+ARG BASE=python:3.14.6-alpine3.23
 
 FROM ${BASE} AS builder
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         # uncomment if you test on these interpreters:
         # 'Programming Language :: Python :: Implementation :: PyPy',
@@ -74,7 +74,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=3.12.2',
+    python_requires='>=3.14.0',
     install_requires=[
                         'lmdb>=1.4.1',
                         'pysodium>=0.7.17',
@@ -83,7 +83,7 @@ setup(
                         'cbor2>=5.6.2',
                         'multidict>=6.0.5',
                         'ordered-set>=4.1.0',
-                        'hio>=0.6.14',
+                        'hio>=0.7.19',
                         'multicommand==1.0.0',
                         'jsonschema>=4.21.1',
                         'falcon>=3.1.3',


### PR DESCRIPTION
It looks like upgrading to Hio is a small lift for KERIpy 1.2.14, from what I can tell.