### PR TITLE
fix: avoid stale HTTP messenger state

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -895,7 +895,6 @@ class HTTPMessenger(doing.DoDoer):
         self.parser = None
         self.auth = auth
         doers = doers if doers is not None else []
-        doers.extend([doing.doify(self.msgDo), doing.doify(self.responseDo)])
 
         up = urlparse(url)
         if up.scheme != kering.Schemes.http and up.scheme != kering.Schemes.https:
@@ -904,7 +903,10 @@ class HTTPMessenger(doing.DoDoer):
         self.client = http.clienting.Client(scheme=up.scheme, hostname=up.hostname, port=up.port)
         clientDoer = http.clienting.ClientDoer(client=self.client)
 
-        doers.extend([clientDoer])
+        # Queue work, service the transport, then read its current state.
+        doers.extend([doing.doify(self.msgDo),
+                      clientDoer,
+                      doing.doify(self.responseDo)])
 
         super(HTTPMessenger, self).__init__(doers=doers, **kwa)
 
@@ -988,13 +990,15 @@ class HTTPStreamMessenger(doing.DoDoer):
         super(HTTPStreamMessenger, self).__init__(doers=doers, **kwa)
 
     def recur(self, tyme, deeds=None):
-        """Poll for a response and stop once received."""
+        """Service the client, then stop when its current response is ready."""
+        done = super(HTTPStreamMessenger, self).recur(tyme, deeds)
+
         if self.client.responses:
             self.rep = self.client.respond()
             self.remove([self.client])
             return True
 
-        return super(HTTPStreamMessenger, self).recur(tyme, deeds)
+        return done
 
 
 def mailbox(hab, cid):

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -6,6 +6,7 @@ tests.app.agenting module
 import time
 
 from hio.base import doing, tyming
+from hio.core import http
 
 from keri import kering, core
 from keri.core import coring, serdering
@@ -14,6 +15,55 @@ from keri.help import nowIso8601
 from keri.app import habbing, indirecting, agenting, directing
 from keri.db import basing, dbing
 from keri.vdr import eventing, viring
+
+
+def test_http_messengers_read_state_after_client_service():
+    expected = http.clienting.Response(
+        version=(1, 1),
+        status=204,
+        reason=None,
+        headers={},
+        body=b"",
+        data=None,
+        request=None,
+        errored=False,
+        error=None,
+    )
+
+    # Test both types of messenger
+    for klas in (agenting.HTTPMessenger, agenting.HTTPStreamMessenger):
+        kwa = dict(
+            hab=None,
+            wit="witness",
+            url="http://127.0.0.1:1",
+        )
+        if klas is agenting.HTTPStreamMessenger:
+            kwa["msg"] = b"message"
+
+        messenger = klas(**kwa)
+        serviced = False
+
+        def service():  # mock just to verify order of call to messenger
+            nonlocal serviced
+            if not serviced:
+                messenger.client.responses.append(expected._asdict())  # mock HTTP success
+                serviced = True
+
+        messenger.client.service = service  # Inject mock into service
+        doist = doing.Doist(tock=0.03125, limit=1.0, doers=[messenger])
+        doist.enter()
+
+        try:
+            doist.recur()  # iterate doers normally exactly once
+
+            assert serviced
+            if isinstance(messenger, agenting.HTTPStreamMessenger):
+                assert messenger.done  # stream messenger is done after one message
+                assert messenger.rep == expected  # should be exactly one response
+            else:
+                assert list(messenger.sent) == [expected]  # should be exactly one response
+        finally:
+            doist.exit()
 
 
 def test_receiptor_tocks_are_generator_local():


### PR DESCRIPTION
## Summary

- run the HTTP client doer between request production and response handling
- advance the one-shot stream client before inspecting its response queue
- cover both messenger variants with a same-recurrence response regression

## Why

HTTPMessenger currently handles responses before its client doer runs, so it reads transport state left over from the prior scheduler recurrence. HTTPStreamMessenger similarly inspects the response queue before advancing its child client. The reordered paths interpret state produced by the current client service pass.

## Scope

This PR contains only the HTTP doer-ordering change and its focused regression. It does not include transport-completion accounting, cutoff policy, Directant lifecycle, retry, timeout, or configuration changes from #1614.

## Verification

- `tests/app/test_agenting.py`: 5 passed
- fatal flake8 gate (`E9,F63,F7,F82`): 0 findings
- diff against `v1.2.14`: one commit, two files