### PR TITLE
Use gleif_hio 0.6.20rc2 on v1.2.14

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest hio
+          pip install flake8 pytest gleif_hio==0.6.20rc2
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint changes
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov hio
+          pip install pytest pytest-cov gleif_hio==0.6.20rc2
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run core KERI tests
         run: |
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov hio pytest-shell
+          pip install pytest pytest-cov gleif_hio==0.6.20rc2 pytest-shell
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run KERI kli tests
         run: |

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
                         'cbor2>=5.6.2',
                         'multidict>=6.0.5',
                         'ordered-set>=4.1.0',
-                        'hio>=0.6.14',
+                        'gleif_hio==0.6.20rc2',
                         'multicommand==1.0.0',
                         'jsonschema>=4.21.1',
                         'falcon>=3.1.3',


### PR DESCRIPTION
## Summary

- replace the upstream `hio` requirement with `gleif_hio==0.6.20rc2`
- use the same package in all CI dependency bootstrap paths
- avoid installing both distributions, which provide the same `hio` import package

## Purpose

The reason we need this is that certain TCP connection lifecycle bugs are in-progress for `hio` on `main` and will be in-progress for a future v0.6.20 release from the `ioflo/hio` repo once the proposed v0.6.20 branch is accepted.

The following PRs are merged to GLEIF's `hio` fork on branch `release/v0.6.20` that we need in the upstream:
- https://github.com/GLEIF-IT/hio/pull/3
  - `txCutoff`: Needed so that Remoter can provide visibility for TCP response cutoff via `Remoter.txCutoff` rather than incorrectly overloading the TCP receive `Remoter.cutoff` var as both receive and response cutoffs. Directant/Reactant should look at `txCutoff` rather than `cutoff` as the teardown signal, as mentioned in https://github.com/ioflo/hio/pull/163 to `hio` `main`.
- https://github.com/GLEIF-IT/hio/pull/2
  - `timeout -> tymeout`: Needed so that expiry/inactivity timeouts work properly on Remoter and the Directant/Reactant pair. Baesd on https://github.com/ioflo/hio/pull/164
- https://github.com/GLEIF-IT/hio/pull/1
  - Needed so that disconnected sockets are cleaned up. Based on https://github.com/GLEIF-IT/hio/pull/1

Once these changes are accepted into upstream HIO on both main and a future `v0.6.20` release branch then the dependency can switch back from `gleif_hio` to `hio`.
