### PR TITLE
fix(structing): stop Blinder.unblind mutating the caller's states and…

### DIFF
--- a/src/keri/core/structing.py
+++ b/src/keri/core/structing.py
@@ -1522,12 +1522,12 @@ class Blinder(Structor):
         acdcs = [acdc]
         if "" not in acdcs:
             acdcs.append('')
-        states = states if states is not None else []
+        states = list(states) if states is not None else []
         if "" not in states:
             states.append("")
 
         if bound:
-            bounds = bounds if bounds is not None else [(0, '')]
+            bounds = list(bounds) if bounds is not None else [(0, '')]
             if (0, '') not in bounds:
                 bounds.append((0, ''))
 

--- a/tests/core/test_structing.py
+++ b/tests/core/test_structing.py
@@ -2003,6 +2003,42 @@ def test_blinder_class():
     """Done Test"""
 
 
+def test_blinder_unblind_leaves_caller_lists_alone():
+    """test Blinder.unblind does not mutate the states or bounds it is given"""
+
+    salt = '0ABdM7EmNFAlGe05ng6s1ljh'
+    acdc = 'EBju1o4x1Ud-z2sL-uxLC5L3iBVD77d_MYbYGGCUQgqQ'
+
+    # unblind adds the empty placeholder state to the states it tries. That addition
+    # must not reach the caller's list, which may be a shared constant reused across
+    # calls and iterated over elsewhere as "the states this issuer uses".
+    states = ['issued', 'revoked']
+    blinder = Blinder.blind(acdc=acdc, state='issued', salt=salt, sn=1)
+    unblinder = Blinder.unblind(said=blinder.said, acdc=acdc, states=states,
+                                salt=salt, sn=1)
+    assert unblinder.crew == blinder.crew
+    assert states == ['issued', 'revoked']          # not ['issued', 'revoked', '']
+
+    # the placeholder trial still works, and still leaves the list alone
+    placeholder = Blinder.blind(salt=salt, sn=1)
+    unblinder = Blinder.unblind(said=placeholder.said, acdc=acdc, states=states,
+                                salt=salt, sn=1)
+    assert unblinder.crew.td == '' and unblinder.crew.ts == ''
+    assert states == ['issued', 'revoked']
+
+    # same for the bound state's (bsn, bd) pairs
+    bounds = [(3, 'EFI7RD_-DnUD7WQFmU9wOgxNIufMICypEIhEsjuq6Ce4')]
+    bound = Blinder.blind(acdc=acdc, state='issued', salt=salt, sn=1, bound=True,
+                          bsn=bounds[0][0], bd=bounds[0][1])
+    unblinder = Blinder.unblind(said=bound.said, acdc=acdc, states=states, salt=salt,
+                                sn=1, bound=True, bounds=bounds)
+    assert unblinder.crew == bound.crew
+    assert bounds == [(3, 'EFI7RD_-DnUD7WQFmU9wOgxNIufMICypEIhEsjuq6Ce4')]
+    assert states == ['issued', 'revoked']
+
+    """Done Test"""
+
+
 def test_blinder():
     """test blinder instance"""
 


### PR DESCRIPTION
`Blinder.unblind` appends the empty placeholder state to the `states` list it is handed, rather than to a copy of it, and does the same to `bounds` when `bound=True`. Both lists belong to the caller, so a shared constant such as `STATES = ['issued', 'revoked']` silently becomes `['issued', 'revoked', '']` the first time anything unblinds against it. Nothing breaks loudly: the extra entry is a state `unblind` would have tried anyway, so the call itself is unaffected. What it costs is elsewhere — code that iterates the same constant as "the states this issuer uses" quietly acquires an empty one, and an assertion written over it stops meaning what it says. I hit exactly that while writing a bulk-issuance worked example, where a loop asserting that no state word appears on the wire began comparing against `b''`, which is in every message.

The fix copies both lists at the top of the method, which is two words. The test asserts that a caller's `states` and `bounds` come back unchanged after a successful unblind, a placeholder unblind, and a bound-state unblind, and it fails on `main` today.