### PR TITLE
fix: backport incomplete Serder shortage handling

### DIFF
--- a/src/keri/core/serdering.py
+++ b/src/keri/core/serdering.py
@@ -1043,6 +1043,9 @@ class Serder:
         else:  # not passed in so smell raw
             proto, vrsn, kind, size, gvrsn = smell(raw)
 
+        if len(raw) < size:
+            raise ShortageError(f"Need more bytes to de-serialize Serder")
+
         sad = self.loads(raw=raw, size=size, kind=kind)
         # ._gvrsn may be set in loads when CESR native deserialization provides _gvrsn
 

--- a/tests/core/test_serdering.py
+++ b/tests/core/test_serdering.py
@@ -2580,6 +2580,11 @@ def test_serdery():
 
     serdery = Serdery()
 
+    partial = bytearray(serderKeri.raw[:-1])
+    with pytest.raises(kering.ShortageError):
+        serdery.reap(partial)
+    assert partial == serderKeri.raw[:-1]
+
     serder = serdery.reap(ims)
     assert isinstance(serder, SerderKERI)
     assert serder.raw == serderKeri.raw


### PR DESCRIPTION
## Summary

- Backport the exact three-line `Serder._inhale` guard from upstream commit [`b1ed02298`](https://github.com/WebOfTrust/keripy/commit/b1ed0229898b752015121353861796d4614a88d3).
- Raise `ShortageError` before deserialization when the available bytes are shorter than the size declared in the version string.
- Extend the existing `test_serdery` case to prove partial input is not consumed.

## Production defect

A normal TCP read can contain a complete version string while still containing fewer serialized-body bytes than that version string declares. The v1.2.14 code proceeds into deserialization and converts this ordinary partial read into `DeserializeError`, preventing the incremental parser from waiting for the remaining bytes.

Placing the guard in `Serder._inhale` matches the upstream abstraction and covers both `Serdery.reap` and direct Serder construction. This PR does not carry a maintenance-branch-specific factory check.

## Scope

This backport is extracted from #1614 so it can be reviewed and merged independently. Once merged, #1614 can rebase onto `v1.2.14` and drop its duplicate Serder commit.

The unrelated `parsing.py` framed-message behavior and `kering.py` documentation edits from upstream commit `b1ed02298` are intentionally excluded.

## Verification

- `./venv/bin/python -m pytest -q tests/core/test_serdering.py` — 23 passed
- `./venv/bin/python -m pytest -q` — 442 passed, 38 warnings
- Direct `SerderKERI(raw=partial)` shortage/non-consumption probe — passed