### PR TITLE
Preserve non-Ed25519 key algorithm across rotations

### DIFF
--- a/src/keri/app/habbing.py
+++ b/src/keri/app/habbing.py
@@ -21,7 +21,7 @@ from ..kering import (Version, Vrsn_1_0, Ilks, Kinds, Roles, Schemes,
                       ValidationError, MissingEntryError, MissingSignatureError)
 from ..core import (Tholder, Diger, Prefixer, Number, Kevery, Parser, Revery,
                     Router, Counter, Salter, SealEvent, SealSource, SealLast,
-                    Codens, MtrDex, TraitDex,
+                    Codens, MtrDex, TraitDex, SeedCodeByVerferCode,
                     messagize, exchange,)
 from ..core import eventing
 from ..recording import HabitatRecord, OobiRecord
@@ -2862,7 +2862,7 @@ class Hab(BaseHab):
         super(Hab, self).__init__(**kwa)
 
     def incept(self, *, secrecies=None, iridx=0, code=MtrDex.Blake3_256,
-               dcode=MtrDex.Blake3_256, icode=MtrDex.Ed25519_Seed,
+               dcode=MtrDex.Blake3_256, icode=MtrDex.Ed25519_Seed, ncode=None,
                transferable=True, isith=None, icount=1, nsith=None, ncount=None,
              toad=None, wits=None, delpre=None, estOnly=False, DnD=False,
              hidden=False, data=None, algo=None, salt=None, tier=None,
@@ -2950,9 +2950,14 @@ class Hab(BaseHab):
             verfers, digers = self.mgr.replay(pre=ipre, advance=False)
 
         else:  # use defaults
+            # An identifier signs with one algorithm, so the next keys default to the algorithm
+            # the current keys were made with rather than to Ed25519. Passing icode alone used
+            # to leave the pre-rotated commitment on the default, and the identifier changed
+            # algorithm at its first rotation without anything saying so.
             verfers, digers = self.mgr.incept(icount=icount,
                                               icode=icode,
                                               ncount=ncount,
+                                              ncode=ncode if ncode is not None else icode,
                                               stem=stem,
                                               transferable=transferable,
                                               dcode=dcode,
@@ -3015,7 +3020,7 @@ class Hab(BaseHab):
         pp = self.ks.prms.get(self.pre)
         return pp.algo
 
-    def rotate(self, *, isith=None, nsith=None, ncount=None, toad=None,
+    def rotate(self, *, isith=None, nsith=None, ncount=None, ncode=None, toad=None,
                cuts=None, adds=None, data=None, **kwa):
         """Perform a rotation operation and register it in the database.
 
@@ -3059,11 +3064,20 @@ class Hab(BaseHab):
         # sync with the KEL (issue #819).
         ps_before = self.mgr.ks.sits.get(self.pre)
 
+        if ncode is None:
+            # Carry the identifier's own algorithm forward. The key store records public keys
+            # and seeds but not the code they were made with, so the current public key is the
+            # only statement of which algorithm this identifier signs with. Defaulting to
+            # Ed25519 here would move a P-256 identifier onto a different curve mid-KEL, which
+            # no verifier holding its certificate could survive.
+            ncode = SeedCodeByVerferCode.get(kever.verfers[0].code, MtrDex.Ed25519_Seed)
+
         try:
             verfers, digers = self.mgr.replay(pre=self.pre, erase=False)
         except IndexError:  # old next is new current
             verfers, digers = self.mgr.rotate(pre=self.pre,
                                               ncount=ncount,
+                                              ncode=ncode,
                                               temp=self.temp,
                                               erase=False)
 

--- a/src/keri/core/__init__.py
+++ b/src/keri/core/__init__.py
@@ -30,7 +30,7 @@ from .routing import Router, Revery, Route, compile_uri_template
 from .scheming import CacheResolver, JSONSchema, Schemer
 from .serdering import FieldDom, Serdery, Serder, SerderKERI, SerderACDC
 from .signing import (Tiers, Signer, Salter, Cipher, CiXDex,
-                      Encrypter, Decrypter, Streamer)
+                      Encrypter, Decrypter, Streamer, SeedCodeByVerferCode)
 from .structing import (SealDigest, SealRoot, SealSource, SealEvent, SealLast,
                         SealBack, SealKind, BlindState, BoundState, TypeMedia,
                         StateEstEvent, StateEvent,

--- a/src/keri/core/signing.py
+++ b/src/keri/core/signing.py
@@ -29,6 +29,25 @@ Tierage = namedtuple("Tierage", 'low med high')
 
 Tiers = Tierage(low='low', med='med', high='high')
 
+# Inverse of the seed-code -> verfer-code derivation Signer.__init__ performs below.
+#
+# Rotation has to carry an identifier's signing algorithm forward, and on an identifier that
+# already exists the only record of that algorithm is the code of its current public key: the
+# key store keeps public keys and seeds, not the code they were made with. Mapping back is
+# therefore how a rotation stays on the curve the inception chose, rather than silently
+# reverting to the Ed25519 default.
+#
+# Both the transferable and non-transferable public codes map to the same seed code, because
+# transferability is a property of how the public key is encoded and not of the algorithm.
+SeedCodeByVerferCode = {
+    MtrDex.Ed25519: MtrDex.Ed25519_Seed,
+    MtrDex.Ed25519N: MtrDex.Ed25519_Seed,
+    MtrDex.ECDSA_256r1: MtrDex.ECDSA_256r1_Seed,
+    MtrDex.ECDSA_256r1N: MtrDex.ECDSA_256r1_Seed,
+    MtrDex.ECDSA_256k1: MtrDex.ECDSA_256k1_Seed,
+    MtrDex.ECDSA_256k1N: MtrDex.ECDSA_256k1_Seed,
+}
+
 
 class Signer(Matter):
     """

--- a/src/keri/core/signing.py
+++ b/src/keri/core/signing.py
@@ -48,6 +48,10 @@ SeedCodeByVerferCode = {
     MtrDex.ECDSA_256k1N: MtrDex.ECDSA_256k1_Seed,
 }
 
+# Every private key seed Signer can be built from. Derived from the mapping above rather than
+# written out again, so the two cannot disagree about which algorithms exist.
+SeedCodes = frozenset(SeedCodeByVerferCode.values())
+
 
 class Signer(Matter):
     """
@@ -824,7 +828,12 @@ class Encrypter(Matter):
             if not code:
                 if prim.code == MtrDex.Salt_128:  # future other salt codes
                     code = MtrDex.X25519_Cipher_Salt
-                elif prim.code == MtrDex.Ed25519_Seed:  # future other seed codes
+                elif prim.code in SeedCodes:
+                    # Every seed code takes the same cipher code. The sealed box is over the
+                    # plain text's *fully qualified* qb64, so the seed's own derivation code
+                    # travels inside the cipher and decryption reconstructs the right kind of
+                    # Signer. The cipher code therefore says how the wrapping was done, not
+                    # which algorithm was wrapped, and one value covers all of them.
                     code = MtrDex.X25519_Cipher_Seed
                 else:
                     raise InvalidValueError(f"Unsupported primitive with code ="

--- a/tests/app/test_habbing_v2.py
+++ b/tests/app/test_habbing_v2.py
@@ -1325,6 +1325,134 @@ def test_habery_reconfigure_v2_with_kram(mockHelpingNowUTC):
     _exercise_habery_reconfigure_v2(enable_kram=True)
 
 
+
+def test_incept_with_ecdsa_256r1_uses_that_curve():
+    """A hab incepted with icode=ECDSA_256r1_Seed signs with a P-256 key."""
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="p256", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="p256", icode=MtrDex.ECDSA_256r1_Seed,
+                          wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+
+
+def test_rotation_preserves_the_inception_key_algorithm():
+    """Rotating a P-256 identifier keeps it on P-256.
+
+    The next-key commitment used to be generated with the Ed25519 default no matter what
+    icode said, so an identifier incepted on P-256 changed algorithm at its first rotation
+    and nothing reported it. A verifier holding a certificate over the old key could not
+    survive that, so it is a silent break rather than a visible one.
+    """
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="p256rot", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="p256rot", icode=MtrDex.ECDSA_256r1_Seed,
+                          wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+
+        hab.rotate()
+        assert hab.kever.sn == 1
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+
+
+def test_repeated_rotation_stays_on_the_same_curve():
+    """The algorithm survives more than one rotation, not just the first."""
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="p256rot3", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="p256rot3", icode=MtrDex.ECDSA_256r1_Seed,
+                          wits=[], toad=0)
+        for expected_sn in (1, 2, 3):
+            hab.rotate()
+            assert hab.kever.sn == expected_sn
+            assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+
+
+def test_signatures_verify_after_rotating_a_p256_identifier():
+    """The rotated key is usable, not merely labelled with the right code."""
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="p256sig", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="p256sig", icode=MtrDex.ECDSA_256r1_Seed,
+                          wits=[], toad=0)
+        hab.rotate()
+        data = b"an assertion signed after rotation"
+        siger = hab.sign(ser=data, indexed=True)[0]
+        assert hab.kever.verfers[0].verify(siger.raw, data)
+
+
+def test_incept_with_secp256k1_also_carries_forward():
+    """The fix is about carrying the algorithm forward, not about P-256 specifically."""
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="k1", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="k1", icode=MtrDex.ECDSA_256k1_Seed,
+                          wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256k1
+        hab.rotate()
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256k1
+
+
+def test_ed25519_remains_the_default_and_is_unaffected():
+    """The default path is untouched: no icode still means Ed25519, before and after rotation."""
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="ed", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="ed", wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.Ed25519
+        hab.rotate()
+        assert hab.kever.verfers[0].code == MtrDex.Ed25519
+
+
+def test_explicit_ncode_overrides_the_icode_default_at_inception():
+    """ncode is separable from icode, for a caller that means to pre-commit a different curve.
+
+    Rotating then lands on the pre-committed algorithm, which is what the next-key commitment
+    said all along -- an intentional change of algorithm rather than a silent one.
+    """
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="mixed", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="mixed", icode=MtrDex.ECDSA_256r1_Seed,
+                          ncode=MtrDex.Ed25519_Seed, wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+        hab.rotate()
+        assert hab.kever.verfers[0].code == MtrDex.Ed25519
+
+
+def test_explicit_ncode_on_rotate_changes_the_next_commitment():
+    """A caller may steer the algorithm at rotation, and the change lands one rotation later.
+
+    Rotation replays the keys already pre-committed, so ncode governs the keys committed
+    *for next time*: the curve changes at the following rotation, not this one.
+    """
+    salt = Salter(raw=b'0123456789abcdef').qb64
+    with openHby(name="steer", temp=True, salt=salt) as hby:
+        hab = hby.makeHab(name="steer", wits=[], toad=0)
+        assert hab.kever.verfers[0].code == MtrDex.Ed25519
+
+        hab.rotate(ncode=MtrDex.ECDSA_256r1_Seed)
+        assert hab.kever.verfers[0].code == MtrDex.Ed25519
+
+        hab.rotate()
+        assert hab.kever.verfers[0].code == MtrDex.ECDSA_256r1
+
+
+def test_seed_code_mapping_covers_every_algorithm_signer_supports():
+    """The inverse map is kept complete by a test rather than by memory.
+
+    Signer derives a verfer code from a seed code; rotation needs the inverse. A new algorithm
+    added to Signer without a matching entry here would silently fall back to Ed25519, which is
+    the exact failure this whole change exists to remove.
+    """
+    from keri.core.signing import SeedCodeByVerferCode
+    from keri.core import Signer
+
+    seed_codes = [MtrDex.Ed25519_Seed, MtrDex.ECDSA_256r1_Seed, MtrDex.ECDSA_256k1_Seed]
+    for seed_code in seed_codes:
+        for transferable in (True, False):
+            signer = Signer(code=seed_code, transferable=transferable)
+            verfer_code = signer.verfer.code
+            assert verfer_code in SeedCodeByVerferCode, (
+                f"Signer produces verfer code {verfer_code} from seed code {seed_code}, "
+                f"but the inverse map has no entry for it"
+            )
+            assert SeedCodeByVerferCode[verfer_code] == seed_code
+
 if __name__ == "__main__":
     test_habery()
     test_make_load_hab_with_habery_v2()

--- a/tests/core/test_signing.py
+++ b/tests/core/test_signing.py
@@ -1373,3 +1373,32 @@ if __name__ == "__main__":
     test_roundtrip()
     test_streamer()
 
+
+
+def test_encrypter_wraps_every_seed_algorithm_signer_supports():
+    """An encrypted key store must be able to hold any key Signer can make.
+
+    Encrypter.encrypt picked its cipher code from a two-branch check that named Ed25519_Seed
+    and nothing else, so a P-256 identifier could be incepted into a plain key store and not
+    into an encrypted one -- and heti's lockbox, like any passcode-protected store, is
+    encrypted. The sealed box is over the seed's fully qualified qb64, so the algorithm
+    travels inside the cipher and one cipher code covers them all.
+    """
+    from keri.core.signing import Encrypter, Decrypter, SeedCodes, Signer
+    from keri.core.coring import MtrDex
+
+    seed = Signer(code=MtrDex.Ed25519_Seed)  # the decryption key pair is always Ed25519
+    encrypter = Encrypter(verkey=seed.verfer.qb64b)
+    decrypter = Decrypter(seed=seed.qb64b)
+
+    assert MtrDex.ECDSA_256r1_Seed in SeedCodes, "P-256 must be wrappable, not just Ed25519"
+
+    for seed_code in sorted(SeedCodes):
+        signer = Signer(code=seed_code, transferable=True)
+        cipher = encrypter.encrypt(prim=signer)
+        assert cipher.code == MtrDex.X25519_Cipher_Seed
+
+        recovered = decrypter.decrypt(cipher=cipher, transferable=True)
+        assert recovered.code == seed_code, "the algorithm must survive the round trip"
+        assert recovered.qb64 == signer.qb64
+        assert recovered.verfer.qb64 == signer.verfer.qb64


### PR DESCRIPTION
An identifier incepted with a non-Ed25519 signing key changes algorithm at its first rotation, and nothing reports it:

```python
hab = hby.makeHab(name="p256", icode=MtrDex.ECDSA_256r1_Seed, wits=[], toad=0)
hab.kever.verfers[0].code   # '1AAJ'  -- ECDSA_256r1, as asked for
hab.rotate()
hab.kever.verfers[0].code   # 'D'     -- Ed25519
```

`Hab.incept` takes `icode` and passes it to `Manager.incept`, but doesn't pass `ncode`, so the pre-rotated next keys get generated with the `MtrDex.Ed25519_Seed` default no matter what the current keys were made with (habbing.py:2953). `Hab.rotate` has the same gap at its `Manager.rotate` call (habbing.py:3065). The manager itself has had `ncode` all along; it just never receives one.

I think this is worth fixing rather than documenting, because the failure is silent and impacts a relying party more than on the caller. Anything holding a certificate or a cached key for the old algorithm stops being able to verify, at a rotation nobody thought was a change of algorithm.

The fix defaults `ncode` to `icode` at inception, on the theory that an identifier signs with one algorithm and a next-key commitment on a different one is rarely what someone means. `Hab.rotate` takes `ncode` too, defaulting to the algorithm the identifier is already using. Recovering that turned out to need a small inverse map: the key store keeps public keys and seeds but not the code they were made with, so the current public key is the only record of the algorithm. `SeedCodeByVerferCode` in `core.signing` is that inverse, sitting next to the forward derivation in `Signer.__init__` so the two stay together. Both parameters stay explicit, so a caller who does want to change algorithm can pre-commit a different one, and the change then takes effect at the rotation the commitment already promised.

There's a second commit for something adjacent that I hit immediately afterward. `Encrypter.encrypt` picks its cipher code from a two-branch check naming `Salt_128` and `Ed25519_Seed`, with a `# future other seed codes` comment on the second (signing.py:806-808). So a P-256 identifier could be incepted into a plain key store but not an encrypted one, which surfaced as `Unsupported primitive with code = Q when cipher code is missing` from a passcode-protected store after the same inception had worked fine against a temp one. One cipher code covers every seed, since the sealed box is over the plain text's fully qualified qb64 and the seed's own derivation code travels inside the cipher. `X25519_Cipher_Seed` says how the wrapping was done rather than which algorithm was wrapped.

There are 10 tests, and 6 of the 9 in `test_habbing_v2.py` fail without the first commit. One in `test_signing.py` drives every seed code through encrypt and decrypt and checks the code survives the round trip. The mapping is kept complete by a test rather than by memory — a newly supported algorithm with no entry would fall back to Ed25519 silently, which is the failure the whole change is about.

Where this came from: Bakobo needs P-256 identifiers for EU digital identity work, where EdDSA isn't available to us. The ARF binds wallet providers, attestation providers, and relying parties to the ECCG Agreed Cryptographic Mechanisms v2.0, and that list has no EdDSA in it. I don't think any of that is keripy's problem, and the bug seems like a defect on its own terms — an `icode` parameter that quietly stops applying after one rotation is surprising regardless of which algorithm you asked for.

Branched off current main; `tests/app` and `tests/core` pass, 421 tests. If you'd rather review the two commits apart, I can split them into separate PRs.