### PR TITLE
Stabilize registry staging and sibling arbitration

### DIFF
--- a/src/keri/acdc/registering.py
+++ b/src/keri/acdc/registering.py
@@ -56,6 +56,11 @@ class RegistryStore:
         return self.baser.ancs.get(keys=said)
 
     def putAnchor(self, said, number, diger):
+        # Keep the earliest verified sealing event for this TEL event so later
+        # re-seals cannot rewrite sibling arbitration order.
+        current = self.anchor(said)
+        if current is not None and current[0].sn <= number.sn:
+            return False
         return self.baser.ancs.pin(keys=said, val=(number, diger))
 
     def head(self, regk):

--- a/src/keri/acdc/registraring.py
+++ b/src/keri/acdc/registraring.py
@@ -325,22 +325,81 @@ class Registry:
         if self.regk is None:
             return
 
-        escrowed = [(sn, said) for _, sn, said in self.store.baser.maes.getTopItemIter(keys=self.regk)]
-        for sn, said in escrowed:
-            serder = self.store.event(said)
-            if serder is None:
-                self.store.clearEscrows(self.regk, sn, said)
-                continue
+        # Re-group missing-anchor escrows by TEL sn so competing
+        # siblings at one slot can be arbitrated together instead of in raw DB
+        # iteration order.
+        escrowed = {}
+        for _, sn, said in self.store.baser.maes.getTopItemIter(keys=self.regk):
+            escrowed.setdefault(sn, []).append(said)
 
-            accepted = self.store.seqEvent(self.regk, sn)
-            if accepted is not None and accepted.said != said:
-                self.store.clearEscrows(self.regk, sn, said)
-                continue
+        for sn in sorted(escrowed):
+            # Collect the surviving candidates for this exact TEL slot before we
+            # decide which anchored sibling should replay first.
+            saids = []
+            for said in escrowed[sn]:
+                serder = self.store.event(said)
+                if serder is None:
+                    # Escrow entries with no serder, should be cleared
+                    self.store.clearEscrows(self.regk, sn, said)
+                    continue
 
-            try:
-                self.processEvent(serder)
-            except ValidationError:
-                self.store.clearEscrows(self.regk, sn, said)
+                accepted = self.store.seqEvent(self.regk, sn)
+                if accepted is not None and accepted.said != said:
+                    # The slot is already taken, the stale candidate can be dropped
+                    self.store.clearEscrows(self.regk, sn, said)
+                    continue
+
+                if self.store.anchor(serder.said) is None:
+                    # Replay may happen after the sealing KEL event exists, so
+                    # re-check local KEL visibility and persist the discovered
+                    # anchor before ordering competing siblings.
+                    regk = serder.said if serder.ilk == "rip" else serder.regid
+                    seal = dict(i=regk, s=serder.sad["n"], d=serder.said)
+                    aserder = self.hab.db.fetchLastSealingEventByEventSeal(pre=self.hab.pre,
+                                                                           seal=seal)
+                    if aserder is not None:
+                        number = Number(num=aserder.sn)
+                        diger = Diger(qb64=aserder.said)
+                        if self._verifyAnchor(serder, number, diger):
+                            self.store.putAnchor(serder.said, number, diger)
+                # Keep every still-viable candidate. Unanchored ones sort to the
+                # end below and remain in maes if nothing can commit them yet.
+                saids.append(said)
+
+            # Use the verified sealing event as the winner policy for this slot:
+            # earliest anchor wins, then digest/SAID provide a stable tie-break.
+            saids = sorted(
+                saids,
+                key=lambda said: (
+                    self.store.anchor(said)[0].sn if self.store.anchor(said) is not None else float("inf"),
+                    self.store.anchor(said)[1].qb64 if self.store.anchor(said) is not None else "",
+                    said,
+                ),
+            )
+
+            for said in saids:
+                serder = self.store.event(said)
+                if serder is None:
+                    # The body may have disappeared between collection and replay;
+                    # clear the now-broken escrow entry defensively.
+                    self.store.clearEscrows(self.regk, sn, said)
+                    continue
+
+                accepted = self.store.seqEvent(self.regk, sn)
+                if accepted is not None and accepted.said != said:
+                    # A previous sibling replay in this same pass may already
+                    # have committed the slot, making this candidate obsolete.
+                    self.store.clearEscrows(self.regk, sn, said)
+                    continue
+
+                try:
+                    # Re-enter the normal state machine so the candidate either
+                    # commits, moves to ooes, or remains staged for later.
+                    self.processEvent(serder)
+                except ValidationError:
+                    # If replay proves the candidate invalid after all, prune it
+                    # instead of letting it poison future escrow passes.
+                    self.store.clearEscrows(self.regk, sn, said)
 
     def _processQueued(self):
         """Advance any queued out-of-order events that are now satisfiable.
@@ -371,12 +430,16 @@ class Registry:
             # When competing siblings exist at one sequence slot, prefer the
             # earliest verified sealing event so "first anchored wins" is
             # deterministic instead of depending on DB iteration order.
-            queued = sorted(queued,
-                            key=lambda said: (
-                                self.store.anchor(said)[0].sn if self.store.anchor(said) is not None else float("inf"),
-                                self.store.anchor(said)[1].qb64 if self.store.anchor(said) is not None else "",
-                                said,
-                            ))
+            # Preserve the same sibling winner policy here as maes replay so
+            # queued and missing-anchor escrows resolve races identically.
+            queued = sorted(
+                queued,
+                key=lambda said: (
+                    self.store.anchor(said)[0].sn if self.store.anchor(said) is not None else float("inf"),
+                    self.store.anchor(said)[1].qb64 if self.store.anchor(said) is not None else "",
+                    said,
+                ),
+            )
 
             # We assume there may be multiple queued events at the same
             # sequence number, but we only commit one per iteration.
@@ -462,16 +525,18 @@ class Registry:
             aserder = self.hab.db.fetchLastSealingEventByEventSeal(pre=self.hab.pre,
                                                                    seal=seal)
             if aserder is not None:
+                # Persist the discovered anchor so the event can either commit
+                # immediately or participate in sibling ordering
                 number = Number(num=aserder.sn)
                 diger = Diger(qb64=aserder.said)
                 if self._verifyAnchor(serder, number, diger):
                     self.store.putAnchor(serder.said, number, diger)
 
-            if self.store.anchor(serder.said) is None:
-                # No valid anchor exists yet, so keep the event staged in
-                # missing-anchor escrow until a sealing KEL event appears.
-                self.store.escrowMissingAnchor(regk, sn, serder.said)
-                return False
+        # After one local-KEL discovery pass, either the event is now anchored
+        # or it must wait in maes for a future sealing event to appear.
+        if self.store.anchor(serder.said) is None:
+            self.store.escrowMissingAnchor(regk, sn, serder.said)
+            return False
 
         # If the event had previously been staged as missing-anchor, clear that
         # escrow entry now that a verified anchor exists.
@@ -597,7 +662,43 @@ class Registry:
                 controlling habitat, or if an unsupported explicit ``blinder``
                 argument is supplied.
         """
-        if self.regk is None or self.store.headEvent(self.regk) is None:
+        # Start from the last committed TEL event, then walk forward through any
+        # single unambiguous staged successor chain before minting the next bup.
+        tip = self.store.headEvent(self.regk) if self.regk is not None else None
+        while tip is not None:
+            # Only the immediate next sequence slot can legally extend the
+            # current tip, so advance one TEL step at a time.
+            sn = int(tip.sad["n"], 16) + 1
+            saids = []
+            seen = set()
+            for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
+                for (said,) in escrowdb.get(keys=self.regk, on=sn):
+                    # The same candidate should only be examined once even if
+                    # it has moved between escrows during previous processing.
+                    if said not in seen:
+                        seen.add(said)
+                        saids.append(said)
+
+            matches = []
+            for said in saids:
+                # Only staged events that explicitly name the current tip as
+                # their prior are valid successors for pipelining.
+                if (staged := self.store.event(said)) is not None and staged.sad.get("p") == tip.said:
+                    matches.append(staged)
+
+            if not matches:
+                # No staged successor continues the chain, so the current tip is
+                # the frontier to build the next blind update from.
+                break
+            if len(matches) > 1:
+                # More than one staged successor means the staged TEL has forked;
+                # fail closed rather than guessing which branch to extend.
+                raise ConfigurationError(f"registry {self.regk} has conflicting staged successors at sn {sn}")
+            # Exactly one staged successor exists, so keep walking until we reach
+            # the latest unambiguous staged frontier.
+            tip = matches[0]
+
+        if tip is None:
             raise ConfigurationError("registry must be anchored before updates")
         if not isinstance(acdc, SerderACDC):
             raise ConfigurationError("acdc must be a SerderACDC")
@@ -621,12 +722,16 @@ class Registry:
             if key in kwa:
                 blindkwa[key] = kwa.pop(key)
 
-        sn = self.sn + 1
+        # The new blind update must extend the effective frontier, which may be
+        # newer than the last committed head when pipelining staged updates.
+        sn = int(tip.sad["n"], 16) + 1
         acdcSaid = acdc.said
         blinder = Blinder.blind(sn=sn, acdc=acdcSaid, state=state, **blindkwa)
 
+        # Build the next TEL event directly off the discovered frontier so the
+        # resulting bup chains correctly through any staged-but-unanchored tip.
         serder = messaging.blindate(regid=self.regk,
-                                    prior=self.store.headEvent(self.regk).said,
+                                    prior=tip.said,
                                     blid=blinder.said,
                                     sn=sn,
                                     **kwa)

--- a/tests/acdc/test_registraring.py
+++ b/tests/acdc/test_registraring.py
@@ -115,6 +115,53 @@ def test_registry_create_and_issue_staged_without_real_seal():
             rgy.close()
 
 
+def test_registry_issue_pipelines_from_staged_tip_before_anchor():
+    """Build a local sn=1 -> sn=2 chain before either update is anchored."""
+    with openHby(name="acdc-registry-pipelined",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        rgy = Regery(hby=hby, name="acdc-registry-pipelined", temp=True)
+        try:
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="pipelined", prefix=hab.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(hab, registry, rip)
+            acdc = acdcmap(israid=hab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+
+            # The second blind issuance should extend the first staged update
+            # instead of creating a competing sibling at sn=1.
+            _, issued = registrar.issue(registry, acdc=acdc, state="issued")
+            _, revoked = registrar.issue(registry, acdc=acdc, state="revoked")
+
+            assert issued.sad["n"] == "1"
+            assert issued.sad["p"] == rip.said
+            assert revoked.sad["n"] == "2"
+            assert revoked.sad["p"] == issued.said
+            assert rgy.store.headEvent(registry.regk).said == rip.said
+            assert rgy.store.baser.maes.get(keys=registry.regk, on=1) == [(issued.said,)]
+            assert rgy.store.baser.maes.get(keys=registry.regk, on=2) == [(revoked.said,)]
+
+            # If the later event is anchored first it should wait in the
+            # out-of-order queue until the earlier state commits.
+            seal = dict(i=registry.regk, s=revoked.sad["n"], d=revoked.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            assert registry.anchorMsg(revoked.said) is False
+            assert rgy.store.baser.ooes.get(keys=registry.regk, on=2) == [(revoked.said,)]
+
+            # Anchoring the first staged update should then commit both slots
+            # into the accepted TEL in sequence.
+            _anchor(hab, registry, issued)
+            assert rgy.store.seqEvent(registry.regk, 1).said == issued.said
+            assert rgy.store.seqEvent(registry.regk, 2).said == revoked.said
+            assert rgy.store.headEvent(registry.regk).said == revoked.said
+        finally:
+            rgy.close()
+
+
 def test_registry_rejects_malformed_inception_before_mutation():
     """Reject a rip with an impossible sequence number before mutating store state."""
     with openHby(name="acdc-registry-bad-rip",
@@ -634,7 +681,7 @@ def test_regery_process_escrows_clears_malformed_missing_anchor_entry():
 
 
 def test_registry_clears_conflicting_missing_anchor_siblings():
-    """Commit one missing-anchor sibling and clear competing staged entries for that slot."""
+    """When missing-anchor siblings race, the earliest anchored sibling wins."""
     with openHby(name="acdc-registry-sibling-maes",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -646,32 +693,37 @@ def test_registry_clears_conflicting_missing_anchor_siblings():
             rip = rgy.store.event(registry.regk)
             _anchor(hab, registry, rip)
 
-            # Create one normal staged blind update and one competing sibling for the same slot
+            # Stage one sibling first, then a competing sibling second for the same slot.
             acdc = acdcmap(israid=hab.pre,
                            regid=registry.regk,
                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                            iseaid=hab.pre)
-            _, winner = registrar.issue(registry, acdc=acdc, state="issued")
-            loser = regbup(regid=registry.regk,
-                           prior=rip.said,
-                           blid=Blinder.blind(acdc=acdc.said,
-                                              state="revoked",
-                                              sn=1).said,
-                           sn=1)
-            assert registry.processEvent(loser) is False
+            _, stagedFirst = registrar.issue(registry, acdc=acdc, state="issued")
+            anchoredFirst = regbup(regid=registry.regk,
+                                   prior=rip.said,
+                                   blid=Blinder.blind(acdc=acdc.said,
+                                                      state="revoked",
+                                                      sn=1).said,
+                                   sn=1)
+            assert registry.processEvent(anchoredFirst) is False
+
             # Both siblings should sit in missing-anchor escrow until one is committed.
             assert sorted(said for (said,) in rgy.store.baser.maes.get(keys=registry.regk, on=1)) == \
-                   sorted([winner.said, loser.said])
+                   sorted([stagedFirst.said, anchoredFirst.said])
 
-            # Note that currently the policy is to deterministically choose the first anchored sibling 
-            # and purge the rest.
-            # Anchoring the winner should commit that slot and clear the losing sibling too
-            _anchor(hab, registry, winner)
-            assert rgy.store.seqEvent(registry.regk, 1).said == winner.said
+            # Create real KEL seals without calling anchorMsg so replay must discover
+            # both anchors from local KEL and choose by earliest seal, not stage order.
+            seal = dict(i=registry.regk, s=anchoredFirst.sad["n"], d=anchoredFirst.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            seal = dict(i=registry.regk, s=stagedFirst.sad["n"], d=stagedFirst.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+
+            rgy.processEscrows()
+            assert rgy.store.seqEvent(registry.regk, 1).said == anchoredFirst.said
             assert rgy.store.baser.maes.get(keys=registry.regk, on=1) == []
 
-            # Reintroducing the stale loser should let replay purge it defensively as junk
-            rgy.store.escrowMissingAnchor(registry.regk, 1, loser.said)
+            # Reintroducing the stale sibling should let replay purge it defensively as junk.
+            rgy.store.escrowMissingAnchor(registry.regk, 1, stagedFirst.said)
             rgy.processEscrows()
             assert rgy.store.baser.maes.get(keys=registry.regk, on=1) == []
         finally:
@@ -679,7 +731,7 @@ def test_registry_clears_conflicting_missing_anchor_siblings():
 
 
 def test_registry_clears_conflicting_out_of_order_siblings():
-    """Commit one queued successor and clear competing out-of-order siblings for that slot."""
+    """When queued siblings race, the earliest anchored sibling wins."""
     with openHby(name="acdc-registry-sibling-ooes",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -697,38 +749,107 @@ def test_registry_clears_conflicting_out_of_order_siblings():
                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                            iseaid=hab.pre)
             _, bup = registrar.issue(registry, acdc=acdc, state="issued")
-            queued = regbup(regid=registry.regk,
-                            prior=bup.said,
-                            blid=Blinder.blind(acdc=acdc.said,
-                                               state="accepted",
-                                               sn=2).said,
-                            sn=2)
-            sibling = regbup(regid=registry.regk,
-                             prior=bup.said,
-                             blid=Blinder.blind(acdc=acdc.said,
-                                                state="revoked",
-                                                sn=2).said,
-                             sn=2)
+            stagedFirst = regbup(regid=registry.regk,
+                                 prior=bup.said,
+                                 blid=Blinder.blind(acdc=acdc.said,
+                                                    state="accepted",
+                                                    sn=2).said,
+                                 sn=2)
+            anchoredFirst = regbup(regid=registry.regk,
+                                   prior=bup.said,
+                                   blid=Blinder.blind(acdc=acdc.said,
+                                                      state="revoked",
+                                                      sn=2).said,
+                                   sn=2)
 
             # Both successors should stage as out-of-order because sn=1 is not committed
-            assert registry.processEvent(queued) is False
-            assert registry.processEvent(sibling) is False
+            assert registry.processEvent(stagedFirst) is False
+            assert registry.processEvent(anchoredFirst) is False
 
-            # After each successor gets its own seal, both should still remain queued at sn=2
-            seal = dict(i=registry.regk, s=queued.sad["n"], d=queued.said)
+            # Anchor the second-staged sibling first, then the first-staged sibling.
+            seal = dict(i=registry.regk, s=anchoredFirst.sad["n"], d=anchoredFirst.said)
             hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
-            assert registry.anchorMsg(queued.said) is False
+            assert registry.anchorMsg(anchoredFirst.said) is False
 
-            seal = dict(i=registry.regk, s=sibling.sad["n"], d=sibling.said)
+            seal = dict(i=registry.regk, s=stagedFirst.sad["n"], d=stagedFirst.said)
             hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
-            assert registry.anchorMsg(sibling.said) is False
+            assert registry.anchorMsg(stagedFirst.said) is False
             assert sorted(said for (said,) in rgy.store.baser.ooes.get(keys=registry.regk, on=2)) == \
-                   sorted([queued.said, sibling.said])
+                   sorted([stagedFirst.said, anchoredFirst.said])
 
-            # Committing the real sn=1 update should now choose the first anchored
-            # sn=2 sibling deterministically and clear the later one.
+            # Committing the real sn=1 update should now choose the earliest anchored
+            # sn=2 sibling, regardless of which one was staged first.
             _anchor(hab, registry, bup)
-            assert rgy.store.seqEvent(registry.regk, 2).said == queued.said
+            assert rgy.store.seqEvent(registry.regk, 2).said == anchoredFirst.said
+            assert rgy.store.baser.ooes.get(keys=registry.regk, on=2) == []
+        finally:
+            rgy.close()
+
+
+def test_registry_preserves_first_verified_anchor_across_reseal():
+    """A later re-seal must not overwrite the first verified anchor for sibling ordering."""
+    with openHby(name="acdc-registry-first-anchor-wins",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        rgy = Regery(hby=hby, name="acdc-registry-first-anchor-wins", temp=True)
+        try:
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="first-anchor-wins", prefix=hab.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(hab, registry, rip)
+
+            # Stage one real sn=1 update plus two competing sn=2 siblings.
+            acdc = acdcmap(israid=hab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+            _, bup = registrar.issue(registry, acdc=acdc, state="issued")
+            firstAnchored = regbup(regid=registry.regk,
+                                   prior=bup.said,
+                                   blid=Blinder.blind(acdc=acdc.said,
+                                                      state="accepted",
+                                                      sn=2).said,
+                                   sn=2)
+            secondAnchored = regbup(regid=registry.regk,
+                                    prior=bup.said,
+                                    blid=Blinder.blind(acdc=acdc.said,
+                                                       state="revoked",
+                                                       sn=2).said,
+                                    sn=2)
+
+            # Both siblings queue behind the still-uncommitted sn=1 update.
+            assert registry.processEvent(firstAnchored) is False
+            assert registry.processEvent(secondAnchored) is False
+
+            # The first sibling seals first and should keep that earlier anchor forever.
+            seal = dict(i=registry.regk, s=firstAnchored.sad["n"], d=firstAnchored.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            first_number = Number(num=hab.kever.sn)
+            first_diger = Diger(qb64=hab.kever.serder.said)
+            assert registry.anchorMsg(firstAnchored.said, number=first_number, diger=first_diger) is False
+
+            # A later sibling seal should not change who currently wins the slot.
+            seal = dict(i=registry.regk, s=secondAnchored.sad["n"], d=secondAnchored.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            assert registry.anchorMsg(secondAnchored.said) is False
+
+            # Re-sealing the already-winning first sibling later used to overwrite its stored anchor.
+            seal = dict(i=registry.regk, s=firstAnchored.sad["n"], d=firstAnchored.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            later_number = Number(num=hab.kever.sn)
+            later_diger = Diger(qb64=hab.kever.serder.said)
+            assert registry.anchorMsg(firstAnchored.said, number=later_number, diger=later_diger) is False
+
+            # The earliest verified anchor should still be the one kept on record.
+            stored_number, stored_diger = rgy.store.anchor(firstAnchored.said)
+            assert stored_number.sn < later_number.sn
+            assert stored_number.sn == first_number.sn
+            assert stored_diger.qb64 != later_diger.qb64
+
+            # Once sn=1 commits, sibling resolution should still pick the event anchored first.
+            _anchor(hab, registry, bup)
+            assert rgy.store.seqEvent(registry.regk, 2).said == firstAnchored.said
             assert rgy.store.baser.ooes.get(keys=registry.regk, on=2) == []
         finally:
             rgy.close()
@@ -820,6 +941,66 @@ def test_regery_reload_uses_stored_rip_issuer_for_reopened_issuance():
                 Registrar(rgy=reopened).issue(reloaded, acdc=foreign, state="issued")
 
             assert reopened.store.records.get(keys="reloadable").registryKey == regk
+        finally:
+            reopened.baser.close(clear=True)
+
+
+def test_regery_reload_retains_staged_tip_for_follow_on_issuance():
+    """Continue a staged local chain after reopening the same durable registry store."""
+    with openHby(name="acdc-registry-reload-staged-tip",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        rgy = Regery(hby=hby,
+                     name="acdc-registry-reload-staged-tip-store",
+                     base="test",
+                     temp=False)
+        try:
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="reloadable", prefix=hab.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(hab, registry, rip)
+
+            acdc = acdcmap(israid=hab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+            _, issued = registrar.issue(registry, acdc=acdc, state="issued")
+            regk = registry.regk
+        finally:
+            rgy.close()
+
+        reopened = Regery(hby=hby,
+                          name="acdc-registry-reload-staged-tip-store",
+                          base="test",
+                          temp=False)
+        try:
+            reloaded = reopened.registryByName("reloadable")
+            assert reloaded is not None
+            assert reloaded.regk == regk
+            assert reopened.store.event(issued.said).said == issued.said
+            assert reopened.store.baser.maes.get(keys=regk, on=1) == [(issued.said,)]
+
+            acdc = acdcmap(israid=hab.pre,
+                           regid=regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+            _, revoked = Registrar(rgy=reopened).issue(reloaded, acdc=acdc, state="revoked")
+
+            assert revoked.sad["n"] == "2"
+            assert revoked.sad["p"] == issued.said
+            assert reopened.store.headEvent(regk).said == rip.said
+
+            # Reopened stores should still be able to anchor the later event
+            # first and let it queue behind the persisted staged predecessor.
+            seal = dict(i=regk, s=revoked.sad["n"], d=revoked.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            assert reloaded.anchorMsg(revoked.said) is False
+
+            _anchor(hab, reloaded, issued)
+            assert reopened.store.seqEvent(regk, 1).said == issued.said
+            assert reopened.store.seqEvent(regk, 2).said == revoked.said
+            assert reopened.store.headEvent(regk).said == revoked.said
         finally:
             reopened.baser.close(clear=True)
 


### PR DESCRIPTION
This PR makes the blindable registry state machine more deterministic when events are staged before anchoring and when multiple competing siblings exist for the same TEL slot.

- Refactored `src/keri/acdc/registraring.py` so `issue()` can pipeline from the latest unambiguous staged event (tip) instead of only from the last committed TEL head.
- Reworked missing-anchor replay so candidates are grouped by TEL sequence number before arbitration.
- Made missing-anchor and queued sibling resolution use the same deterministic ordering policy.
- Preserved the policy that the earliest verified anchor wins when competing siblings target the same TEL slot.
- Changed `src/keri/acdc/registering.py` so stored anchor metadata is monotonic:
  - the stored anchor means first verified anchor,
  - later re-seals do not overwrite earlier verified anchors.

Before these changes, behavior could vary depending on:
- whether a race lived in missing-anchor escrow or out-of-order escrow,
- raw DB iteration order,
- whether a later re-seal overwrote earlier anchor metadata,
- whether issuance happened before earlier staged events were anchored.

This PR expands the registry-focused test coverage for:
- pipelined staged issuance,
- missing-anchor sibling races,
- out-of-order sibling races,
- first-anchor-wins behavior across later re-seals,
- reload behavior with persisted staged tips.