### PR TITLE
Split local TEL eventing into regeventing.py

### DIFF
--- a/src/keri/acdc/regeventing.py
+++ b/src/keri/acdc/regeventing.py
@@ -4,29 +4,37 @@ keri.acdc.regeventing module
 
 Registry (TEL) event support
 
-Party-side verification core for ACDC v2 blindable state registries (TELs)
-made of 'rip' (registry inception) and 'bup' (blindable update) events.  Given
-a supplied registry event chain, the issuer's KEL evidence, and optionally a
-disclosed blinded-state block, vet() and the vet* helpers determine the
-registry's verified state.  The core fetches nothing and concludes only from
-the evidence handed to it; KEL verification remains the caller's job.
+Shared TEL support for ACDC v2 blindable state registries made of 'rip'
+(registry inception) and 'bup' (blindable update) events.
 
-This complements keri.acdc.registraring, which manages the registries a local
-habitat controls.  Where that module issues, this one judges: its evidence is
-another party's, its anchor search runs against that party's KEL, and its
-refusals are named so a caller can tell a permanent one from a retryable one.
+This module now holds three closely related concerns:
+
+1. Verifier-side evidence vetting through vet() and the vet* helpers. Given a
+   supplied registry event chain, the issuer's KEL evidence, and optionally a
+   disclosed blinded-state block, these functions determine the registry's
+   verified state. They fetch nothing and conclude only from the evidence
+   handed to them; KEL verification remains the caller's job.
+2. Shared TEL validation and anchor helpers reused across verifier and issuer
+   flows so registry-event rules live in one place.
+3. The private issuer-side local event engine used by registraring.py to
+   process, anchor, escrow, replay, and accept TEL events for registries the
+   local habitat controls.
+
+In short, regeventing.py owns the TEL-specific validation and event workflow.
 """
 
 from collections.abc import Mapping
 from collections import namedtuple
 
 from .. import help
-from ..kering import (Ilks, ValidationError, InvalidValueError,
+from ..kering import (Ilks, ValidationError, ConfigurationError,
+                      InvalidValueError,
                       MissingAnchorError, MisdigestError, MissequenceError,
                       MisregistryError, MisanchorError, RootSealError,
                       MisbindingError, DuplicitousRegistryError,
                       UnverifiedBlindError)
-from ..core import Blinder, BlindState, BoundState, Number, SerderACDC
+from ..core import Blinder, BlindState, BoundState, Diger, Number, SerderACDC
+from . import messaging
 
 logger = help.ogler.getLogger()
 
@@ -56,7 +64,23 @@ Fields:
         issuer KEL event in which that TEL event's anchoring seal was found
 """
 
+# Shared TEL records
+_RegEventRecord = namedtuple("_RegEventRecord",
+                             "serder said ilk regk sn prior issuer")
+"""Normalized TEL event facts reused across issuer and verifier flows.
 
+Fields:
+    serder (SerderACDC): parsed registry event serder
+    said (str): qb64 SAID of the event
+    ilk (str): registry event type, currently ``rip`` or ``bup``
+    regk (str): qb64 registry identifier for the event's TEL
+    sn (int): sequence number of the event
+    prior (str|None): prior-event SAID for updates, else None for inception
+    issuer (str|None): qb64 issuer AID carried by the event when present
+"""
+
+
+# Shared TEL validation kernel
 def _coerce(evt):
     """Coerce evt to SerderACDC.  Accepts a SerderACDC instance or raw
     serialized bytes/str (one event's serialization).
@@ -74,6 +98,132 @@ def _coerce(evt):
                             f"{type(evt)}: expected SerderACDC or raw bytes.")
 
 
+def _normalizeEventRecord(evt):
+    """Normalize one TEL event into a parsed record
+
+    Parameters:
+        evt (SerderACDC | bytes | str): registry event material to normalize.
+
+    Returns:
+        _RegEventRecord: normalized TEL event facts shared across the issuer
+            and verifier flows.
+
+    Raises:
+        InvalidValueError: if ``evt`` cannot be coerced into a
+            ``SerderACDC``.
+        ValidationError: if the event's ``ilk`` is not one of the supported
+            v2 registry event types.
+    """
+    
+    # Parse once so every later step reads the same regk/sn/prior/issuer
+    serder = _coerce(evt)
+    ilk = serder.ilk
+
+    # The v2 ACDC TEL only supports registry inception and blind updates
+    if ilk not in (Ilks.rip, Ilks.bup):
+        raise ValidationError(f"Unsupported registry event type {ilk} for "
+                              f"event {serder.said}.")
+    return _RegEventRecord(serder=serder,
+                           said=serder.said,
+                           ilk=ilk,
+                           # For a rip the registry id is the event's own SAID;
+                           # for a bup it is carried in rd.
+                           regk=serder.said if ilk == Ilks.rip else serder.sad['rd'],
+                           sn=Number(numh=serder.sad['n']).num,
+                           prior=None if ilk == Ilks.rip else serder.sad['p'],
+                           issuer=serder.sad.get('i'))
+
+
+def _validateRip(evt, *, issuer=None):
+    """Validate one registry inception event against shared TEL rules.
+
+    Parameters:
+        evt (SerderACDC | bytes | str): registry inception event to validate.
+        issuer (str | None): optional expected issuer AID for the inception.
+
+    Returns:
+        _RegEventRecord: normalized facts for the validated inception event.
+
+    Raises:
+        ValidationError: if the event is not a ``rip`` or the issuer does not
+            match the expected local or presented issuer.
+        MissequenceError: if the inception event is not at sequence number
+            ``n = 0``.
+    """
+
+    # Normalize the event first so regk, sn, and issuer are interpreted consistently
+    event = _normalizeEventRecord(evt)
+
+    # Raise if the event is not a rip
+    if event.ilk != Ilks.rip:
+        raise ValidationError(f"Expected registry inception ilk={Ilks.rip} "
+                              f"got ilk={event.ilk} for event "
+                              f"{event.said}.")
+
+    # Validate correct sequence number for a rip
+    if event.sn != 0:
+        raise MissequenceError(f"Registry inception {event.said} has "
+                               f"n={event.serder.sad['n']} but inception "
+                               f"must be at n=0.")
+
+    # Validate the issuer is the same as the one provided
+    if issuer is not None and event.issuer != issuer:
+        raise ValidationError(f"Registry inception event {event.said} has "
+                              f"invalid issuer {event.issuer}.")
+    return event
+
+
+def _validateUpdate(evt, *, regid, prior=None):
+    """Validate one blindable registry update against shared TEL rules.
+
+    Parameters:
+        evt (SerderACDC | bytes | str): registry update event to validate.
+        regid (str): expected qb64 registry identifier for the update.
+        prior (str | None): optional expected prior-event SAID when the caller
+            already knows the accepted predecessor.
+
+    Returns:
+        _RegEventRecord: normalized facts for the validated update event.
+
+    Raises:
+        ValidationError: if the event is not a ``bup``.
+        MisregistryError: if the update names a different registry.
+        MissequenceError: if the update is not at sequence number ``n >= 1``.
+        MisdigestError: if the update's ``p`` field does not match the
+            provided predecessor.
+    """
+
+    # Normalize first so regid, sn, and prior are interpreted consistently.
+    event = _normalizeEventRecord(evt)
+
+    # Only blindable updates belong in this path
+    if event.ilk != Ilks.bup:
+        raise ValidationError(f"Expected registry update ilk={Ilks.bup} got "
+                              f"ilk={event.ilk} for event {event.said}.")
+
+    # Validate the registry id matches the one provided
+    if event.regk != regid:
+        raise MisregistryError(f"Registry update {event.said} has "
+                               f"rd={event.regk} which is not the "
+                               f"presented registry inception's said "
+                               f"{regid}.")
+
+    # sn 0 is reserved for the rip, so updates start at one.
+    if event.sn < 1:
+        raise MissequenceError(f"Registry update {event.said} has "
+                               f"n={event.serder.sad['n']} but updates must "
+                               f"be at n >= 1.")
+
+    # When a caller already knows the prior, require the chain link to
+    # match before any deeper processing happens.
+    if prior is not None and event.prior != prior:
+        raise MisdigestError(f"Registry event {event.said} at n={event.sn} "
+                             f"has p={event.prior} which is not the prior "
+                             f"event's said {prior}.")
+    return event
+
+
+# Shared KEL anchor primitives
 def _kever(db, pre):
     """Return the Kever for pre from db's read-through kevers cache, or None
     when the KEL is not available."""
@@ -81,6 +231,17 @@ def _kever(db, pre):
         return db.kevers[pre]
     except KeyError:
         return None
+
+
+def _kelEvent(db, pre, claim):
+    """Resolve a claimed anchoring key event of pre's KEL by sequence number
+    (int) or SAID (str).  Returns the event serder or None when absent."""
+    if isinstance(claim, int):
+        dig = db.kels.getLast(keys=pre, on=claim)
+        if dig is None:
+            return None
+        return db.evts.get(keys=(pre, dig))
+    return db.evts.get(keys=(pre, claim))
 
 
 def sealDigests(serder):
@@ -128,17 +289,64 @@ def _scanKel(db, pre, said):
     return None
 
 
-def _kelEvent(db, pre, claim):
-    """Resolve a claimed anchoring key event of pre's KEL by sequence number
-    (int) or SAID (str).  Returns the event serder or None when absent."""
-    if isinstance(claim, int):
-        dig = db.kels.getLast(keys=pre, on=claim)
-        if dig is None:
-            return None
-        return db.evts.get(keys=(pre, dig))
-    return db.evts.get(keys=(pre, claim))
+def _verifyAnchorCouple(serder, *, db, issuer, number, diger):
+    """Verify one explicit local KEL anchor couple against a TEL event seal.
+
+    Parameters:
+        serder (SerderACDC): TEL event whose anchor couple to verify.
+        db (Baser): local KEL database that stores the controlling habitat's
+            verified key events.
+        issuer (str): qb64 AID whose KEL must contain the sealing event.
+        number (Number | None): claimed sequence number of the sealing KEL
+            event.
+        diger (Diger | None): claimed digest of the sealing KEL event.
+
+    Returns:
+        bool: True when the claimed sealing event exists, is fully witnessed,
+            matches ``diger``, and contains the full TEL seal tuple for
+            ``serder``. False otherwise.
+    """
+
+    # Return False if either is missing
+    if number is None or diger is None:
+        return False
+
+    # Retrieve dig of KEL event by issuer and sequence number
+    dig = db.kels.getLast(keys=issuer, on=number.sn)
+    if dig is None:
+        return False
+
+    dig = dig.encode("utf-8")
+    
+    # Retrieve serder from evts
+    aserder = db.evts.get(keys=(issuer, dig))
+    if aserder is None:
+        return False
+
+    # The claimed SAID must match, and the key event must be fully witnessed
+    if aserder.said != diger.qb64 or not db.fullyWitnessed(aserder):
+        return False
+
+    # Compare against the full TEL seal tuple used by the local issuer path,
+    # not just the TEL event digest.
+    event = _normalizeEventRecord(serder)
+
+    # Build the seal tuple from the TEL event for comparison
+    seal = dict(i=event.regk, s=event.serder.sad['n'], d=event.said)
+
+    # Loop through the seals in serder and return True if any match the TEL event's seal
+    for candidate in aserder.ked.get("a", []):
+        if not isinstance(candidate, Mapping):
+            continue
+        if (candidate.get("i") == seal["i"] and
+                candidate.get("s") == seal["s"] and
+                candidate.get("d") == seal["d"]):
+            return True
+
+    return False
 
 
+# Verifier-side public API
 def vetAnchor(serder, *, db, issuer, source=None, told=()):
     """Verify that the registry (TEL) event serder is anchored in the
     issuer's KEL: some key event of the issuer carries a seal whose digest is
@@ -221,16 +429,7 @@ def vetRip(rip):
     Returns:
         serder (SerderACDC): the validated rip event
     """
-    serder = _coerce(rip)
-    if serder.ilk != Ilks.rip:
-        raise ValidationError(f"Expected registry inception ilk={Ilks.rip} "
-                              f"got ilk={serder.ilk} for event "
-                              f"{serder.said}.")
-    if Number(numh=serder.sad['n']).num != 0:
-        raise MissequenceError(f"Registry inception {serder.said} has "
-                               f"n={serder.sad['n']} but inception must be "
-                               f"at n=0.")
-    return serder
+    return _validateRip(rip).serder
 
 
 def vetUpdate(bup, rip):
@@ -240,20 +439,7 @@ def vetUpdate(bup, rip):
     Returns:
         serder (SerderACDC): the validated bup event
     """
-    serder = _coerce(bup)
-    if serder.ilk != Ilks.bup:
-        raise ValidationError(f"Expected registry update ilk={Ilks.bup} got "
-                              f"ilk={serder.ilk} for event {serder.said}.")
-    if serder.sad['rd'] != rip.said:
-        raise MisregistryError(f"Registry update {serder.said} has "
-                               f"rd={serder.sad['rd']} which is not the "
-                               f"presented registry inception's said "
-                               f"{rip.said}.")
-    if Number(numh=serder.sad['n']).num < 1:
-        raise MissequenceError(f"Registry update {serder.said} has "
-                               f"n={serder.sad['n']} but updates must be at "
-                               f"n >= 1.")
-    return serder
+    return _validateUpdate(bup, regid=vetRip(rip).said).serder
 
 
 def vetBlind(blinder, *, blid):
@@ -448,3 +634,571 @@ def vet(rip, updates=None, *, db, acdc=None, blinder=None, sources=None):
                           sn=Number(numh=head.sad['n']).num, ilk=head.ilk,
                           acdc=acdcsaid, state=state, stamp=head.sad['dt'],
                           binding=binding, anchors=tuple(anchors))
+
+
+# Issuer-side local TEL engine
+class _RegEventer:
+    """Private issuer-side TEL event engine for one local registry.
+
+    It owns the local TEL workflow that ``Registry`` delegates to:
+    shared TEL validation, local KEL anchor discovery and verification,
+    acceptance into the ordered registry log, and replay of missing-anchor
+    and out-of-order escrows.
+    """
+
+    def __init__(self, hab, store, regk=None, regd=None):
+        """Create one local TEL event engine bound to a habitat and store.
+
+        Parameters:
+            hab (Hab): controlling habitat whose KEL anchors registry events.
+            store (RegistryStore): storage adapter for TEL events, accepted
+                ordering, anchors, and escrows.
+            regk (str | None): bound registry identifier when reopening or
+                attaching to an existing local registry state.
+            regd (str | None): accepted head-event SAID when already known.
+        """
+        # The engine needs the controlling habitat for local KEL inspection,
+        # the registry store for persistence, and the current accepted TEL tip
+        self.hab = hab
+        self.store = store
+        self.regk = regk
+        self.regd = regd
+    
+    
+    @property
+    def head(self):
+        """Return the accepted head SAID for the bound local registry.
+
+        Returns:
+            Saider | None: current accepted head SAID, or None when the
+                registry has not yet committed any event.
+        """
+        return self.store.head(self.regk) if self.regk is not None else None
+
+    @property
+    def sn(self):
+        """Return the accepted head sequence number for the bound registry.
+
+        Returns:
+            int: accepted head sequence number, or ``-1`` when no TEL event
+                has been committed yet.
+        """
+        head = self.store.headEvent(self.regk) if self.regk is not None else None
+        return _normalizeEventRecord(head).sn if head is not None else -1
+
+    @property
+    def regser(self):
+        """Return the accepted registry inception event when available.
+
+        Returns:
+            SerderACDC | None: committed ``rip`` event, or None when the
+                registry inception has not yet been accepted.
+        """
+        return self.store.seqEvent(self.regk, 0) if self.regk is not None else None
+
+    # Public TEL event API
+    def processEvent(self, serder):
+        """Store one TEL event and commit it when anchor and order allow.
+
+        Parameters:
+            serder (SerderACDC): candidate local registry event to process.
+
+        Returns:
+            bool: True when the event commits immediately or replays
+                idempotently as already accepted. False when the event is
+                staged in missing-anchor or out-of-order escrow.
+
+        Raises:
+            ValidationError: if the event fails shared TEL validation or
+                conflicts with accepted local registry state.
+        """
+        # First apply shared TEL rules plus local store consistency checks.
+        event, existing, prior = self._validateEvent(serder)
+
+        # The first accepted or staged rip binds this engine instance to the
+        # registry key it will manage from then on.
+        if self.regk is None and event.ilk == Ilks.rip:
+            self.regk = event.regk
+            self.regd = event.said
+
+        # Idempotent replay of an already accepted event is a success.
+        if existing is not None:
+            self.regk = event.regk
+            self.regd = existing.said
+            return True
+
+        # Persist the body before any escrow decision so later replay can load
+        # the full event again.
+        self.store.putEvent(event.serder)
+
+        # Try a single local KEL discovery pass before deciding whether the
+        # event must wait in missing-anchor escrow.
+        self._discoverAnchor(event)
+        if self.store.anchor(event.said) is None:
+            self.store.escrowMissingAnchor(event.regk, event.sn, event.said)
+            return False
+
+        # Once an anchor exists, remove any stale maes entry for this event.
+        self.store.baser.maes.rem(keys=event.regk, on=event.sn, val=event.said)
+
+        # A rip only depends on its own verified anchor.
+        if event.ilk == Ilks.rip:
+            self._commit(event)
+            self._processQueued()
+            return True
+
+        # Updates with a verified anchor but no accepted predecessor move to
+        # out-of-order escrow until the chain gap is filled.
+        if prior is None:
+            self.store.escrowOutOfOrder(event.regk, event.sn, event.said)
+            return False
+
+        # Anchored and properly ordered updates can commit immediately.
+        self._commit(event)
+        self._processQueued()
+        return True
+
+    def anchorMsg(self, said, number=None, diger=None):
+        """Validate and record the local KEL anchor for one stored TEL event.
+
+        Parameters:
+            said (str): SAID of the stored TEL event to anchor.
+            number (Number | None): optional sequence number of the sealing
+                KEL event. Must be supplied together with ``diger``.
+            diger (Diger | None): optional digest of the sealing KEL event.
+                Must be supplied together with ``number``.
+
+        Returns:
+            bool: True when anchoring lets the event commit immediately or it
+                was already accepted, False when the event remains queued
+                behind a missing predecessor.
+
+        Raises:
+            ValidationError: if the stored TEL event is unknown, if only one of
+                ``number`` or ``diger`` is supplied, or if the explicit or
+                discovered local anchor does not verify.
+        """
+        # Explicit anchoring always starts from the already stored TEL body.
+        serder = self.store.event(said)
+        if serder is None:
+            raise ValidationError(f"unknown registry event {said}")
+
+        # Reuse the normal validation gate so bad stored bodies do not leave
+        # anchors behind.
+        event, _, _ = self._validateEvent(serder)
+        if (number is None) != (diger is None):
+            raise ValidationError("anchorMsg requires both number and diger or neither")
+
+        if number is None or diger is None:
+            # With no explicit couple, fall back to the same local KEL discovery
+            # path used by normal event ingestion and escrow replay.
+            self._discoverAnchor(event)
+        elif not _verifyAnchorCouple(event.serder,
+                                     db=self.hab.db,
+                                     issuer=self.hab.pre,
+                                     number=number,
+                                     diger=diger):
+            raise ValidationError(f"invalid anchor for registry event {said}")
+        else:
+            # Store the verified explicit couple so the normal state machine can
+            # continue from the exact same persisted anchor representation.
+            self.store.putAnchor(said, number, diger)
+
+        if self.store.anchor(said) is None:
+            raise ValidationError(f"invalid anchor for registry event {said}")
+
+        # Hand back to the main event path so commit vs ooes behavior stays
+        # centralized in one place.
+        return self.processEvent(event.serder)
+
+    def processEscrows(self):
+        """Retry missing-anchor and out-of-order escrows for this registry.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+        self._processMissingAnchors()
+        self._processQueued()
+
+    def blind(self, acdc, state, **kwa):
+        """Create and stage one blindable registry state update event.
+
+        Parameters:
+            acdc (SerderACDC): transaction-state ACDC that must already belong
+                to this registry and be issued by this habitat.
+            state (str): logical state value committed by the new blinded TEL
+                update.
+            **kwa: keyword arguments forwarded to ``Blinder.blind`` and
+                ``messaging.blindate``. Blinder-construction keys are removed
+                before the TEL event body is created.
+
+        Returns:
+            tuple: ``(blinder, serder)`` where ``blinder`` is the derived
+                ``Blinder`` and ``serder`` is the staged ``bup`` event.
+
+        Raises:
+            ConfigurationError: if the registry has no accepted anchored
+                frontier yet, if ``acdc`` is invalid, if it does not belong to
+                this registry or issuer, or if a caller-supplied ``blinder``
+                override is provided.
+        """
+        # Build the next bup off the effective staged frontier, not just the
+        # last committed head, so pipelined local issuance chains correctly.
+        tip = self._effectiveFrontier()
+        if tip is None:
+            raise ConfigurationError("registry must be anchored before updates")
+
+        # The issuer-side blind path only accepts a full, self-verifying ACDC.
+        if not isinstance(acdc, SerderACDC):
+            raise ConfigurationError("acdc must be a SerderACDC")
+        if not acdc.verify():
+            raise ConfigurationError(f"acdc {acdc.said} is invalid")
+
+        # The ACDC must already declare this registry as its governing TEL.
+        regid = getattr(acdc, "regid", None)
+        if regid is None:
+            regid = acdc.sad.get("rd")
+        if regid != self.regk:
+            raise ConfigurationError(f"acdc {acdc.said} does not belong to registry {self.regk}")
+
+        # The current habitat must also be the ACDC's issuer.
+        issuer = getattr(acdc, "israid", None)
+        if issuer is None:
+            issuer = acdc.sad.get("i")
+        if issuer != self.hab.pre:
+            raise ConfigurationError(f"acdc {acdc.said} has issuer {issuer} not {self.hab.pre}")
+        if "blinder" in kwa:
+            raise ConfigurationError("caller-supplied blinder overrides are not supported")
+
+        blindkwa = {}
+        for key in ("raw", "salt", "tier", "bound", "bsn", "bd"):
+            if key in kwa:
+                # These options belong to blinder construction, not the TEL
+                # event body, so peel them off before calling blindate().
+                blindkwa[key] = kwa.pop(key)
+
+        tipEvent = _normalizeEventRecord(tip)
+        sn = tipEvent.sn + 1
+        # Derive the blinder from the next TEL sequence number so the bup and
+        # blinded state commit to the same step in the chain.
+        blinder = Blinder.blind(sn=sn, acdc=acdc.said, state=state, **blindkwa)
+        serder = messaging.blindate(regid=self.regk,
+                                    prior=tipEvent.said,
+                                    blid=blinder.said,
+                                    sn=sn,
+                                    **kwa)
+        self.processEvent(serder)
+        return blinder, serder
+
+    # Shared local validation and acceptance helpers
+    def _validateEvent(self, serder):
+        """Validate one TEL event against shared TEL rules and local state.
+
+        Parameters:
+            serder (SerderACDC): candidate TEL event to validate for local
+                issuer-side processing.
+
+        Returns:
+            tuple: ``(event, existing, prior)`` where ``event`` is the
+                normalized ``_RegEventRecord``, ``existing`` is the already
+                accepted event at the same slot when present, and ``prior`` is
+                the accepted predecessor event for updates when already known.
+
+        Raises:
+            ValidationError: if the event does not belong to this registry, if
+                the first local event is not a ``rip``, if the issuer is
+                invalid, or if a different event already occupies the accepted
+                ``(regk, sn)`` slot.
+            MisregistryError, MissequenceError, MisdigestError: if shared TEL
+                validation fails for registry id, sequence number, or prior
+                linkage.
+        """
+
+        # Before a registry is bound, first event must be a rip
+        if self.regk is None:
+            if serder.ilk != Ilks.rip:
+                raise ValidationError("registry must start with an inception event")
+
+            # Validate the rip against the local habitat's AID
+            event = _validateRip(serder, issuer=self.hab.pre)
+        else:
+            # Once bound, reuse the shared TEL validators against the already
+            # known registry id and local habitat issuer.
+            event = _validateRip(serder, issuer=self.hab.pre) if serder.ilk == Ilks.rip \
+                else _validateUpdate(serder, regid=self.regk)
+
+        # Validate that the event belongs to the same registry
+        if self.regk is not None and event.regk != self.regk:
+            raise ValidationError(f"registry event {event.said} does not belong "
+                                  f"to {self.regk}")
+
+        # Validate that the event's sequence number is not already accepted with a different SAID
+        existing = self.store.seqEvent(event.regk, event.sn)
+        if existing is not None and existing.said != event.said:
+            raise ValidationError(f"conflicting registry event at "
+                                  f"{event.regk}:{event.sn}")
+
+        prior = None
+        if event.ilk != Ilks.rip:
+            # If the predecessor is already accepted locally, make the update's
+            # p field prove it before we stage or replay anything.
+            prior = self.store.seqEvent(event.regk, event.sn - 1)
+
+            if prior is not None:
+                _validateUpdate(event.serder, regid=event.regk, prior=prior.said)
+
+        return event, existing, prior
+
+    def _commit(self, event):
+        """Accept one verified TEL event into the ordered local registry log.
+
+        Parameters:
+            event (_RegEventRecord): normalized TEL event already verified for
+                registry membership, anchor presence, and ordering.
+
+        Returns:
+            SerderACDC: committed TEL event serder.
+        """
+
+        # Persist the winner into the ordered TEL and then clear all escrow
+        # entries for that exact slot because the slot is now decided.
+        self.store.accept(event.regk, event.sn, event.serder)
+        for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
+            for (said,) in escrowdb.get(keys=event.regk, on=event.sn):
+                escrowdb.rem(keys=event.regk, on=event.sn, val=said)
+
+        # Update the registry key and digest
+        self.regk = event.regk
+        self.regd = event.said
+
+        return event.serder
+
+    def _discoverAnchor(self, event):
+        """Find and persist the first verified local KEL seal for one TEL event.
+
+        Parameters:
+            event (_RegEventRecord): normalized TEL event whose local KEL
+                anchor to discover.
+
+        Returns:
+            bool: True when an anchor is already stored or a newly discovered
+                local KEL seal verifies and is persisted. False when no usable
+                local sealing event is visible yet.
+        """
+        
+        # Check if the anchor is already known and stored
+        if self.store.anchor(event.said) is not None:
+            return True
+
+        # Ask the local habitat KEL for the latest key event whose seal payload
+        # points at this TEL event.
+        aserder = self.hab.db.fetchLastSealingEventByEventSeal(
+            pre=self.hab.pre,
+            seal=dict(i=event.regk, s=event.serder.sad['n'], d=event.said),
+        )
+        if aserder is None:
+            return False
+
+        # Retrieve the sn and and dig from the sealing event and verify the anchor couple
+        number = Number(num=aserder.sn)
+        diger = Diger(qb64=aserder.said)
+        if not _verifyAnchorCouple(event.serder,
+                                   db=self.hab.db,
+                                   issuer=self.hab.pre,
+                                   number=number,
+                                   diger=diger):
+            return False
+
+        self.store.putAnchor(event.said, number, diger)
+        return True
+
+    # Escrow replay helpers
+    def _anchorWinnerKey(self, said):
+        """Return the deterministic sibling winner key for one staged event.
+
+        Parameters:
+            said (str): SAID of the staged TEL event being ordered.
+
+        Returns:
+            tuple: sibling arbitration key ordered by earliest verified anchor,
+                then diger, then event SAID.
+        """
+        anchor = self.store.anchor(said)
+        if anchor is None:
+            return float("inf"), "", said
+        number, diger = anchor
+        return number.sn, diger.qb64, said
+
+    def _replayCandidate(self, said, sn):
+        """Load and revalidate one escrowed TEL event for replay.
+
+        Parameters:
+            said (str): SAID of the escrowed TEL event.
+            sn (int): escrow slot sequence number used to clear stale entries.
+
+        Returns:
+            tuple | None: ``(event, prior)`` for a replayable staged TEL event,
+                or None when the escrow entry is unrecoverable and has been
+                pruned.
+        """
+        serder = self.store.event(said)
+        if serder is None:
+            # A dangling escrow entry with no body cannot recover.
+            self.store.clearEscrows(self.regk, sn, said)
+            return None
+
+        try:
+            # Re-validate on replay so malformed staged data is pruned instead
+            # of being retried forever.
+            event, existing, prior = self._validateEvent(serder)
+        except ValidationError:
+            self.store.clearEscrows(self.regk, sn, said)
+            return None
+
+        if existing is not None and existing.said != said:
+            # A different sibling has already claimed the accepted slot.
+            self.store.clearEscrows(self.regk, sn, said)
+            return None
+
+        return event, prior
+
+    def _processMissingAnchors(self):
+        """Retry missing-anchor escrows using newly visible local KEL seals.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+        if self.regk is None:
+            return
+
+        # Re-group by TEL sequence number so sibling candidates compete as a
+        # set instead of in database iteration order.
+        escrowed = {}
+        for _, sn, said in self.store.baser.maes.getTopItemIter(keys=self.regk):
+            escrowed.setdefault(sn, []).append(said)
+
+        for sn in sorted(escrowed):
+            candidates = []
+            for said in escrowed[sn]:
+                replay = self._replayCandidate(said, sn)
+                if replay is None:
+                    continue
+
+                event, _ = replay
+                # Replay is what lets a now-visible KEL seal move an event from
+                # "missing anchor" toward acceptance.
+                self._discoverAnchor(event)
+                candidates.append(event.serder)
+
+            # Order competing siblings by their earliest verified anchor so the
+            # same event wins regardless of raw database iteration order.
+            for serder in sorted(candidates, key=lambda serder: self._anchorWinnerKey(serder.said)):
+                try:
+                    # Re-enter the normal state machine so the candidate either
+                    # commits, moves to ooes, or remains staged in maes.
+                    self.processEvent(serder)
+                except ValidationError:
+                    self.store.clearEscrows(self.regk, sn, serder.said)
+
+    def _processQueued(self):
+        """Advance out-of-order escrows whose predecessors now exist locally.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+        if self.regk is None:
+            return
+
+        while True:
+            # Only the next sequence number after the accepted head can advance.
+            sn = self.sn + 1
+            queued = [said for (said,) in self.store.baser.ooes.get(keys=self.regk, on=sn)]
+            if not queued:
+                return
+
+            advanced = False
+            # Use the same sibling winner policy here as missing-anchor replay
+            # so queued and missing-anchor escrows resolve races identically.
+            for said in sorted(queued, key=self._anchorWinnerKey):
+                replay = self._replayCandidate(said, sn)
+                if replay is None:
+                    continue
+
+                event, prior = replay
+                # ooes only advances events whose anchors are already known.
+                if self.store.anchor(said) is None:
+                    continue
+
+                # If the immediate predecessor still is not accepted, the event
+                # remains queued for a later pass.
+                if prior is None:
+                    continue
+
+                # Commit one event per pass, then loop so the next sequence slot
+                # sees the updated accepted head.
+                self._commit(event)
+                advanced = True
+                break
+
+            if not advanced:
+                return
+
+    # Issuance helper
+    def _effectiveFrontier(self):
+        """Return the effective TEL frontier, including one staged successor chain.
+
+        Returns:
+            SerderACDC | None: accepted head event extended by a single
+                unambiguous staged successor chain, or None when no accepted
+                head exists yet.
+
+        Raises:
+            ConfigurationError: if multiple staged successors compete for the
+                same next TEL sequence number.
+        """
+        
+        # Start from the accepted TEL head and then walk forward through any
+        # single unambiguous staged successor chain.
+        tip = self.store.headEvent(self.regk) if self.regk is not None else None
+        while tip is not None:
+            tipEvent = _normalizeEventRecord(tip)
+            sn = tipEvent.sn + 1
+            saids = []
+            seen = set()
+            for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
+                for (said,) in escrowdb.get(keys=self.regk, on=sn):
+                    # The same event may be observed across escrows during
+                    # replay-heavy flows, so de-duplicate by SAID.
+                    if said not in seen:
+                        seen.add(said)
+                        saids.append(said)
+
+            matches = []
+            for said in saids:
+                staged = self.store.event(said)
+                if staged is None:
+                    continue
+                stagedEvent = _normalizeEventRecord(staged)
+                # Only events that point at the current frontier are eligible
+                # to extend it for pipelined issuance.
+                if stagedEvent.prior == tipEvent.said:
+                    matches.append(stagedEvent)
+
+            if not matches:
+                break
+            # Multiple staged successors at one slot mean the local staged TEL
+            # has forked, so issuance fails closed instead of guessing.
+            if len(matches) > 1:
+                raise ConfigurationError(f"registry {self.regk} has conflicting staged successors at sn {sn}")
+            tip = matches[0].serder
+
+        return tip

--- a/src/keri/acdc/regeventing.py
+++ b/src/keri/acdc/regeventing.py
@@ -1002,7 +1002,7 @@ class _RegEventer:
         if aserder is None:
             return False
 
-        # Retrieve the sn and and dig from the sealing event and verify the anchor couple
+        # Retrieve the sn and dig from the sealing event and verify the anchor couple
         number = Number(num=aserder.sn)
         diger = Diger(qb64=aserder.said)
         if not _verifyAnchorCouple(event.serder,

--- a/src/keri/acdc/registraring.py
+++ b/src/keri/acdc/registraring.py
@@ -10,8 +10,7 @@ Registrar service support for managing Registries of ACDC state
 from hio.help import ogler
 
 from ..kering import ClosedError, ConfigurationError, ValidationError
-from ..core import Blinder, Diger, Number, SerderACDC
-from . import messaging
+from . import messaging, regeventing
 from .registering import RegistryStore, openRegistry
 
 logger = ogler.getLogger()
@@ -169,8 +168,29 @@ class Registry:
         self.hab = hab
         self.store = store
         self.name = name
-        self.regk = regk
-        self.regd = None
+        # Registry remains the public facade, but the TEL event state machine
+        # now lives in the private regeventing engine.
+        self._eventer = regeventing._RegEventer(hab=hab,
+                                                store=store,
+                                                regk=regk)
+
+    @property
+    def regk(self):
+        # Surface the engine's current registry binding through the legacy API.
+        return self._eventer.regk
+
+    @regk.setter
+    def regk(self, regk):
+        self._eventer.regk = regk
+
+    @property
+    def regd(self):
+        # Surface the engine's current accepted TEL head SAID.
+        return self._eventer.regd
+
+    @regd.setter
+    def regd(self, regd):
+        self._eventer.regd = regd
 
     @property
     def head(self):
@@ -180,7 +200,7 @@ class Registry:
             Saider | None: SAID of the current accepted head event, or None when
                 the registry has no accepted head yet.
         """
-        return self.store.head(self.regk) if self.regk is not None else None
+        return self._eventer.head
 
     @property
     def sn(self):
@@ -190,8 +210,7 @@ class Registry:
             int: accepted head sequence number, or ``-1`` when the registry has
                 not committed any event yet.
         """
-        head = self.store.headEvent(self.regk) if self.regk is not None else None
-        return int(head.sad["n"], 16) if head is not None else -1
+        return self._eventer.sn
 
     @property
     def regser(self):
@@ -201,280 +220,7 @@ class Registry:
             SerderACDC | None: accepted ``rip`` event, or None when inception has
                 not been committed yet.
         """
-        return self.store.seqEvent(self.regk, 0) if self.regk is not None else None
-
-    def _verifyAnchor(self, serder, number, diger):
-        """Verify that one KEL event actually seals the given registry event
-
-        Parameters:
-            serder (SerderACDC): registry event whose anchor is being checked
-            number (Number): sequence number of the supposed anchoring KEL
-                event
-            diger (Diger): digest of the supposed anchoring KEL event
-
-        Returns:
-            bool: True when the controlling habitat's KEL contains a fully
-                witnessed event at ``number`` whose SAID matches ``diger`` and
-                whose seal list includes this registry event
-        """
-        if number is None or diger is None:
-            return False
-
-        dig = self.hab.db.kels.getLast(keys=self.hab.pre, on=number.sn)
-        if not dig:
-            return False
-
-        dig = dig.encode("utf-8")
-        if not (aserder := self.hab.db.evts.get(keys=(self.hab.pre, dig))):
-            return False
-
-        if aserder.said != diger.qb64 or not self.hab.db.fullyWitnessed(aserder):
-            return False
-
-        regk = serder.said if serder.ilk == "rip" else serder.regid
-        for seal in aserder.ked.get("a", []):
-            if (isinstance(seal, dict) and
-                    seal.get("i") == regk and
-                    seal.get("s") == serder.sad["n"] and
-                    seal.get("d") == serder.said):
-                return True
-
-        return False
-
-    def _validateEvent(self, serder):
-        """Validate registry-event structure and current-slot consistency.
-
-        Parameters:
-            serder (SerderACDC): candidate registry event to validate.
-
-        Returns:
-            tuple: ``(regk, sn, existing, prior)`` where ``regk`` is the
-                registry identifier, ``sn`` is the integer sequence number,
-                ``existing`` is any already accepted event at this slot, and
-                ``prior`` is the accepted predecessor when one exists.
-
-        Raises:
-            ValidationError: if the event type is unsupported, the event has an
-                invalid sequence shape, the ``rip`` issuer does not match the
-                controlling habitat, the event belongs to another bound
-                registry, the accepted slot is occupied by another SAID, or the
-                accepted prior does not match ``p``.
-        """
-        if serder.ilk not in ("rip", "bup"):
-            raise ValidationError(f"unsupported registry event type {serder.ilk}")
-
-        regk = serder.said if serder.ilk == "rip" else serder.regid
-        sn = int(serder.sad["n"], 16)
-        if serder.ilk == "rip" and sn != 0:
-            raise ValidationError(f"registry inception event {serder.said} has invalid sn {sn}")
-        if serder.ilk == "rip" and serder.sad["i"] != self.hab.pre:
-            raise ValidationError(f"registry inception event {serder.said} has invalid issuer {serder.sad['i']}")
-        if serder.ilk != "rip" and sn < 1:
-            raise ValidationError(f"registry event {serder.said} has invalid sn {sn}")
-
-        if self.regk is not None and regk != self.regk:
-            raise ValidationError(f"registry event {serder.said} does not belong to {self.regk}")
-
-        existing = self.store.seqEvent(regk, sn)
-        if existing is not None and existing.said != serder.said:
-            raise ValidationError(f"conflicting registry event at {regk}:{sn}")
-
-        prior = None
-        if serder.ilk != "rip":
-            prior = self.store.seqEvent(regk, sn - 1)
-            if prior is not None and prior.said != serder.sad["p"]:
-                raise ValidationError(f"registry event {serder.said} has invalid prior {serder.sad['p']}")
-
-        return regk, sn, existing, prior
-
-    def _commit(self, serder):
-        """Accept one verified registry event into the ordered registry log.
-
-        Parameters:
-            serder (SerderACDC): verified registry event ready to be committed.
-
-        Returns:
-            SerderACDC: the same committed registry event.
-        """
-        # Retrieve the registry key and sn from the event
-        regk = serder.said if serder.ilk == "rip" else serder.regid
-        sn = int(serder.sad["n"], 16)
-
-        # Update the registry store and clear every escrowed candidate for this
-        # slot now that one event has won it
-        self.store.accept(regk, sn, serder)
-        for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
-            for (said,) in escrowdb.get(keys=regk, on=sn):
-                escrowdb.rem(keys=regk, on=sn, val=said)
-
-        # Update the registry state with the new head
-        self.regk = regk
-        self.regd = serder.said
-
-        return serder
-
-    def _processMissingAnchors(self):
-        """Retry missing-anchor escrows using any now-visible local KEL seals.
-
-        Parameters:
-            None
-
-        Returns:
-            None
-        """
-        if self.regk is None:
-            return
-
-        # Re-group missing-anchor escrows by TEL sn so competing
-        # siblings at one slot can be arbitrated together instead of in raw DB
-        # iteration order.
-        escrowed = {}
-        for _, sn, said in self.store.baser.maes.getTopItemIter(keys=self.regk):
-            escrowed.setdefault(sn, []).append(said)
-
-        for sn in sorted(escrowed):
-            # Collect the surviving candidates for this exact TEL slot before we
-            # decide which anchored sibling should replay first.
-            saids = []
-            for said in escrowed[sn]:
-                serder = self.store.event(said)
-                if serder is None:
-                    # Escrow entries with no serder, should be cleared
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                accepted = self.store.seqEvent(self.regk, sn)
-                if accepted is not None and accepted.said != said:
-                    # The slot is already taken, the stale candidate can be dropped
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                if self.store.anchor(serder.said) is None:
-                    # Replay may happen after the sealing KEL event exists, so
-                    # re-check local KEL visibility and persist the discovered
-                    # anchor before ordering competing siblings.
-                    regk = serder.said if serder.ilk == "rip" else serder.regid
-                    seal = dict(i=regk, s=serder.sad["n"], d=serder.said)
-                    aserder = self.hab.db.fetchLastSealingEventByEventSeal(pre=self.hab.pre,
-                                                                           seal=seal)
-                    if aserder is not None:
-                        number = Number(num=aserder.sn)
-                        diger = Diger(qb64=aserder.said)
-                        if self._verifyAnchor(serder, number, diger):
-                            self.store.putAnchor(serder.said, number, diger)
-                # Keep every still-viable candidate. Unanchored ones sort to the
-                # end below and remain in maes if nothing can commit them yet.
-                saids.append(said)
-
-            # Use the verified sealing event as the winner policy for this slot:
-            # earliest anchor wins, then digest/SAID provide a stable tie-break.
-            saids = sorted(
-                saids,
-                key=lambda said: (
-                    self.store.anchor(said)[0].sn if self.store.anchor(said) is not None else float("inf"),
-                    self.store.anchor(said)[1].qb64 if self.store.anchor(said) is not None else "",
-                    said,
-                ),
-            )
-
-            for said in saids:
-                serder = self.store.event(said)
-                if serder is None:
-                    # The body may have disappeared between collection and replay;
-                    # clear the now-broken escrow entry defensively.
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                accepted = self.store.seqEvent(self.regk, sn)
-                if accepted is not None and accepted.said != said:
-                    # A previous sibling replay in this same pass may already
-                    # have committed the slot, making this candidate obsolete.
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                try:
-                    # Re-enter the normal state machine so the candidate either
-                    # commits, moves to ooes, or remains staged for later.
-                    self.processEvent(serder)
-                except ValidationError:
-                    # If replay proves the candidate invalid after all, prune it
-                    # instead of letting it poison future escrow passes.
-                    self.store.clearEscrows(self.regk, sn, said)
-
-    def _processQueued(self):
-        """Advance any queued out-of-order events that are now satisfiable.
-
-        Parameters:
-            None
-
-        Returns:
-            None
-
-        Notes:
-            This only advances events that already have a verified stored anchor
-            and whose immediate prior event has since been committed.
-        """
-        if self.regk is None:
-            return
-
-        # Iteratively check for queued events at the next sequence number and attempt 
-        # to commit them if possible
-        while True:
-            # Look at the next sequence number and retrieve any queued out-of-order events
-            sn = self.sn + 1
-            queued = [said for (said,) in self.store.baser.ooes.get(keys=self.regk, on=sn)]
-            if not queued:
-                return
-
-            advanced = False
-            # When competing siblings exist at one sequence slot, prefer the
-            # earliest verified sealing event so "first anchored wins" is
-            # deterministic instead of depending on DB iteration order.
-            # Preserve the same sibling winner policy here as maes replay so
-            # queued and missing-anchor escrows resolve races identically.
-            queued = sorted(
-                queued,
-                key=lambda said: (
-                    self.store.anchor(said)[0].sn if self.store.anchor(said) is not None else float("inf"),
-                    self.store.anchor(said)[1].qb64 if self.store.anchor(said) is not None else "",
-                    said,
-                ),
-            )
-
-            # We assume there may be multiple queued events at the same
-            # sequence number, but we only commit one per iteration.
-            for said in queued:
-                serder = self.store.event(said)
-                if serder is None:
-                    # Body is missing, escrow entry is invalid, clear it and continue
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                accepted = self.store.seqEvent(self.regk, sn)
-                if accepted is not None and accepted.said != said:
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                if self.store.anchor(said) is None:
-                    # Anchor is missing, cannot commit yet
-                    continue
-
-                # Retrieve the prior event and check if it matches the expected prior SAID
-                prior = self.store.seqEvent(self.regk, sn - 1)
-                if prior is None:
-                    continue
-                if prior.said != serder.sad["p"]:
-                    self.store.clearEscrows(self.regk, sn, said)
-                    continue
-
-                # All prerequisites are satisfied, commit the event and then
-                # let the loop continue iteratively to the next sequence slot.
-                self._commit(serder)
-                advanced = True
-                break
-
-            if not advanced:
-                return
+        return self._eventer.regser
 
     def processEvent(self, serder):
         """Store one registry event and commit it when anchor and order allow.
@@ -495,65 +241,8 @@ class Registry:
                 has an invalid inception sequence number, or names an invalid
                 prior event.
         """
-        # Validate the event shape and any accepted-slot/accepted-prior
-        # constraints before mutating in-memory or persisted state.
-        regk, sn, existing, prior = self._validateEvent(serder)
-
-        # If this is the first rip being processed for this Registry object,
-        # bind it to that registry key now that validation has succeeded.
-        if self.regk is None and serder.ilk == "rip":
-            self.regk = regk
-            self.regd = serder.said
-
-        # Check whether this registry slot has already been accepted.
-        if existing is not None:
-            self.regk = regk
-            self.regd = existing.said
-            return True
-
-        # Store new events before escrowing so they can be replayed later once
-        # their anchor or prior dependency arrives.
-        self.store.putEvent(serder)
-
-        if self.store.anchor(serder.said) is None:
-            # For the normal V2 path, discover the sealing KEL event from the
-            # local KEL instead of accepting an anchor couple through
-            # processEvent. Explicit caller-supplied anchors go through
-            # anchorMsg, while the state machine either finds a verified local
-            # seal here or stages the event in missing-anchor escrow.
-            seal = dict(i=regk, s=serder.sad["n"], d=serder.said)
-            aserder = self.hab.db.fetchLastSealingEventByEventSeal(pre=self.hab.pre,
-                                                                   seal=seal)
-            if aserder is not None:
-                # Persist the discovered anchor so the event can either commit
-                # immediately or participate in sibling ordering
-                number = Number(num=aserder.sn)
-                diger = Diger(qb64=aserder.said)
-                if self._verifyAnchor(serder, number, diger):
-                    self.store.putAnchor(serder.said, number, diger)
-
-        # After one local-KEL discovery pass, either the event is now anchored
-        # or it must wait in maes for a future sealing event to appear.
-        if self.store.anchor(serder.said) is None:
-            self.store.escrowMissingAnchor(regk, sn, serder.said)
-            return False
-
-        # If the event had previously been staged as missing-anchor, clear that
-        # escrow entry now that a verified anchor exists.
-        self.store.baser.maes.rem(keys=regk, on=sn, val=serder.said)
-
-        if serder.ilk == "rip":
-            self._commit(serder)
-            self._processQueued()
-            return True
-
-        if prior is None:
-            self.store.escrowOutOfOrder(regk, sn, serder.said)
-            return False
-
-        self._commit(serder)
-        self._processQueued()
-        return True
+        # Delegate TEL ingestion to the shared local event engine.
+        return self._eventer.processEvent(serder)
               
     def processEscrows(self):
         """Retry missing-anchor and out-of-order escrows for this registry.
@@ -564,8 +253,9 @@ class Registry:
         Returns:
             None
         """
-        self._processMissingAnchors()
-        self._processQueued()
+        # Keep the public entrypoint here while the actual replay workflow
+        # lives beside the rest of the TEL engine in regeventing.py.
+        self._eventer.processEscrows()
 
     def anchorMsg(self, said, number=None, diger=None):
         """Validate and record the KEL anchor for one stored registry event.
@@ -591,35 +281,9 @@ class Registry:
                 ``number``/``diger`` is supplied, or if the supplied anchor
                 does not validate against the controlling habitat's KEL.
         """
-        serder = self.store.event(said)
-        if serder is None:
-            raise ValidationError(f"unknown registry event {said}")
-
-        regk = serder.said if serder.ilk == "rip" else serder.regid
-        if self.regk is not None and regk != self.regk:
-            raise ValidationError(f"registry event {said} does not belong to {self.regk}")
-
-        # Reuse the same event-shape and accepted-slot validation that
-        # processEvent() will enforce so a rejected event never leaves a stored
-        # anchor behind.
-        self._validateEvent(serder)
-
-        if (number is None) != (diger is None):
-            raise ValidationError("anchorMsg requires both number and diger or neither")
-
-        if number is None or diger is None:
-            seal = dict(i=regk, s=serder.sad["n"], d=serder.said)
-            aserder = self.hab.db.fetchLastSealingEventByEventSeal(pre=self.hab.pre,
-                                                                   seal=seal)
-            if aserder is not None:
-                number = Number(num=aserder.sn)
-                diger = Diger(qb64=aserder.said)
-
-        if not self._verifyAnchor(serder, number, diger):
-            raise ValidationError(f"invalid anchor for registry event {said}")
-
-        self.store.putAnchor(said, number, diger)
-        return self.processEvent(serder)
+        # Preserve the existing public API while delegating anchor handling to
+        # the shared local event engine.
+        return self._eventer.anchorMsg(said, number=number, diger=diger)
 
     def make(self, **kwa):
         """Create and stage a registry inception event for this registry.
@@ -662,81 +326,9 @@ class Registry:
                 controlling habitat, or if an unsupported explicit ``blinder``
                 argument is supplied.
         """
-        # Start from the last committed TEL event, then walk forward through any
-        # single unambiguous staged successor chain before minting the next bup.
-        tip = self.store.headEvent(self.regk) if self.regk is not None else None
-        while tip is not None:
-            # Only the immediate next sequence slot can legally extend the
-            # current tip, so advance one TEL step at a time.
-            sn = int(tip.sad["n"], 16) + 1
-            saids = []
-            seen = set()
-            for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
-                for (said,) in escrowdb.get(keys=self.regk, on=sn):
-                    # The same candidate should only be examined once even if
-                    # it has moved between escrows during previous processing.
-                    if said not in seen:
-                        seen.add(said)
-                        saids.append(said)
-
-            matches = []
-            for said in saids:
-                # Only staged events that explicitly name the current tip as
-                # their prior are valid successors for pipelining.
-                if (staged := self.store.event(said)) is not None and staged.sad.get("p") == tip.said:
-                    matches.append(staged)
-
-            if not matches:
-                # No staged successor continues the chain, so the current tip is
-                # the frontier to build the next blind update from.
-                break
-            if len(matches) > 1:
-                # More than one staged successor means the staged TEL has forked;
-                # fail closed rather than guessing which branch to extend.
-                raise ConfigurationError(f"registry {self.regk} has conflicting staged successors at sn {sn}")
-            # Exactly one staged successor exists, so keep walking until we reach
-            # the latest unambiguous staged frontier.
-            tip = matches[0]
-
-        if tip is None:
-            raise ConfigurationError("registry must be anchored before updates")
-        if not isinstance(acdc, SerderACDC):
-            raise ConfigurationError("acdc must be a SerderACDC")
-        if not acdc.verify():
-            raise ConfigurationError(f"acdc {acdc.said} is invalid")
-        regid = getattr(acdc, "regid", None)
-        if regid is None:
-            regid = acdc.sad.get("rd")
-        if regid != self.regk:
-            raise ConfigurationError(f"acdc {acdc.said} does not belong to registry {self.regk}")
-        issuer = getattr(acdc, "israid", None)
-        if issuer is None:
-            issuer = acdc.sad.get("i")
-        if issuer != self.hab.pre:
-            raise ConfigurationError(f"acdc {acdc.said} has issuer {issuer} not {self.hab.pre}")
-        if "blinder" in kwa:
-            raise ConfigurationError("caller-supplied blinder overrides are not supported")
-
-        blindkwa = {}
-        for key in ("raw", "salt", "tier", "bound", "bsn", "bd"):
-            if key in kwa:
-                blindkwa[key] = kwa.pop(key)
-
-        # The new blind update must extend the effective frontier, which may be
-        # newer than the last committed head when pipelining staged updates.
-        sn = int(tip.sad["n"], 16) + 1
-        acdcSaid = acdc.said
-        blinder = Blinder.blind(sn=sn, acdc=acdcSaid, state=state, **blindkwa)
-
-        # Build the next TEL event directly off the discovered frontier so the
-        # resulting bup chains correctly through any staged-but-unanchored tip.
-        serder = messaging.blindate(regid=self.regk,
-                                    prior=tip.said,
-                                    blid=blinder.said,
-                                    sn=sn,
-                                    **kwa)
-        self.processEvent(serder)
-        return blinder, serder
+        # Blind issuance remains a Registry method for callers, but the staged
+        # frontier walk and TEL event creation now live in regeventing.py.
+        return self._eventer.blind(acdc=acdc, state=state, **kwa)
 
 
 class Registrar:

--- a/tests/acdc/test_regeventing.py
+++ b/tests/acdc/test_regeventing.py
@@ -29,9 +29,9 @@ import pytest
 
 from keri import kering
 from keri import Vrsn_2_0, Ilks
-from keri.core import Blinder, BlindState, Diger, SerderACDC
+from keri.core import Blinder, BlindState, Diger, Number, SerderACDC
 from keri.core.signing import Salter
-from keri.acdc import regcept, blindate, acdcmap
+from keri.acdc import Registry, Regery, regcept, blindate, acdcmap
 from keri.acdc import regeventing
 from keri.acdc.regeventing import RegStateRecord, vet, vetBlind
 from keri.app import habbing
@@ -258,6 +258,44 @@ def test_V7_field_order_and_said_mutations_refused():
                 SerderACDC(raw=traw)
 
 
+def test_shared_tel_validation_kernel_rejects_overlap_rules():
+    """The shared TEL validators reject the malformed field combinations both sides care about."""
+    with openIssuer("shared-kernel") as (hby, hab):
+        # Set up 2 registry, and one ACDC 
+        ripper = makeRegistry(hab, anchored=False)
+        acdc = makeAcdc(hab, regid=ripper.said)
+        other = makeRegistry(hab, stamp=STAMP2, anchored=False)
+
+        # sn = 0 for rip
+        bad_rip = remake(ripper, n='1')
+        with pytest.raises(kering.MissequenceError):
+            regeventing._validateRip(bad_rip, issuer=hab.pre)
+
+        # issuer is unknown
+        foreign_rip = remake(ripper, i="EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        with pytest.raises(kering.ValidationError):
+            regeventing._validateRip(foreign_rip, issuer=hab.pre)
+
+        # sn = 0 for bup
+        _, zero_bup = makeUpdate(ripper.said, ripper.said, acdc.said, 'issued',
+                                 sn=0, stamp=STAMP1)
+        with pytest.raises(kering.MissequenceError):
+            regeventing._validateUpdate(zero_bup, regid=ripper.said)
+
+        # registry mismatch
+        _, stray = makeUpdate(other.said, ripper.said, acdc.said, 'issued',
+                              sn=1, stamp=STAMP1)
+        with pytest.raises(kering.MisregistryError):
+            regeventing._validateUpdate(stray, regid=ripper.said)
+
+        # wrong prior
+        _, crooked = makeUpdate(ripper.said, acdc.said, acdc.said, 'issued',
+                                sn=1, stamp=STAMP1)
+        with pytest.raises(kering.MisdigestError):
+            regeventing._validateUpdate(crooked, regid=ripper.said,
+                                        prior=ripper.said)
+
+
 # ---------------------------------------------------------------------------
 # Anchors (the seal-anchored verification core)
 # ---------------------------------------------------------------------------
@@ -277,6 +315,49 @@ def test_V8_unanchored_update_retryable():
         anchor(hab, bup)
         rec = vet(rip=ripper, updates=[bup], db=hby.db, blinder=blinder)
         assert rec.state == 'issued'
+
+
+def test_shared_anchor_couple_verifier_matches_local_and_verifier_policies():
+    """The shared anchor-couple verifier drives local commit while verifier-side still treats missing anchors as retryable."""
+    with openIssuer("shared-anchor-couple") as (hby, hab):
+        rgy = Regery(hby=hby, name="shared-anchor-couple", temp=True)
+        try:
+            registry = Registry(hab=hab, store=rgy.store, name="shared-anchor-couple")
+
+            # Setup registry and anchor the rip event 
+            ripper = registry.make(stamp=STAMP0)
+            seal = dict(i=ripper.said, s=ripper.sad['n'], d=ripper.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            assert registry.anchorMsg(ripper.said) is True
+
+            # Stage a valid update without its KEL anchor so the local path
+            # must escrow it in maes rather than accept it immediately.
+            acdc = makeAcdc(hab, regid=registry.regk)
+            blinder, bup = makeUpdate(registry.regk, ripper.said, acdc.said,
+                                      'issued', sn=1, stamp=STAMP1)
+            assert registry.processEvent(bup) is False
+            assert rgy.store.baser.maes.get(keys=registry.regk, on=1) == [(bup.said,)]
+
+            # The verifier-side policy is stricter: the same missing anchor is
+            # still a retryable failure, not an escrowed local state.
+            with pytest.raises(kering.MissingAnchorError):
+                vet(rip=ripper, updates=[bup], db=hby.db, blinder=blinder)
+
+            # Once the issuer does anchor the update, both paths should rely on
+            # the same explicit anchor-couple verifier for the KEL event.
+            seal = dict(i=registry.regk, s=bup.sad['n'], d=bup.said)
+            hab.interact(data=[seal], framed=True, gvrsn=Vrsn_2_0)
+            number = Number(num=hab.kever.sn)
+            diger = Diger(qb64=hab.kever.serder.said)
+            
+            assert regeventing._verifyAnchorCouple(bup,
+                                                   db=hby.db,
+                                                   issuer=hab.pre,
+                                                   number=number,
+                                                   diger=diger)
+            assert registry.anchorMsg(bup.said, number=number, diger=diger) is True
+        finally:
+            rgy.close()
 
 
 def test_V9_anchor_in_strangers_kel_refused():


### PR DESCRIPTION
This PR moves the local TEL event engine out of `registraring.py` and into `regeventing.py`.

The intended architecture:
- `registraring.py` coordinates registries
- `regeventing.py` owns TEL event logic
- shared TEL rules now live in one place instead of being split across issuer-side and verifier-side implementations

`regeventing.py`
- Added a private issuer-side engine: `_RegEventer`
- Moved the local TEL workflow into `_RegEventer`, including:
  - `processEvent`
  - `processEscrows`
  - `anchorMsg`
  - local missing-anchor replay
  - out-of-order replay
  - staged-frontier walking for `blind()`
  - local anchor-couple verification
- Added a normalized event record helper to avoid repeatedly re-parsing TEL event fields across local and verifier paths
- Consolidated shared TEL validation rules into shared helpers for:
  - `rip` validation
  - `bup` validation
  - prior-link checking
  - explicit local anchor-couple verification

`registraring.py`
- Reduced `Registry` to a thin public facade over `_RegEventer`
- Kept `Regery` responsible for creating/loading registries and processing escrows across managed registries
- Preserved the caller-facing `Registry` and `Registrar` API while moving TEL state-machine behavior out of the registrar layer