### PR TITLE
Add the party-side verification core for v2 blindable state registries

### DIFF
--- a/src/keri/acdc/regeventing.py
+++ b/src/keri/acdc/regeventing.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-keri.acdc.registring module
+keri.acdc.regeventing module
 
 Registry (TEL) event support
 

--- a/src/keri/acdc/registring.py
+++ b/src/keri/acdc/registring.py
@@ -4,5 +4,447 @@ keri.acdc.registring module
 
 Registry (TEL) event support
 
+Party-side verification core for ACDC v2 blindable state registries (TELs)
+made of 'rip' (registry inception) and 'bup' (blindable update) events.  Given
+a supplied registry event chain, the issuer's KEL evidence, and optionally a
+disclosed blinded-state block, vet() and the vet* helpers determine the
+registry's verified state.  The core fetches nothing and concludes only from
+the evidence handed to it; KEL verification remains the caller's job.
 
+This complements keri.acdc.registraring, which manages the registries a local
+habitat controls.  Where that module issues, this one judges: its evidence is
+another party's, its anchor search runs against that party's KEL, and its
+refusals are named so a caller can tell a permanent one from a retryable one.
 """
+
+from collections.abc import Mapping
+from collections import namedtuple
+
+from .. import help
+from ..kering import (Ilks, ValidationError, InvalidValueError,
+                      MissingAnchorError, MisdigestError, MissequenceError,
+                      MisregistryError, MisanchorError, RootSealError,
+                      MisbindingError, DuplicitousRegistryError,
+                      UnverifiedBlindError)
+from ..core import Blinder, BlindState, BoundState, Number, SerderACDC
+
+logger = help.ogler.getLogger()
+
+
+RegStateRecord = namedtuple("RegStateRecord",
+                            "regid issuer said sn ilk acdc state stamp "
+                            "binding anchors")
+"""Verified state of a registry (TEL) as determined by vet().
+
+Fields:
+    regid (str): qb64 registry SAID (the rip event's said)
+    issuer (str): qb64 AID of the registry's issuer (the rip's i field)
+    said (str): qb64 SAID of the head (latest verified) registry event
+    sn (int): sequence number of the head event
+    ilk (str): message type of the head event (rip or bup)
+    acdc (str|None): qb64 SAID of the transaction ACDC the head state
+        commits to; None when the registry has no update yet or the head is
+        blinded and undisclosed
+    state (str|None): transaction state string at the head; None when the
+        registry has no update yet or the head is blinded and undisclosed
+    stamp (str): the head event's issuer-relative ISO datetime (dt field)
+    binding (str|None): how the presented ACDC binds to the registry:
+        'mutual' when td == acdc.d and acdc.rd == rip.d both hold, 'oneway'
+        when the ACDC carries no rd so only the registry commits to the ACDC
+        (registry->ACDC), None when no ACDC was presented
+    anchors (tuple): one (sn, said) couple per verified chain event, the
+        issuer KEL event in which that TEL event's anchoring seal was found
+"""
+
+
+def _coerce(evt):
+    """Coerce evt to SerderACDC.  Accepts a SerderACDC instance or raw
+    serialized bytes/str (one event's serialization).
+
+    Returns:
+        serder (SerderACDC): the coerced event
+    """
+    if isinstance(evt, SerderACDC):
+        return evt
+    if isinstance(evt, str):
+        evt = evt.encode()
+    if isinstance(evt, (bytes, bytearray, memoryview)):
+        return SerderACDC(raw=bytes(evt))
+    raise InvalidValueError(f"Invalid registry event material type "
+                            f"{type(evt)}: expected SerderACDC or raw bytes.")
+
+
+def _kever(db, pre):
+    """Return the Kever for pre from db's read-through kevers cache, or None
+    when the KEL is not available."""
+    try:
+        return db.kevers[pre]
+    except KeyError:
+        return None
+
+
+def sealDigests(serder):
+    """Extract the candidate seal digests from a key event's seal data list.
+
+    A seal may be as simple as the sealed event's SAID (a bare digest
+    string), or a mapping bearing a 'd' field, with or without an 's'
+    sequence-number hint.  The hint is never load-bearing: matching is by
+    digest only, so a wrong or absent 's' does not disqualify a seal.
+
+    Returns:
+        digs (list[str]): qb64 seal digests found in serder's 'a' field
+    """
+    seals = serder.sad.get('a') or ()
+    digs = []
+    if isinstance(seals, (list, tuple)):
+        for seal in seals:
+            if isinstance(seal, str):
+                digs.append(seal)
+            elif isinstance(seal, Mapping) and 'd' in seal:
+                digs.append(seal['d'])
+    return digs
+
+
+def _scanKel(db, pre, said):
+    """Scan the KEL of pre in db for a key event whose seals include a digest
+    equal to said.
+
+    Returns:
+        couple (tuple|None): (sn, said) of the anchoring key event, or None
+            when no seal in the KEL matches
+    """
+    kever = _kever(db, pre)
+    if kever is None:
+        return None
+    for sn in range(kever.sn + 1):
+        dig = db.kels.getLast(keys=pre, on=sn)
+        if dig is None:
+            continue
+        eserder = db.evts.get(keys=(pre, dig))
+        if eserder is None:
+            continue
+        if said in sealDigests(eserder):
+            return (sn, eserder.said)
+    return None
+
+
+def _kelEvent(db, pre, claim):
+    """Resolve a claimed anchoring key event of pre's KEL by sequence number
+    (int) or SAID (str).  Returns the event serder or None when absent."""
+    if isinstance(claim, int):
+        dig = db.kels.getLast(keys=pre, on=claim)
+        if dig is None:
+            return None
+        return db.evts.get(keys=(pre, dig))
+    return db.evts.get(keys=(pre, claim))
+
+
+def vetAnchor(serder, *, db, issuer, source=None, told=()):
+    """Verify that the registry (TEL) event serder is anchored in the
+    issuer's KEL: some key event of the issuer carries a seal whose digest is
+    the TEL event's SAID.
+
+    Returns:
+        couple (tuple): (sn, said) of the anchoring key event in the
+            issuer's KEL
+
+    Parameters:
+        serder (SerderACDC): registry event whose anchor to verify
+        db (Baser): KEL database the caller has already populated and
+            verified.  KEL verification is not performed here.
+        issuer (str): qb64 AID of the registry's issuer (the rip's i field).
+            The anchoring KEL's controller must be this AID: a seal in any
+            other KEL is an endorsement, not a commitment.
+        source (int|str|None): optional caller's claim of where the anchor
+            lives in the issuer's KEL, by key event sequence number (int) or
+            SAID (str).  A claim that resolves to an event whose seal
+            digests match no event of the presented TEL (per told) is an
+            aggregate (Merkle/SMT root) seal and is refused by name.  A
+            claim that does not pan out otherwise falls back to a full scan,
+            since a wrong hint is indistinguishable from an anchor not yet
+            gathered.
+        told (Iterable[str]): SAIDs of all events of the presented TEL, used
+            only to discriminate an aggregate seal from a merely mistaken
+            source claim.
+
+    Raises:
+        MisanchorError: seal found, but only in a KEL whose controller is
+            not the issuer (permanent refusal)
+        RootSealError: the claimed anchoring event seals digests foreign to
+            the whole presented TEL (permanent refusal)
+        MissingAnchorError: no seal found anywhere; the anchor may still be
+            in flight (retryable)
+    """
+    if _kever(db, issuer) is None:
+        raise MissingAnchorError(f"Issuer KEL for {issuer} not available to "
+                                 f"verify the anchor of registry event "
+                                 f"{serder.said}.")
+
+    if source is not None:
+        eserder = _kelEvent(db, issuer, source)
+        if eserder is not None:
+            digs = sealDigests(eserder)
+            if serder.said in digs:
+                return (eserder.sn, eserder.said)
+            if digs and not set(digs) & set(told):
+                raise RootSealError(f"Claimed anchoring key event "
+                                    f"{eserder.said} at sn={eserder.sn} of "
+                                    f"issuer {issuer} seals digest(s) "
+                                    f"matching no event of the presented "
+                                    f"registry {list(told)[:1]}: an "
+                                    f"aggregate (Merkle/SMT root) seal "
+                                    f"requires an inclusion proof and is "
+                                    f"not supported.")
+        # a claim that did not pan out is just a bad hint: fall through
+
+    couple = _scanKel(db, issuer, serder.said)
+    if couple is not None:
+        return couple
+
+    for pre in list(db.kevers):
+        if pre == issuer:
+            continue
+        if _scanKel(db, pre, serder.said) is not None:
+            raise MisanchorError(f"Seal for registry event {serder.said} "
+                                 f"found in the KEL of {pre}, which is not "
+                                 f"the registry issuer {issuer}: an "
+                                 f"endorsement is not a commitment.")
+
+    raise MissingAnchorError(f"No anchoring seal for registry event "
+                             f"{serder.said} in the KEL of issuer {issuer}.")
+
+
+def vetRip(rip):
+    """Validate a registry inception (rip) event's registry-level fields.
+    Field presence, order, and SAID are already SerderACDC's own validation.
+
+    Returns:
+        serder (SerderACDC): the validated rip event
+    """
+    serder = _coerce(rip)
+    if serder.ilk != Ilks.rip:
+        raise ValidationError(f"Expected registry inception ilk={Ilks.rip} "
+                              f"got ilk={serder.ilk} for event "
+                              f"{serder.said}.")
+    if Number(numh=serder.sad['n']).num != 0:
+        raise MissequenceError(f"Registry inception {serder.said} has "
+                               f"n={serder.sad['n']} but inception must be "
+                               f"at n=0.")
+    return serder
+
+
+def vetUpdate(bup, rip):
+    """Validate a blindable registry update (bup) event's registry-level
+    fields against its registry inception.
+
+    Returns:
+        serder (SerderACDC): the validated bup event
+    """
+    serder = _coerce(bup)
+    if serder.ilk != Ilks.bup:
+        raise ValidationError(f"Expected registry update ilk={Ilks.bup} got "
+                              f"ilk={serder.ilk} for event {serder.said}.")
+    if serder.sad['rd'] != rip.said:
+        raise MisregistryError(f"Registry update {serder.said} has "
+                               f"rd={serder.sad['rd']} which is not the "
+                               f"presented registry inception's said "
+                               f"{rip.said}.")
+    if Number(numh=serder.sad['n']).num < 1:
+        raise MissequenceError(f"Registry update {serder.said} has "
+                               f"n={serder.sad['n']} but updates must be at "
+                               f"n >= 1.")
+    return serder
+
+
+def vetBlind(blinder, *, blid):
+    """Verify a disclosed blinded-state attribute block against the BLID
+    anchored by a blindable update (bup) event, by recomputing the BLID over
+    the disclosed fields.
+
+    Returns:
+        (acdc, state) (tuple[str, str]): the disclosed transaction ACDC said
+            and transaction state string; both empty for a placeholder
+
+    Parameters:
+        blinder (Blinder|str|bytes): the disclosed block, either a Blinder
+            instance or the qb64 concatenation of its CESR field values as a
+            discloser attaches it on the wire
+        blid (str): qb64 BLID, the b field of the bup event
+
+    Raises:
+        UnverifiedBlindError: the disclosure does not reproduce blid, so it
+            proves nothing about the registry's state
+    """
+    candidates = []
+    if isinstance(blinder, Blinder):
+        candidates.append(blinder)
+    else:
+        qb64 = blinder.decode() if hasattr(blinder, "decode") else blinder
+        for clan in (BlindState, BoundState):
+            try:
+                candidates.append(Blinder(clan=clan, qb64=qb64))
+            except Exception:
+                continue
+        if not candidates:
+            raise UnverifiedBlindError(f"Undecodable disclosed blinded-state "
+                                       f"block for blid={blid}.")
+
+    for candidate in candidates:
+        crew = dict(candidate.crew._asdict())
+        crew['d'] = ''
+        redone = Blinder(crew=candidate.clan(**crew), makify=True)
+        if redone.said == blid:
+            return (redone.acdc, redone.state)
+
+    raise UnverifiedBlindError(f"Disclosed blinded-state block does not "
+                               f"reproduce the anchored blid={blid}: the "
+                               f"disclosure proves nothing.")
+
+
+def vetBindings(acdc, *, regid, td):
+    """Verify the binding equalities between a presented ACDC and its
+    registry evidence.  These two equalities are the issuer's only
+    commitment to the credential: v2 ACDCs are not directly signed, so a
+    verifier that skips them passes every other obligation while accepting a
+    substituted credential.
+
+    Returns:
+        binding (str): 'mutual' when td == acdc.d and acdc.rd == rip.d both
+            hold; 'oneway' when the ACDC carries no rd, so only the
+            registry->ACDC direction is committed and the caller's policy
+            can weigh the weaker basis
+
+    Parameters:
+        acdc (SerderACDC|bytes): the presented ACDC
+        regid (str): qb64 SAID of the presented registry inception (rip)
+        td (str|None): qb64 transaction ACDC said the registry's verified
+            head state commits to
+
+    Raises:
+        MisbindingError: either equality fails (permanent refusal)
+    """
+    serder = _coerce(acdc)
+    if td != serder.said:
+        raise MisbindingError(f"Registry state's transaction ACDC said "
+                              f"td={td} does not bind the presented ACDC's "
+                              f"said {serder.said}.")
+    rd = serder.sad.get('rd')
+    if rd:
+        if rd != regid:
+            raise MisbindingError(f"Presented ACDC's registry said rd={rd} "
+                                  f"does not bind the presented registry "
+                                  f"inception's said {regid}.")
+        return 'mutual'
+    return 'oneway'
+
+
+def vet(rip, updates=None, *, db, acdc=None, blinder=None, sources=None):
+    """Verify a registry (TEL) event chain against the issuer's KEL and
+    determine the registry's verified state.  This is the party-side
+    verification core: it fetches nothing and concludes only from the
+    supplied evidence.
+
+    The registry's state is the state at the highest-n event that
+    chain-verifies from the rip and whose anchor verifies in the issuer's
+    KEL.  Every presented event must anchor-verify: an event whose anchor is
+    missing establishes nothing and the whole determination is retryable
+    (MissingAnchorError), since concluding from an anchored prefix could
+    silently bless an issuer's half-commitment or hide duplicity still in
+    flight.
+
+    Returns:
+        record (RegStateRecord): the verified registry state
+
+    Parameters:
+        rip (SerderACDC|bytes): registry inception event
+        updates (Iterable|None): registry update (bup) events, in any order
+        db (Baser): KEL database the caller has already populated; KEL
+            verification is the caller's job
+        acdc (SerderACDC|bytes|None): optionally, the presented ACDC to
+            bind-check against the verified head state
+        blinder (Blinder|str|bytes|None): optionally, the disclosed
+            blinded-state block for the head bup event.  Without it a bup
+            head verifies as a chain but its state stays blinded (state and
+            acdc None in the record).  There is no salt parameter: only the
+            per-event disclosure is accepted.
+        sources (Mapping|None): optional caller's claims of anchor
+            locations, mapping TEL event said -> issuer KEL event sn (int)
+            or said (str).  See vetAnchor.
+
+    Raises:
+        MissequenceError, MisdigestError, MisregistryError,
+        MisanchorError, RootSealError, DuplicitousRegistryError,
+        MisbindingError, UnverifiedBlindError: permanent, named refusals
+        MissingAnchorError: establishes nothing, retryably
+    """
+    ripper = vetRip(rip)
+    issuer = ripper.sad['i']
+    updates = [vetUpdate(update, ripper)
+               for update in (updates if updates is not None else ())]
+    sources = sources if sources is not None else {}
+    told = [ripper.said] + [serder.said for serder in updates]
+
+    chain = [ripper]
+    anchors = [vetAnchor(ripper, db=db, issuer=issuer,
+                         source=sources.get(ripper.said), told=told)]
+
+    remaining = list(updates)
+    prior = ripper
+    n = 1
+    while remaining:
+        cands = [serder for serder in remaining
+                 if Number(numh=serder.sad['n']).num == n]
+        if not cands:
+            ns = sorted(Number(numh=serder.sad['n']).num
+                        for serder in remaining)
+            raise MissequenceError(f"Gapped chain for registry "
+                                   f"{ripper.said}: no event at n={n} but "
+                                   f"events remain at n={ns}; n = prior + 1 "
+                                   f"exactly.")
+        for serder in cands:
+            if serder.sad['p'] != prior.said:
+                raise MisdigestError(f"Registry event {serder.said} at "
+                                     f"n={n} has p={serder.sad['p']} which "
+                                     f"is not the prior event's said "
+                                     f"{prior.said}.")
+        unique = list({serder.said: serder for serder in cands}.values())
+        couples = {}
+        for serder in unique:  # every event must anchor before any concludes
+            couples[serder.said] = vetAnchor(serder, db=db, issuer=issuer,
+                                             source=sources.get(serder.said),
+                                             told=told)
+        if len(unique) > 1:
+            raise DuplicitousRegistryError(f"Registry duplicity for "
+                                           f"{ripper.said}: {len(unique)} "
+                                           f"distinct anchored events at "
+                                           f"n={n}: "
+                                           f"{[s.said for s in unique]}.")
+        accepted = unique[0]
+        chain.append(accepted)
+        anchors.append(couples[accepted.said])
+        remaining = [serder for serder in remaining
+                     if Number(numh=serder.sad['n']).num != n]
+        prior = accepted
+        n += 1
+
+    head = chain[-1]
+    acdcsaid = state = None
+    if head.ilk == Ilks.bup and blinder is not None:
+        disclosed, toldState = vetBlind(blinder=blinder, blid=head.sad['b'])
+        acdcsaid = disclosed or None
+        state = toldState or None
+
+    binding = None
+    if acdc is not None:
+        serder = _coerce(acdc)
+        if head.ilk == Ilks.bup and blinder is None:
+            raise UnverifiedBlindError(f"Registry {ripper.said} head at "
+                                       f"n={head.sad['n']} is blinded and "
+                                       f"no state was disclosed: nothing "
+                                       f"binds ACDC {serder.said} to it.")
+        binding = vetBindings(acdc=serder, regid=ripper.said, td=acdcsaid)
+
+    return RegStateRecord(regid=ripper.said, issuer=issuer, said=head.said,
+                          sn=Number(numh=head.sad['n']).num, ilk=head.ilk,
+                          acdc=acdcsaid, state=state, stamp=head.sad['dt'],
+                          binding=binding, anchors=tuple(anchors))

--- a/src/keri/kering.py
+++ b/src/keri/kering.py
@@ -811,6 +811,107 @@ class MissingDelegableApprovalError(ValidationError):
     """
 
 
+class MisdigestError(ValidationError):
+    """
+    Error event's prior event digest does not match the digest of the event it
+    claims to follow, so the backward hash chain is broken at this event.
+
+    Distinct from OutOfOrderError, where the prior event is merely absent and
+    may still arrive: a mismatched prior digest is decided against events
+    already in hand, so no later arrival resolves it.
+
+    Usage:
+        raise MisdigestError("error message")
+    """
+
+
+class MissequenceError(ValidationError):
+    """
+    Error registry (TEL) event's sequence number breaks the strict chain rule:
+    a rip whose n is not 0, or an update whose n is not exactly prior + 1.
+    A gapped chain is decided malformed on the evidence in hand, so it is a
+    permanent refusal, never an escrow candidate.
+
+    Usage:
+        raise MissequenceError("error message")
+    """
+
+
+class MisregistryError(ValidationError):
+    """
+    Error registry (TEL) update event's registry SAID, rd field, does not
+    match the SAID of the registry inception (rip) event it is presented
+    with, so the update belongs to some other registry. Permanent refusal.
+
+    Usage:
+        raise MisregistryError("error message")
+    """
+
+
+class MisanchorError(ValidationError):
+    """
+    Error registry (TEL) event's anchoring seal was found, but in a KEL whose
+    controller AID is not the registry's issuer. A seal in a stranger's KEL
+    is merely a nonrepudiable endorsement, not a duplicity-evident commitment
+    by the issuer. Permanent refusal, distinct from MissingAnchorError where
+    no seal has been found anywhere and one may yet arrive.
+
+    Usage:
+        raise MisanchorError("error message")
+    """
+
+
+class RootSealError(ValidationError):
+    """
+    Error the KEL event claimed to anchor a registry (TEL) event carries seal
+    digest(s) that match no event in the presented TEL: an aggregate seal in
+    the style of a Merkle/SMT root over many transaction events. Verifying
+    such an anchor requires an inclusion proof, which is not supported, so
+    this is its own named refusal, distinct from an anchor that is merely
+    missing (MissingAnchorError).
+
+    Usage:
+        raise RootSealError("error message")
+    """
+
+
+class MisbindingError(ValidationError):
+    """
+    Error the binding equalities between a presented ACDC and its registry
+    (TEL) evidence fail: the registry state's transaction ACDC SAID (td) does
+    not equal the ACDC's SAID, or the ACDC's registry SAID (rd) does not
+    equal the registry inception (rip) event's SAID. Each artifact may verify
+    alone; the substitution lives in the binding between them. Permanent
+    refusal.
+
+    Usage:
+        raise MisbindingError("error message")
+    """
+
+
+class DuplicitousRegistryError(ValidationError):
+    """
+    Error registry (TEL) duplicity: two distinct registry events at the same
+    sequence number both chain-verify and are both anchored in the issuer's
+    KEL. No ordering of the evidence may hide this. Permanent refusal.
+
+    Usage:
+        raise DuplicitousRegistryError("error message")
+    """
+
+
+class UnverifiedBlindError(ValidationError):
+    """
+    Error a disclosed blinded state attribute block does not reproduce the
+    BLID (blinded state SAID) anchored by the blindable update (bup) event it
+    is disclosed against, so the disclosure proves nothing about the
+    registry's state.
+
+    Usage:
+        raise UnverifiedBlindError("error message")
+    """
+
+
 # Stream Parsing and Extraction Errors
 class ExtractionError(KeriError):
     """

--- a/tests/acdc/test_clc_disclosure.py
+++ b/tests/acdc/test_clc_disclosure.py
@@ -55,7 +55,7 @@ and it is the right altitude for a first worked example. keripy is midway throug
 a deliberate v1->v2 reorganization. ACDC v1 -- and its v1 IPEX handlers in
 keri.vc.protocoling -- stays in keri.vc; the new keri.acdc subpackage is the v2
 home, with keri.acdc.messaging filled in (the v2 message builders these examples
-use) and the other modules -- keri.acdc.ipexing, registring, registraring,
+use) and the other modules -- keri.acdc.ipexing, regeventing, registraring,
 scheming, ... -- still placeholder stubs awaiting migration. The v1
 keri.vc.protocoling handlers do not speak v2 messaging, so this example does NOT
 route through them; doing so would only mislead a reader about how v2 IPEX works.

--- a/tests/acdc/test_regeventing.py
+++ b/tests/acdc/test_regeventing.py
@@ -1,12 +1,12 @@
 # -*- encoding: utf-8 -*-
 """
-tests.acdc.test_registring module
+tests.acdc.test_regeventing module
 
-Tests for keri.acdc.registring: the ACDC v2 registry (TEL) verification core.
+Tests for keri.acdc.regeventing: the ACDC v2 registry (TEL) verification core.
 
 The verification core answers, for a party holding evidence: given a registry
 event chain (rip + bup events), the issuer's KEL (a Baser the caller has
-already populated -- KEL verification is not registring's job), and optionally
+already populated -- KEL verification is not regeventing's job), and optionally
 a disclosed blinded-state block, what is the registry's verified state?
 
 All valid material is built with keripy's own builders (regcept, blindate,
@@ -32,8 +32,8 @@ from keri import Vrsn_2_0, Ilks
 from keri.core import Blinder, BlindState, Diger, SerderACDC
 from keri.core.signing import Salter
 from keri.acdc import regcept, blindate, acdcmap
-from keri.acdc import registring
-from keri.acdc.registring import RegStateRecord, vet, vetBlind
+from keri.acdc import regeventing
+from keri.acdc.regeventing import RegStateRecord, vet, vetBlind
 from keri.app import habbing
 
 
@@ -578,8 +578,8 @@ def test_V23_no_salt_parameter_anywhere():
     """V23: the verify path's API surface -- no parameter anywhere accepts a
     salt.  The salt's absence from every signature is itself the row."""
     checked = 0
-    for name, obj in inspect.getmembers(registring):
-        if getattr(obj, "__module__", None) != registring.__name__:
+    for name, obj in inspect.getmembers(regeventing):
+        if getattr(obj, "__module__", None) != regeventing.__name__:
             continue
         if inspect.isfunction(obj):
             assert 'salt' not in inspect.signature(obj).parameters, name

--- a/tests/acdc/test_registring.py
+++ b/tests/acdc/test_registring.py
@@ -1,0 +1,618 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.acdc.test_registring module
+
+Tests for keri.acdc.registring: the ACDC v2 registry (TEL) verification core.
+
+The verification core answers, for a party holding evidence: given a registry
+event chain (rip + bup events), the issuer's KEL (a Baser the caller has
+already populated -- KEL verification is not registring's job), and optionally
+a disclosed blinded-state block, what is the registry's verified state?
+
+All valid material is built with keripy's own builders (regcept, blindate,
+acdcmap) and real Habs (habbing) with anchors written through Hab.interact.
+Adversarial cases are reached by mutating valid material, never by hand-rolling
+events.
+
+The test names carry the row ids (V1..V23) of the approved test catalogue so
+the mapping from obligation to test is auditable.  V17 (parallel-registry
+equivocation) and V24 (a chain mixing upd and bup events) are absent from this
+module: the first belongs with a multi-registry policy layer, and the second
+tests the 'upd' event, which is deprecated.  V16b is an added row covering an
+ACDC presented against a blinded head with no disclosure.
+"""
+
+import inspect
+import json
+
+import pytest
+
+from keri import kering
+from keri import Vrsn_2_0, Ilks
+from keri.core import Blinder, BlindState, Diger, SerderACDC
+from keri.core.signing import Salter
+from keri.acdc import regcept, blindate, acdcmap
+from keri.acdc import registring
+from keri.acdc.registring import RegStateRecord, vet, vetBlind
+from keri.app import habbing
+
+
+# Fixed stamps (all the same length so raw mutations preserve size).
+STAMP0 = '2025-07-04T17:50:00.000000+00:00'
+STAMP1 = '2025-08-01T18:06:10.988921+00:00'
+STAMP2 = '2025-09-01T18:06:10.988921+00:00'
+STAMP3 = '2025-10-01T18:06:10.988921+00:00'
+
+# Issuer-side secret used only to construct valid blinded material in tests.
+# The verify path itself never sees it (that absence is row V23).
+SALT = Salter(raw=b'0123456789abcdef').qb64
+
+# The ACDC specification's BLID conformance vectors (spec-body.md ~:2166-2170
+# placeholder, ~:2209-2213 issued).  Lineage caveat: the spec's worked examples
+# were synced from keripy, so these defend against drift, not shared error.
+SPEC_PLACEHOLDER_UUID = "aG1lSjdJSNl7TiroPl67Uqzd5eFvzmr6bPlL7Lh4ukv8"
+SPEC_PLACEHOLDER_BLID = "ECVr7QWEp_aqVQuz4yprRFXVxJ-9uWLx_d6oDinlHU6J"
+SPEC_ISSUED_UUID = "aLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzB"
+SPEC_ISSUED_TD = "EP-iKGmXD-iZu3RhVA2FTI-dOdX50bRBV3VDCy-peOtv"
+SPEC_ISSUED_BLID = "EItpXDP26bvHIRZ0GrJwhOIR5lLEaviFcIxFodP6IJ8N"
+
+
+def seal(serder):
+    """Transaction event seal couple {s, d} where s is the TEL event's own
+    sequence number (a lookup hint, never a KEL sn) and d its SAID."""
+    return dict(s=serder.sad['n'], d=serder.said)
+
+
+def anchor(hab, *serders, data=None):
+    """Anchor seals for the given TEL events in one interaction event in
+    hab's KEL.  Returns the anchoring key event's serder."""
+    if data is None:
+        data = [seal(serder) for serder in serders]
+    hab.interact(data=data)
+    return hab.kever.serder
+
+
+def makeRegistry(hab, stamp=STAMP0, anchored=True):
+    """Create a registry inception (rip) for hab and, unless told otherwise,
+    anchor it in hab's KEL."""
+    ripper = regcept(israid=hab.pre, stamp=stamp)
+    if anchored:
+        anchor(hab, ripper)
+    return ripper
+
+
+def makeUpdate(regid, prior, acdc, state, *, sn=1, stamp=None, salt=SALT):
+    """Build one blindable update: the issuer-side blinded state block and the
+    bup event that anchors its BLID.
+
+    Returns:
+        (blinder, bup) (tuple[Blinder, SerderACDC])
+    """
+    blinder = Blinder.blind(acdc=acdc, state=state, salt=salt, sn=sn)
+    bup = blindate(regid=regid, prior=prior, blid=blinder.said, sn=sn,
+                   stamp=stamp)
+    return blinder, bup
+
+
+def makeAcdc(hab, regid=None, name="Sunspot College"):
+    """Create a real ACDC (acm) issued by hab, optionally bound to a registry
+    through its rd field."""
+    return acdcmap(israid=hab.pre, regid=regid,
+                   attribute=dict(d='', name=name, level="gold"))
+
+
+def remake(serder, **changes):
+    """Mutate a valid event's sad and remake it as a self-consistent serder
+    (recomputed SAID).  This is the named mutation-operator route to
+    adversarial material that the builders refuse to produce."""
+    sad = dict(serder.sad)
+    sad.update(changes)
+    sad['d'] = ''
+    return SerderACDC(sad=sad, makify=True)
+
+
+def openIssuer(name):
+    """Context manager for a fresh v2 issuer hab."""
+    return habbing.openHab(name=name, temp=True, version=Vrsn_2_0)
+
+
+# ---------------------------------------------------------------------------
+# Chain and fields
+# ---------------------------------------------------------------------------
+
+def test_V1_rip_bup_issued_verifies():
+    """V1: rip -> bup(issued), both anchored: verifies, state issued at n 1."""
+    with openIssuer("v1") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bup)
+
+        rec = vet(rip=ripper, updates=[bup], db=hby.db, acdc=acdc,
+                  blinder=blinder)
+        assert isinstance(rec, RegStateRecord)
+        assert rec.regid == ripper.said
+        assert rec.issuer == hab.pre
+        assert rec.said == bup.said
+        assert rec.sn == 1
+        assert rec.ilk == Ilks.bup
+        assert rec.acdc == acdc.said
+        assert rec.state == 'issued'
+        assert rec.binding == 'mutual'
+        assert len(rec.anchors) == 2  # one verified couple per TEL event
+        for kelsn, kelsaid in rec.anchors:
+            assert hby.db.kels.getLast(keys=hab.pre, on=kelsn) is not None
+
+        # the core accepts raw streams as well as SerderACDC instances
+        rec2 = vet(rip=bytes(ripper.raw), updates=[bytes(bup.raw)],
+                   db=hby.db, blinder=blinder)
+        assert rec2.said == bup.said
+        assert rec2.state == 'issued'
+        assert rec2.binding is None  # no ACDC presented, no binding claimed
+
+
+def test_V2_revoking_bup_state_revoked():
+    """V2: V1 plus a revoking bup, anchored: state revoked at head n 2."""
+    with openIssuer("v2") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        blinder1, bup1 = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                    'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bup1)
+        blinder2, bup2 = makeUpdate(ripper.said, bup1.said, acdc.said,
+                                    'revoked', sn=2, stamp=STAMP2)
+        anchor(hab, bup2)
+
+        rec = vet(rip=ripper, updates=[bup1, bup2], db=hby.db, acdc=acdc,
+                  blinder=blinder2)
+        assert rec.sn == 2
+        assert rec.said == bup2.said
+        assert rec.state == 'revoked'
+        assert rec.acdc == acdc.said
+
+
+def test_V3_rip_n_nonzero_refused():
+    """V3: a rip whose n is not "0" is refused as malformed."""
+    with openIssuer("v3") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        bad = remake(ripper, n='1')  # builder refuses; mutation reaches it
+        anchor(hab, bad)
+        with pytest.raises(kering.MissequenceError):
+            vet(rip=bad, db=hby.db)
+
+
+def test_V4_n_gap_refused():
+    """V4: a chain with an n gap (0, 2) is refused as malformed; n = prior + 1
+    exactly.  A gap is not an escrow candidate on the party-side core."""
+    with openIssuer("v4") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, gapped = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                               sn=2, stamp=STAMP1)
+        anchor(hab, gapped)  # anchored, so the gap is the only defect
+        with pytest.raises(kering.MissequenceError):
+            vet(rip=ripper, updates=[gapped], db=hby.db)
+
+
+def test_V5_p_mismatch_refused():
+    """V5: an update whose p is not the prior event's d is refused."""
+    with openIssuer("v5") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, crooked = makeUpdate(ripper.said, acdc.said, acdc.said, 'issued',
+                                sn=1, stamp=STAMP1)
+        anchor(hab, crooked)
+        with pytest.raises(kering.MisdigestError):
+            vet(rip=ripper, updates=[crooked], db=hby.db)
+
+
+def test_V6_rd_mismatch_refused():
+    """V6: an update whose rd is not the rip's d is refused."""
+    with openIssuer("v6") as (hby, hab):
+        ripper = makeRegistry(hab)
+        other = makeRegistry(hab, stamp=STAMP2)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, stray = makeUpdate(other.said, ripper.said, acdc.said, 'issued',
+                              sn=1, stamp=STAMP1)
+        anchor(hab, stray)
+        with pytest.raises(kering.MisregistryError):
+            vet(rip=ripper, updates=[stray], db=hby.db)
+
+
+def test_V7_field_order_and_said_mutations_refused():
+    """V7: field-order and SAID mutations across both event types are each
+    refused by SerderACDC's own validation (one row standing for the mutation
+    battery)."""
+    with openIssuer("v7") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, bup = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                            sn=1, stamp=STAMP1)
+
+        for serder in (ripper, bup):
+            raw = bytes(serder.raw)
+
+            # SAID mutation: tamper the embedded said
+            said = serder.said
+            flipped = said[:-1] + ('A' if said[-1] != 'A' else 'B')
+            traw = raw.replace(said.encode(), flipped.encode())
+            assert traw != raw
+            with pytest.raises(kering.ValidationError):
+                SerderACDC(raw=traw)
+
+            # value mutation without recomputing the said
+            traw = raw.replace(serder.sad['dt'].encode(), STAMP3.encode())
+            assert traw != raw
+            with pytest.raises(kering.ValidationError):
+                SerderACDC(raw=traw)
+
+            # field-order mutation: same fields and values, order broken
+            sad = json.loads(raw.decode())
+            keys = list(sad)
+            keys[-1], keys[-2] = keys[-2], keys[-1]
+            resad = {k: sad[k] for k in keys}
+            traw = json.dumps(resad, separators=(",", ":")).encode()
+            assert len(traw) == len(raw)
+            with pytest.raises(kering.ValidationError):
+                SerderACDC(raw=traw)
+
+
+# ---------------------------------------------------------------------------
+# Anchors (the seal-anchored verification core)
+# ---------------------------------------------------------------------------
+
+def test_V8_unanchored_update_retryable():
+    """V8: an update never anchored in the issuer's KEL establishes nothing,
+    retryably (the maes posture) -- distinct from any refusal class."""
+    with openIssuer("v8") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        # deliberately not anchored
+        with pytest.raises(kering.MissingAnchorError):
+            vet(rip=ripper, updates=[bup], db=hby.db)
+        # once the anchor arrives, the same evidence verifies (retryable)
+        anchor(hab, bup)
+        rec = vet(rip=ripper, updates=[bup], db=hby.db, blinder=blinder)
+        assert rec.state == 'issued'
+
+
+def test_V9_anchor_in_strangers_kel_refused():
+    """V9: every event anchored, but in a KEL whose controller is not rip.i:
+    refused -- an endorsement is not a commitment -- naming the mismatch."""
+    with habbing.openHby(name="v9", temp=True, version=Vrsn_2_0) as hby:
+        issuer = hby.makeHab(name="issuer", version=Vrsn_2_0)
+        stranger = hby.makeHab(name="stranger", version=Vrsn_2_0)
+        ripper = regcept(israid=issuer.pre, stamp=STAMP0)
+        anchor(stranger, ripper)  # endorsement by the wrong controller
+        with pytest.raises(kering.MisanchorError) as ex:
+            vet(rip=ripper, db=hby.db)
+        assert issuer.pre in str(ex.value)
+        assert stranger.pre in str(ex.value)
+
+
+def test_V10_bare_digest_seal_accepted():
+    """V10: a seal carrying only the digest, no s, is accepted -- matched by
+    digest; seal.s is a lookup hint, never load-bearing."""
+    with openIssuer("v10") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        anchor(hab, data=[dict(d=ripper.said)])  # digest-only seal
+        rec = vet(rip=ripper, db=hby.db)
+        assert rec.said == ripper.said
+        assert rec.sn == 0
+
+        # a seal as simple as the bare SAID string also anchors (spec :1918)
+        second = makeRegistry(hab, stamp=STAMP1, anchored=False)
+        anchor(hab, data=[second.said])
+        rec2 = vet(rip=second, db=hby.db)
+        assert rec2.said == second.said
+
+
+def test_V11_multiple_seals_tolerated():
+    """V11: the anchoring KEL event carries several seals, ours among them:
+    accepted.  A wrong s hint on our own seal is also tolerated (digest is
+    what matches)."""
+    with openIssuer("v11") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        noise1 = Diger(ser=b'some other commitment').qb64
+        noise2 = Diger(ser=b'yet another commitment').qb64
+        anchor(hab, data=[dict(s='99', d=noise1),
+                          dict(s='7', d=ripper.said),  # wrong s hint, right d
+                          dict(d=noise2)])
+        rec = vet(rip=ripper, db=hby.db)
+        assert rec.said == ripper.said
+
+
+def test_V12_smt_root_anchor_refused_by_name():
+    """V12: a registry whose claimed anchor is an SMT root -- a seal digest
+    matching no TEL event SAID -- is refused by its own name, not as a
+    generic "unanchored"."""
+    with openIssuer("v12") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        root = Diger(ser=ripper.saidb + b'sibling tel event saids').qb64
+        anchor(hab, data=[dict(d=root)])  # Merkle-root style bulk seal
+        claim = hab.kever.sn  # the caller claims this KEL event anchors it
+
+        with pytest.raises(kering.RootSealError):
+            vet(rip=ripper, db=hby.db, sources={ripper.said: claim})
+
+        # without the claim there is nothing to refuse: the seal is simply
+        # not found, which establishes nothing, retryably
+        with pytest.raises(kering.MissingAnchorError):
+            vet(rip=ripper, db=hby.db)
+
+
+def test_V13_seal_reference_without_seal_retryable():
+    """V13: a seal reference naming a KEL event that does not contain the
+    seal establishes nothing, retryably -- indistinguishable from an anchor
+    not yet gathered."""
+    with openIssuer("v13") as (hby, hab):
+        ripper = makeRegistry(hab, anchored=False)
+        anchor(hab, data=[dict(note="no seal here")])  # sealless event
+        claim = hab.kever.sn
+        with pytest.raises(kering.MissingAnchorError):
+            vet(rip=ripper, db=hby.db, sources={ripper.said: claim})
+        # the claim may also name the KEL event by SAID; same outcome
+        with pytest.raises(kering.MissingAnchorError):
+            vet(rip=ripper, db=hby.db,
+                sources={ripper.said: hab.kever.serder.said})
+
+
+# ---------------------------------------------------------------------------
+# Bindings -- the substitution family
+# ---------------------------------------------------------------------------
+
+def test_V14_substitution_sibling_registry_refused():
+    """V14: revoked ACDC-A presented with sibling registry RB's genuine
+    issued chain, same issuer: refused because td != acdc.d.  Every other
+    check passes by construction."""
+    with openIssuer("v14") as (hby, hab):
+        # registry RA: acdcA issued then revoked
+        ripA = makeRegistry(hab, stamp=STAMP0)
+        acdcA = makeAcdc(hab, regid=ripA.said, name="Sunspot College")
+        _, bupA1 = makeUpdate(ripA.said, ripA.said, acdcA.said, 'issued',
+                              sn=1, stamp=STAMP1)
+        anchor(hab, bupA1)
+        blindA2, bupA2 = makeUpdate(ripA.said, bupA1.said, acdcA.said,
+                                    'revoked', sn=2, stamp=STAMP2)
+        anchor(hab, bupA2)
+
+        # sibling registry RB: acdcB genuinely issued
+        ripB = makeRegistry(hab, stamp=STAMP1)
+        acdcB = makeAcdc(hab, regid=ripB.said, name="Moonspot College")
+        blindB1, bupB1 = makeUpdate(ripB.said, ripB.said, acdcB.said,
+                                    'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bupB1)
+
+        # both registries verify on their own evidence
+        assert vet(rip=ripA, updates=[bupA1, bupA2], db=hby.db, acdc=acdcA,
+                   blinder=blindA2).state == 'revoked'
+        assert vet(rip=ripB, updates=[bupB1], db=hby.db, acdc=acdcB,
+                   blinder=blindB1).state == 'issued'
+
+        # the substitution: revoked acdcA riding RB's issued chain
+        with pytest.raises(kering.MisbindingError) as ex:
+            vet(rip=ripB, updates=[bupB1], db=hby.db, acdc=acdcA,
+                blinder=blindB1)
+        assert 'td' in str(ex.value)
+
+
+def test_V15_acdc_rd_mismatch_refused():
+    """V15: an ACDC carrying rd that is not the presented rip's d is refused:
+    the mutual binding fails even though td matches."""
+    with openIssuer("v15") as (hby, hab):
+        ripA = makeRegistry(hab, stamp=STAMP0)
+        acdcA = makeAcdc(hab, regid=ripA.said)
+
+        ripB = makeRegistry(hab, stamp=STAMP1)
+        # RB's update genuinely commits td = acdcA -- but acdcA names RA
+        blindB1, bupB1 = makeUpdate(ripB.said, ripB.said, acdcA.said,
+                                    'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bupB1)
+
+        with pytest.raises(kering.MisbindingError) as ex:
+            vet(rip=ripB, updates=[bupB1], db=hby.db, acdc=acdcA,
+                blinder=blindB1)
+        assert 'rd' in str(ex.value)
+
+
+def test_V16_rdless_acdc_oneway_binding():
+    """V16: an rd-less ACDC whose chain td matches verifies, and the verdict
+    names the one-directional binding (registry->ACDC only)."""
+    with openIssuer("v16") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=None)  # correlation-minimized: no rd
+        assert 'rd' not in acdc.sad
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bup)
+
+        rec = vet(rip=ripper, updates=[bup], db=hby.db, acdc=acdc,
+                  blinder=blinder)
+        assert rec.state == 'issued'
+        assert rec.binding == 'oneway'  # nothing commits ACDC->registry
+
+
+def test_V16b_blinded_head_undisclosed_binds_nothing():
+    """V16b: an ACDC presented against a blinded head with no disclosure is
+    refused: the chain verifies, but nothing binds the ACDC to it."""
+    with openIssuer("v16b") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, bup = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                            sn=1, stamp=STAMP1)
+        anchor(hab, bup)
+
+        with pytest.raises(kering.UnverifiedBlindError):
+            vet(rip=ripper, updates=[bup], db=hby.db, acdc=acdc)
+
+
+# ---------------------------------------------------------------------------
+# Latest-state and duplicity
+# ---------------------------------------------------------------------------
+
+def test_V18_equal_n_duplicity_both_orders():
+    """V18: two verifying events at equal n, both anchored, are refused as
+    registry duplicity in both evidence orders."""
+    with openIssuer("v18") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, forkA = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                              sn=1, stamp=STAMP1)
+        _, forkB = makeUpdate(ripper.said, ripper.said, acdc.said, 'revoked',
+                              sn=1, stamp=STAMP2)
+        anchor(hab, forkA)
+        anchor(hab, forkB)
+
+        for updates in ([forkA, forkB], [forkB, forkA]):
+            with pytest.raises(kering.DuplicitousRegistryError):
+                vet(rip=ripper, updates=updates, db=hby.db)
+
+
+def test_V19_later_event_wins():
+    """V19: when the evidence holds a later verifying event than the one the
+    presenter relies on, the later state wins -- evidence is evidence."""
+    with openIssuer("v19") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        _, bup1 = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                             sn=1, stamp=STAMP1)
+        anchor(hab, bup1)
+        blinder2, bup2 = makeUpdate(ripper.said, bup1.said, acdc.said,
+                                    'revoked', sn=2, stamp=STAMP2)
+        anchor(hab, bup2)
+
+        # the presenter would rely on bup1 (issued); the evidence knows better,
+        # in whatever order the events arrive
+        for updates in ([bup1, bup2], [bup2, bup1]):
+            rec = vet(rip=ripper, updates=updates, db=hby.db, acdc=acdc,
+                      blinder=blinder2)
+            assert rec.sn == 2
+            assert rec.said == bup2.said
+            assert rec.state == 'revoked'
+
+
+# ---------------------------------------------------------------------------
+# Blinded registries, verify-side
+# ---------------------------------------------------------------------------
+
+def test_V20_bup_disclosed_blind_verifies():
+    """V20: a bup chain with a disclosed blinded block that reproduces the
+    BLID: state established from the disclosed ts."""
+    with openIssuer("v20") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bup)
+
+        rec = vet(rip=ripper, updates=[bup], db=hby.db, acdc=acdc,
+                  blinder=blinder)
+        assert rec.sn == 1
+        assert rec.ilk == Ilks.bup
+        assert rec.acdc == acdc.said
+        assert rec.state == 'issued'
+        assert rec.binding == 'mutual'
+
+        # the disclosure may arrive as the raw qb64 concatenation (what a
+        # discloser attaches on the wire), not only as a Blinder instance
+        rec2 = vet(rip=ripper, updates=[bup], db=hby.db, blinder=blinder.qb64)
+        assert rec2.state == 'issued'
+        assert rec2.acdc == acdc.said
+
+        # without a disclosure the chain still verifies but the state stays
+        # blinded: the record reports no state rather than guessing
+        rec3 = vet(rip=ripper, updates=[bup], db=hby.db)
+        assert rec3.sn == 1
+        assert rec3.state is None
+        assert rec3.acdc is None
+
+
+def test_V21_blind_not_reproducing_refused():
+    """V21: a disclosed block that does not reproduce the anchored b is
+    refused -- the disclosure proves nothing."""
+    with openIssuer("v21") as (hby, hab):
+        ripper = makeRegistry(hab)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        anchor(hab, bup)
+
+        # same salt and sn, wrong state: the recomputed BLID differs
+        wrong = Blinder.blind(acdc=acdc.said, state='revoked', salt=SALT, sn=1)
+        with pytest.raises(kering.UnverifiedBlindError):
+            vet(rip=ripper, updates=[bup], db=hby.db, blinder=wrong)
+
+        # right state, wrong sn: the blind derives per event, so it also fails
+        stale = Blinder.blind(acdc=acdc.said, state='issued', salt=SALT, sn=2)
+        with pytest.raises(kering.UnverifiedBlindError):
+            vet(rip=ripper, updates=[bup], db=hby.db, blinder=stale)
+
+
+def test_V22_spec_blid_vectors():
+    """V22: the spec text's BLID conformance vectors (placeholder and issued)
+    are reproduced exactly.  Lineage caveat: the spec's examples were synced
+    from keripy, so this defends against drift, not against shared error."""
+    placeholder = Blinder(crew=BlindState(d='', u=SPEC_PLACEHOLDER_UUID,
+                                          td='', ts=''), makify=True)
+    assert placeholder.said == SPEC_PLACEHOLDER_BLID
+    issued = Blinder(crew=BlindState(d='', u=SPEC_ISSUED_UUID,
+                                     td=SPEC_ISSUED_TD, ts='issued'),
+                     makify=True)
+    assert issued.said == SPEC_ISSUED_BLID
+
+    # the verify-side operation accepts each disclosure against its BLID
+    acdc, state = vetBlind(blinder=placeholder, blid=SPEC_PLACEHOLDER_BLID)
+    assert (acdc, state) == ('', '')
+    acdc, state = vetBlind(blinder=issued.qb64, blid=SPEC_ISSUED_BLID)
+    assert (acdc, state) == (SPEC_ISSUED_TD, 'issued')
+
+    # and refuses a disclosure presented against the wrong BLID
+    with pytest.raises(kering.UnverifiedBlindError):
+        vetBlind(blinder=issued, blid=SPEC_PLACEHOLDER_BLID)
+
+
+def test_V23_no_salt_parameter_anywhere():
+    """V23: the verify path's API surface -- no parameter anywhere accepts a
+    salt.  The salt's absence from every signature is itself the row."""
+    checked = 0
+    for name, obj in inspect.getmembers(registring):
+        if getattr(obj, "__module__", None) != registring.__name__:
+            continue
+        if inspect.isfunction(obj):
+            assert 'salt' not in inspect.signature(obj).parameters, name
+            checked += 1
+        elif inspect.isclass(obj):
+            for mname, meth in inspect.getmembers(obj, inspect.isfunction):
+                assert 'salt' not in inspect.signature(meth).parameters, (
+                    f"{name}.{mname}")
+                checked += 1
+    assert checked > 0  # the sweep saw a real API surface
+
+
+if __name__ == "__main__":
+    test_V1_rip_bup_issued_verifies()
+    test_V2_revoking_bup_state_revoked()
+    test_V3_rip_n_nonzero_refused()
+    test_V4_n_gap_refused()
+    test_V5_p_mismatch_refused()
+    test_V6_rd_mismatch_refused()
+    test_V7_field_order_and_said_mutations_refused()
+    test_V8_unanchored_update_retryable()
+    test_V9_anchor_in_strangers_kel_refused()
+    test_V10_bare_digest_seal_accepted()
+    test_V11_multiple_seals_tolerated()
+    test_V12_smt_root_anchor_refused_by_name()
+    test_V13_seal_reference_without_seal_retryable()
+    test_V14_substitution_sibling_registry_refused()
+    test_V15_acdc_rd_mismatch_refused()
+    test_V16_rdless_acdc_oneway_binding()
+    test_V16b_blinded_head_undisclosed_binds_nothing()
+    test_V18_equal_n_duplicity_both_orders()
+    test_V19_later_event_wins()
+    test_V20_bup_disclosed_blind_verifies()
+    test_V21_blind_not_reproducing_refused()
+    test_V22_spec_blid_vectors()
+    test_V23_no_salt_parameter_anywhere()


### PR DESCRIPTION
#1612 gave keripy the issuer side of v2 blindable state registries. This is the other half: the verification a party performs on someone else's registry. Specifically, this fills the `keri/acdc/registring.py` stub (now renamed to regeventing.py, BTW) with another party's registry evidence and decides what it establishes. `vet()` takes a registry event chain, a `Baser` the caller has already populated with the issuer's KEL, and optionally a disclosed blinded-state block, and returns a `RegStateRecord` or raises a named refusal. It fetches nothing, opens nothing, and needs no local `Hab`.

This is what it checks, beyond the field and SAID validation `SerderACDC` already does:

- Chain rules: `n` starts at 0 and increments by exactly one, `p` chains by SAID, `rd` names the `rip`. I believe a gap is malformed in this case, so it is a refusal rather than an escrow candidate.
- KEL anchoring per event, matched by seal digest. A bare digest seal, a seal mapping with an `s` hint, and one without all anchor; several seals per key event are tolerated; the `s` is a lookup hint but not more. The anchoring KEL's controller must be the `rip`'s `i`.
- The binding equalities, as first-class named checks: the head state's `td` equals the presented ACDC's SAID, and the ACDC's `rd`, when it has one, equals the `rip`'s SAID. v2 ACDCs are not directly signed, so these two are the issuer's only commitment to the credential. A verifier that skips them discharges every other obligation and still accepts a substituted one, so there's a test in the PR that proves we reject a revoked ACDC riding a sibling registry's genuine issued chain, same issuer, where nothing else is wrong.
- Latest state at the highest `n` that chain- and anchor-verifies, with two distinct anchored events at one `n` refused as duplicity in either evidence order.
- BLID reproduction for a disclosed `bup` state. There is no salt parameter anywhere in the module — only the per-event disclosure is accepted, which is the independent verifier's position rather than the holder's. `Blinder.unblind` already serves the holder who has the uuid; nothing wired that to a `bup`'s `b` field.

Every presented event must anchor-verify before any conclusion is drawn. A missing anchor makes the whole determination retryable (`MissingAnchorError`) rather than partially conclusive.