### PR TITLE
narrowing playwright install to prevent hanging runner

### DIFF
--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   wasm-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -46,9 +47,9 @@ jobs:
         if: matrix.runner == 'playwright'
         run: |
           if [ "${{ matrix.playwright_browser }}" = "chromium" ]; then
-            python -m playwright install --with-deps --only-shell chromium
+            python -m playwright install --only-shell chromium
           else
-            python -m playwright install --with-deps ${{ matrix.playwright_browser }}
+            python -m playwright install ${{ matrix.playwright_browser }}
           fi
       - name: Prepare test directory
         run: |


### PR DESCRIPTION
Added a timeout so the tests do not hang forever and narrowing the install set so that the CI actually passes.