### PR TITLE
Reconcile Reactants after transport removal

### DIFF
--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -307,11 +307,15 @@ class Reactor(doing.DoDoer):
 class Directant(doing.DoDoer):
     """Supervise inbound direct-mode TCP connections with one Reactant each.
 
-    Directant owns every accepted raw-TCP ``Remoter`` and its corresponding
-    ``Reactant``. HIO ``cutoff`` means only that receive is closed, so it is a
-    transition into draining rather than permission to discard accepted input
-    or generated responses. HIO ``txCutoff`` independently reports that sending
-    has become terminal.
+    HIO owns each accepted raw-TCP ``Remoter`` while Directant owns its
+    corresponding ``Reactant`` application lifecycle. HIO ``cutoff`` means only
+    that receive is closed, so it is a transition into draining rather than
+    permission to discard accepted input or generated responses. HIO
+    ``txCutoff`` independently reports that sending has become terminal.
+
+    HIO may remove a Remoter after a transport error. Before scheduling its
+    children, Directant removes any Reactant whose exact Remoter is no longer
+    registered at its connection address.
 
     During draining, Directant waits for the active parser to end or fail,
     response production to settle, and ``txbs`` to empty. Terminal ``txCutoff``
@@ -371,6 +375,27 @@ class Directant(doing.DoDoer):
         """
         super(Directant, self).wind(tymth)
         self.server.wind(tymth)
+
+    def recur(self, tyme, deeds=None):
+        """Reconcile transport-owned connections before scheduling children."""
+        self._reconcileStaleReactants()
+        return super(Directant, self).recur(tyme=tyme, deeds=deeds)
+
+    def _reconcileStaleReactants(self):
+        """Remove Reactants whose Remoters left the HIO connection registry."""
+        for ca, rant in list(self.rants.items()):
+            if self.server.ixes.get(ca) is rant.remoter:
+                continue
+
+            ix = rant.remoter
+            if (ix.rxbs or ix.txbs or rant.messageInProgress or
+                    not rant.responseSettled):
+                self._logDrainFailure(ca=ca, ix=ix, rant=rant,
+                                      reason="transport removed connection")
+
+            self.remove([rant])
+            del self.rants[ca]
+            self.drainStops.pop(ca, None)
 
     def serviceDo(self, tymth=None, tock=0.0, **opts):
         """Create, retain, drain, and remove per-connection Reactants.

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -316,6 +316,45 @@ def test_directant_closes_receive_cutoff_without_buffered_input(directHabs):
     server.close()
 
 
+def test_directant_reconciles_transport_removed_reactant(directHabs):
+    _, bob = directHabs
+    oldSocket, oldPeer = socket.socketpair()
+    replacementSocket, replacementPeer = socket.socketpair()
+
+    oldRemoter = makeRemoter(cs=oldSocket)
+    ca = oldRemoter.ca
+    server = serving.Server()
+    server.ixes[ca] = oldRemoter
+    directant = directing.Directant(hab=bob, server=server)
+    doist = doing.Doist(tock=0.03125, limit=1.0, doers=[directant])
+    doist.enter()
+
+    try:
+        doist.recur()
+        oldRant = directant.rants[ca]
+        oldRant.sendMessage(b"pending response")
+        oldRemoter.cutoff = True
+        doist.recur()
+        assert ca in directant.drainStops
+
+        server.removeIx(ca)
+        replacement = makeRemoter(cs=replacementSocket)
+        server.ixes[ca] = replacement
+
+        doist.recur()
+
+        assert oldRant not in directant.doers
+        assert directant.rants[ca] is not oldRant
+        assert directant.rants[ca].remoter is replacement
+        assert ca not in directant.drainStops
+        assert server.ixes[ca] is replacement
+    finally:
+        doist.exit()
+        server.close()
+        oldPeer.close()
+        replacementPeer.close()
+
+
 def test_directant_waits_for_all_output_from_one_cue(
         directHabs, monkeypatch):
     _, bob = directHabs


### PR DESCRIPTION
## Summary

- reconcile Directant Reactants against the exact Remoters currently registered by HIO
- remove stale Reactant doers and drain deadlines before scheduling children
- preserve and admit a replacement Remoter that reuses the same connection address
- document that HIO owns transport connections while Directant owns their application lifecycle

## Rationale

HIO Server service may remove a Remoter from `server.ixes` after a receive error. That path bypasses `Directant.closeConnection`, leaving the corresponding Reactant scheduled and its drain deadline retained even though the socket is already gone.

Directant now performs a small identity-based sweep at the start of each `recur`, before `DoDoer` schedules children. Address membership alone is insufficient because a newly accepted connection may reuse the same address; the registered Remoter must be the exact object owned by the Reactant.

The sweep removes only stale application children. It does not close the current HIO connection, so a replacement Remoter remains active and receives a new Reactant during normal service.

## Tests

- `tests/app/test_directing.py`: 12 passed

The focused regression enters a Reactant-backed response drain, models the HIO ownership boundary through `Server.removeIx`, installs a replacement under the same address, and verifies stale-child cleanup plus replacement ownership. It does not duplicate HIO errno classification tests.