### PR TITLE
Add single-DAG IPEX nesting, origin walk, and node verification

### DIFF
--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -393,15 +393,14 @@ class IpexHandler:
         elif not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
             return False
 
-        # Stage 4: when an offer carries a metadata DAG, or when a grant
-        # carries the final disclosure DAG, the nests must describe one exact
-        # reachable graph rooted at the message's `a.o[0]`.
+        # Stage 4: offer may disclose only a reachable metadata subgraph,
+        # while grant must disclose one fully closed reachable DAG rooted at
+        # the message's `a.o[0]`.
         if verb == Ipex.offer and nests:
-            if self._walkGraph(origin=attrs["o"][0], nests=nests) is None:
+            if self._walkGraph(origin=attrs["o"][0], nests=nests, closed=False) is None:
                 return False
         elif verb == Ipex.grant:
-            walked = self._walkGraph(origin=attrs["o"][0], nests=nests)
-            if walked is None:
+            if self._walkGraph(origin=attrs["o"][0], nests=nests, closed=True) is None:
                 return False
 
             # Stage 5: after the disclosed graph shape is accepted, each walked
@@ -486,17 +485,21 @@ class IpexHandler:
 
         return True
 
-    def _walkGraph(self, origin, nests):
+    def _walkGraph(self, origin, nests, *, closed):
         """Walk the disclosed origin DAG and return the visited node order.
 
         Parameters:
             origin (str): SAID of the origin node named by ``a.o[0]``.
             nests (list): Parsed nested ACDC node substreams carried by the
-                grant message.
+                offer or grant message.
+            closed (bool): True requires every referenced edge target to be
+                carried in ``nests``. False allows undisclosed far nodes, but
+                every carried nest must still be reachable from ``origin``.
 
         Returns:
             tuple | None: ``(nodes, order)`` when the disclosed nests form one
-                exact DAG rooted at ``origin``; otherwise ``None``.
+                reachable disclosed graph rooted at ``origin`` under the
+                selected closure rule; otherwise ``None``.
         """
         # Reuse the disclosed-node validation so graph walking starts from a
         # well-formed set of unique ACDC nests.
@@ -514,7 +517,9 @@ class IpexHandler:
         order = []
         queue = deque([origin])
 
-        # Walk the graph BFS, reject if any edge fails to resolve to a carried nest
+        # Walk the graph BFS. Grant fails closed on dangling references, while
+        # offer may omit farther undisclosed nodes as long as carried nodes
+        # still form one root-reachable subgraph.
         while queue:
             said = queue.popleft()
             if said in seen:
@@ -551,7 +556,9 @@ class IpexHandler:
                             except Exception:
                                 return None
                             if edgeSaid not in nodes:
-                                return None
+                                if closed:
+                                    return None
+                                continue
                             if edgeSaid not in seen:
                                 queue.append(edgeSaid)
                             continue
@@ -563,7 +570,8 @@ class IpexHandler:
                                 return None
                             groups.append(node)
 
-        # If any carried nest was never reached, the payload is not one exact DAG.
+        # Even when offer omits farther nodes, every carried nest must still be
+        # part of the root-reachable disclosed graph.
         if len(seen) != len(nodes):
             return None
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -443,8 +443,9 @@ class IpexHandler:
 
         Returns:
             bool: True when the reply points to an allowed prior message, keeps
-                sender/receiver roles consistent, and does not duplicate an
-                existing response; False otherwise.
+                sender/receiver roles consistent, does not duplicate an
+                existing response, and for ``grant`` keeps the disclosed origin
+                committed to the earlier ``offer``; False otherwise.
         """
         pserder, _ = cloneMessage(self.hby, said=dig)
         if pserder is None:
@@ -474,6 +475,23 @@ class IpexHandler:
 
         if self.response(pserder) is not None:
             return False
+
+        # A reply-chain grant must disclose the same origin DAG root the offer
+        # negotiated. Offer stays metadata-only, but its `a.o[0]` is still a
+        # commitment to the exact later grant root, not just a loose topic hint.
+        if verb == Ipex.grant:
+            offerDig = pserder.ked.get("p", "")
+            if not offerDig:
+                return False
+            offer, _ = cloneMessage(self.hby, said=offerDig)
+            if offer is None:
+                return False
+            oattrs = offer.ked.get("a")
+            if not isinstance(oattrs, dict) or not _validSingleDagList(oattrs.get("o"), str):
+                return False
+            if serder.ked["a"]["o"] != oattrs["o"]:
+                return False
+
         return True
 
     def _walkGraph(self, origin, nests):
@@ -782,7 +800,8 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
         message (str): Human-readable offer message.
         origin (Serder | bytes | bytearray): Origin disclosed ACDC node whose
             SAID is copied into ``a.o[0]``. ``offer`` does not disclose nested
-            node bodies; ``grant`` later carries the actual ACDC node nests.
+            node bodies, but this root SAID commits the negotiation to the
+            exact DAG that ``grant`` must later disclose.
         artifacts (list[Serder | bytes | bytearray] | None): Reserved for
             signature compatibility. ``offer`` does not disclose additional
             DAG nodes, so providing artifacts is rejected.
@@ -838,8 +857,8 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
         raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
 
-    # Offer stays metadata-only: it names the disclosed DAG
-    # origin, but does not reveal the ACDC node bodies until grant.
+    # Offer stays metadata-only: it names the exact disclosed DAG origin up
+    # front, but does not reveal the ACDC node bodies until grant.
     originSerder = _streamSerder(origin)
     if originSerder.proto != Protocols.acdc or originSerder.ilk not in DisclosedNodeIlks:
         raise ValueError("offer origin must identify a disclosed ACDC node")

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -403,23 +403,43 @@ class IpexHandler:
             except Exception:
                 return False
 
-            # The first disclosed node is always the origin named in a.o[0].
-            # Every carried nest must be an ACDC body plus that node's
-            # attachment section.
-            for idx, nest in enumerate(nests):
-                nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
-                if not nserder.verify():
-                    return False
-                if nserder.proto != Protocols.acdc:
-                    return False
-                if idx == 0 and not nserder.compare(attrs["o"][0]):
-                    return False
+            if self._validNodeNest(origin=attrs["o"][0], nests=nests) is None:
+                return False
 
         # The other verbs never disclose nested ACDC nodes.
         elif nests:
             return False
 
         return True
+
+    def _validNodeNest(self, origin, nests):
+        """Validate disclosed node nests and index them by ACDC SAID.
+
+        Parameters:
+            origin (str): SAID of the origin node named in ``a.o[0]``.
+            nests (list): Parsed nested ACDC node substreams.
+
+        Returns:
+            dict | None: Mapping of disclosed node SAID to its parsed nest when
+                every nest is a unique ACDC node and the first nest matches the
+                origin; otherwise None.
+        """
+        nodes = {}
+        for idx, nest in enumerate(nests):
+            nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
+            if not nserder.verify():
+                return None
+            if nserder.proto != Protocols.acdc:
+                return None
+            if idx == 0 and not nserder.compare(origin):
+                return None
+            # Each disclosed DAG node must occupy exactly one nest so the node
+            # body cannot appear twice with conflicting attachment groups.
+            if nserder.said in nodes:
+                return None
+            nodes[nserder.said] = nest
+
+        return nodes
 
     def _verifyOpener(self, verb, serder, attrs, nests):
         """Validate a flow-opening IPEX message that has no prior.
@@ -512,13 +532,11 @@ class IpexHandler:
         # Retrieve the root SAID
         origin = attrs["o"][0]
 
-        # Build a mapping of SAID to nest for all carried nodes, reject if duplicates
-        nodes = {}
-        for nest in nests:
-            nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
-            if nserder.said in nodes:
-                return False
-            nodes[nserder.said] = nest
+        # Reuse the disclosed-node validation so graph walking starts from a
+        # well-formed set of unique ACDC nests.
+        nodes = self._validNodeNest(origin=origin, nests=nests)
+        if nodes is None:
+            return False
 
         # Reject if origin is not carried in the nests
         if origin not in nodes:

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -32,6 +32,8 @@ PreviousRoutes = {
 }
 
 DisclosedNodeIlks = (None, Ilks.acm, Ilks.ace, Ilks.act, Ilks.acg)
+EdgeGroupLabels = ("d", "u", "o", "w")
+EdgeNodeLabels = ("d", "u", "n", "s", "o", "w")
 
 def _streamSerder(stream):
     """Extract the message serder from a bare or nested artifact stream.
@@ -526,8 +528,6 @@ class IpexHandler:
             # Retrieve the edges from the node
             edges = nserder.sad.get("e")
             if edges:
-                # `e` must stay directly walkable as a mapping or list of mappings.
-                #  A compacted edge SAID/string fails closed.
                 if isinstance(edges, Mapping):
                     blocks = [edges]
                 elif isinstance(edges, list) and all(isinstance(edge, Mapping) for edge in edges):
@@ -535,24 +535,33 @@ class IpexHandler:
                 else:
                     return None
 
-                # Walk each edge block, reject if any edge fails to resolve to a nest
+                # Expanded edge sections may contain nested edge groups
                 for edge in blocks:
-                    for label, node in edge.items():
-                        if label in ("d", "o"):
+                    groups = [edge]
+                    while groups:
+                        group = groups.pop()
+                        if "n" in group:
+                            if any(label not in EdgeNodeLabels for label in group):
+                                return None
+                            edgeSaid = group.get("n")
+                            if not isinstance(edgeSaid, str):
+                                return None
+                            try:
+                                Saider(qb64=edgeSaid)
+                            except Exception:
+                                return None
+                            if edgeSaid not in nodes:
+                                return None
+                            if edgeSaid not in seen:
+                                queue.append(edgeSaid)
                             continue
-                        if not isinstance(node, Mapping):
-                            return None
-                        edgeSaid = node.get("n")
-                        if not isinstance(edgeSaid, str):
-                            return None
-                        try:
-                            Saider(qb64=edgeSaid)
-                        except Exception:
-                            return None
-                        if edgeSaid not in nodes:
-                            return None
-                        if edgeSaid not in seen:
-                            queue.append(edgeSaid)
+
+                        for label, node in group.items():
+                            if label in EdgeGroupLabels:
+                                continue
+                            if not isinstance(node, Mapping):
+                                return None
+                            groups.append(node)
 
         # If any carried nest was never reached, the payload is not one exact DAG.
         if len(seen) != len(nodes):

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -311,8 +311,9 @@ class IpexHandler:
             serder (Serder): Incoming IPEX exchange message.
             attachments (list | None): Parsed attachment payloads, unused in the
                 current linear workflow validation.
-            nests (list | None): Parsed V2 nested artifacts carried by offer
-                and grant messages.
+            nests (list | None): Parsed V2 nested artifacts. In the current
+                single-DAG workflow only ``grant`` may disclose nested ACDC
+                nodes; ``offer`` stays metadata-only.
 
         Returns:
             bool: True when the message is valid for the linear IPEX workflow,
@@ -341,12 +342,20 @@ class IpexHandler:
             return False
 
         # Stage 2: apply/offer carry disclose-paths, while offer/grant also
-        # carry disclosed node nests rooted at `a.o[0]`.
+        # carry a single-DAG origin SAID in `a.o[0]`. Only grant may disclose
+        # nested node bodies for that DAG.
         if verb in (Ipex.apply, Ipex.offer):
             if "dp" not in q or not _validDisclosurePath(q["dp"]):
                 return False
 
-        if verb in (Ipex.offer, Ipex.grant):
+        if verb == Ipex.offer:
+            if "o" not in attrs or not _validSingleDagList(attrs["o"], str) or nests:
+                return False
+            try:
+                Saider(qb64=attrs["o"][0])
+            except Exception:
+                return False
+        elif verb == Ipex.grant:
             if "o" not in attrs or not _validSingleDagList(attrs["o"], str) or not nests:
                 return False
             try:
@@ -379,16 +388,16 @@ class IpexHandler:
         elif not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
             return False
 
-        # Stage 4: offer and grant both carry disclosed ACDC node nests. Those
-        # nests must describe exactly one reachable DAG rooted at a.o[0].
-        if verb in (Ipex.offer, Ipex.grant):
+        # Stage 4: grant is the disclosure step. Its node nests must
+        # describe exactly one reachable DAG rooted at a.o[0].
+        if verb == Ipex.grant:
             walked = self._walkGraph(origin=attrs["o"][0], nests=nests)
             if walked is None:
                 return False
 
-            # Stage 5: only grant currently vets issuer-auth proof groups. Offer
-            # carries the same node-local framing but does not enforce proofs yet.
-            if verb == Ipex.grant and not self._verifyIssuerAuthGraph(nodes=walked[0], order=walked[1]):
+            # Stage 5: after the disclosed graph shape is accepted, each walked
+            # registry-backed node must vet its own node-local proof group.
+            if not self._verifyIssuerAuthGraph(nodes=walked[0], order=walked[1]):
                 return False
 
         return True
@@ -473,7 +482,7 @@ class IpexHandler:
         Parameters:
             origin (str): SAID of the origin node named by ``a.o[0]``.
             nests (list): Parsed nested ACDC node substreams carried by the
-                offer or grant message.
+                grant message.
 
         Returns:
             tuple | None: ``(nodes, order)`` when the disclosed nests form one
@@ -771,10 +780,12 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable offer message.
-        origin (Serder | bytes | bytearray): Origin ACDC node identified in
-            ``a.o[0]`` and carried as the first nested artifact.
-        artifacts (list[Serder | bytes | bytearray] | None): Optional
-            additional disclosed ACDC nodes carried after ``origin``.
+        origin (Serder | bytes | bytearray): Origin disclosed ACDC node whose
+            SAID is copied into ``a.o[0]``. ``offer`` does not disclose nested
+            node bodies; ``grant`` later carries the actual ACDC node nests.
+        artifacts (list[Serder | bytes | bytearray] | None): Reserved for
+            signature compatibility. ``offer`` does not disclose additional
+            DAG nodes, so providing artifacts is rejected.
         apply (Serder | None): Optional prior ``apply`` exchange.
         recp (str | None): Recipient AID. Defaults to the prior ``apply``
             sender; must be supplied directly for an offer-first exchange
@@ -827,16 +838,15 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
         raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
 
-    # Offer emits the origin in list form and nests each disclosed ACDC node
-    # separately so node-local attachment groups stay with their owner.
-    data["o"] = [_streamSerder(origin).said]
-    nests = [_normalizeNodeStream(origin)]
+    # Offer stays metadata-only: it names the disclosed DAG
+    # origin, but does not reveal the ACDC node bodies until grant.
+    originSerder = _streamSerder(origin)
+    if originSerder.proto != Protocols.acdc or originSerder.ilk not in DisclosedNodeIlks:
+        raise ValueError("offer origin must identify a disclosed ACDC node")
+    data["o"] = [originSerder.said]
 
     if artifacts is not None:
-        if not isinstance(artifacts, list):
-            raise TypeError("artifacts must be a list when provided")
-        for artifact in artifacts:
-            nests.append(_normalizeNodeStream(artifact))
+        raise ValueError("offer does not disclose DAG nodes; use grant artifacts instead")
 
     # Build the body
     serder = exchange(
@@ -853,7 +863,7 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
         kind=kind if kind is not None else hab.kever.serder.kind,
     )
 
-    atc = bytearray(_sign(hab=hab, serder=serder, nests=nests, gvrsn=gvrsn))
+    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
     del atc[:serder.size]
     return serder, atc
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -341,19 +341,22 @@ class IpexHandler:
         if "ax" in attrs and not _validSingleDagList(attrs["ax"], bool, allow_empty=True):
             return False
 
-        # Stage 2: apply/offer carry disclose-paths, while offer/grant also
-        # carry a single-DAG origin SAID in `a.o[0]`. Only grant may disclose
-        # nested node bodies for that DAG.
+        # Stage 2: apply/offer carry disclose-paths. Offer may optionally name
+        # or carry a metadata DAG in `a.o[0]`, while grant must name and carry
+        # the final disclosed DAG root.
         if verb in (Ipex.apply, Ipex.offer):
             if "dp" not in q or not _validDisclosurePath(q["dp"]):
                 return False
 
         if verb == Ipex.offer:
-            if "o" not in attrs or not _validSingleDagList(attrs["o"], str) or nests:
-                return False
-            try:
-                Saider(qb64=attrs["o"][0])
-            except Exception:
+            if "o" in attrs:
+                if not _validSingleDagList(attrs["o"], str):
+                    return False
+                try:
+                    Saider(qb64=attrs["o"][0])
+                except Exception:
+                    return False
+            elif nests:
                 return False
         elif verb == Ipex.grant:
             if "o" not in attrs or not _validSingleDagList(attrs["o"], str) or not nests:
@@ -388,9 +391,13 @@ class IpexHandler:
         elif not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
             return False
 
-        # Stage 4: grant is the disclosure step. Its node nests must
-        # describe exactly one reachable DAG rooted at a.o[0].
-        if verb == Ipex.grant:
+        # Stage 4: when an offer carries a metadata DAG, or when a grant
+        # carries the final disclosure DAG, the nests must describe one exact
+        # reachable graph rooted at the message's `a.o[0]`.
+        if verb == Ipex.offer and nests:
+            if self._walkGraph(origin=attrs["o"][0], nests=nests) is None:
+                return False
+        elif verb == Ipex.grant:
             walked = self._walkGraph(origin=attrs["o"][0], nests=nests)
             if walked is None:
                 return False
@@ -443,9 +450,8 @@ class IpexHandler:
 
         Returns:
             bool: True when the reply points to an allowed prior message, keeps
-                sender/receiver roles consistent, does not duplicate an
-                existing response, and for ``grant`` keeps the disclosed origin
-                committed to the earlier ``offer``; False otherwise.
+                sender/receiver roles consistent, and does not duplicate an
+                existing response; False otherwise.
         """
         pserder, _ = cloneMessage(self.hby, said=dig)
         if pserder is None:
@@ -475,22 +481,6 @@ class IpexHandler:
 
         if self.response(pserder) is not None:
             return False
-
-        # A reply-chain grant must disclose the same origin DAG root the offer
-        # negotiated. Offer stays metadata-only, but its `a.o[0]` is still a
-        # commitment to the exact later grant root, not just a loose topic hint.
-        if verb == Ipex.grant:
-            offerDig = pserder.ked.get("p", "")
-            if not offerDig:
-                return False
-            offer, _ = cloneMessage(self.hby, said=offerDig)
-            if offer is None:
-                return False
-            oattrs = offer.ked.get("a")
-            if not isinstance(oattrs, dict) or not _validSingleDagList(oattrs.get("o"), str):
-                return False
-            if serder.ked["a"]["o"] != oattrs["o"]:
-                return False
 
         return True
 
@@ -798,13 +788,13 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable offer message.
-        origin (Serder | bytes | bytearray): Origin disclosed ACDC node whose
-            SAID is copied into ``a.o[0]``. ``offer`` does not disclose nested
-            node bodies, but this root SAID commits the negotiation to the
-            exact DAG that ``grant`` must later disclose.
-        artifacts (list[Serder | bytes | bytearray] | None): Reserved for
-            signature compatibility. ``offer`` does not disclose additional
-            DAG nodes, so providing artifacts is rejected.
+        origin (Serder | bytes | bytearray | None): Optional origin ACDC node
+            for the offer DAG. When provided, its SAID is copied into
+            ``a.o[0]``. When omitted, the offer may negotiate only through its
+            disclose-path plan.
+        artifacts (list[Serder | bytes | bytearray] | None): Optional
+            additional metadata-DAG nodes carried after ``origin``. Passing a
+            list, including ``[]``, means the offer carries a nested DAG.
         apply (Serder | None): Optional prior ``apply`` exchange.
         recp (str | None): Recipient AID. Defaults to the prior ``apply``
             sender; must be supplied directly for an offer-first exchange
@@ -845,8 +835,13 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     data = dict(attrs) if attrs is not None else {}
     data["m"] = message
 
-    # Retrieve dp from modifiers if present
+    # Retrieve dp from modifiers if present. When the offer answers an apply,
+    # inherit the requested disclose-path plan unless the caller overrides it.
     mods = dict(modifiers) if modifiers else {}
+    if "dp" not in mods and apply is not None:
+        aq = apply.ked.get("q")
+        if isinstance(aq, dict) and "dp" in aq:
+            mods["dp"] = aq["dp"]
     mods.setdefault("dp", [])     # defaults to an empty list if none is provided
 
     # Validate dp field, it must be a list of lists.
@@ -857,15 +852,27 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
         raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
 
-    # Offer stays metadata-only: it names the exact disclosed DAG origin up
-    # front, but does not reveal the ACDC node bodies until grant.
-    originSerder = _streamSerder(origin)
-    if originSerder.proto != Protocols.acdc or originSerder.ilk not in DisclosedNodeIlks:
-        raise ValueError("offer origin must identify a disclosed ACDC node")
-    data["o"] = [originSerder.said]
+    # Offer may either negotiate only via dp, name a metadata root SAID, or
+    # carry a full metadata DAG whose shape mirrors the later grant DAG.
+    nests = None
+    if origin is not None:
+        originSerder = _streamSerder(origin)
+        if originSerder.proto != Protocols.acdc or originSerder.ilk not in DisclosedNodeIlks:
+            raise ValueError("offer origin must identify a disclosed ACDC node")
+        data["o"] = [originSerder.said]
+    elif artifacts:
+        raise ValueError("offer artifacts require an origin")
 
     if artifacts is not None:
-        raise ValueError("offer does not disclose DAG nodes; use grant artifacts instead")
+        if not isinstance(artifacts, list):
+            raise TypeError("artifacts must be a list when provided")
+        if origin is None:
+            if artifacts:
+                raise ValueError("offer artifacts require an origin")
+        else:
+            nests = [_normalizeNodeStream(origin)]
+            for artifact in artifacts:
+                nests.append(_normalizeNodeStream(artifact))
 
     # Build the body
     serder = exchange(
@@ -882,7 +889,7 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
         kind=kind if kind is not None else hab.kever.serder.kind,
     )
 
-    atc = bytearray(_sign(hab=hab, serder=serder, gvrsn=gvrsn))
+    atc = bytearray(_sign(hab=hab, serder=serder, nests=nests, gvrsn=gvrsn))
     del atc[:serder.size]
     return serder, atc
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -827,8 +827,9 @@ class IpexHandler:
         Returns:
             bool: ``True`` when the node is either not registry-backed or its
             node-local proof vets successfully against TEL evidence already
-            loaded in the verifier's local ``Regery`` store; ``False`` when the
-            node's proof is permanently invalid for this ACDC.
+            loaded in the verifier's injected local ``Regery`` store; ``False``
+            when the node's proof is permanently invalid for this ACDC or the
+            handler was not configured with verifier-side registry access.
 
         Raises:
             MissingChainError: When the verifier is still missing retryable TEL
@@ -842,25 +843,17 @@ class IpexHandler:
             bsqs = nest.get("bsqs", []) if isinstance(nest, dict) else nest.bsqs
             bsss = nest.get("bsss", []) if isinstance(nest, dict) else nest.bsss
 
-            # The parser gives us primitive instances. Rebuild those into the
-            # canonical crew form so regeventing.vetBlind() sees the expected
-            # cast (d as qb64 digest, u/td/bd as nonce strings, ts as text).
+            # The parser gives us primitive tuples. Rebuild those as the
+            # canonical BlindState / BoundState data records before handing
+            # them back to Blinder.
             proofs = []
             for proof in bsqs:
-                crew = BlindState(d=proof[0].qb64,
-                                  u=proof[1].nonce,
-                                  td=proof[2].nonce,
-                                  ts=proof[3].text)
-                proofs.append(Blinder(crew=crew))
+                data = proof if isinstance(proof, BlindState) else BlindState(*proof)
+                proofs.append(Blinder(data=data))
 
             for proof in bsss:
-                crew = BoundState(d=proof[0].qb64,
-                                  u=proof[1].nonce,
-                                  td=proof[2].nonce,
-                                  ts=proof[3].text,
-                                  bn=proof[4].sn,
-                                  bd=proof[5].nonce)
-                proofs.append(Blinder(crew=crew))
+                data = proof if isinstance(proof, BoundState) else BoundState(*proof)
+                proofs.append(Blinder(data=data))
 
             # The proof group must disclose exactly one blinded state for the registry's root event.
             if len(proofs) != 1:
@@ -868,13 +861,10 @@ class IpexHandler:
 
             # IPEX verification assumes the disclosee has already learned the
             # foreign TEL chain, for example by retrieving it from observers
-            # before processing the grant
+            # before processing the grant, and the app injects that local
+            # registry store into the handler up front.
             if self.rgy is None:
-                from .registraring import Regery
-                self.rgy = Regery(hby=self.hby,
-                                  name=self.hby.name,
-                                  base=self.hby.base,
-                                  temp=self.hby.temp)
+                return False
 
             rip = self.rgy.store.seqEvent(regk, 0)
             head = self.rgy.store.headEvent(regk)

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -12,7 +12,10 @@ from collections.abc import Mapping
 from hio.help import ogler
 
 from .. import Kinds, Protocols
-from ..kering import Colds, Ilks, Vrsn_2_0, sniff
+from ..kering import (Colds, DuplicitousRegistryError, Ilks, MisanchorError,
+                      MisbindingError, MissingAnchorError, MissingChainError,
+                      MisdigestError, MisregistryError, MissequenceError,
+                      RootSealError, UnverifiedBlindError, Vrsn_2_0, sniff)
 from ..core import (BlindState, Blinder, BoundState, Counter, Codens, Diger, GenDex, Noncer,
                     Number, Saider, Serdery, Texter, exchange, messagize)
 from ..peer import cloneMessage
@@ -228,23 +231,32 @@ def _validSingleDagList(value, itemtype, *, allow_empty=False):
 
 
 def _validDisclosurePath(value):
-    """Validate ``q.dp`` as one disclose-path list for the current DAG.
+    """Validate one DAG's disclose-path plan.
 
     Parameters:
-        value: Candidate ``q.dp`` wire value.
+        value: Candidate disclose-path list for one DAG.
 
     Returns:
         bool: True when ``value`` is a list whose entries are disclosure-path
-            triples of ``[schema SAID, DAG path, ACDC paths]``, False
-            otherwise.
+            triples of ``[schema SAID, DAG path, ACDC paths]`` for one DAG,
+            False otherwise.
     """
-    return (isinstance(value, list)
-            and all(isinstance(item, list)
-                    and len(item) == 3
-                    and isinstance(item[0], str)
-                    and isinstance(item[1], str)
-                    and isinstance(item[2], list)
-                    for item in value))
+    if not isinstance(value, list):
+        return False
+
+    for item in value:
+        if not isinstance(item, list) or len(item) != 3:
+            return False
+
+        schema, path, fields = item
+        if not isinstance(schema, str):
+            return False
+        if not isinstance(path, str):
+            return False
+        if not isinstance(fields, list):
+            return False
+
+    return True
 
 
 def _sign(hab, serder, *, nests=None, gvrsn=None):
@@ -314,12 +326,17 @@ class IpexHandler:
             attachments (list | None): Parsed attachment payloads, unused in the
                 current linear workflow validation.
             nests (list | None): Parsed V2 nested artifacts. In the current
-                single-DAG workflow only ``grant`` may disclose nested ACDC
-                nodes; ``offer`` stays metadata-only.
+                single-DAG workflow ``offer`` may carry a metadata DAG subset
+                and ``grant`` may carry the final disclosed DAG.
 
         Returns:
             bool: True when the message is valid for the linear IPEX workflow,
                 False otherwise.
+
+        Raises:
+            MissingChainError: When a grant's issuer-auth proof needs TEL
+                evidence that is not yet available locally and the exchange
+                should be retried from escrow later.
         """
         nests = nests if nests is not None else []
         q = serder.ked.get("q")
@@ -343,11 +360,15 @@ class IpexHandler:
         if "ax" in attrs and not _validSingleDagList(attrs["ax"], bool, allow_empty=True):
             return False
 
-        # Stage 2: apply/offer carry disclose-paths. Offer may optionally name
-        # or carry a metadata DAG in `a.o[0]`, while grant must name and carry
-        # the final disclosed DAG root.
+        # Stage 2: apply/offer carry disclose-paths. The wire shape is now one
+        # disclose-path list per DAG, so today's single-DAG form is a one-item
+        # outer list. Offer may optionally name or carry a metadata DAG in
+        # `a.o[0]`, while grant must name and carry the final disclosed DAG
+        # root.
         if verb in (Ipex.apply, Ipex.offer):
-            if "dp" not in q or not _validDisclosurePath(q["dp"]):
+            if ("dp" not in q
+                    or not _validSingleDagList(q["dp"], list)
+                    or not _validDisclosurePath(q["dp"][0])):
                 return False
 
         if verb == Ipex.offer:
@@ -400,7 +421,8 @@ class IpexHandler:
             if self._walkGraph(origin=attrs["o"][0], nests=nests, closed=False) is None:
                 return False
         elif verb == Ipex.grant:
-            if self._walkGraph(origin=attrs["o"][0], nests=nests, closed=True) is None:
+            walked = self._walkGraph(origin=attrs["o"][0], nests=nests, closed=True)
+            if walked is None:
                 return False
 
             # Stage 5: after the disclosed graph shape is accepted, each walked
@@ -587,6 +609,10 @@ class IpexHandler:
         Returns:
             bool: True when every walked node either has no registry binding or
                 vets successfully against its node-local proof group.
+
+        Raises:
+            MissingChainError: When a registry-backed node names TEL evidence
+                that the verifier has not loaded locally yet.
         """
         # Run proof verification in graph order so each registry-backed node is
         # checked against the exact nested substream that carried its body.
@@ -632,8 +658,13 @@ class IpexHandler:
         Returns:
             bool: ``True`` when the node is either not registry-backed or its
             node-local proof vets successfully against TEL evidence already
-            loaded in the verifier's local ``Regery`` store; otherwise
-            ``False``.
+            loaded in the verifier's local ``Regery`` store; ``False`` when the
+            node's proof is permanently invalid for this ACDC.
+
+        Raises:
+            MissingChainError: When the verifier is still missing retryable TEL
+                evidence, such as the registry inception, a later update, or an
+                anchor that has not replicated yet.
         """
         regk = serder.sad.get("rd")
         if regk:
@@ -679,12 +710,12 @@ class IpexHandler:
             rip = self.rgy.store.seqEvent(regk, 0)
             head = self.rgy.store.headEvent(regk)
             if rip is None or head is None:
-                return False
+                raise MissingChainError(f"missing local TEL evidence for registry {regk}")
 
             updates = []
             for sn in range(1, Number(numh=head.sad["n"]).num + 1):
                 if not (update := self.rgy.store.seqEvent(regk, sn)):
-                    return False
+                    raise MissingChainError(f"missing local TEL update {sn} for registry {regk}")
                 updates.append(update)
 
             from . import regeventing
@@ -694,7 +725,15 @@ class IpexHandler:
                                 db=self.hby.db,
                                 acdc=serder,
                                 blinder=proofs[0])
-            except Exception:
+            # Missing anchors mean the local verifier does not yet know enough
+            # to conclude; keep the grant retryable instead of dropping it.
+            except MissingAnchorError as ex:
+                raise MissingChainError(f"registry {regk} is missing anchored TEL evidence") from ex
+            # Named vet refusals are permanent: the disclosed node and its proof
+            # do not match the registry evidence the verifier already has.
+            except (MisdigestError, MissequenceError, MisregistryError,
+                    MisanchorError, RootSealError, MisbindingError,
+                    DuplicitousRegistryError, UnverifiedBlindError):
                 return False
 
         return True
@@ -765,9 +804,10 @@ def apply(hab, recp, message, modifiers=None, attrs=None, dt=None, kind=None, gv
     data["m"] = message
     mods = dict(modifiers) if modifiers else {}
 
-    # Validate dp field, it must be the DAG's disclose-path list.
-    if "dp" not in mods or not _validDisclosurePath(mods["dp"]):
-        raise ValueError("modifiers['dp'] is required and must be a list of disclosure-path triples")
+    if ("dp" not in mods
+            or not _validSingleDagList(mods["dp"], list)
+            or not _validDisclosurePath(mods["dp"][0])):
+        raise ValueError("modifiers['dp'] is required and must carry one disclose-path list per DAG")
 
     # Validate ax field, must be a list of booleans, is allowed to be empty
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
@@ -857,11 +897,11 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
         aq = apply.ked.get("q")
         if isinstance(aq, dict) and "dp" in aq:
             mods["dp"] = aq["dp"]
-    mods.setdefault("dp", [])     # defaults to an empty list if none is provided
+    mods.setdefault("dp", [[]])     # default to one empty disclose-path list for the one DAG
 
-    # Validate dp field, it must be a list of lists.
-    if not _validDisclosurePath(mods["dp"]):
-        raise ValueError("modifiers['dp'] must be a list of disclosure-path triples")
+    # Offer uses the same canonical q.dp builder contract as apply.
+    if not _validSingleDagList(mods["dp"], list) or not _validDisclosurePath(mods["dp"][0]):
+        raise ValueError("modifiers['dp'] must carry one disclose-path list per DAG")
 
     # Validate the ax field if present. It must be a list of booleans
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from hio.help import ogler
 
 from .. import Kinds, Protocols
-from ..kering import Colds, Vrsn_2_0, sniff
+from ..kering import Colds, Ilks, Vrsn_2_0, sniff
 from ..core import (BlindState, Blinder, BoundState, Counter, Codens, Diger, GenDex, Noncer,
                     Number, Saider, Serdery, Texter, exchange, messagize)
 from ..peer import cloneMessage
@@ -30,6 +30,8 @@ PreviousRoutes = {
     Ipex.admit: (Ipex.grant,),
     Ipex.spurn: (Ipex.apply, Ipex.offer, Ipex.agree, Ipex.grant),
 }
+
+DisclosedNodeIlks = (None, Ilks.acm, Ilks.ace, Ilks.act, Ilks.acg)
 
 def _streamSerder(stream):
     """Extract the message serder from a bare or nested artifact stream.
@@ -173,16 +175,16 @@ def _normalizeNodeStream(stream, attachment=None):
     # way IPEX expects: one ACDC body plus that node's attachment section.
     if _isNestedStream(stream):
         serder = _streamSerder(stream)
-        if serder.proto != Protocols.acdc:
-            raise ValueError("IPEX node nests must carry ACDC messages")
+        if serder.proto != Protocols.acdc or serder.ilk not in DisclosedNodeIlks:
+            raise ValueError("IPEX node nests must carry disclosed ACDC nodes")
         if attachment:
             raise ValueError("cannot append attachment bytes to a pre-nested ACDC node")
         return bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
 
     raw = bytes(stream.raw) if hasattr(stream, "raw") else bytes(stream)
     serder = _streamSerder(raw)
-    if serder.proto != Protocols.acdc:
-        raise ValueError("IPEX node nests must carry ACDC messages")
+    if serder.proto != Protocols.acdc or serder.ilk not in DisclosedNodeIlks:
+        raise ValueError("IPEX node nests must carry disclosed ACDC nodes")
 
     # Rebuild plain ACDC input into the same per-node framing so later proof
     # groups can live on the owning node without changing the outer layout.
@@ -408,7 +410,9 @@ class IpexHandler:
             nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
             if not nserder.verify():
                 return None
-            if nserder.proto != Protocols.acdc:
+            # Each nest must carry a real disclosed credential node, not just
+            # any ACDC-protocol message such as a registry TEL event.
+            if nserder.proto != Protocols.acdc or nserder.ilk not in DisclosedNodeIlks:
                 return None
             if idx == 0 and not nserder.compare(origin):
                 return None

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -623,8 +623,9 @@ class IpexHandler:
 
         Returns:
             bool: ``True`` when the node is either not registry-backed or its
-            node-local proof vets successfully against local TEL evidence;
-            otherwise ``False``.
+            node-local proof vets successfully against TEL evidence already
+            loaded in the verifier's local ``Regery`` store; otherwise
+            ``False``.
         """
         regk = serder.sad.get("rd")
         if regk:
@@ -657,9 +658,9 @@ class IpexHandler:
             if len(proofs) != 1:
                 return False
 
-            # Reuse an injected Regery when available. Otherwise reopen the local
-            # registry store for this Habery so IPEX can vet against persisted TEL
-            # evidence without changing the public handler API.
+            # IPEX verification assumes the disclosee has already learned the
+            # foreign TEL chain, for example by retrieving it from observers
+            # before processing the grant
             if self.rgy is None:
                 from .registraring import Regery
                 self.rgy = Regery(hby=self.hby,
@@ -667,16 +668,13 @@ class IpexHandler:
                                   base=self.hby.base,
                                   temp=self.hby.temp)
 
-            # The proof group only discloses one event's blinded state. The TEL
-            # chain itself is loaded from the local registry store and passed into
-            # regeventing.vet(), which checks anchoring and ACDC binding.
             rip = self.rgy.store.seqEvent(regk, 0)
             head = self.rgy.store.headEvent(regk)
             if rip is None or head is None:
                 return False
 
             updates = []
-            for sn in range(1, int(head.sad["n"], 16) + 1):
+            for sn in range(1, Number(numh=head.sad["n"]).num + 1):
                 if not (update := self.rgy.store.seqEvent(regk, sn)):
                     return False
                 updates.append(update)

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -330,67 +330,16 @@ class IpexHandler:
         if verb not in (Ipex.apply, *PreviousRoutes.keys()):
             return False
 
-        # Stage 1: validate the common V2 IPEX payload shape shared by every verb.
-        if not self._verifyCommonShape(attrs=attrs, q=q):
-            return False
-
-        # Stage 2: validate the fields that depend on which IPEX verb this is,
-        # such as disclose plans for apply/offer and disclosed node nests for
-        # offer/grant.
-        if not self._verifyVerbShape(verb=verb, attrs=attrs, q=q, nests=nests):
-            return False
-
-        # Stage 3: opener flows validate directly from the message itself,
-        # while replies must first resolve and validate their prior exchange.
-        if not dig:
-            return self._verifyOpener(verb=verb, serder=serder, attrs=attrs, nests=nests)
-        if verb == Ipex.apply:
-            return False
-
-        if not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
-            return False
-
-        # Stage 4: only grant has extra semantic verification beyond the linear
-        # thread rules. The carried disclosed nodes must form exactly one DAG.
-        if verb == Ipex.grant:
-            return self._verifyGraph(attrs=attrs, nests=nests)
-
-        return True
-
-    def _verifyCommonShape(self, attrs, q):
-        """Validate the common payload shape shared by every V2 IPEX verb.
-
-        Parameters:
-            attrs (dict): Exchange attributes section from ``serder.ked["a"]``.
-            q (dict): Exchange query/modifier section from ``serder.ked["q"]``.
-
-        Returns:
-            bool: True when the shared V2 IPEX fields have the expected shape,
-                including optional single-DAG ``ax`` semantics.
-        """
-        if not isinstance(attrs, dict):
-            return False
-        if "m" not in attrs:
-            return False
-        if not isinstance(q, dict):
+        # Stage 1: every inbound IPEX message must at least carry an attrs map
+        # with a human message and a query/modifier map. `ax` is the only shared
+        # optional list field and remains syntax-only for this ticket.
+        if not isinstance(attrs, dict) or "m" not in attrs or not isinstance(q, dict):
             return False
         if "ax" in attrs and not _validSingleDagList(attrs["ax"], bool, allow_empty=True):
             return False
-        return True
 
-    def _verifyVerbShape(self, verb, attrs, q, nests):
-        """Validate the fields that depend on the current IPEX verb.
-
-        Parameters:
-            verb (str): IPEX route suffix such as ``apply`` or ``grant``.
-            attrs (dict): Exchange attributes section.
-            q (dict): Exchange query/modifier section.
-            nests (list): Parsed nested substreams carried on the message.
-
-        Returns:
-            bool: True when the verb-specific fields are well formed for the
-                current single-DAG wire shape, False otherwise.
-        """
+        # Stage 2: apply/offer carry disclose-paths, while offer/grant also
+        # carry disclosed node nests rooted at `a.o[0]`.
         if verb in (Ipex.apply, Ipex.offer):
             if "dp" not in q or not _validDisclosurePath(q["dp"]):
                 return False
@@ -403,12 +352,42 @@ class IpexHandler:
             except Exception:
                 return False
 
-            if self._validNodeNest(origin=attrs["o"][0], nests=nests) is None:
-                return False
-
         # The other verbs never disclose nested ACDC nodes.
         elif nests:
             return False
+
+        # Stage 3: opener flows validate directly from the message itself,
+        # while replies must first resolve and validate their prior exchange.
+        if not dig:
+            if verb == Ipex.apply:
+                # Apply is always a thread opener, so it must provide both
+                # receiver and transaction id on the message body.
+                if not (serder.ked.get("ri", "") and serder.ked.get("x", "")):
+                    return False
+            elif verb in (Ipex.offer, Ipex.grant):
+                # Offer and grant may also open a thread, but must then carry
+                # both the receiver and the generated exchange id themselves.
+                if not (serder.ked.get("ri", "") and serder.ked.get("x", "")):
+                    return False
+            else:
+                # Agree, admit, and spurn can only appear as replies.
+                return False
+        elif verb == Ipex.apply:
+            return False
+        elif not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
+            return False
+
+        # Stage 4: offer and grant both carry disclosed ACDC node nests. Those
+        # nests must describe exactly one reachable DAG rooted at a.o[0].
+        if verb in (Ipex.offer, Ipex.grant):
+            walked = self._walkGraph(origin=attrs["o"][0], nests=nests)
+            if walked is None:
+                return False
+
+            # Stage 5: only grant currently vets issuer-auth proof groups. Offer
+            # carries the same node-local framing but does not enforce proofs yet.
+            if verb == Ipex.grant and not self._verifyIssuerAuthGraph(nodes=walked[0], order=walked[1]):
+                return False
 
         return True
 
@@ -440,36 +419,6 @@ class IpexHandler:
             nodes[nserder.said] = nest
 
         return nodes
-
-    def _verifyOpener(self, verb, serder, attrs, nests):
-        """Validate a flow-opening IPEX message that has no prior.
-
-        Parameters:
-            verb (str): IPEX route suffix such as ``apply`` or ``offer``.
-            serder (Serder): Incoming exchange message being verified.
-            attrs (dict): Exchange attributes section.
-            nests (list): Parsed nested substreams carried on the opener.
-
-        Returns:
-            bool: True when the opener is legal for its verb and carries the
-                required thread/bootstrap data; False otherwise.
-        """
-        if verb == Ipex.apply:
-            # Apply is always a thread opener, so it must provide both receiver
-            # and transaction id directly on the message body.
-            return bool(serder.ked.get("ri", "") and serder.ked.get("x", ""))
-
-        if verb in (Ipex.offer, Ipex.grant):
-            # Offer and grant may also open a thread, but must then carry both
-            # the receiver and the generated exchange id on the opener itself.
-            if not (serder.ked.get("ri", "") and serder.ked.get("x", "")):
-                return False
-            # A flow-starting grant still has to prove that its carried nodes
-            # form exactly one DAG rooted at a.o[0].
-            return self._verifyGraph(attrs=attrs, nests=nests) if verb == Ipex.grant else True
-
-        # Agree, admit, and spurn cannot open an IPEX thread.
-        return False
 
     def _verifyReplyChain(self, verb, serder, dig):
         """Validate the prior-link rules for a reply inside an IPEX thread.
@@ -514,36 +463,32 @@ class IpexHandler:
             return False
         return True
 
-    def _verifyGraph(self, attrs, nests):
-        """Verify that the carried nested ACDCs form exactly one origin DAG.
+    def _walkGraph(self, origin, nests):
+        """Walk the disclosed origin DAG and return the visited node order.
 
         Parameters:
-            attrs (dict): Exchange attributes section. ``attrs["o"][0]`` names
-                the origin node for the disclosed DAG.
+            origin (str): SAID of the origin node named by ``a.o[0]``.
             nests (list): Parsed nested ACDC node substreams carried by the
-                grant message.
+                offer or grant message.
 
         Returns:
-            bool: True when the disclosed nests form one exact DAG rooted at
-                ``a.o[0]`` and every walked node passes issuer-auth checks;
-                False otherwise.
+            tuple | None: ``(nodes, order)`` when the disclosed nests form one
+                exact DAG rooted at ``origin``; otherwise ``None``.
         """
-
-        # Retrieve the root SAID
-        origin = attrs["o"][0]
-
         # Reuse the disclosed-node validation so graph walking starts from a
         # well-formed set of unique ACDC nests.
         nodes = self._validNodeNest(origin=origin, nests=nests)
         if nodes is None:
-            return False
+            return None
 
         # Reject if origin is not carried in the nests
         if origin not in nodes:
-            return False
+            return None
 
-        # Use deque for BFS traversal of the graph
+        # Use deque for BFS traversal so we start at the disclosed origin and
+        # then fan out across every referenced child node in graph order.
         seen = set()
+        order = []
         queue = deque([origin])
 
         # Walk the graph BFS, reject if any edge fails to resolve to a carried nest
@@ -552,6 +497,7 @@ class IpexHandler:
             if said in seen:
                 continue
             seen.add(said)
+            order.append(said)
 
             nest = nodes[said]
             nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
@@ -566,7 +512,7 @@ class IpexHandler:
                 elif isinstance(edges, list) and all(isinstance(edge, Mapping) for edge in edges):
                     blocks = edges
                 else:
-                    return False
+                    return None
 
                 # Walk each edge block, reject if any edge fails to resolve to a nest
                 for edge in blocks:
@@ -574,26 +520,45 @@ class IpexHandler:
                         if label in ("d", "o"):
                             continue
                         if not isinstance(node, Mapping):
-                            return False
+                            return None
                         edgeSaid = node.get("n")
                         if not isinstance(edgeSaid, str):
-                            return False
+                            return None
                         try:
                             Saider(qb64=edgeSaid)
                         except Exception:
-                            return False
+                            return None
                         if edgeSaid not in nodes:
-                            return False
+                            return None
                         if edgeSaid not in seen:
                             queue.append(edgeSaid)
 
-            # The issuer-auth hook runs in graph order so later proof-group
-            # checks can evaluate each node in the context of its own nest.
-            if not self._verifyIssuerAuthNode(serder=nserder, nest=nodes[said]):
+        # If any carried nest was never reached, the payload is not one exact DAG.
+        if len(seen) != len(nodes):
+            return None
+
+        return nodes, order
+
+    def _verifyIssuerAuthGraph(self, nodes, order):
+        """Verify issuer-auth proof groups for each walked disclosed DAG node.
+
+        Parameters:
+            nodes (dict): Mapping of disclosed node SAID to parsed nest.
+            order (list): Breadth-first walk order returned by ``_walkGraph``.
+
+        Returns:
+            bool: True when every walked node either has no registry binding or
+                vets successfully against its node-local proof group.
+        """
+        # Run proof verification in graph order so each registry-backed node is
+        # checked against the exact nested substream that carried its body.
+        for said in order:
+            nest = nodes[said]
+            nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
+            if not self._verifyIssuerAuthNode(serder=nserder, nest=nest):
                 return False
 
-        # If any carried nest was never reached, the payload is not one exact DAG.
-        return len(seen) == len(nodes)
+        return True
 
     def _verifyIssuerAuthNode(self, serder, nest):
         """Verify the issuer-auth proof carried on one disclosed ACDC node.

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -238,8 +238,10 @@ def _validDisclosurePath(value):
 
     Returns:
         bool: True when ``value`` is a list whose entries are disclosure-path
-            triples of ``[schema SAID, DAG path, ACDC paths]`` for one DAG,
-            False otherwise.
+            triples of ``[schema SAID, DAG path, ACDC paths]`` for one DAG.
+            The DAG path is either ``"/"`` for the root node or a canonical
+            edge-to-node prefix that starts and ends with ``/`` and terminates
+            at the far-node hop ``"_/"`` such as ``"/e/holder/_/"``.
     """
     if not isinstance(value, list):
         return False
@@ -253,7 +255,23 @@ def _validDisclosurePath(value):
             return False
         if not isinstance(path, str):
             return False
+        if path == "/":
+            pass
+        else:
+            # Non-root DAG prefixes must point at a far-node hop so later
+            # field paths append cleanly beneath that disclosed node.
+            if not (path.startswith("/") and path.endswith("/")):
+                return False
+
+            segments = path.strip("/").split("/")
+            if not segments or any(not isinstance(segment, str) or not segment for segment in segments):
+                return False
+            if segments[-1] != "_":
+                return False
+
         if not isinstance(fields, list):
+            return False
+        if any(not isinstance(field, str) or not field for field in fields):
             return False
 
     return True

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -37,10 +37,12 @@ PreviousRoutes = {
 }
 
 DisclosedNodeIlks = (None, Ilks.acm, Ilks.ace, Ilks.act, Ilks.acg)
-EdgeGroupLabels = ("d", "u", "o", "w")
+EdgeSectionLabels = ("d", "u", "o", "w")
+EdgeGroupLabels = ("d", "u", "s", "o", "w")
 EdgeNodeLabels = ("d", "u", "n", "s", "o", "w")
 UnaryEdgeOps = ("I2I", "NI2I", "DI2I", "E1E", "NOT")
 DelegativeEdgeOps = ("I2I", "NI2I", "DI2I")
+EdgeGroupOps = ("AND", "OR")
 
 def _streamSerder(stream):
     """Extract the message serder from a bare or nested artifact stream.
@@ -590,12 +592,14 @@ class IpexHandler:
 
                 # Expanded edge sections may contain nested edge groups
                 for edge in blocks:
-                    groups = [edge]
+                    groups = [(edge, False)]
                     while groups:
-                        group = groups.pop()
+                        group, nested = groups.pop()
+                        labels = EdgeGroupLabels if nested else EdgeSectionLabels   # Leaf vs group labels
                         if "n" in group:
-                            if any(label not in EdgeNodeLabels for label in group):
-                                return None
+                            for label in group:
+                                if label not in EdgeNodeLabels:
+                                    return None
                             edgeSaid = group.get("n")
                             if not isinstance(edgeSaid, str):
                                 return None
@@ -612,11 +616,11 @@ class IpexHandler:
                             continue
 
                         for label, node in group.items():
-                            if label in EdgeGroupLabels:
+                            if label in labels:
                                 continue
                             if not isinstance(node, Mapping):
                                 return None
-                            groups.append(node)
+                            groups.append((node, True))
 
         # Even when offer omits farther nodes, every carried nest must still be
         # part of the root-reachable disclosed graph.
@@ -624,6 +628,187 @@ class IpexHandler:
             return None
 
         return nodes, order
+
+    def _evaluateLeafEdge(self, group, *, nodes, nserder, inheritedSchema):
+        """Evaluate one disclosed leaf edge against its referenced far node.
+
+        Parameters:
+            group (Mapping): Leaf edge mapping that must carry an ``n`` field
+                naming the far-node SAID, and may carry scalar-string ``o``
+                and ``s`` fields for operator and schema-pin semantics.
+            nodes (dict): Mapping of disclosed node SAIDs to parsed nests built
+                during the origin-graph walk.
+            nserder (Serder): Serder for the current near node whose edge block
+                is being evaluated.
+            inheritedSchema (str | Mapping | None): Optional schema pin passed
+                down from a parent edge group.
+
+        Returns:
+            bool | None: ``True`` when the leaf edge semantics are satisfied,
+                ``False`` when the leaf is well-formed but its relation or
+                schema constraints do not match, or ``None`` when the leaf
+                shape itself is malformed and verification must fail closed.
+        """
+        # Reject unknown leaf labels before we inspect the reference.
+        for label in group:
+            if label not in EdgeNodeLabels:
+                return None
+
+        # Resolve the far node that this edge claims to reference.
+        edgeSaid = group.get("n")
+        if edgeSaid not in nodes:
+            return None
+        far = nodes[edgeSaid]
+        fserder = far["serder"] if isinstance(far, dict) else far.serder
+
+        # Leaf edge operators are optional scalar strings in the V2 shape.
+        op = group.get("o")
+        if op is not None and not isinstance(op, str):
+            return None
+
+        # Missing `o` is valid and means there is no explicit unary operator
+        # constraint on this leaf. A provided but unrecognized operator fails
+        # closed instead of being treated like an omitted one.
+        if op is None:
+            recognizedOp = None
+        elif op not in UnaryEdgeOps:
+            return None
+        else:
+            recognizedOp = op
+
+        # Edge operators either drive the issuer/issuee relation
+        # check directly or, for E1E, add an issuee-to-issuee constraint.
+        dop = recognizedOp if recognizedOp in DelegativeEdgeOps else None
+
+        # Unsupported leaf operators fail closed instead of being ignored.
+        if recognizedOp == "NOT" or dop == "DI2I":
+            return None
+
+        # Start from a passing state, then knock the edge down to False if
+        # any required relation check fails.
+        matched = True
+        if recognizedOp == "E1E":
+            if (not nserder.iseaid
+                    or not fserder.iseaid
+                    or nserder.iseaid != fserder.iseaid):
+                matched = False
+
+        # Delegative operators compare the near node's issuer relation to the
+        # far node's issuer AID.
+        if matched and dop is not None and dop != "NI2I":
+            if not fserder.iseaid:
+                matched = False
+            elif dop == "I2I" and nserder.israid != fserder.iseaid:
+                matched = False
+
+        # A leaf may pin the far node's schema directly, otherwise it
+        # inherits the schema pin from its parent group.
+        edgeSchema = group["s"] if "s" in group else inheritedSchema
+        if matched and edgeSchema is not None:
+            edgeSchemer = None
+            if isinstance(edgeSchema, str):
+                edgeSchemaId = edgeSchema
+            elif isinstance(edgeSchema, Mapping):
+                declared = edgeSchema.get("$id")
+                if not isinstance(declared, str):
+                    return None
+                try:
+                    edgeSchemer = Schemer(sed=deepcopy(edgeSchema))
+                except (ValidationError, ValueError):
+                    return None
+                if edgeSchemer.said != declared:
+                    return None
+                edgeSchemaId = edgeSchemer.said
+            else:
+                return None
+
+            farSchema = fserder.schema
+            if isinstance(farSchema, Mapping):
+                farSchemaId = farSchema.get("$id")
+            elif isinstance(farSchema, str):
+                farSchemaId = farSchema
+            else:
+                return None
+            if not isinstance(farSchemaId, str):
+                return None
+
+            # A direct schema SAID match is enough. Otherwise load or build
+            # the schema and verify the far node against it.
+            if edgeSchemaId != farSchemaId:
+                if edgeSchemer is None:
+                    edgeSchemer = self.hby.db.schema.get(edgeSchemaId)
+                    if edgeSchemer is None:
+                        return None
+                try:
+                    edgeSchemer.verify(fserder.raw)
+                except ValidationError:
+                    matched = False
+
+        return matched
+
+    def _evaluateGroupEdge(self, group, *, nodes, nserder, nested, inheritedSchema):
+        """Evaluate one disclosed edge group and reduce its child results.
+
+        Parameters:
+            group (Mapping): Edge-section or nested edge-group mapping whose
+                child entries are either more groups or leaf edges.
+            nodes (dict): Mapping of disclosed node SAIDs to parsed nests built
+                during the origin-graph walk.
+            nserder (Serder): Serder for the current near node whose edge block
+                is being evaluated.
+            nested (bool): ``True`` when ``group`` is a nested edge group and
+                therefore allows group-only labels like ``s``; ``False`` for a
+                top-level edge section.
+            inheritedSchema (str | Mapping | None): Optional schema pin passed
+                down from the parent edge group.
+
+        Returns:
+            bool | None: ``True`` when the group is well-formed and its child
+                results satisfy the group's ``AND`` or ``OR`` semantics,
+                ``False`` when the group is well-formed but the reduced child
+                result fails, or ``None`` when the group shape is malformed and
+                verification must fail closed.
+        """
+        # Top-level edge sections and nested edge groups allow slightly
+        # different reserved labels, so choose the right set up front.
+        labels = EdgeGroupLabels if nested else EdgeSectionLabels
+
+        # Nested groups may contribute an m-ary operator and a shared schema
+        # pin for every child below them.
+        groupOp = group.get("o", "AND")
+        if not isinstance(groupOp, str) or groupOp not in EdgeGroupOps:
+            return None
+
+        # Nested groups can pin one schema for every child below them.
+        nextSchema = group.get("s", inheritedSchema) if nested else inheritedSchema
+        results = []
+        for label, node in group.items():
+            if label in labels:
+                continue
+            if not isinstance(node, Mapping):
+                return None
+
+            # Recurse into each child and fail closed if any child is malformed.
+            if "n" in node:
+                matched = self._evaluateLeafEdge(node,
+                                                 nodes=nodes,
+                                                 nserder=nserder,
+                                                 inheritedSchema=nextSchema)
+            else:
+                matched = self._evaluateGroupEdge(node,
+                                                  nodes=nodes,
+                                                  nserder=nserder,
+                                                  nested=True,
+                                                  inheritedSchema=nextSchema)
+            if matched is None:
+                return None
+            results.append(matched)
+
+        if not results:
+            return None
+
+        # Reduce the child booleans according to the group's operator.
+        return any(results) if groupOp == "OR" else all(results)
 
     def _verifyGraphSemantics(self, nodes, order):
         """Verify grant edge operators and edge-schema pins across walked nodes.
@@ -633,8 +818,8 @@ class IpexHandler:
             order (list): Breadth-first walk order returned by ``_walkGraph``.
 
         Returns:
-            bool: True when every walked edge leaf names a disclosed far node
-                and every leaf-level operator and schema constraint is
+            bool: True when every walked edge block is well-formed and its
+                leaf-level and group-level operator/schema constraints are
                 satisfied; False on any malformed or violated edge semantics.
         """
         for said in order:
@@ -658,113 +843,22 @@ class IpexHandler:
                 return False
 
             for edge in blocks:
-                # Walk nested edge groups until we reach each leaf `n`
-                groups = [edge]
-                while groups:
-                    group = groups.pop()
-                    if "n" in group:
-                        # Leaf edges may only use leaf labels
-                        if any(label not in EdgeNodeLabels for label in group):
-                            return False
-
-                        # `n` points to the far disclosed node
-                        edgeSaid = group.get("n")
-                        if edgeSaid not in nodes:
-                            return False
-                        far = nodes[edgeSaid]
-                        # Normalize access to the far-node serder
-                        fserder = far["serder"] if isinstance(far, dict) else far.serder
-
-                        # `o` may be missing, one string, or a list of strings
-                        op = group.get("o")
-                        if op is None:
-                            ops = []
-                        elif isinstance(op, str):
-                            ops = [op]
-                        elif isinstance(op, (list, tuple)) and all(isinstance(item, str) for item in op):
-                            ops = list(op)
-                        else:
-                            return False
-
-                        # Keep only the operators this verifier understands
-                        ops = [cand for cand in ops if cand in UnaryEdgeOps]
-                        # The last delegative operator wins
-                        dop = next((cand for cand in reversed(ops) if cand in DelegativeEdgeOps), None)
-                        if not ops:
-                            # Default from the far-node shape
-                            dop = "I2I" if fserder.iseaid is not None else "NI2I"
-
-                        # Reject unsupported grant edge semantics
-                        if "NOT" in ops or dop == "DI2I":
-                            return False
-
-                        # E1E requires matching `i` values on both nodes
-                        if "E1E" in ops:
-                            if not nserder.iseaid or not fserder.iseaid or nserder.iseaid != fserder.iseaid:
-                                return False
-
-                        # Issuer-linked edges require a valid far-node issuer
-                        if dop is not None and dop != "NI2I":
-                            if not fserder.iseaid:
-                                return False
-                            if dop == "I2I" and nserder.israid != fserder.iseaid:
-                                return False
-
-                        # `s` optionally pins the far-node schema
-                        if "s" in group:
-                            edgeSchema = group["s"]
-                            edgeSchemer = None
-                            if isinstance(edgeSchema, str):
-                                edgeSchemaId = edgeSchema
-                            elif isinstance(edgeSchema, Mapping):
-                                # Inline schemas must match their declared `$id`
-                                declared = edgeSchema.get("$id")
-                                if not isinstance(declared, str):
-                                    return False
-                                try:
-                                    edgeSchemer = Schemer(sed=deepcopy(edgeSchema))
-                                except (ValidationError, ValueError):
-                                    return False
-                                if edgeSchemer.said != declared:
-                                    return False
-                                edgeSchemaId = edgeSchemer.said
-                            else:
-                                return False
-
-                            # Read the far node's schema reference
-                            farSchema = fserder.schema
-                            if isinstance(farSchema, Mapping):
-                                farSchemaId = farSchema.get("$id")
-                            elif isinstance(farSchema, str):
-                                farSchemaId = farSchema
-                            else:
-                                return False
-                            if not isinstance(farSchemaId, str):
-                                return False
-
-                            # If the IDs differ, the far node must still validate
-                            # against the schema named by the edge
-                            if edgeSchemaId != farSchemaId:
-                                if edgeSchemer is None:
-                                    # Resolve SAID-only schema pins from the local cache
-                                    edgeSchemer = self.hby.db.schema.get(edgeSchemaId)
-                                    if edgeSchemer is None:
-                                        return False
-                                try:
-                                    # Enforce the schema pin
-                                    edgeSchemer.verify(fserder.raw)
-                                except ValidationError:
-                                    return False
-                        continue
-
-                    # Group operators shape traversal only
-                    for label, node in group.items():
-                        if label in EdgeGroupLabels:
-                            continue
-                        # Child groups must also be edge mappings
-                        if not isinstance(node, Mapping):
-                            return False
-                        groups.append(node)
+                # Evaluate the whole edge tree from the root down. Each leaf
+                # returns one boolean and each group reduces its child booleans
+                # with AND/OR using any inherited schema pin.
+                if "n" in edge:
+                    matched = self._evaluateLeafEdge(edge,
+                                                     nodes=nodes,
+                                                     nserder=nserder,
+                                                     inheritedSchema=None)
+                else:
+                    matched = self._evaluateGroupEdge(edge,
+                                                      nodes=nodes,
+                                                      nserder=nserder,
+                                                      nested=False,
+                                                      inheritedSchema=None)
+                if matched is not True:
+                    return False
 
         return True
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -6,14 +6,15 @@ IPEx protocol service support (Issuance and Presentation Exchange)
 
 """
 
-from collections import namedtuple
+from collections import deque, namedtuple
+from collections.abc import Mapping
 
 from hio.help import ogler
 
-from .. import Kinds
+from .. import Kinds, Protocols
 from ..kering import Colds, Vrsn_2_0, sniff
-from ..core import (Counter, Codens, Diger, GenDex, Noncer, Number, Saider, Serdery, Texter,
-                    exchange, messagize)
+from ..core import (BlindState, Blinder, BoundState, Counter, Codens, Diger, GenDex, Noncer,
+                    Number, Saider, Serdery, Texter, exchange, messagize)
 from ..peer import cloneMessage
 
 logger = ogler.getLogger()
@@ -155,6 +156,93 @@ def _normalizeNestedStream(stream):
                            version=Vrsn_2_0)
 
 
+def _normalizeNodeStream(stream, attachment=None):
+    """Normalize one disclosed ACDC node into a nested V2 substream.
+
+    Parameters:
+        stream (Serder | bytes | bytearray): ACDC body, body+attachments
+            stream, or already-nested node stream.
+        attachment (bytes | bytearray | None): Optional attachment section to
+            pair with the ACDC body when ``stream`` is not already a stream
+            carrying attachments.
+
+    Returns:
+        bytearray: Nested V2 body-with-attachments group for one ACDC node.
+    """
+    # Preserve a caller-supplied node substream when it is already framed the
+    # way IPEX expects: one ACDC body plus that node's attachment section.
+    if _isNestedStream(stream):
+        serder = _streamSerder(stream)
+        if serder.proto != Protocols.acdc:
+            raise ValueError("IPEX node nests must carry ACDC messages")
+        if attachment:
+            raise ValueError("cannot append attachment bytes to a pre-nested ACDC node")
+        return bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+
+    raw = bytes(stream.raw) if hasattr(stream, "raw") else bytes(stream)
+    serder = _streamSerder(raw)
+    if serder.proto != Protocols.acdc:
+        raise ValueError("IPEX node nests must carry ACDC messages")
+
+    # Rebuild plain ACDC input into the same per-node framing so later proof
+    # groups can live on the owning node without changing the outer layout.
+    atc = raw[serder.size:] if attachment is None else bytes(attachment)
+    return _normalizeNestedStream(raw[:serder.size] + atc)
+
+
+def _validSingleDagList(value, itemtype, *, allow_empty=False):
+    """Validate one of the single-item list fields used by single-DAG IPEX.
+
+    Parameters:
+        value: Candidate wire value for a single-DAG field such as ``o`` or
+            ``ax``.
+        itemtype (type): Required Python type for each outer-list entry.
+        allow_empty (bool): When True, ``[]`` is accepted in addition to a
+            one-item list. This is used only for today's unanchored ``ax``
+            behavior.
+
+    Returns:
+        bool: True when ``value`` matches the current single-DAG wire shape,
+            False otherwise.
+    """
+
+    # The single-DAG outer-wire contract for `o` and `ax` is a list that can
+    # later grow for multi-DAG without changing field type.
+    if not isinstance(value, list):
+        return False
+
+    # We currently only support one DAG (until Multi DAG), so at most one entry is allowed.
+    # `allow_empty=True` is used only for today's unanchored `ax=[]` behavior;
+    # every other caller requires exactly one entry in the outer list.
+    if len(value) > 1 or (not allow_empty and len(value) != 1):
+        return False
+
+    # The inner item type differs by field:
+    # - `o` carries one origin SAID string
+    # - `ax` carries zero or one booleans
+    return all(isinstance(item, itemtype) for item in value)
+
+
+def _validDisclosurePath(value):
+    """Validate ``q.dp`` as one disclose-path list for the current DAG.
+
+    Parameters:
+        value: Candidate ``q.dp`` wire value.
+
+    Returns:
+        bool: True when ``value`` is a list whose entries are disclosure-path
+            triples of ``[schema SAID, DAG path, ACDC paths]``, False
+            otherwise.
+    """
+    return (isinstance(value, list)
+            and all(isinstance(item, list)
+                    and len(item) == 3
+                    and isinstance(item[0], str)
+                    and isinstance(item[1], str)
+                    and isinstance(item[2], list)
+                    for item in value))
+
+
 def _sign(hab, serder, *, nests=None, gvrsn=None):
     """Sign and messagize an outer IPEX exchange with optional nested streams.
 
@@ -196,13 +284,15 @@ def _sign(hab, serder, *, nests=None, gvrsn=None):
 class IpexHandler:
     """Verify and handle the linear V2 IPEX `exn` workflow."""
 
-    def __init__(self, resource, hby, notifier):
+    def __init__(self, resource, hby, notifier, rgy=None):
         """Create a handler for one IPEX route.
 
         Parameters:
             resource (str): Route string handled by this instance.
             hby (Habery): Habitat environment and backing database.
             notifier: Notifier-like object with an ``add`` method.
+            rgy (Regery | None): Optional local registry manager used when a
+                disclosed node's ``rd`` requires verifier-side issuer-auth checks.
 
         Returns:
             None
@@ -210,6 +300,7 @@ class IpexHandler:
         self.resource = resource
         self.hby = hby
         self.notifier = notifier
+        self.rgy = rgy
 
     def verify(self, serder, attachments=None, nests=None):
         """Validate the verb, prior link, and single-response rule.
@@ -226,82 +317,158 @@ class IpexHandler:
                 False otherwise.
         """
         nests = nests if nests is not None else []
-
-        # Get route
-        route = serder.ked["r"]
+        q = serder.ked.get("q")
         attrs = serder.ked["a"]
-        
-        # Get digest of prior
         dig = serder.ked["p"]
-        
+
+        route = serder.ked["r"]
         parts = route.split("/")
         if len(parts) != 3 or parts[:2] != ["", "ipex"]:
             return False
+
         verb = parts[2]
-
-        q = serder.ked.get("q")
-        if not isinstance(attrs, dict) or "m" not in attrs or not isinstance(q, dict):
+        if verb not in (Ipex.apply, *PreviousRoutes.keys()):
             return False
 
-        if verb in (Ipex.apply, Ipex.agree, Ipex.admit, Ipex.spurn):
-            # These IPEX verbs do not carry nested artifacts.
-            if nests:
-                return False
-        elif verb == Ipex.offer:
-            if ("o" not in attrs or not isinstance(attrs["o"], str)
-                    or "dp" not in q or not isinstance(q["dp"], list) or not nests):
-                return False
-            try:
-                Saider(qb64=attrs["o"])
-            except Exception:
-                return False
-            for idx, nest in enumerate(nests):
-                nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
-                if not nserder.verify():
-                    return False
-                if idx == 0 and not nserder.compare(attrs["o"]):
-                    return False
+        # Stage 1: validate the common V2 IPEX payload shape shared by every verb.
+        if not self._verifyCommonShape(attrs=attrs, q=q):
+            return False
 
-        elif verb == Ipex.grant:
-            if "o" not in attrs or not isinstance(attrs["o"], str) or not nests:
-                return False
-            try:
-                Saider(qb64=attrs["o"])
-            except Exception:
-                return False
-            for idx, nest in enumerate(nests):
-                nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
-                if not nserder.verify():
-                    return False
-                if idx == 0 and not nserder.compare(attrs["o"]):
-                    return False
+        # Stage 2: validate the fields that depend on which IPEX verb this is,
+        # such as disclose plans for apply/offer and disclosed node nests for
+        # offer/grant.
+        if not self._verifyVerbShape(verb=verb, attrs=attrs, q=q, nests=nests):
+            return False
 
-        # Apply starts the flow, so it must have no prior and must carry both
-        # the recipient and the transaction id.
+        # Stage 3: opener flows validate directly from the message itself,
+        # while replies must first resolve and validate their prior exchange.
+        if not dig:
+            return self._verifyOpener(verb=verb, serder=serder, attrs=attrs, nests=nests)
         if verb == Ipex.apply:
-            if "dp" not in q or not isinstance(q["dp"], list):
-                return False
-            return bool(not dig and serder.ked.get("ri", "") and serder.ked.get("x", ""))
-        
-        # Offer and Grant can start a flow, but flow-openers must carry both
-        # the recipient and the transaction id.
-        if verb in (Ipex.offer, Ipex.grant):
-            if not dig:
-                return bool(serder.ked.get("ri", "") and serder.ked.get("x", ""))
-
-        # Admit, Agree and Spurn are not allowed to start a flow so empty prior rejected
-        elif verb in (Ipex.admit, Ipex.agree, Ipex.spurn):
-            if not dig:
-                return False
-        else:
             return False
 
-        # Load the prior, reject if missing
+        if not self._verifyReplyChain(verb=verb, serder=serder, dig=dig):
+            return False
+
+        # Stage 4: only grant has extra semantic verification beyond the linear
+        # thread rules. The carried disclosed nodes must form exactly one DAG.
+        if verb == Ipex.grant:
+            return self._verifyGraph(attrs=attrs, nests=nests)
+
+        return True
+
+    def _verifyCommonShape(self, attrs, q):
+        """Validate the common payload shape shared by every V2 IPEX verb.
+
+        Parameters:
+            attrs (dict): Exchange attributes section from ``serder.ked["a"]``.
+            q (dict): Exchange query/modifier section from ``serder.ked["q"]``.
+
+        Returns:
+            bool: True when the shared V2 IPEX fields have the expected shape,
+                including optional single-DAG ``ax`` semantics.
+        """
+        if not isinstance(attrs, dict):
+            return False
+        if "m" not in attrs:
+            return False
+        if not isinstance(q, dict):
+            return False
+        if "ax" in attrs and not _validSingleDagList(attrs["ax"], bool, allow_empty=True):
+            return False
+        return True
+
+    def _verifyVerbShape(self, verb, attrs, q, nests):
+        """Validate the fields that depend on the current IPEX verb.
+
+        Parameters:
+            verb (str): IPEX route suffix such as ``apply`` or ``grant``.
+            attrs (dict): Exchange attributes section.
+            q (dict): Exchange query/modifier section.
+            nests (list): Parsed nested substreams carried on the message.
+
+        Returns:
+            bool: True when the verb-specific fields are well formed for the
+                current single-DAG wire shape, False otherwise.
+        """
+        if verb in (Ipex.apply, Ipex.offer):
+            if "dp" not in q or not _validDisclosurePath(q["dp"]):
+                return False
+
+        if verb in (Ipex.offer, Ipex.grant):
+            if "o" not in attrs or not _validSingleDagList(attrs["o"], str) or not nests:
+                return False
+            try:
+                Saider(qb64=attrs["o"][0])
+            except Exception:
+                return False
+
+            # The first disclosed node is always the origin named in a.o[0].
+            # Every carried nest must be an ACDC body plus that node's
+            # attachment section.
+            for idx, nest in enumerate(nests):
+                nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
+                if not nserder.verify():
+                    return False
+                if nserder.proto != Protocols.acdc:
+                    return False
+                if idx == 0 and not nserder.compare(attrs["o"][0]):
+                    return False
+
+        # The other verbs never disclose nested ACDC nodes.
+        elif nests:
+            return False
+
+        return True
+
+    def _verifyOpener(self, verb, serder, attrs, nests):
+        """Validate a flow-opening IPEX message that has no prior.
+
+        Parameters:
+            verb (str): IPEX route suffix such as ``apply`` or ``offer``.
+            serder (Serder): Incoming exchange message being verified.
+            attrs (dict): Exchange attributes section.
+            nests (list): Parsed nested substreams carried on the opener.
+
+        Returns:
+            bool: True when the opener is legal for its verb and carries the
+                required thread/bootstrap data; False otherwise.
+        """
+        if verb == Ipex.apply:
+            # Apply is always a thread opener, so it must provide both receiver
+            # and transaction id directly on the message body.
+            return bool(serder.ked.get("ri", "") and serder.ked.get("x", ""))
+
+        if verb in (Ipex.offer, Ipex.grant):
+            # Offer and grant may also open a thread, but must then carry both
+            # the receiver and the generated exchange id on the opener itself.
+            if not (serder.ked.get("ri", "") and serder.ked.get("x", "")):
+                return False
+            # A flow-starting grant still has to prove that its carried nodes
+            # form exactly one DAG rooted at a.o[0].
+            return self._verifyGraph(attrs=attrs, nests=nests) if verb == Ipex.grant else True
+
+        # Agree, admit, and spurn cannot open an IPEX thread.
+        return False
+
+    def _verifyReplyChain(self, verb, serder, dig):
+        """Validate the prior-link rules for a reply inside an IPEX thread.
+
+        Parameters:
+            verb (str): IPEX route suffix for the reply being checked.
+            serder (Serder): Incoming reply exchange message.
+            dig (str): SAID of the prior message named by ``serder.ked["p"]``.
+
+        Returns:
+            bool: True when the reply points to an allowed prior message, keeps
+                sender/receiver roles consistent, and does not duplicate an
+                existing response; False otherwise.
+        """
         pserder, _ = cloneMessage(self.hby, said=dig)
         if pserder is None:
             return False
-        
-        # Retrieve the verb and check if previous route validates
+
+        # Replies must point at the allowed prior verb in the linear IPEX chain.
         proute = pserder.ked["r"]
         pparts = proute.split("/")
         if len(pparts) != 3 or pparts[:2] != ["", "ipex"]:
@@ -323,7 +490,195 @@ class IpexHandler:
         if serder.ked.get("x", "") != pserder.ked.get("x", ""):
             return False
 
-        return self.response(pserder) is None
+        if self.response(pserder) is not None:
+            return False
+        return True
+
+    def _verifyGraph(self, attrs, nests):
+        """Verify that the carried nested ACDCs form exactly one origin DAG.
+
+        Parameters:
+            attrs (dict): Exchange attributes section. ``attrs["o"][0]`` names
+                the origin node for the disclosed DAG.
+            nests (list): Parsed nested ACDC node substreams carried by the
+                grant message.
+
+        Returns:
+            bool: True when the disclosed nests form one exact DAG rooted at
+                ``a.o[0]`` and every walked node passes issuer-auth checks;
+                False otherwise.
+        """
+
+        # Retrieve the root SAID
+        origin = attrs["o"][0]
+
+        # Build a mapping of SAID to nest for all carried nodes, reject if duplicates
+        nodes = {}
+        for nest in nests:
+            nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
+            if nserder.said in nodes:
+                return False
+            nodes[nserder.said] = nest
+
+        # Reject if origin is not carried in the nests
+        if origin not in nodes:
+            return False
+
+        # Use deque for BFS traversal of the graph
+        seen = set()
+        queue = deque([origin])
+
+        # Walk the graph BFS, reject if any edge fails to resolve to a carried nest
+        while queue:
+            said = queue.popleft()
+            if said in seen:
+                continue
+            seen.add(said)
+
+            nest = nodes[said]
+            nserder = nest["serder"] if isinstance(nest, dict) else nest.serder
+
+            # Retrieve the edges from the node
+            edges = nserder.sad.get("e")
+            if edges:
+                # `e` must stay directly walkable as a mapping or list of mappings.
+                #  A compacted edge SAID/string fails closed.
+                if isinstance(edges, Mapping):
+                    blocks = [edges]
+                elif isinstance(edges, list) and all(isinstance(edge, Mapping) for edge in edges):
+                    blocks = edges
+                else:
+                    return False
+
+                # Walk each edge block, reject if any edge fails to resolve to a nest
+                for edge in blocks:
+                    for label, node in edge.items():
+                        if label in ("d", "o"):
+                            continue
+                        if not isinstance(node, Mapping):
+                            return False
+                        edgeSaid = node.get("n")
+                        if not isinstance(edgeSaid, str):
+                            return False
+                        try:
+                            Saider(qb64=edgeSaid)
+                        except Exception:
+                            return False
+                        if edgeSaid not in nodes:
+                            return False
+                        if edgeSaid not in seen:
+                            queue.append(edgeSaid)
+
+            # The issuer-auth hook runs in graph order so later proof-group
+            # checks can evaluate each node in the context of its own nest.
+            if not self._verifyIssuerAuthNode(serder=nserder, nest=nodes[said]):
+                return False
+
+        # If any carried nest was never reached, the payload is not one exact DAG.
+        return len(seen) == len(nodes)
+
+    def _verifyIssuerAuthNode(self, serder, nest):
+        """Verify the issuer-auth proof carried on one disclosed ACDC node.
+
+        This hook only applies to registry-backed credentials. When the ACDC
+        body has a top-level ``rd`` field, that field names the registry whose
+        TEL history must authenticate the node. The proof material is expected
+        to live on the same nested substream as the ACDC body. 
+        In other words, one disclosed DAG node is:
+
+        ``ACDC body + that node's issuer-auth attachment group``
+
+        Workflow:
+            1. Read ``rd`` from the ACDC body. If there is no ``rd``, this node
+               is not registry-backed and there is nothing to vet here.
+            2. Read the node-local blind proof group (`bsqs` or `bsss`) from the
+               parsed nest and normalize the parsed tuples back into the crew
+               shape expected by ``Blinder``.
+            3. Require exactly one blinded state proof for this node's registry
+               root event. Missing or multiple proofs fail closed.
+            4. Load the registry inception event and subsequent TEL updates from
+               the local ``Regery`` store.
+            5. Call ``regeventing.vet(...)`` with the ACDC, the disclosed blind
+               proof, and the persisted TEL evidence so registry anchoring and
+               ACDC binding are checked in one place.
+
+        Parameters:
+            serder (Serder): The disclosed ACDC node being verified.
+            nest (dict | object): The parsed nested substream that carried the
+                node. It must expose any attached blind proof groups as ``bsqs``
+                or ``bsss``.
+
+        Returns:
+            bool: ``True`` when the node is either not registry-backed or its
+            node-local proof vets successfully against local TEL evidence;
+            otherwise ``False``.
+        """
+        regk = serder.sad.get("rd")
+        if regk:
+            # Registry-backed ACDCs must carry their proof group on the node's own
+            # nest so issuer-auth evidence travels with the ACDC it authenticates.
+            bsqs = nest.get("bsqs", []) if isinstance(nest, dict) else nest.bsqs
+            bsss = nest.get("bsss", []) if isinstance(nest, dict) else nest.bsss
+
+            # The parser gives us primitive instances. Rebuild those into the
+            # canonical crew form so regeventing.vetBlind() sees the expected
+            # cast (d as qb64 digest, u/td/bd as nonce strings, ts as text).
+            proofs = []
+            for proof in bsqs:
+                crew = BlindState(d=proof[0].qb64,
+                                  u=proof[1].nonce,
+                                  td=proof[2].nonce,
+                                  ts=proof[3].text)
+                proofs.append(Blinder(crew=crew))
+
+            for proof in bsss:
+                crew = BoundState(d=proof[0].qb64,
+                                  u=proof[1].nonce,
+                                  td=proof[2].nonce,
+                                  ts=proof[3].text,
+                                  bn=proof[4].sn,
+                                  bd=proof[5].nonce)
+                proofs.append(Blinder(crew=crew))
+
+            # The proof group must disclose exactly one blinded state for the registry's root event.
+            if len(proofs) != 1:
+                return False
+
+            # Reuse an injected Regery when available. Otherwise reopen the local
+            # registry store for this Habery so IPEX can vet against persisted TEL
+            # evidence without changing the public handler API.
+            if self.rgy is None:
+                from .registraring import Regery
+                self.rgy = Regery(hby=self.hby,
+                                  name=self.hby.name,
+                                  base=self.hby.base,
+                                  temp=self.hby.temp)
+
+            # The proof group only discloses one event's blinded state. The TEL
+            # chain itself is loaded from the local registry store and passed into
+            # regeventing.vet(), which checks anchoring and ACDC binding.
+            rip = self.rgy.store.seqEvent(regk, 0)
+            head = self.rgy.store.headEvent(regk)
+            if rip is None or head is None:
+                return False
+
+            updates = []
+            for sn in range(1, int(head.sad["n"], 16) + 1):
+                if not (update := self.rgy.store.seqEvent(regk, sn)):
+                    return False
+                updates.append(update)
+
+            from . import regeventing
+            try:
+                regeventing.vet(rip=rip,
+                                updates=updates,
+                                db=self.hby.db,
+                                acdc=serder,
+                                blinder=proofs[0])
+            except Exception:
+                return False
+
+        return True
 
     def response(self, serder):
         """Look up the recorded response to a prior IPEX exchange.
@@ -374,7 +729,8 @@ def apply(hab, recp, message, modifiers=None, attrs=None, dt=None, kind=None, gv
         kind (str | None): Optional serialization kind override.
         gvrsn (Versionage | None): Optional CESR genus version override.
         modifiers (dict | None): Query-section fields for ``q``. ``apply``
-            requires an explicit disclosure plan at ``modifiers["dp"]``.
+            requires an explicit single-DAG disclosure plan at
+            ``modifiers["dp"]``.
 
     Returns:
         tuple[Serder, bytearray]: Outer exchange serder and detached attachment
@@ -389,8 +745,14 @@ def apply(hab, recp, message, modifiers=None, attrs=None, dt=None, kind=None, gv
     data = dict(attrs) if attrs is not None else {}
     data["m"] = message
     mods = dict(modifiers) if modifiers else {}
-    if "dp" not in mods or not isinstance(mods["dp"], list):
-        raise ValueError("modifiers['dp'] is required and must be a list")
+
+    # Validate dp field, it must be the DAG's disclose-path list.
+    if "dp" not in mods or not _validDisclosurePath(mods["dp"]):
+        raise ValueError("modifiers['dp'] is required and must be a list of disclosure-path triples")
+
+    # Validate ax field, must be a list of booleans, is allowed to be empty
+    if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
+        raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
 
     # Build the body
     serder = exchange(
@@ -422,10 +784,10 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
     Parameters:
         hab (Hab): Habitat creating and signing the exchange.
         message (str): Human-readable offer message.
-        origin (Serder | bytes | bytearray): Origin metadata artifact
-            identified in ``a.o`` and carried as the first nested artifact.
+        origin (Serder | bytes | bytearray): Origin ACDC node identified in
+            ``a.o[0]`` and carried as the first nested artifact.
         artifacts (list[Serder | bytes | bytearray] | None): Optional
-            attached metadata artifacts carried after ``origin``.
+            additional disclosed ACDC nodes carried after ``origin``.
         apply (Serder | None): Optional prior ``apply`` exchange.
         recp (str | None): Recipient AID. Defaults to the prior ``apply``
             sender; must be supplied directly for an offer-first exchange
@@ -465,15 +827,29 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
             xid = ""
     data = dict(attrs) if attrs is not None else {}
     data["m"] = message
-    data["o"] = _streamSerder(origin).said
-    nests = [_normalizeNestedStream(origin)]
+
+    # Retrieve dp from modifiers if present
+    mods = dict(modifiers) if modifiers else {}
+    mods.setdefault("dp", [])     # defaults to an empty list if none is provided
+
+    # Validate dp field, it must be a list of lists.
+    if not _validDisclosurePath(mods["dp"]):
+        raise ValueError("modifiers['dp'] must be a list of disclosure-path triples")
+
+    # Validate the ax field if present. It must be a list of booleans
+    if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
+        raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
+
+    # Offer emits the origin in list form and nests each disclosed ACDC node
+    # separately so node-local attachment groups stay with their owner.
+    data["o"] = [_streamSerder(origin).said]
+    nests = [_normalizeNodeStream(origin)]
+
     if artifacts is not None:
         if not isinstance(artifacts, list):
             raise TypeError("artifacts must be a list when provided")
         for artifact in artifacts:
-            nests.append(_normalizeNestedStream(artifact))
-    mods = dict(modifiers) if modifiers else {}
-    mods.setdefault("dp", [])
+            nests.append(_normalizeNodeStream(artifact))
 
     # Build the body
     serder = exchange(
@@ -549,11 +925,10 @@ def grant(hab, recp, message, origin, artifacts=None, agree=None,
         hab (Hab): Habitat creating and signing the exchange.
         recp (str): Recipient AID for the disclosure.
         message (str): Human-readable disclosure message.
-        origin (Serder | bytes | bytearray): Origin presentation or credential
-            artifact identified in ``a.o`` and carried as the first nested
-            artifact.
+        origin (Serder | bytes | bytearray): Origin ACDC node identified in
+            ``a.o[0]`` and carried as the first nested artifact.
         artifacts (list[Serder | bytes | bytearray] | None): Optional
-            attached proofs or supporting artifacts carried after ``origin``.
+            additional disclosed ACDC nodes carried after ``origin``.
         agree (Serder | None): Optional prior ``agree`` exchange.
         dt (str | None): Optional RFC-3339 timestamp override.
         kind (str | None): Optional serialization kind override.
@@ -583,14 +958,21 @@ def grant(hab, recp, message, origin, artifacts=None, agree=None,
             xid = ""
     data = dict(attrs) if attrs is not None else {}
     data["m"] = message
-    data["o"] = _streamSerder(origin).said
-    nests = [_normalizeNestedStream(origin)]
+
+    # Validate ax field, it must be a list of bool, it's allowed to be empty
+    if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):
+        raise ValueError("attrs['ax'] must be [] or a one-item list of booleans")
+
+    # Grant mirrors offer framing: a.o[0] names the origin node, and any later
+    # nests are more disclosed ACDC nodes from that same origin DAG.
+    data["o"] = [_streamSerder(origin).said]
+    nests = [_normalizeNodeStream(origin)]
 
     if artifacts is not None:
         if not isinstance(artifacts, list):
             raise TypeError("artifacts must be a list when provided")
         for artifact in artifacts:
-            nests.append(_normalizeNestedStream(artifact))
+            nests.append(_normalizeNodeStream(artifact))
 
     serder = exchange(
         sender=hab.pre,
@@ -703,20 +1085,22 @@ def spurn(hab, message, spurned, recp=None, dt=None, kind=None, gvrsn=None):
     return serder, atc
 
 
-def loadHandlers(hby, exc, notifier):
+def loadHandlers(hby, exc, notifier, rgy=None):
     """Register handlers for the six V2 IPEX verb routes.
 
     Parameters:
         hby (Habery): Habitat environment and backing database.
         exc (Exchanger): Exchange router to register handlers on.
         notifier: Notifier-like object passed through to each handler.
+        rgy (Regery | None): Optional local registry manager reused by every
+            IPEX handler for verifier-side registry proof checks.
 
     Returns:
         None
     """
-    exc.addHandler(IpexHandler(resource="/ipex/apply", hby=hby, notifier=notifier))
-    exc.addHandler(IpexHandler(resource="/ipex/offer", hby=hby, notifier=notifier))
-    exc.addHandler(IpexHandler(resource="/ipex/agree", hby=hby, notifier=notifier))
-    exc.addHandler(IpexHandler(resource="/ipex/grant", hby=hby, notifier=notifier))
-    exc.addHandler(IpexHandler(resource="/ipex/admit", hby=hby, notifier=notifier))
-    exc.addHandler(IpexHandler(resource="/ipex/spurn", hby=hby, notifier=notifier))
+    exc.addHandler(IpexHandler(resource="/ipex/apply", hby=hby, notifier=notifier, rgy=rgy))
+    exc.addHandler(IpexHandler(resource="/ipex/offer", hby=hby, notifier=notifier, rgy=rgy))
+    exc.addHandler(IpexHandler(resource="/ipex/agree", hby=hby, notifier=notifier, rgy=rgy))
+    exc.addHandler(IpexHandler(resource="/ipex/grant", hby=hby, notifier=notifier, rgy=rgy))
+    exc.addHandler(IpexHandler(resource="/ipex/admit", hby=hby, notifier=notifier, rgy=rgy))
+    exc.addHandler(IpexHandler(resource="/ipex/spurn", hby=hby, notifier=notifier, rgy=rgy))

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -388,6 +388,8 @@ class IpexHandler:
                     or not _validSingleDagList(q["dp"], list)
                     or not _validDisclosurePath(q["dp"][0])):
                 return False
+            if verb == Ipex.offer and not dig and not q["dp"][0]:
+                return False
 
         if verb == Ipex.offer:
             if "o" in attrs:
@@ -910,16 +912,22 @@ def offer(hab, message, origin, artifacts=None, apply=None, recp=None, dt=None,
 
     # Retrieve dp from modifiers if present. When the offer answers an apply,
     # inherit the requested disclose-path plan unless the caller overrides it.
+    # Offer-first flows have no earlier disclosure request to inherit, so they
+    # must provide their own explicit disclosure plan.
     mods = dict(modifiers) if modifiers else {}
-    if "dp" not in mods and apply is not None:
-        aq = apply.ked.get("q")
-        if isinstance(aq, dict) and "dp" in aq:
-            mods["dp"] = aq["dp"]
-    mods.setdefault("dp", [[]])     # default to one empty disclose-path list for the one DAG
+    if "dp" not in mods:
+        if apply is not None:
+            aq = apply.ked.get("q")
+            if isinstance(aq, dict) and "dp" in aq:
+                mods["dp"] = aq["dp"]
+        else:
+            raise ValueError("modifiers['dp'] is required when no prior apply is provided")
 
     # Offer uses the same canonical q.dp builder contract as apply.
     if not _validSingleDagList(mods["dp"], list) or not _validDisclosurePath(mods["dp"][0]):
         raise ValueError("modifiers['dp'] must carry one disclose-path list per DAG")
+    if apply is None and not mods["dp"][0]:
+        raise ValueError("offer-first modifiers['dp'] must include at least one disclosure-path entry")
 
     # Validate the ax field if present. It must be a list of booleans
     if "ax" in data and not _validSingleDagList(data["ax"], bool, allow_empty=True):

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -8,6 +8,7 @@ IPEx protocol service support (Issuance and Presentation Exchange)
 
 from collections import deque, namedtuple
 from collections.abc import Mapping
+from copy import deepcopy
 
 from hio.help import ogler
 
@@ -15,9 +16,10 @@ from .. import Kinds, Protocols
 from ..kering import (Colds, DuplicitousRegistryError, Ilks, MisanchorError,
                       MisbindingError, MissingAnchorError, MissingChainError,
                       MisdigestError, MisregistryError, MissequenceError,
-                      RootSealError, UnverifiedBlindError, Vrsn_2_0, sniff)
+                      RootSealError, UnverifiedBlindError, ValidationError,
+                      Vrsn_2_0, sniff)
 from ..core import (BlindState, Blinder, BoundState, Counter, Codens, Diger, GenDex, Noncer,
-                    Number, Saider, Serdery, Texter, exchange, messagize)
+                    Number, Saider, Schemer, Serdery, Texter, exchange, messagize)
 from ..peer import cloneMessage
 
 logger = ogler.getLogger()
@@ -37,6 +39,8 @@ PreviousRoutes = {
 DisclosedNodeIlks = (None, Ilks.acm, Ilks.ace, Ilks.act, Ilks.acg)
 EdgeGroupLabels = ("d", "u", "o", "w")
 EdgeNodeLabels = ("d", "u", "n", "s", "o", "w")
+UnaryEdgeOps = ("I2I", "NI2I", "DI2I", "E1E", "NOT")
+DelegativeEdgeOps = ("I2I", "NI2I", "DI2I")
 
 def _streamSerder(stream):
     """Extract the message serder from a bare or nested artifact stream.
@@ -444,6 +448,8 @@ class IpexHandler:
             walked = self._walkGraph(origin=attrs["o"][0], nests=nests, closed=True)
             if walked is None:
                 return False
+            if not self._verifyGraphSemantics(nodes=walked[0], order=walked[1]):
+                return False
 
             # Stage 5: after the disclosed graph shape is accepted, each walked
             # registry-backed node must vet its own node-local proof group.
@@ -618,6 +624,149 @@ class IpexHandler:
             return None
 
         return nodes, order
+
+    def _verifyGraphSemantics(self, nodes, order):
+        """Verify grant edge operators and edge-schema pins across walked nodes.
+
+        Parameters:
+            nodes (dict): Mapping of disclosed node SAID to parsed nest.
+            order (list): Breadth-first walk order returned by ``_walkGraph``.
+
+        Returns:
+            bool: True when every walked edge leaf names a disclosed far node
+                and every leaf-level operator and schema constraint is
+                satisfied; False on any malformed or violated edge semantics.
+        """
+        for said in order:
+            # Current near node from the walked grant DAG
+            near = nodes[said]
+
+            # Retrieve node serder
+            nserder = near["serder"] if isinstance(near, dict) else near.serder
+
+            # No edges means nothing more to validate for this node
+            edges = nserder.sad.get("e")
+            if not edges:
+                continue
+
+            # Normalize a single edge block or a list of edge blocks
+            if isinstance(edges, Mapping):
+                blocks = [edges]
+            elif isinstance(edges, list) and all(isinstance(edge, Mapping) for edge in edges):
+                blocks = edges
+            else:
+                return False
+
+            for edge in blocks:
+                # Walk nested edge groups until we reach each leaf `n`
+                groups = [edge]
+                while groups:
+                    group = groups.pop()
+                    if "n" in group:
+                        # Leaf edges may only use leaf labels
+                        if any(label not in EdgeNodeLabels for label in group):
+                            return False
+
+                        # `n` points to the far disclosed node
+                        edgeSaid = group.get("n")
+                        if edgeSaid not in nodes:
+                            return False
+                        far = nodes[edgeSaid]
+                        # Normalize access to the far-node serder
+                        fserder = far["serder"] if isinstance(far, dict) else far.serder
+
+                        # `o` may be missing, one string, or a list of strings
+                        op = group.get("o")
+                        if op is None:
+                            ops = []
+                        elif isinstance(op, str):
+                            ops = [op]
+                        elif isinstance(op, (list, tuple)) and all(isinstance(item, str) for item in op):
+                            ops = list(op)
+                        else:
+                            return False
+
+                        # Keep only the operators this verifier understands
+                        ops = [cand for cand in ops if cand in UnaryEdgeOps]
+                        # The last delegative operator wins
+                        dop = next((cand for cand in reversed(ops) if cand in DelegativeEdgeOps), None)
+                        if not ops:
+                            # Default from the far-node shape
+                            dop = "I2I" if fserder.iseaid is not None else "NI2I"
+
+                        # Reject unsupported grant edge semantics
+                        if "NOT" in ops or dop == "DI2I":
+                            return False
+
+                        # E1E requires matching `i` values on both nodes
+                        if "E1E" in ops:
+                            if not nserder.iseaid or not fserder.iseaid or nserder.iseaid != fserder.iseaid:
+                                return False
+
+                        # Issuer-linked edges require a valid far-node issuer
+                        if dop is not None and dop != "NI2I":
+                            if not fserder.iseaid:
+                                return False
+                            if dop == "I2I" and nserder.israid != fserder.iseaid:
+                                return False
+
+                        # `s` optionally pins the far-node schema
+                        if "s" in group:
+                            edgeSchema = group["s"]
+                            edgeSchemer = None
+                            if isinstance(edgeSchema, str):
+                                edgeSchemaId = edgeSchema
+                            elif isinstance(edgeSchema, Mapping):
+                                # Inline schemas must match their declared `$id`
+                                declared = edgeSchema.get("$id")
+                                if not isinstance(declared, str):
+                                    return False
+                                try:
+                                    edgeSchemer = Schemer(sed=deepcopy(edgeSchema))
+                                except (ValidationError, ValueError):
+                                    return False
+                                if edgeSchemer.said != declared:
+                                    return False
+                                edgeSchemaId = edgeSchemer.said
+                            else:
+                                return False
+
+                            # Read the far node's schema reference
+                            farSchema = fserder.schema
+                            if isinstance(farSchema, Mapping):
+                                farSchemaId = farSchema.get("$id")
+                            elif isinstance(farSchema, str):
+                                farSchemaId = farSchema
+                            else:
+                                return False
+                            if not isinstance(farSchemaId, str):
+                                return False
+
+                            # If the IDs differ, the far node must still validate
+                            # against the schema named by the edge
+                            if edgeSchemaId != farSchemaId:
+                                if edgeSchemer is None:
+                                    # Resolve SAID-only schema pins from the local cache
+                                    edgeSchemer = self.hby.db.schema.get(edgeSchemaId)
+                                    if edgeSchemer is None:
+                                        return False
+                                try:
+                                    # Enforce the schema pin
+                                    edgeSchemer.verify(fserder.raw)
+                                except ValidationError:
+                                    return False
+                        continue
+
+                    # Group operators shape traversal only
+                    for label, node in group.items():
+                        if label in EdgeGroupLabels:
+                            continue
+                        # Child groups must also be edge mappings
+                        if not isinstance(node, Mapping):
+                            return False
+                        groups.append(node)
+
+        return True
 
     def _verifyIssuerAuthGraph(self, nodes, order):
         """Verify issuer-auth proof groups for each walked disclosed DAG node.

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -646,8 +646,10 @@ class IpexHandler:
         Returns:
             bool | None: ``True`` when the leaf edge semantics are satisfied,
                 ``False`` when the leaf is well-formed but its relation or
-                schema constraints do not match, or ``None`` when the leaf
-                shape itself is malformed and verification must fail closed.
+                schema constraints do not match, including recognized operators
+                that this verifier cannot yet evaluate, or ``None`` when the
+                leaf shape itself is malformed and verification must fail
+                closed.
         """
         # Reject unknown leaf labels before we inspect the reference.
         for label in group:
@@ -680,9 +682,10 @@ class IpexHandler:
         # check directly or, for E1E, add an issuee-to-issuee constraint.
         dop = recognizedOp if recognizedOp in DelegativeEdgeOps else None
 
-        # Unsupported leaf operators fail closed instead of being ignored.
+        # Recognized but unevaluated leaf operators fail as unsatisfied
+        # relations instead of malformed input.
         if recognizedOp == "NOT" or dop == "DI2I":
-            return None
+            return False
 
         # Start from a passing state, then knock the edge down to False if
         # any required relation check fails.

--- a/src/keri/acdc/regeventing.py
+++ b/src/keri/acdc/regeventing.py
@@ -301,12 +301,14 @@ def vetBlind(blinder, *, blid):
                                f"disclosure proves nothing.")
 
 
-def vetBindings(acdc, *, regid, td):
-    """Verify the binding equalities between a presented ACDC and its
-    registry evidence.  These two equalities are the issuer's only
-    commitment to the credential: v2 ACDCs are not directly signed, so a
-    verifier that skips them passes every other obligation while accepting a
-    substituted credential.
+def vetBindings(acdc, *, regid, issuer, td):
+    """Verify the bindings between a presented ACDC and its registry evidence.
+
+    The registry evidence must commit to the presented ACDC, the ACDC must
+    name the presented registry when ``rd`` is present, and the ACDC's own
+    issuer must match the issuer that incepted the presented registry. V2
+    ACDCs are not directly signed, so a verifier that skips these bindings
+    passes every other obligation while accepting a substituted credential.
 
     Returns:
         binding (str): 'mutual' when td == acdc.d and acdc.rd == rip.d both
@@ -317,6 +319,8 @@ def vetBindings(acdc, *, regid, td):
     Parameters:
         acdc (SerderACDC|bytes): the presented ACDC
         regid (str): qb64 SAID of the presented registry inception (rip)
+        issuer (str): qb64 AID of the issuer that incepted the presented
+            registry
         td (str|None): qb64 transaction ACDC said the registry's verified
             head state commits to
 
@@ -328,6 +332,10 @@ def vetBindings(acdc, *, regid, td):
         raise MisbindingError(f"Registry state's transaction ACDC said "
                               f"td={td} does not bind the presented ACDC's "
                               f"said {serder.said}.")
+    if serder.sad.get('i') != issuer:
+        raise MisbindingError(f"Presented ACDC issuer {serder.sad.get('i')} "
+                              f"does not match presented registry issuer "
+                              f"{issuer}.")
     rd = serder.sad.get('rd')
     if rd:
         if rd != regid:
@@ -442,7 +450,8 @@ def vet(rip, updates=None, *, db, acdc=None, blinder=None, sources=None):
                                        f"n={head.sad['n']} is blinded and "
                                        f"no state was disclosed: nothing "
                                        f"binds ACDC {serder.said} to it.")
-        binding = vetBindings(acdc=serder, regid=ripper.said, td=acdcsaid)
+        binding = vetBindings(acdc=serder, regid=ripper.said,
+                              issuer=issuer, td=acdcsaid)
 
     return RegStateRecord(regid=ripper.said, issuer=issuer, said=head.said,
                           sn=Number(numh=head.sad['n']).num, ilk=head.ilk,

--- a/src/keri/acdc/registraring.py
+++ b/src/keri/acdc/registraring.py
@@ -191,7 +191,7 @@ class Registry:
                 not committed any event yet.
         """
         head = self.store.headEvent(self.regk) if self.regk is not None else None
-        return int(head.sad["n"], 16) if head is not None else -1
+        return Number(numh=head.sad["n"]).num if head is not None else -1
 
     @property
     def regser(self):
@@ -264,7 +264,7 @@ class Registry:
             raise ValidationError(f"unsupported registry event type {serder.ilk}")
 
         regk = serder.said if serder.ilk == "rip" else serder.regid
-        sn = int(serder.sad["n"], 16)
+        sn = Number(numh=serder.sad["n"]).num
         if serder.ilk == "rip" and sn != 0:
             raise ValidationError(f"registry inception event {serder.said} has invalid sn {sn}")
         if serder.ilk == "rip" and serder.sad["i"] != self.hab.pre:
@@ -298,7 +298,7 @@ class Registry:
         """
         # Retrieve the registry key and sn from the event
         regk = serder.said if serder.ilk == "rip" else serder.regid
-        sn = int(serder.sad["n"], 16)
+        sn = Number(numh=serder.sad["n"]).num
 
         # Update the registry store and clear every escrowed candidate for this
         # slot now that one event has won it
@@ -668,7 +668,7 @@ class Registry:
         while tip is not None:
             # Only the immediate next sequence slot can legally extend the
             # current tip, so advance one TEL step at a time.
-            sn = int(tip.sad["n"], 16) + 1
+            sn = Number(numh=tip.sad["n"]).num + 1
             saids = []
             seen = set()
             for escrowdb in (self.store.baser.maes, self.store.baser.ooes):
@@ -724,7 +724,7 @@ class Registry:
 
         # The new blind update must extend the effective frontier, which may be
         # newer than the last committed head when pipelining staged updates.
-        sn = int(tip.sad["n"], 16) + 1
+        sn = Number(numh=tip.sad["n"]).num + 1
         acdcSaid = acdc.said
         blinder = Blinder.blind(sn=sn, acdc=acdcSaid, state=state, **blindkwa)
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -14,7 +14,7 @@ from ..kering import (Vrsn_1_0, Vrsn_2_0, Ilks,
 from ..core import (Counter, Pather, Dater, Diger,
                     Prefixer, Seqner, Saider,
                     Noncer, Sadder, Serder, SerderKERI, Texter,
-                    Saids, Codens, FirstSeen, Parser,
+                    Saids, Codens, BlindState, BoundState, FirstSeen, Parser,
                     messagize,
                     verifySigs)
 from ..db import fetchTsgs
@@ -789,8 +789,16 @@ def serializeParsedSubstream(parsed, gvrsn=Vrsn_2_0):
         raise ValueError("Unsupported mixed signature groups for nested substream serialization")
 
     bonds = []
-    for name in ("sscs", "ssts", "tdcs", "bsqs", "bsss", "tmqs"):
+    for name in ("sscs", "ssts", "tdcs"):
         bonds.extend(parsed.get(name) or [])
+    # Parsed blind-state proof groups come back as plain tuples of primitive
+    # instances, but messagize() expects namedtuple bond records when it
+    # reserializes the nested node into storage.
+    bonds.extend(item if isinstance(item, BlindState) else BlindState(*item)
+                 for item in (parsed.get("bsqs") or []))
+    bonds.extend(item if isinstance(item, BoundState) else BoundState(*item)
+                 for item in (parsed.get("bsss") or []))
+    bonds.extend(parsed.get("tmqs") or [])
     for item in parsed.get("frcs") or []:
         bonds.append(item if isinstance(item, FirstSeen) else FirstSeen(*item))
 

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -10,7 +10,8 @@ from hio.help import decking, ogler
 
 from ..kering import (Vrsn_1_0, Vrsn_2_0, Ilks,
                       Kinds, Version, versify,
-                      ValidationError, MissingSignatureError)
+                      ValidationError, MissingChainError,
+                      MissingSignatureError)
 from ..core import (Counter, Pather, Dater, Diger,
                     Prefixer, Seqner, Saider,
                     Noncer, Sadder, Serder, SerderKERI, Texter,
@@ -75,6 +76,12 @@ class Exchanger:
             ptds (list[bytes]): pathed Cesr Streams
             essrs (list[Texter]): ESSR streams as Texters
             kwa: optional parsed V2 nested substreams under ``nests``
+
+        Returns:
+            bool | None: ``True`` when the exchange verified and was persisted,
+                ``False`` when behavior verification failed permanently, or
+                ``None`` when the message was escrowed for retry because it is
+                waiting on external evidence such as TEL proof material.
 
         """
         ptds = ptds if ptds is not None else []
@@ -174,7 +181,18 @@ class Exchanger:
             if not behavior.verify(serder=serder, **kwa):
                 logger.error("exn event for route %s failed behavior verification. said=%s", route, serder.said)
                 logger.debug(f"Event=\n%s\n", serder.pretty())
-                return
+                return False
+        except MissingChainError as ex:
+            # Registry-backed IPEX grants may arrive before the disclosee has
+            # fetched the issuer's TEL history from observers. Keep those
+            # messages in exchange escrow and cue the app to fetch proof data.
+            if self.escrowPSEvent(serder=serder, tsgs=tsgs or [], pathed=ptds,
+                                  nests=nests):
+                self.cues.append(dict(kin="proof", said=serder.said))
+            logger.info("Escrowed exchange awaiting proof evidence: said=%s reason=%s",
+                        serder.said, ex)
+            logger.debug("Exchange message body=\n%s\n", serder.pretty())
+            return None
 
         except AttributeError:
             logger.debug("Behavior for %s missing or does not have verify for said %s", route, serder.said)
@@ -190,6 +208,8 @@ class Exchanger:
         except AttributeError:
             logger.debug("Behavior for %s missing or does not have handle for SAID=%s", route, serder.said)
             logger.debug("Event=\n%s\n", serder.pretty())
+
+        return True
 
     def processEscrow(self):
         """ Process all escrows for `exn` messages"""
@@ -258,8 +278,8 @@ class Exchanger:
                 essrs = [texter for texter in self.hby.db.essrs.get(keys=(dig,))]
                 nests = loadParsedNestedSubstreams(self.hby, dig)
 
-                self.processEvent(serder=serder, tsgs=tsgs, ptds=pathed,
-                                  essrs=essrs, nests=nests)
+                result = self.processEvent(serder=serder, tsgs=tsgs, ptds=pathed,
+                                           essrs=essrs, nests=nests)
 
             except MissingSignatureError as ex:
                 if logger.isEnabledFor(logging.TRACE):
@@ -278,6 +298,11 @@ class Exchanger:
                 else:
                     logger.error("Exchange partially signed unescrowed: %s", ex.args[0])
             else:
+                if result is None:
+                    if logger.isEnabledFor(logging.TRACE):
+                        logger.trace("Exchange proof unescrow still pending: said=%s", serder.said)
+                    continue
+
                 saved = self.hby.db.exns.get(keys=(dig,)) is not None
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -1144,6 +1144,17 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
                 origin=_proofed(acdc, issuedBlinder),
             )
             assert len(issuedGrantResult.nests[0].bsqs) == 1
+            issuedProof = issuedGrantResult.nests[0].bsqs[0]
+            assert issuedProof[0].qb64 == issuedBlinder.said
+            assert issuedProof[1].nonce == issuedBlinder.uuid
+            assert issuedProof[2].nonce == acdc.said
+            assert issuedProof[3].text == 'issued'
+            unblinder = Blinder.unblind(said=issuedProof[0].qb64,
+                                        uuid=issuedProof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=['issued', 'revoked'])
+            assert unblinder is not None
+            assert unblinder.state == 'issued'
             assert salt.encode() not in issuedWire
             assert issuedBlinder.uuid.encode() in issuedWire
 
@@ -1169,9 +1180,36 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
                 origin=_proofed(acdc, revokedBlinder),
             )
             assert len(revokedGrantResult.nests[0].bsqs) == 1
+            revokedProof = revokedGrantResult.nests[0].bsqs[0]
+            assert revokedProof[0].qb64 == revokedBlinder.said
+            assert revokedProof[1].nonce == revokedBlinder.uuid
+            assert revokedProof[2].nonce == acdc.said
+            assert revokedProof[3].text == 'revoked'
+            unblinder = Blinder.unblind(said=revokedProof[0].qb64,
+                                        uuid=revokedProof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=['issued', 'revoked'])
+            assert unblinder is not None
+            assert unblinder.state == 'revoked'
             assert salt.encode() not in revokedWire
             assert issuedBlinder.uuid.encode() not in revokedWire
             assert revokedBlinder.uuid.encode() in revokedWire
+
+            # The exact nonce disclosed in the first IPEX grant still opens only
+            # the issued event, not the later revoked event.
+            laterPeek = Blinder.unblind(said=revokedProof[0].qb64,
+                                        uuid=issuedProof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=['issued', 'revoked'])
+            assert laterPeek is None
+
+            # And the nonce disclosed in the later grant cannot retroactively
+            # reveal the earlier issued event either.
+            earlierPeek = Blinder.unblind(said=issuedProof[0].qb64,
+                                          uuid=revokedProof[1].nonce,
+                                          acdc=acdc.said,
+                                          states=['issued', 'revoked'])
+            assert earlierPeek is None
 
             assert [(item["r"], item["m"]) for item in recorder.items] == [
                 ("/exn/ipex/grant", "Current registry snapshot"),

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -25,8 +25,8 @@ from jsonschema.exceptions import SchemaError, ValidationError
 
 from keri import Vrsn_2_0, Kinds, Protocols, Ilks
 from keri.core import (Noncer, Blinder, GenDex, Aggor, Compactor, Diger,
-                       DigDex, Parser)
-from keri.acdc import (regcept, blindate, acdcmap, acdcagg, loadHandlers,
+                       DigDex, Parser, messagize)
+from keri.acdc import (Regery, Registrar, regcept, blindate, acdcmap, acdcagg, loadHandlers,
                        grant as ipexGrant, admit as ipexAdmit)
 from keri.app import openHby
 from keri.peer import Exchanger
@@ -76,9 +76,40 @@ class Recorder:
         self.items.append(attrs)
 
 
+def _serder(stream):
+    """Extract the carried ACDC serder from a bare or proof-bearing node stream."""
+    if hasattr(stream, "said") and hasattr(stream, "raw"):
+        return stream
+
+    ims = bytearray(stream.raw) if hasattr(stream, "raw") else bytearray(stream)
+    results = Parser(version=Vrsn_2_0).parse(ims=ims,
+                                             framed=False,
+                                             processive=False)
+    assert ims == bytearray()
+    assert len(results) == 1
+    return results[0].serder
+
+
+def _proofed(acdc, *proofs):
+    """Attach one node-local registry proof group to the disclosed ACDC stream."""
+    return messagize(serder=acdc,
+                     bonds=[proof.data for proof in proofs],
+                     framed=False,
+                     gvrsn=Vrsn_2_0)
+
+
+def _anchor(hab, registry, serder, *, framed=False):
+    """Seal one registry event into the issuer's KEL so verifiers can vet it."""
+    seal = dict(i=registry.regk, s=serder.sad["n"], d=serder.said)
+    anc = hab.interact(data=[seal], framed=framed, gvrsn=Vrsn_2_0)
+    assert registry.anchorMsg(serder.said) is True
+    return anc
+
+
 def ipexExn(*, hby, exc, sender, receiver, message, admitMessage,
             origin, artifacts=None):
     """Round-trip one IPEX grant and its admit, returning the parsed grant."""
+    originSerder = _serder(origin)
     grant, grantAtc = ipexGrant(hab=sender, recp=receiver.pre, message=message,
                                 origin=origin, artifacts=artifacts)
     grantIms = bytearray(grant.raw)
@@ -93,10 +124,10 @@ def ipexExn(*, hby, exc, sender, receiver, message, admitMessage,
     assert grantResult.serder.ked['p'] == ""
     assert grantResult.serder.ked['i'] == sender.pre
     assert grantResult.serder.ked['ri'] == receiver.pre
-    assert grantResult.serder.ked['a']['o'] == origin.said
-    nestSaids = [origin.said]
+    assert grantResult.serder.ked['a']['o'] == [originSerder.said]
+    nestSaids = [originSerder.said]
     if artifacts:
-        nestSaids.extend(artifact.said for artifact in artifacts)
+        nestSaids.extend(_serder(artifact).said for artifact in artifacts)
     assert [nest.serder.said for nest in grantResult.nests] == nestSaids
     wire = bytes(grant.raw) + bytes(grantAtc)
 
@@ -106,7 +137,7 @@ def ipexExn(*, hby, exc, sender, receiver, message, admitMessage,
     assert grantDispatch == bytearray()
     storedGrant = hby.db.exns.get(keys=(grant.said,))
     assert storedGrant is not None
-    assert storedGrant.ked['a']['o'] == origin.said
+    assert storedGrant.ked['a']['o'] == [originSerder.said]
     assert "iss" not in storedGrant.ked['a']
     assert "anc" not in storedGrant.ked['a']
 
@@ -294,113 +325,92 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
 
     This stays distinct from test_clc_disclosure.py's gated exchange. The point
     here is not pre-disclosure negotiation; it is to carry the foundational
-    registry artifacts inside the IPEX builders and route them through the real
-    IPEX handlers we have today.
-
-    The current ``ipexing.grant`` builder gives us three carried artifacts:
-    ``acdc`` (the credential), ``iss`` (the current registry update), and
-    ``anc`` (one ancillary artifact). For this registry lifecycle example we use
-    that ancillary slot for the registry inception (`rip`) itself, so one bare
-    grant snapshots the whole state package the holder needs:
-
-      credential + current `bup` state + originating registry `rip`
-
-    A second bare grant later carries the revoked-state snapshot. Each bare
-    grant is acknowledged by an IPEX admit.
+    registry-backed ACDC through the real IPEX handlers we have today. In the
+    single-DAG wire shape for this ticket, the grant carries one nested ACDC
+    node per disclosure graph node, and TEL/KEL issuer-auth material is no
+    longer shipped as sibling grant artifacts.
     """
 
     with openHby(name="ipex-registry-lifecycle",
                  base="test") as hby:
         amy = hby.makeHab(name="amy")
         bob = hby.makeHab(name="bob")
+        rgy = Regery(hby=hby, name="ipex-registry-lifecycle", temp=True)
+        try:
+            # The live IPEX example now uses a real registry/TEL so the handler
+            # can vet the node-local proof group carried on the disclosed ACDC.
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="amy-registry", prefix=amy.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(amy, registry, rip, framed=True)
 
-        # Rebuild the same artifact pattern as the JSON worked example, but with
-        # live Hab AIDs because the current IPEX builders sign through Hab.
-        regStamp = '2025-07-04T17:50:00.000000+00:00'
-        ripper = regcept(israid=amy.pre, uuid=NONCES[0], stamp=regStamp)
-        assert ripper.ilk == Ilks.rip
-        regid = ripper.said
+            attribute = dict(d='', u=NONCES[7], name="Sunspot College", level="gold")
+            acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=registry.regk,
+                           attribute=attribute, iseaid=bob.pre)
+            assert acdc.ilk == Ilks.acm
+            assert acdc.sad['rd'] == registry.regk
+            assert acdc.sad['a']['i'] == bob.pre
+            assert_acdc_schema_valid(acdc)
 
-        attribute = dict(d='', u=NONCES[7], name="Sunspot College", level="gold")
-        acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=regid,
-                       attribute=attribute, iseaid=bob.pre)
-        assert acdc.ilk == Ilks.acm
-        assert acdc.sad['rd'] == regid
-        assert acdc.sad['a']['i'] == bob.pre
-        assert_acdc_schema_valid(acdc)
+            salt = NONCES[15]
+            issuedBlinder, issued = registrar.issue(registry,
+                                                    acdc=acdc,
+                                                    state='issued',
+                                                    salt=salt)
+            _anchor(amy, registry, issued, framed=False)
 
-        salt = NONCES[15]
-        issuedBlinder = Blinder.blind(acdc=acdc.said, state='issued', salt=salt, sn=1)
-        issued = blindate(regid=regid, prior=regid, blid=issuedBlinder.said,
-                          sn=1, stamp='2025-08-01T18:06:10.988921+00:00')
-        revokedBlinder = Blinder.blind(acdc=acdc.said, state='revoked', salt=salt, sn=2)
-        revoked = blindate(regid=regid, prior=issued.said, blid=revokedBlinder.said,
-                           sn=2, stamp='2025-09-01T18:06:10.988921+00:00')
+            recorder = Recorder()
+            exc = Exchanger(hby=hby, handlers=[])
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            # The first presentation discloses only the current issued event's
+            # proof group on the ACDC's own nest.
+            issuedGrantResult, issuedGrantWire = ipexExn(
+                hby=hby,
+                exc=exc,
+                sender=amy,
+                receiver=bob,
+                message="Issued registry snapshot",
+                admitMessage="Received issued snapshot",
+                origin=_proofed(acdc, issuedBlinder),
+            )
+            assert issuedGrantResult.serder.ked['ri'] == bob.pre
+            assert len(issuedGrantResult.nests[0].bsqs) == 1
+            assert salt.encode() not in issuedGrantWire
+            assert issuedBlinder.uuid.encode() in issuedGrantWire
 
-        # Bare grant 1: the issued-state snapshot. The grant carries the
-        # credential as the origin plus the current `bup` and registry
-        # inception as attached artifacts.
-        issuedGrantResult, issuedGrantWire = ipexExn(
-            hby=hby,
-            exc=exc,
-            sender=amy,
-            receiver=bob,
-            message="Issued registry snapshot",
-            admitMessage="Received issued snapshot",
-            origin=acdc,
-            artifacts=[issued, ripper],
-        )
-        assert issuedGrantResult.serder.ked['ri'] == bob.pre
-        # The disclosed credential is present on the wire, but the registry state
-        # word itself remains hidden because the nested `bup` is blindable
-        assert b'issued' not in issuedGrantWire
-        assert b'revoked' not in issuedGrantWire
-        assert salt.encode() not in issuedGrantWire
+            # Once the registry advances, the later presentation carries only
+            # the new event's proof group and the earlier blind stays absent.
+            revokedBlinder, revoked = registrar.issue(registry,
+                                                      acdc=acdc,
+                                                      state='revoked',
+                                                      salt=salt)
+            _anchor(amy, registry, revoked, framed=False)
 
-        # The holder/verifier can now pull the carried `bup` out of the IPEX
-        # grant and perform the same unblinding confirmation as in the base test
-        issuedNest = issuedGrantResult.nests[1].serder
-        unblinder = Blinder.unblind(said=issuedNest.sad['b'], acdc=acdc.said,
-                                    states=['issued', 'revoked'], salt=salt, sn=1)
-        assert unblinder is not None
-        assert unblinder.state == 'issued'
-        assert unblinder.acdc == acdc.said
-        assert unblinder.crew == issuedBlinder.crew
+            assert revokedBlinder.uuid.encode() not in issuedGrantWire
 
-        # Bare grant 2: later the issuer ships the revoked-state snapshot the
-        # same way, again through the handler chain.
-        revokedGrantResult, revokedGrantWire = ipexExn(
-            hby=hby,
-            exc=exc,
-            sender=amy,
-            receiver=bob,
-            message="Revoked registry snapshot",
-            admitMessage="Received revoked snapshot",
-            origin=acdc,
-            artifacts=[revoked, ripper],
-        )
-        assert b'issued' not in revokedGrantWire
-        assert b'revoked' not in revokedGrantWire
-        assert salt.encode() not in revokedGrantWire
+            revokedGrantResult, revokedGrantWire = ipexExn(
+                hby=hby,
+                exc=exc,
+                sender=amy,
+                receiver=bob,
+                message="Revoked registry snapshot",
+                admitMessage="Received revoked snapshot",
+                origin=_proofed(acdc, revokedBlinder),
+            )
+            assert len(revokedGrantResult.nests[0].bsqs) == 1
+            assert salt.encode() not in revokedGrantWire
+            assert issuedBlinder.uuid.encode() not in revokedGrantWire
+            assert revokedBlinder.uuid.encode() in revokedGrantWire
 
-        revokedNest = revokedGrantResult.nests[1].serder
-        reunblinder = Blinder.unblind(said=revokedNest.sad['b'], acdc=acdc.said,
-                                      states=['issued', 'revoked'], salt=salt, sn=2)
-        assert reunblinder is not None
-        assert reunblinder.state == 'revoked'
-        assert reunblinder.acdc == acdc.said
-        assert reunblinder.crew == revokedBlinder.crew
-
-        assert [(item["r"], item["m"]) for item in recorder.items] == [
-            ("/exn/ipex/grant", "Issued registry snapshot"),
-            ("/exn/ipex/admit", "Received issued snapshot"),
-            ("/exn/ipex/grant", "Revoked registry snapshot"),
-            ("/exn/ipex/admit", "Received revoked snapshot"),
-        ]
+            assert [(item["r"], item["m"]) for item in recorder.items] == [
+                ("/exn/ipex/grant", "Issued registry snapshot"),
+                ("/exn/ipex/admit", "Received issued snapshot"),
+                ("/exn/ipex/grant", "Revoked registry snapshot"),
+                ("/exn/ipex/admit", "Received revoked snapshot"),
+            ]
+        finally:
+            rgy.close()
 
 
 def test_selective_disclosure_aggregate_JSON():
@@ -520,9 +530,11 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
         aggor = Aggor(ael=iael, makify=True, kind=kind)
         agid = aggor.agid
 
-        acdc = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+        # This live IPEX example is about selective disclosure shape, not
+        # registry proofing, so keep the carried ACDC unbound from a registry.
+        acdc = acdcagg(israid=amy.pre, uuid=NONCES[10],
                        aggregate=aggor.ael, kind=kind)
-        compact = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+        compact = acdcagg(israid=amy.pre, uuid=NONCES[10],
                           aggregate=agid, kind=kind)
         schema = assert_acdc_schema_valid(acdc)
         assert_acdc_schema_valid(compact, schema=schema)
@@ -535,7 +547,7 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
         full, k = aggor.disclose()
         assert k == kind
         assert Aggor.verifyDisclosure(full, kind=kind)
-        collapsed = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+        collapsed = acdcagg(israid=amy.pre, uuid=NONCES[10],
                             aggregate=full, kind=kind)
         assert collapsed.said == acdc.said
 
@@ -543,7 +555,7 @@ def test_selective_disclosure_aggregate_IPEX_JSON():
         # withhold the score/name elements as bare SAIDs.
         disclosed, k = aggor.disclose(indices=[1])
         assert k == kind
-        selective = acdcagg(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
+        selective = acdcagg(israid=amy.pre, uuid=NONCES[10],
                             aggregate=disclosed, kind=kind)
         assert selective.said == acdc.said
         assert_acdc_schema_valid(selective, schema=schema)
@@ -774,10 +786,12 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         ruleText = "AS IS basis. MUST NOT be shared."
         attrMad = dict(d='', u=NONCES[7], name="Bob Student", gpa=4)
         ruleMad = dict(d='', l=ruleText)
-        expanded = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+        # These IPEX examples exercise section-level disclosure only, so they
+        # intentionally omit rd and avoid the step-4 registry-proof path.
+        expanded = acdcmap(israid=amy.pre, uuid=NONCES[13],
                            attribute=dict(attrMad), iseaid=bob.pre, rule=dict(ruleMad),
                            compactify=False, kind=kind)
-        compact = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+        compact = acdcmap(israid=amy.pre, uuid=NONCES[13],
                           attribute=dict(attrMad), iseaid=bob.pre, rule=dict(ruleMad),
                           compactify=True, kind=kind)
         assert expanded.said == compact.said             # same commitment either way
@@ -788,7 +802,7 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         assert b"MUST NOT" not in compact.raw
 
         # Build the rule section disclosure
-        ruleOnly = acdcmap(israid=amy.pre, uuid=NONCES[13], regid=ripper.said,
+        ruleOnly = acdcmap(israid=amy.pre, uuid=NONCES[13],
                            schema=compact.sad['s'], attribute=compact.sad['a'],
                            rule=expanded.sad['r'], kind=kind)
         assert ruleOnly.said == compact.said == expanded.said
@@ -833,13 +847,13 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         withheld = compactor.partials[('', )]
         revealed = compactor.partials[('.grades', )]
 
-        gradesBase = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+        gradesBase = acdcmap(israid=amy.pre, uuid=NONCES[11],
                              attribute=nested, kind=kind)
         gradesSchema = assert_acdc_schema_valid(gradesBase)
-        gradesWithheld = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+        gradesWithheld = acdcmap(israid=amy.pre, uuid=NONCES[11],
                                  schema=gradesBase.sad['s'], attribute=withheld.mad,
                                  kind=kind)
-        gradesRevealed = acdcmap(israid=amy.pre, uuid=NONCES[11], regid=ripper.said,
+        gradesRevealed = acdcmap(israid=amy.pre, uuid=NONCES[11],
                                  schema=gradesBase.sad['s'], attribute=revealed.mad,
                                  kind=kind)
         assert withheld.said == sectSaid and revealed.said == sectSaid
@@ -906,10 +920,10 @@ def test_partial_disclosure_compaction_IPEX_JSON():
         mixed = dict(allCompact)
         mixed['grades'] = allExpanded['grades']
 
-        mixedBase = acdcmap(israid=amy.pre, uuid=NONCES[12], regid=ripper.said,
+        mixedBase = acdcmap(israid=amy.pre, uuid=NONCES[12],
                             attribute=multi, kind=kind)
         mixedSchema = assert_acdc_schema_valid(mixedBase)
-        mixedAcdc = acdcmap(israid=amy.pre, uuid=NONCES[12], regid=ripper.said,
+        mixedAcdc = acdcmap(israid=amy.pre, uuid=NONCES[12],
                             schema=mixedBase.sad['s'], attribute=mixed, kind=kind)
         assert mixedAcdc.said == mixedBase.said
         assert_acdc_schema_valid(mixedAcdc, schema=mixedSchema)
@@ -1071,12 +1085,11 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
     """Per-event blind disclosure carried through the real IPEX grant path.
 
     The sibling JSON worked example proves that a disclosed blind reads exactly
-    one blindable registry update and no others. This companion test packages
-    those blinded registry updates as nested `bup` artifacts inside real IPEX
-    `grant` messages, routes them through the v2 handlers, and shows that the
-    verifier can unblind only the event whose per-sn nonce the holder chooses to
-    disclose out of band. The IPEX wire itself never carries the salt or either
-    cleartext state word.
+    one blindable registry update and no others. This companion test shows the
+    current IPEX shape for the same registry-backed credential: the grant
+    carries the ACDC node itself plus exactly one event's blind proof group on
+    that node's own nest. The salt still stays off wire, and each presentation
+    reveals only the one event-specific blind needed for that disclosed state.
     """
 
     with openHby(name="ipex-correlation-minimizing",
@@ -1084,107 +1097,80 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
         amy = hby.makeHab(name="amy")
         bob = hby.makeHab(name="bob")
         vic = hby.makeHab(name="vic")
+        rgy = Regery(hby=hby, name="ipex-correlation-minimizing", temp=True)
+        try:
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="correlation", prefix=amy.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(amy, registry, rip, framed=True)
 
-        kind = Kinds.json
-        states = ['issued', 'revoked']
+            kind = Kinds.json
+            acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=registry.regk,
+                           attribute=dict(d='', u=NONCES[7], name="Sunspot College",
+                                          level="gold"),
+                           iseaid=bob.pre, kind=kind)
+            assert_acdc_schema_valid(acdc)
+            salt = NONCES[15]
 
-        ripper = regcept(israid=amy.pre, uuid=NONCES[0],
-                         stamp='2025-07-04T17:50:00.000000+00:00')
-        acdc = acdcmap(israid=amy.pre, uuid=NONCES[10], regid=ripper.said,
-                       attribute=dict(d='', u=NONCES[7], name="Sunspot College",
-                                      level="gold"),
-                       iseaid=bob.pre, kind=kind)
-        assert_acdc_schema_valid(acdc)
-        salt = NONCES[15]
+            issuedBlinder, issued = registrar.issue(registry,
+                                                    acdc=acdc,
+                                                    state='issued',
+                                                    salt=salt)
+            _anchor(amy, registry, issued, framed=False)
 
-        issuedBlinder = Blinder.blind(acdc=acdc.said, state='issued', salt=salt, sn=1)
-        revokedBlinder = Blinder.blind(acdc=acdc.said, state='revoked', salt=salt, sn=2)
-        assert issuedBlinder.said != revokedBlinder.said
-        assert issuedBlinder.uuid != revokedBlinder.uuid
+            recorder = Recorder()
+            exc = Exchanger(hby=hby, handlers=[])
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
-        issued = blindate(regid=ripper.said, prior=ripper.said, blid=issuedBlinder.said,
-                          sn=1, stamp='2025-08-01T18:06:10.988921+00:00')
-        revoked = blindate(regid=ripper.said, prior=issued.said, blid=revokedBlinder.said,
-                           sn=2, stamp='2025-09-01T18:06:10.988921+00:00')
+            # Bob presents the currently issued snapshot to Vic. The grant wire
+            # carries the ACDC and only sn=1's disclosed blind proof.
+            issuedGrantResult, issuedWire = ipexExn(
+                hby=hby,
+                exc=exc,
+                sender=bob,
+                receiver=vic,
+                message="Current registry snapshot",
+                admitMessage="Received current registry snapshot",
+                origin=_proofed(acdc, issuedBlinder),
+            )
+            assert len(issuedGrantResult.nests[0].bsqs) == 1
+            assert salt.encode() not in issuedWire
+            assert issuedBlinder.uuid.encode() in issuedWire
 
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            revokedBlinder, revoked = registrar.issue(registry,
+                                                      acdc=acdc,
+                                                      state='revoked',
+                                                      salt=salt)
+            _anchor(amy, registry, revoked, framed=False)
 
-        # Bob presents the issuance-state snapshot to Vic. The IPEX grant carries
-        # the blinded registry update, but not the per-event nonce Vic needs to
-        # interpret it; that nonce is modeled here as the separately-shared
-        # issuedBlinder.uuid, just as in the JSON example.
-        issuedGrantResult, issuedWire = ipexExn(
-            hby=hby,
-            exc=exc,
-            sender=bob,
-            receiver=vic,
-            message="Current registry snapshot",
-            admitMessage="Received current registry snapshot",
-            origin=acdc,
-            artifacts=[issued, ripper],
-        )
-        carriedIssued = issuedGrantResult.nests[1].serder
-        assert carriedIssued.said == issued.said
-        assert carriedIssued.sad['b'] == issuedBlinder.said
-        assert b'issued' not in carriedIssued.raw
-        assert b'revoked' not in carriedIssued.raw
-        assert salt.encode() not in issuedWire
-        assert issuedBlinder.uuid.encode() not in issuedWire
-        assert revokedBlinder.uuid.encode() not in issuedWire
+            assert issuedBlinder.said != revokedBlinder.said
+            assert issuedBlinder.uuid != revokedBlinder.uuid
+            assert revokedBlinder.uuid.encode() not in issuedWire
 
-        verifierAtIssuance = Blinder.unblind(said=carriedIssued.sad['b'],
-                                             uuid=issuedBlinder.uuid,
-                                             acdc=acdc.said, states=states)
-        assert verifierAtIssuance is not None
-        assert verifierAtIssuance.state == 'issued'
-        assert verifierAtIssuance.acdc == acdc.said
+            # Later Bob can disclose the later revoked snapshot, but that new
+            # presentation still reveals only one event-specific blind.
+            revokedGrantResult, revokedWire = ipexExn(
+                hby=hby,
+                exc=exc,
+                sender=bob,
+                receiver=vic,
+                message="Later registry snapshot",
+                admitMessage="Received later registry snapshot",
+                origin=_proofed(acdc, revokedBlinder),
+            )
+            assert len(revokedGrantResult.nests[0].bsqs) == 1
+            assert salt.encode() not in revokedWire
+            assert issuedBlinder.uuid.encode() not in revokedWire
+            assert revokedBlinder.uuid.encode() in revokedWire
 
-        # Later the holder sends a new blinded registry snapshot. A verifier that
-        # remembers only the earlier nonce still cannot read this later event.
-        revokedGrantResult, revokedWire = ipexExn(
-            hby=hby,
-            exc=exc,
-            sender=bob,
-            receiver=vic,
-            message="Later registry snapshot",
-            admitMessage="Received later registry snapshot",
-            origin=acdc,
-            artifacts=[revoked, ripper],
-        )
-        carriedRevoked = revokedGrantResult.nests[1].serder
-        assert carriedRevoked.said == revoked.said
-        assert carriedRevoked.sad['b'] == revokedBlinder.said
-        assert b'issued' not in carriedRevoked.raw
-        assert b'revoked' not in carriedRevoked.raw
-        assert salt.encode() not in revokedWire
-        assert issuedBlinder.uuid.encode() not in revokedWire
-        assert revokedBlinder.uuid.encode() not in revokedWire
-
-        laterPeek = Blinder.unblind(said=carriedRevoked.sad['b'],
-                                    uuid=issuedBlinder.uuid,
-                                    acdc=acdc.said, states=states)
-        assert laterPeek is None
-
-        earlierPeek = Blinder.unblind(said=carriedIssued.sad['b'],
-                                      uuid=revokedBlinder.uuid,
-                                      acdc=acdc.said, states=states)
-        assert earlierPeek is None
-
-        holderAtRevocation = Blinder.unblind(said=carriedRevoked.sad['b'],
-                                             acdc=acdc.said,
-                                             states=states, salt=salt, sn=2)
-        assert holderAtRevocation is not None
-        assert holderAtRevocation.state == 'revoked'
-        assert holderAtRevocation.acdc == acdc.said
-
-        assert [(item["r"], item["m"]) for item in recorder.items] == [
-            ("/exn/ipex/grant", "Current registry snapshot"),
-            ("/exn/ipex/admit", "Received current registry snapshot"),
-            ("/exn/ipex/grant", "Later registry snapshot"),
-            ("/exn/ipex/admit", "Received later registry snapshot"),
-        ]
+            assert [(item["r"], item["m"]) for item in recorder.items] == [
+                ("/exn/ipex/grant", "Current registry snapshot"),
+                ("/exn/ipex/admit", "Received current registry snapshot"),
+                ("/exn/ipex/grant", "Later registry snapshot"),
+                ("/exn/ipex/admit", "Received later registry snapshot"),
+            ]
+        finally:
+            rgy.close()
 
 
 @pytest.mark.parametrize("kind", [Kinds.json, Kinds.cesr, Kinds.cbor, Kinds.mgpk])

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -328,7 +328,10 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
     registry-backed ACDC through the real IPEX handlers we have today. In the
     single-DAG wire shape for this ticket, the grant carries one nested ACDC
     node per disclosure graph node, and TEL/KEL issuer-auth material is no
-    longer shipped as sibling grant artifacts.
+    longer shipped as sibling grant artifacts. This example keeps every actor
+    in one Habery/Regery, so the verifier-side TEL view is already local; the
+    two-Habery IPEX tests cover the separate-party case where that TEL would be
+    learned beforehand, for example from observers.
     """
 
     with openHby(name="ipex-registry-lifecycle",
@@ -364,7 +367,9 @@ def test_registry_issuance_lifecycle_IPEX_JSON():
             loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             # The first presentation discloses only the current issued event's
-            # proof group on the ACDC's own nest.
+            # proof group on the ACDC's own nest. Because this example uses one
+            # shared Regery, the disclosee-side TEL chain is already present
+            # locally instead of being fetched separately from observers.
             issuedGrantResult, issuedGrantWire = ipexExn(
                 hby=hby,
                 exc=exc,
@@ -1090,6 +1095,9 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
     carries the ACDC node itself plus exactly one event's blind proof group on
     that node's own nest. The salt still stays off wire, and each presentation
     reveals only the one event-specific blind needed for that disclosed state.
+    This example also runs in one Habery/Regery, so the verifier already has
+    local TEL state; the separate-party observer-preload assumption is covered
+    by the two-Habery IPEX tests instead.
     """
 
     with openHby(name="ipex-correlation-minimizing",
@@ -1123,7 +1131,9 @@ def test_blindable_registry_correlation_minimizing_IPEX_JSON():
             loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             # Bob presents the currently issued snapshot to Vic. The grant wire
-            # carries the ACDC and only sn=1's disclosed blind proof.
+            # carries the ACDC and only sn=1's disclosed blind proof. TEL
+            # lookup still succeeds here because this example's shared Regery
+            # already contains the issuer's registry history.
             issuedGrantResult, issuedWire = ipexExn(
                 hby=hby,
                 exc=exc,

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -87,8 +87,7 @@ def _nest(stream):
 
 def _proofed(acdc, *proofs):
     """Attach one node-local registry proof group to a disclosed ACDC stream."""
-    # Step 4 keeps issuer-auth evidence on the same node substream, so grant()
-    # can wrap this body+proof stream as one nested BodyWithAttachmentGroup.
+    # Step 4 keeps only the issuer-auth proof group on the disclosed node.
     return messagize(serder=acdc,
                      bonds=[proof.data for proof in proofs],
                      framed=False,
@@ -2482,12 +2481,17 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                   version=Vrsn_2_0) as recipientHby):
         issuerHab = issuerHby.makeHab(name="issuer")
         recipientHab = recipientHby.makeHab(name="recipient")
-        rgy = Regery(hby=issuerHby, name="ipex-v2-blind-registry-kram-two-haberies", temp=True)
+        issuerRgy = Regery(hby=issuerHby,
+                           name="ipex-v2-blind-registry-kram-two-haberies-issuer",
+                           temp=True)
+        recipientRgy = Regery(hby=recipientHby,
+                              name="ipex-v2-blind-registry-kram-two-haberies-recipient",
+                              temp=True)
         try:
             # Build the issuer-owned registry inside the issuer's Habery.
-            registrar = Registrar(rgy=rgy)
+            registrar = Registrar(rgy=issuerRgy)
             registry = registrar.makeRegistry(name="blind-kram", prefix=issuerHab.pre)
-            rip = rgy.store.event(registry.regk)
+            rip = issuerRgy.store.event(registry.regk)
             ripAnc = _anchor(issuerHab, registry, rip, framed=True)
 
             # Issue one credential from the issuer to the recipient so the later
@@ -2521,7 +2525,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
 
             # Feed the issuer's KEL and TEL anchor material into the recipient's
             # local db so the recipient can authenticate the issuer's replies and
-            # verify the registry artifacts nested inside the later grant.
+            # verify the registry artifacts referenced by the later grant.
             issuerIcp = issuerHab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerIcp), kvy=recipientRemoteKvy)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(ripAnc), kvy=recipientRemoteKvy)
@@ -2530,17 +2534,22 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                                            kvy=recipientRemoteKvy)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerRot), kvy=recipientRemoteKvy)
 
+            # Simulate observer retrieval by preloading the issuer's TEL chain
+            # into the recipient's local Regery before the grant is verified.
+            recipientRgy.store.accept(registry.regk, 0, rip)
+            recipientRgy.store.accept(registry.regk, 1, issued)
+            assert recipientRgy.store.seqEvent(registry.regk, 0).said == rip.said
+            assert recipientRgy.store.seqEvent(registry.regk, 1).said == issued.said
+
             # Give each Habery its own IPEX exchanger and recorder so the test
             # can prove which side actually received which messages.
             issuerRecorder = Recorder()
             issuerExc = Exchanger(hby=issuerHby, handlers=[])
-            loadHandlers(hby=issuerHby, exc=issuerExc, notifier=issuerRecorder, rgy=rgy)
+            loadHandlers(hby=issuerHby, exc=issuerExc, notifier=issuerRecorder, rgy=issuerRgy)
 
             recipientRecorder = Recorder()
             recipientExc = Exchanger(hby=recipientHby, handlers=[])
-            # The recipient verifies the issuer-auth proof against the issuer's
-            # preloaded TEL chain, so share the same test Regery here.
-            loadHandlers(hby=recipientHby, exc=recipientExc, notifier=recipientRecorder, rgy=rgy)
+            loadHandlers(hby=recipientHby, exc=recipientExc, notifier=recipientRecorder, rgy=recipientRgy)
 
             with (openCF(name="ipex-v2-kram-two-haberies-issuer", base="test", temp=True) as issuerCf,
                   openCF(name="ipex-v2-kram-two-haberies-recipient", base="test", temp=True) as recipientCf):
@@ -2851,7 +2860,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert recipientHby.db.exns.get(keys=(staleOfferExn.said,)) is None
                 assert recipientHby.db.exns.get(keys=(offerExn.said,)) is not None
         finally:
-            rgy.close()
+            recipientRgy.close()
+            issuerRgy.close()
 
 
 def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeHelpingClock):
@@ -2877,13 +2887,18 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                   version=Vrsn_2_0) as recipientHby):
         issuerHab = issuerHby.makeHab(name="issuer")
         recipientHab = recipientHby.makeHab(name="recipient")
-        rgy = Regery(hby=issuerHby, name="ipex-v2-dag-kram-two-haberies", temp=True)
+        issuerRgy = Regery(hby=issuerHby,
+                           name="ipex-v2-dag-kram-two-haberies-issuer",
+                           temp=True)
+        recipientRgy = Regery(hby=recipientHby,
+                              name="ipex-v2-dag-kram-two-haberies-recipient",
+                              temp=True)
         try:
             # Build the issuer-owned registry and anchor its inception so the
             # recipient can later vet the origin node's blind proof group.
-            registrar = Registrar(rgy=rgy)
+            registrar = Registrar(rgy=issuerRgy)
             registry = registrar.makeRegistry(name="blind-dag-kram", prefix=issuerHab.pre)
-            rip = rgy.store.event(registry.regk)
+            rip = issuerRgy.store.event(registry.regk)
             ripAnc = _anchor(issuerHab, registry, rip, framed=True)
 
             # The disclosed DAG has a registry-backed origin node that points to
@@ -2924,15 +2939,28 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                                            kvy=recipientRemoteKvy)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerRot), kvy=recipientRemoteKvy)
 
+            # Simulate observer retrieval by preloading the issuer's TEL chain
+            # into the recipient's local Regery before the grant is verified.
+            recipientRgy.store.accept(registry.regk, 0, rip)
+            recipientRgy.store.accept(registry.regk, 1, issued)
+            assert recipientRgy.store.seqEvent(registry.regk, 0).said == rip.said
+            assert recipientRgy.store.seqEvent(registry.regk, 1).said == issued.said
+
 
             # Set up each Habery with its IPEX exchanger and recorder
             issuerRecorder = Recorder()
             issuerInboundExc = Exchanger(hby=issuerHby, handlers=[])
-            loadHandlers(hby=issuerHby, exc=issuerInboundExc, notifier=issuerRecorder, rgy=rgy)
+            loadHandlers(hby=issuerHby,
+                         exc=issuerInboundExc,
+                         notifier=issuerRecorder,
+                         rgy=issuerRgy)
 
             recipientRecorder = Recorder()
             recipientInboundExc = Exchanger(hby=recipientHby, handlers=[])
-            loadHandlers(hby=recipientHby, exc=recipientInboundExc, notifier=recipientRecorder, rgy=rgy)
+            loadHandlers(hby=recipientHby,
+                         exc=recipientInboundExc,
+                         notifier=recipientRecorder,
+                         rgy=recipientRgy)
 
             with (openCF(name="ipex-v2-dag-kram-issuer", base="test", temp=True) as issuerCf,
                   openCF(name="ipex-v2-dag-kram-recipient", base="test", temp=True) as recipientCf):
@@ -3138,7 +3166,8 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                     ("/exn/ipex/grant", "Here is the registry-backed DAG disclosure"),
                 ]
         finally:
-            rgy.close()
+            recipientRgy.close()
+            issuerRgy.close()
 
 
 def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -13,6 +13,7 @@ from keri.acdc import (Regery, Registrar, acdcmap, blindate, apply as ipexApply,
                        spurn as ipexSpurn)
 from keri.app import openCF, openHby
 from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Parser,
+                       messagize,
                        SerderKERI, Serdery, Texter, exchange)
 from keri.kering import Colds, sniff
 from keri.help import helping
@@ -84,12 +85,30 @@ def _nest(stream):
                            version=Vrsn_2_0)
 
 
+def _proofed(acdc, *proofs):
+    """Attach one node-local registry proof group to a disclosed ACDC stream."""
+    # Step 4 keeps issuer-auth evidence on the same node substream, so grant()
+    # can wrap this body+proof stream as one nested BodyWithAttachmentGroup.
+    return messagize(serder=acdc,
+                     bonds=[proof.data for proof in proofs],
+                     framed=False,
+                     gvrsn=Vrsn_2_0)
+
+
 def _anchor(hab, registry, serder, *, framed=False):
     """Create a KEL interaction event that seals one registry event."""
     seal = dict(i=registry.regk, s=serder.sad["n"], d=serder.said)
     anc = hab.interact(data=[seal], framed=framed, gvrsn=Vrsn_2_0)
     assert registry.anchorMsg(serder.said) is True
     return anc
+
+
+def _edge(label, node, *, op="I2I", schema=None):
+    """Create a simple edge block that points at another disclosed ACDC node."""
+    target = dict(d="", n=node.said, o=op)
+    if schema is not None:
+        target["s"] = schema
+    return dict(d="", **{label: target})
 
 # Tests
 def test_ipex_v2_builders_parse_happypath():
@@ -103,32 +122,23 @@ def test_ipex_v2_builders_parse_happypath():
         # Build artifacts
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
-        anc = hab.msgOwnEvent(sn=0, framed=False)
-        
         # Extract schema from acdc
         schema = acdc.sad["s"]["$id"]
-
-        # Parse anchor event to get the serder
-        ancSerder = _serder(anc)
 
         # Build apply message
         applyExn, applyAtc = ipexApply(hab=hab,
                                           recp=hab.pre,
                                           message="Please issue a credential",
-                                          attrs=dict(role="member"),
+                                          attrs=dict(role="member", ax=[False]),
                                           modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
 
         # Build Offer message chained to apply 
         offerExn, offerAtc = ipexOffer(hab=hab,
                                        message="Here is the offered credential",
                                        origin=acdc,
+                                       attrs=dict(ax=[False]),
                                        apply=applyExn)
 
         # Build an agree chained to the offer
@@ -141,7 +151,7 @@ def test_ipex_v2_builders_parse_happypath():
                                           recp=hab.pre,
                                           message="Here is the granted credential",
                                           origin=acdc,
-                                          artifacts=[_nest(iss), anc],
+                                          attrs=dict(ax=[False]),
                                           agree=agreeExn)
 
         # Build the admit chained to the grant
@@ -163,10 +173,12 @@ def test_ipex_v2_builders_parse_happypath():
 
         # Assert fields
         assert applyExn.ked["a"]["m"] == "Please issue a credential"    # message
+        assert applyExn.ked["a"]["ax"] == [False]
         assert applyExn.ked["q"]["dp"] == [[schema, "/", ["a/role"]]]
 
         assert offerExn.ked["a"]["m"] == "Here is the offered credential"
-        assert offerExn.ked["a"]["o"] == acdc.said
+        assert offerExn.ked["a"]["ax"] == [False]
+        assert offerExn.ked["a"]["o"] == [acdc.said]
         assert offerExn.ked["p"] == applyExn.said       # prior
         assert offerExn.ked["q"]["dp"] == []
 
@@ -174,7 +186,8 @@ def test_ipex_v2_builders_parse_happypath():
         assert agreeExn.ked["p"] == offerExn.said
 
         assert grantExn.ked["a"]["m"] == "Here is the granted credential"
-        assert grantExn.ked["a"]["o"] == acdc.said
+        assert grantExn.ked["a"]["o"] == [acdc.said]
+        assert grantExn.ked["a"]["ax"] == [False]
         assert "iss" not in grantExn.ked["a"]
         assert "anc" not in grantExn.ked["a"]
         assert grantExn.ked["p"] == agreeExn.said
@@ -247,11 +260,7 @@ def test_ipex_v2_builders_parse_happypath():
         assert grantResult.serder.ked["r"] == "/ipex/grant"
         assert grantResult.serder.ked["a"] == grantExn.ked["a"]
         assert grantResult.serder.ked["p"] == agreeExn.said
-        assert [nest.serder.said for nest in grantResult.nests] == [
-            acdc.said,
-            iss.said,
-            ancSerder.said,
-        ]
+        assert [nest.serder.said for nest in grantResult.nests] == [acdc.said]
 
         # Admit
         admitIms = bytearray(admitExn.raw)
@@ -286,24 +295,76 @@ def test_ipex_v2_builders_parse_happypath():
         assert spurnResult.nests == []
 
 
-def test_ipex_v2_grant_carries_multiple_registry_updates():
-    """Grant can carry multiple supporting registry-update artifacts."""
-    with openHby(name="ipex-v2-grant-updates",
+def test_ipex_v2_accepts_empty_ax_list_as_unanchored():
+    """Single-DAG IPEX accepts [] for ax as explicit unanchored intent."""
+    with openHby(name="ipex-v2-empty-ax",
                  base="test",
                  version=Vrsn_2_0) as hby:
         hab = hby.makeHab(name="test")
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-        issued = blindate(regid=registry.said,
-                          prior=registry.said,
-                          blid=Blinder.blind(acdc=acdc.said, state="issued", sn=1).said)
-        revoked = blindate(regid=registry.said,
-                           prior=issued.said,
-                           blid=Blinder.blind(acdc=acdc.said, state="revoked", sn=2).said,
-                           sn=2)
+        schema = acdc.sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=hab,
+                                       recp=hab.pre,
+                                       message="Please issue a credential",
+                                       attrs=dict(role="member", ax=[]),
+                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        offerExn, offerAtc = ipexOffer(hab=hab,
+                                       message="Here is the offered credential",
+                                       origin=acdc,
+                                       attrs=dict(ax=[]),
+                                       apply=applyExn)
+        agreeExn, agreeAtc = ipexAgree(hab=hab,
+                                       message="I agree to the offer",
+                                       offer=offerExn)
+        grantExn, grantAtc = ipexGrant(hab=hab,
+                                       recp=hab.pre,
+                                       message="Here is the granted credential",
+                                       origin=acdc,
+                                       attrs=dict(ax=[]),
+                                       agree=agreeExn)
+
+        for exn, atc in (
+            (applyExn, applyAtc),
+            (offerExn, offerAtc),
+            (agreeExn, agreeAtc),
+            (grantExn, grantAtc),
+        ):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        assert applyExn.ked["a"]["ax"] == []
+        assert offerExn.ked["a"]["ax"] == []
+        assert grantExn.ked["a"]["ax"] == []
+
+        assert hby.db.exns.get(keys=(applyExn.said,)).ked["a"]["ax"] == []
+        assert hby.db.exns.get(keys=(offerExn.said,)).ked["a"]["ax"] == []
+        assert hby.db.exns.get(keys=(grantExn.said,)).ked["a"]["ax"] == []
+
+
+def test_ipex_v2_grant_carries_multiple_dag_nodes():
+    """Grant can carry multiple disclosed ACDC nodes in one origin DAG."""
+    with openHby(name="ipex-v2-grant-updates",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        registry = regcept(israid=hab.pre)
+        child = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=hab.pre)
+        acdc = acdcmap(israid=hab.pre,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       edge=_edge("holder", child),
+                       iseaid=hab.pre)
 
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
@@ -311,11 +372,11 @@ def test_ipex_v2_grant_carries_multiple_registry_updates():
 
         grantExn, grantAtc = ipexGrant(hab=hab,
                                        recp=hab.pre,
-                                       message="Here are the registry updates",
+                                       message="Here is the disclosed DAG",
                                        origin=acdc,
-                                       artifacts=[issued, revoked])
+                                       artifacts=[child])
 
-        assert grantExn.ked["a"]["o"] == acdc.said
+        assert grantExn.ked["a"]["o"] == [acdc.said]
         assert "iss" not in grantExn.ked["a"]
         assert "anc" not in grantExn.ked["a"]
 
@@ -328,8 +389,7 @@ def test_ipex_v2_grant_carries_multiple_registry_updates():
         assert len(grantResults) == 1
         assert [nest.serder.said for nest in grantResults[0].nests] == [
             acdc.said,
-            issued.said,
-            revoked.said,
+            child.said,
         ]
 
         dispatch = bytearray(grantExn.raw)
@@ -339,8 +399,110 @@ def test_ipex_v2_grant_carries_multiple_registry_updates():
 
         storedGrant = hby.db.exns.get(keys=(grantExn.said,))
         assert storedGrant is not None
-        assert storedGrant.ked["a"]["o"] == acdc.said
+        assert storedGrant.ked["a"]["o"] == [acdc.said]
         assert "iss" not in storedGrant.ked["a"]
+
+
+def test_ipex_v2_rejects_grant_with_missing_edged_node():
+    """Grant must include every ACDC node referenced by the origin DAG."""
+    with openHby(name="ipex-v2-bad-grant-dangling-edge",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        registry = regcept(israid=hab.pre)
+        child = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         iseaid=hab.pre)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the incomplete DAG",
+                             origin=origin)
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
+
+
+def test_ipex_v2_rejects_grant_with_nonwalkable_compact_edges():
+    """Grant rejects ACDCs whose edge block is compacted to a non-walkable value."""
+    with openHby(name="ipex-v2-bad-grant-compact-edge",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        registry = regcept(israid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         iseaid=hab.pre)
+        sad = dict(origin.sad)
+        sad["e"] = regcept(israid=hab.pre).said
+        compactOrigin = type(origin)(sad=sad, makify=True)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the compacted DAG",
+                             origin=compactOrigin)
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
+
+
+def test_ipex_v2_rejects_grant_with_unreachable_nested_node():
+    """Grant must not carry extra nested ACDCs outside the origin DAG."""
+    with openHby(name="ipex-v2-bad-grant-extra-node",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        registry = regcept(israid=hab.pre)
+        child = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=hab.pre)
+        extra = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", department="kitchen"),
+                        iseaid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         iseaid=hab.pre)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the overstuffed DAG",
+                             origin=origin,
+                             artifacts=[child, extra])
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
 
 
 def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
@@ -351,19 +513,12 @@ def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
         hab = hby.makeHab(name="test")
         registry = regcept(israid=hab.pre)
         offerMeta = acdcmap(israid=hab.pre,
-                            regid=registry.said,
                             attribute=dict(d="", rules="club-entry"),
                             iseaid=hab.pre)
         grantOrigin = acdcmap(israid=hab.pre,
-                              regid=registry.said,
                               attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                               iseaid=hab.pre)
         schema = grantOrigin.sad["s"]["$id"]
-        issued = blindate(regid=registry.said,
-                          prior=registry.said,
-                          blid=Blinder.blind(acdc=grantOrigin.said, state="issued", sn=1).said)
-        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
-
         applyExn, _ = ipexApply(hab=hab,
                                 recp=hab.pre,
                                 message="Please issue a credential",
@@ -380,7 +535,6 @@ def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
                                        recp=hab.pre,
                                        message="Here is the granted credential",
                                        origin=grantOrigin,
-                                       artifacts=[issued, anc],
                                        agree=agreeExn)
 
         offerIms = bytearray(offerExn.raw)
@@ -399,15 +553,11 @@ def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
         assert grantIms == bytearray()
         assert len(grantResults) == 1
 
-        assert offerExn.ked["a"]["o"] == offerMeta.said
-        assert grantExn.ked["a"]["o"] == grantOrigin.said
+        assert offerExn.ked["a"]["o"] == [offerMeta.said]
+        assert grantExn.ked["a"]["o"] == [grantOrigin.said]
         assert offerExn.ked["a"]["o"] != grantExn.ked["a"]["o"]
         assert [nest.serder.said for nest in offerResults[0].nests] == [offerMeta.said]
-        assert [nest.serder.said for nest in grantResults[0].nests] == [
-            grantOrigin.said,
-            issued.said,
-            _serder(anc).said,
-        ]
+        assert [nest.serder.said for nest in grantResults[0].nests] == [grantOrigin.said]
 
 
 def test_ipex_v2_dispatch_linear_and_spurn():
@@ -417,14 +567,8 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         hab = hby.makeHab(name="test")
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
-        anc = hab.msgOwnEvent(sn=0, framed=False)
         schema = acdc.sad["s"]["$id"]
 
         # Create recorder
@@ -449,7 +593,6 @@ def test_ipex_v2_dispatch_linear_and_spurn():
                                         recp=hab.pre,
                                         message="Here is the granted credential",
                                         origin=acdc,
-                                        artifacts=[iss, anc],
                                         agree=agree0)
         admit0, admit0Atc = ipexAdmit(hab=hab,
                                         message="Thanks for the credential",
@@ -504,7 +647,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
 
         storedOffer = hby.db.exns.get(keys=(offer0.said,))
         assert storedOffer.ked["a"]["m"] == "Here is the offered credential"
-        assert storedOffer.ked["a"]["o"] == acdc.said
+        assert storedOffer.ked["a"]["o"] == [acdc.said]
         assert "acdc" not in storedOffer.ked["a"]
         assert storedOffer.ked["q"]["dp"] == []
         assert storedOffer.ked["p"] == apply0.said
@@ -524,7 +667,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
 
         storedGrant = hby.db.exns.get(keys=(grant0.said,))
         assert storedGrant.ked["a"]["m"] == "Here is the granted credential"
-        assert storedGrant.ked["a"]["o"] == acdc.said
+        assert storedGrant.ked["a"]["o"] == [acdc.said]
         assert "iss" not in storedGrant.ked["a"]
         assert "anc" not in storedGrant.ked["a"]
         assert storedGrant.ked["p"] == agree0.said
@@ -557,8 +700,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         grant1, grant1Atc = ipexGrant(hab=hab,
                                         recp=hab.pre,
                                         message="Bare grant without agreement",
-                                        origin=acdc,
-                                        artifacts=[_nest(iss)])
+                                        origin=acdc)
 
         # Build a spurn against that grant
         spurn1, spurn1Atc = ipexSpurn(hab=hab,
@@ -646,17 +788,10 @@ def test_ipex_v2_nontransferable_nested_artifacts():
         # Registry Inception
         registry = regcept(israid=hab.pre)
 
-        # Create ACDC, ISS and an ANC
+        # Create one ACDC node for the nested grant body
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
-        anc = hab.msgOwnEvent(sn=0, framed=False)
-        ancSerder = _serder(anc)
         schema = acdc.sad["s"]["$id"]
 
         # Build IPEX messages
@@ -676,7 +811,6 @@ def test_ipex_v2_nontransferable_nested_artifacts():
                                        recp=hab.pre,
                                        message="Here is the granted credential",
                                        origin=acdc,
-                                       artifacts=[iss, anc],
                                        agree=agreeExn)
 
         # Parse Offer for assertions
@@ -700,8 +834,7 @@ def test_ipex_v2_nontransferable_nested_artifacts():
         assert len(grantResults) == 1
         grantResult = grantResults[0]
         assert grantResult.nests[0].serder.said == acdc.said
-        assert grantResult.nests[1].serder.said == iss.said
-        assert grantResult.nests[2].serder.said == ancSerder.said
+        assert len(grantResult.nests) == 1
 
         # Dispatch the whole chain
         for exn, atc in ((applyExn, applyAtc),
@@ -756,7 +889,6 @@ def test_ipex_v2_rejects_offer_without_dp():
 
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
 
@@ -804,7 +936,6 @@ def test_ipex_v2_rejects_offer_with_missing_origin_attr_without_throwing():
 
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
 
@@ -845,7 +976,6 @@ def test_ipex_v2_rejects_offer_with_nonstring_origin_without_throwing():
 
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
 
@@ -886,11 +1016,9 @@ def test_ipex_v2_rejects_offer_without_origin_nested_artifact():
 
         registry = regcept(israid=hab.pre)
         origin = acdcmap(israid=hab.pre,
-                         regid=registry.said,
                          attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                          iseaid=hab.pre)
         sibling = acdcmap(israid=hab.pre,
-                          regid=registry.said,
                           attribute=dict(d="", rules="club-entry"),
                           iseaid=hab.pre)
 
@@ -928,28 +1056,21 @@ def test_ipex_v2_rejects_grant_with_invalid_origin_said_without_throwing():
 
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=Blinder.blind(acdc=acdc.said, state="issued", sn=1).said)
-        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
-
         exn, _ = ipexGrant(hab=hab,
                            recp=hab.pre,
                            message="Here is the granted credential",
-                           origin=acdc,
-                           artifacts=[iss, anc])
+                           origin=acdc)
         sad = dict(exn.ked)
         sad["a"] = dict(exn.ked["a"])
-        sad["a"]["o"] = "not-a-said"
+        sad["a"]["o"] = ["not-a-said"]
         badGrant = SerderKERI(sad=sad, makify=True, verify=False)
 
         atc = bytearray(hab.endorse(serder=badGrant,
                                     framed=False,
                                     gvrsn=Vrsn_2_0,
-                                    nests=[_nest(acdc), _nest(iss), _nest(anc)]))
+                                    nests=[_nest(acdc)]))
         del atc[:badGrant.size]
 
         ims = bytearray(badGrant.raw)
@@ -976,32 +1097,26 @@ def test_ipex_v2_rejects_grant_without_origin_nested_artifact():
         # Create the registry and ACDC referenced by the grant
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
 
-        # Create the TEL issuance event that the grant body says should accompany the ACDC
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
+        sibling = acdcmap(israid=hab.pre,
+                          attribute=dict(d="", status="member"),
+                          iseaid=hab.pre)
 
-        # Create the anchoring KEL event that the grant body also says should be present
-        anc = hab.msgOwnEvent(sn=0, framed=False)
-
-        # Build a correct grant body that carries the origin plus two supporting artifacts.
+        # Build a correct grant body that carries the origin plus one linked sibling node.
         exn, _ = ipexGrant(hab=hab,
                            recp=hab.pre,
                            message="Here is the granted credential",
                            origin=acdc,
-                           artifacts=[iss, anc])
+                           artifacts=[sibling])
 
         # Re-endorse the same body but omit the origin artifact. In V2 the grant
         # must carry the presentation/ACDC as the first nested artifact matching a.o.
         atc = bytearray(hab.endorse(serder=exn,
                                     framed=False,
                                     gvrsn=Vrsn_2_0,
-                                    nests=[_nest(iss), _nest(anc)]))
+                                    nests=[_nest(sibling)]))
 
         # Strip the body returned by `endorse`; we only want the tampered attachments
         del atc[:exn.size]
@@ -1038,23 +1153,15 @@ def test_ipex_v2_rejects_grant_with_missing_origin_attr_without_throwing():
         # Create the registry artifacts carried by the malformed grant.
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
-
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
-        anc = hab.msgOwnEvent(sn=0, framed=False, gvrsn=Vrsn_2_0)
 
         # Start from a valid grant, then remove `a.o` and re-sign it so the
         # parser reaches the handler with a malformed but otherwise authentic body.
         exn, _ = ipexGrant(hab=hab,
                            recp=hab.pre,
                            message="Here is the granted credential",
-                           origin=acdc,
-                           artifacts=[iss, anc])
+                           origin=acdc)
         sad = dict(exn.ked)
         sad["a"] = dict(exn.ked["a"])
         sad["a"].pop("o")
@@ -1063,7 +1170,7 @@ def test_ipex_v2_rejects_grant_with_missing_origin_attr_without_throwing():
         atc = bytearray(hab.endorse(serder=badGrant,
                                     framed=False,
                                     gvrsn=Vrsn_2_0,
-                                    nests=[_nest(acdc), _nest(iss), _nest(anc)]))
+                                    nests=[_nest(acdc)]))
         del atc[:badGrant.size]
 
         ims = bytearray(badGrant.raw)
@@ -1093,14 +1200,8 @@ def test_ipex_v2_responders_set_receiver():
 
         registry = regcept(israid=holder.pre)
         acdc = acdcmap(israid=holder.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=holder.pre)
-        blinder = Blinder.blind(acdc=acdc.said, state="issued", sn=1).said
-        iss = blindate(regid=registry.said,
-                       prior=registry.said,
-                       blid=blinder)
-        anc = holder.msgOwnEvent(sn=0, framed=False)
         schema = acdc.sad["s"]["$id"]
 
         # verifier applies to holder
@@ -1131,7 +1232,6 @@ def test_ipex_v2_responders_set_receiver():
                                 recp=verifier.pre,
                                 message="Disclosure",
                                 origin=acdc,
-                                artifacts=[_nest(iss), anc],
                                 agree=agreeExn)
         assert grantExn.ked["ri"] == verifier.pre
 
@@ -1178,7 +1278,6 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
         # Create one credential payload so the later grant builder has a real origin artifact
         registry = regcept(israid=holder.pre)
         acdc = acdcmap(israid=holder.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=holder.pre)
         # Reuse the credential schema in the apply disclosure request.
@@ -1287,7 +1386,7 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
         assert bareOffer.ked["p"] == ""
         assert bareOffer.ked["ri"] == verifier.pre
         assert bareOffer.ked["x"] != ""
-        assert bareOffer.ked["a"]["o"] == acdc.said
+        assert bareOffer.ked["a"]["o"] == [acdc.said]
         # Supplying xid directly is no longer supported at all.
         with pytest.raises(TypeError):
             ipexOffer(hab=holder,
@@ -1333,6 +1432,11 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
                       recp=holder.pre,
                       message="Bad disclosure plan type",
                       modifiers=dict(dp="not-a-list"))
+        with pytest.raises(ValueError):
+            ipexApply(hab=verifier,
+                      recp=holder.pre,
+                      message="Bad disclosure plan nesting",
+                      modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
 
 
 def test_ipex_v2_rejects_third_party_prior_response_without_throwing():
@@ -1350,7 +1454,6 @@ def test_ipex_v2_rejects_third_party_prior_response_without_throwing():
 
         registry = regcept(israid=holder.pre)
         acdc = acdcmap(israid=holder.pre,
-                       regid=registry.said,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=holder.pre)
         schema = acdc.sad["s"]["$id"]
@@ -1433,21 +1536,20 @@ def test_ipex_v2_blindable_registry_roundtrip():
                            iseaid=hab.pre)
 
             # Issue one blindable registry update and capture the anchoring KEL event for it
-            _, iss = registrar.issue(registry, acdc=acdc, state="issued")
-            anc = _anchor(hab, registry, iss, framed=False)
-            ancSerder = _serder(anc)
+            issuedBlinder, iss = registrar.issue(registry, acdc=acdc, state="issued")
+            _anchor(hab, registry, iss, framed=False)
 
             # Wire an exchanger with IPEX handlers so the grant can be parsed end to end
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
-            # Grant the blindable ACDC plus its registry artifacts through one IPEX message
+            # Grant the registry-backed ACDC through one IPEX message, carrying
+            # its issuer-auth proof group on the same disclosed node.
             grantExn, grantAtc = ipexGrant(hab=hab,
                                            recp=hab.pre,
                                            message="Blindable disclosure",
-                                           origin=acdc,
-                                           artifacts=[iss, anc])
+                                           origin=_proofed(acdc, issuedBlinder))
 
             # Parse the transmitted EXN stream and ensure the whole message is consumed
             grantIms = bytearray(grantExn.raw)
@@ -1464,13 +1566,11 @@ def test_ipex_v2_blindable_registry_roundtrip():
             parsed = Parser(version=Vrsn_2_0).parse(ims=bytearray().join(nests),
                                                     framed=True,
                                                     processive=False)
-            assert [nest.serder.said for nest in parsed] == [
-                acdc.said,
-                iss.said,
-                ancSerder.said,
-            ]
+            assert [nest.serder.said for nest in parsed] == [acdc.said]
+            assert len(parsed[0].bsqs) == 1
 
-            # Serializing the whole stored message should round-trip the same nested substreams
+            # Serializing the whole stored message should round-trip the same
+            # nested node and its proof-group attachment section.
             msg = serializeMessage(hby, grantExn.said, framed=True)
             ims = bytearray(msg)
             results = Parser(version=Vrsn_2_0).parse(ims=ims,
@@ -1478,11 +1578,50 @@ def test_ipex_v2_blindable_registry_roundtrip():
                                                      processive=False)
             assert ims == bytearray()
             assert len(results) == 1
-            assert [nest.serder.said for nest in results[0].nests] == [
-                acdc.said,
-                iss.said,
-                ancSerder.said,
-            ]
+            assert [nest.serder.said for nest in results[0].nests] == [acdc.said]
+            assert len(results[0].nests[0].bsqs) == 1
+        finally:
+            rgy.close()
+
+
+def test_ipex_v2_rejects_registry_backed_grant_without_node_proof_group():
+    """A grant with rd must carry exactly one node-local registry proof group."""
+    with openHby(name="ipex-v2-missing-node-proof",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        rgy = Regery(hby=hby, name="ipex-v2-missing-node-proof", temp=True)
+        try:
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="missing-proof", prefix=hab.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(hab, registry, rip, framed=True)
+
+            acdc = acdcmap(israid=hab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+            issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
+            _anchor(hab, registry, issued, framed=False)
+
+            recorder = Recorder()
+            exc = Exchanger(hby=hby, handlers=[])
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
+
+            # The nested origin carries the registry-backed ACDC body only, so
+            # the handler must fail closed instead of guessing at alternates.
+            exn, atc = ipexGrant(hab=hab,
+                                 recp=hab.pre,
+                                 message="Missing node-local proof",
+                                 origin=acdc)
+
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+            assert ims == bytearray()
+            assert hby.db.exns.get(keys=(exn.said,)) is None
+            assert recorder.items == []
         finally:
             rgy.close()
 
@@ -1510,8 +1649,7 @@ def test_ipex_v2_blind_registry_update_roundtrip():
 
             # Commit one blindable registry update and capture both the blinder and the KEL event that sealed it
             blinder, bup = registrar.issue(registry, acdc=acdc, state="revoked")
-            bupAnc = _anchor(hab, registry, bup, framed=False)
-            bupAncSerder = _serder(bupAnc)
+            _anchor(hab, registry, bup, framed=False)
 
             # The accepted TEL should now contain the registry inception followed by the blindable update
             assert rgy.store.seqEvent(registry.regk, 0).said == rip.said
@@ -1527,7 +1665,7 @@ def test_ipex_v2_blind_registry_update_roundtrip():
             # Wire an exchanger with the V2 IPEX handlers and build one full apply -> offer -> agree -> grant -> admit chain
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             applyExn, applyAtc = ipexApply(hab=hab,
                                            recp=hab.pre,
@@ -1544,8 +1682,7 @@ def test_ipex_v2_blind_registry_update_roundtrip():
             grantExn, grantAtc = ipexGrant(hab=hab,
                                            recp=hab.pre,
                                            message="Here is the blind registry disclosure",
-                                           origin=acdc,
-                                           artifacts=[bup, bupAnc],
+                                           origin=_proofed(acdc, blinder),
                                            agree=agreeExn)
             admitExn, admitAtc = ipexAdmit(hab=hab,
                                            message="Thanks for the blind credential",
@@ -1569,11 +1706,12 @@ def test_ipex_v2_blind_registry_update_roundtrip():
             # The grant body should name the exact artifacts it transported
             storedGrant = hby.db.exns.get(keys=(grantExn.said,))
             assert storedGrant.ked["p"] == agreeExn.said
-            assert storedGrant.ked["a"]["o"] == acdc.said
+            assert storedGrant.ked["a"]["o"] == [acdc.said]
             assert "iss" not in storedGrant.ked["a"]
             assert "anc" not in storedGrant.ked["a"]
 
-            # The stored message should round-trip with the same nested ACDC, blind update, and anchoring KEL event
+            # The stored message should round-trip with the same nested ACDC and
+            # the node-local blind proof group used to vet it.
             msg = serializeMessage(hby, grantExn.said, framed=True)
             ims = bytearray(msg)
             results = Parser(version=Vrsn_2_0).parse(ims=ims,
@@ -1581,11 +1719,8 @@ def test_ipex_v2_blind_registry_update_roundtrip():
                                                      processive=False)
             assert ims == bytearray()
             assert len(results) == 1
-            assert [nest.serder.said for nest in results[0].nests] == [
-                acdc.said,
-                bup.said,
-                bupAncSerder.said,
-            ]
+            assert [nest.serder.said for nest in results[0].nests] == [acdc.said]
+            assert len(results[0].nests[0].bsqs) == 1
 
             # The notifier should report the accepted linear IPEX exchange in send order
             assert [(item["r"], item["m"]) for item in recorder.items] == [
@@ -1657,8 +1792,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
             # Commit one blindable state update and capture the KEL event that
             # anchors it so the IPEX grant can disclose the full package.
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
-            issuedAnc = _anchor(hab, registry, issued, framed=False)
-            issuedAncSerder = _serder(issuedAnc)
+            _anchor(hab, registry, issued, framed=False)
 
             # IPEX builders sign transferable messages against lastEst. After the
             # registry anchors, make current key state an establishment event again
@@ -1672,7 +1806,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
             # authenticated and dispatched through the usual handler path.
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             with openCF(name="ipex-v2-kram", base="test", temp=True) as cf:
                 cf.put(kramConfig)
@@ -1817,8 +1951,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
                 grantExn, grantAtc = ipexGrant(hab=hab,
                                                recp=recipient.pre,
                                                message="Here is the blind registry disclosure",
-                                               origin=acdc,
-                                               artifacts=[issued, issuedAnc],
+                                               origin=_proofed(acdc, issuedBlinder),
                                                agree=agreeExn,
                                                dt=grantStamp)
                 grantReceiveMs = helping.fromIso8601(helping.nowIso8601()).timestamp() * 1000
@@ -1873,8 +2006,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
                 assert (admitReceiveMs - d - sl) <= admitMdtMs <= (admitReceiveMs + d)
                 assert admitXdtMs <= admitMdtMs <= (admitXdtMs + xl)
 
-                # Re-serialize the stored grant and confirm the exact nested ACDC,
-                # blind update, and anchor survive the KRAM + exchanger path.
+                # Re-serialize the stored grant and confirm the exact nested
+                # ACDC survives the KRAM + exchanger path.
                 grantMsg = serializeMessage(hby, grantExn.said, framed=True)
                 grantIms = bytearray(grantMsg)
                 grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
@@ -1882,23 +2015,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
                                                               processive=False)
                 assert grantIms == bytearray()
                 assert len(grantResults) == 1
-                assert [nest.serder.said for nest in grantResults[0].nests] == [
-                    acdc.said,
-                    issued.said,
-                    issuedAncSerder.said,
-                ]
-
-                # The carried blindable update must still unblind to the expected
-                # issued state once pulled back out of the accepted IPEX grant.
-                carriedBup = grantResults[0].nests[1].serder
-                unblinder = Blinder.unblind(said=carriedBup.sad["b"],
-                                            uuid=issuedBlinder.uuid,
-                                            acdc=acdc.said,
-                                            states=["issued", "revoked"])
-                assert unblinder is not None
-                assert unblinder.state == "issued"
-                assert unblinder.acdc == acdc.said
-                assert unblinder.crew == issuedBlinder.crew
+                assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
+                assert len(grantResults[0].nests[0].bsqs) == 1
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -1984,7 +2102,6 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
             # event that anchors it so the grant can carry the full package.
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
             issuedAnc = _anchor(issuerHab, registry, issued, framed=False)
-            issuedAncSerder = _serder(issuedAnc)
 
             # Rotate after the TEL anchors so the later IPEX exchanges sign
             # against a fresh establishment event KRAM can authenticate.
@@ -2017,11 +2134,13 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
             # can prove which side actually received which messages.
             issuerRecorder = Recorder()
             issuerExc = Exchanger(hby=issuerHby, handlers=[])
-            loadHandlers(hby=issuerHby, exc=issuerExc, notifier=issuerRecorder)
+            loadHandlers(hby=issuerHby, exc=issuerExc, notifier=issuerRecorder, rgy=rgy)
 
             recipientRecorder = Recorder()
             recipientExc = Exchanger(hby=recipientHby, handlers=[])
-            loadHandlers(hby=recipientHby, exc=recipientExc, notifier=recipientRecorder)
+            # The recipient verifies the issuer-auth proof against the issuer's
+            # preloaded TEL chain, so share the same test Regery here.
+            loadHandlers(hby=recipientHby, exc=recipientExc, notifier=recipientRecorder, rgy=rgy)
 
             with (openCF(name="ipex-v2-kram-two-haberies-issuer", base="test", temp=True) as issuerCf,
                   openCF(name="ipex-v2-kram-two-haberies-recipient", base="test", temp=True) as recipientCf):
@@ -2228,15 +2347,13 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert (agreeReceiveMs - d - sl) <= agreeMdtMs <= (agreeReceiveMs + d)
                 assert agreeXdtMs <= agreeMdtMs <= (agreeXdtMs + xl)
 
-                # The issuer now grants the actual disclosure package, including
-                # the credential plus the blindable registry artifacts.
+                # The issuer now grants the disclosed credential node.
                 clock.advance(milliseconds=500)
                 grantStamp = helping.nowIso8601()
                 grantExn, grantAtc = ipexGrant(hab=issuerHab,
                                                recp=recipientHab.pre,
                                                message="Here is the blind registry disclosure",
-                                               origin=acdc,
-                                               artifacts=[issued, issuedAnc],
+                                               origin=_proofed(acdc, issuedBlinder),
                                                agree=storedAgree,
                                                dt=grantStamp)
                 grantReceiveMs = helping.fromIso8601(helping.nowIso8601()).timestamp() * 1000
@@ -2303,8 +2420,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert admitXdtMs <= admitMdtMs <= (admitXdtMs + xl)
 
                 # Re-serialize the stored grant from the recipient side to prove
-                # the nested ACDC, blind update, and anchor all survived the
-                # full cross-Habery KRAM plus exchanger path unchanged.
+                # the nested ACDC survived the full cross-Habery KRAM plus
+                # exchanger path unchanged.
                 grantMsg = serializeMessage(recipientHby, grantExn.said, framed=True)
                 grantWire = bytearray(grantMsg)
                 grantResults = Parser(version=Vrsn_2_0).parse(ims=grantWire,
@@ -2312,23 +2429,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                                                               processive=False)
                 assert grantWire == bytearray()
                 assert len(grantResults) == 1
-                assert [nest.serder.said for nest in grantResults[0].nests] == [
-                    acdc.said,
-                    issued.said,
-                    issuedAncSerder.said,
-                ]
-
-                # Pull the carried blindable update back out of the stored grant
-                # and prove it still unblinds to the expected issued state.
-                carriedBup = grantResults[0].nests[1].serder
-                unblinder = Blinder.unblind(said=carriedBup.sad["b"],
-                                            uuid=issuedBlinder.uuid,
-                                            acdc=acdc.said,
-                                            states=["issued", "revoked"])
-                assert unblinder is not None
-                assert unblinder.state == "issued"
-                assert unblinder.acdc == acdc.said
-                assert unblinder.crew == issuedBlinder.crew
+                assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
+                assert len(grantResults[0].nests[0].bsqs) == 1
 
                 # Recorder contents should show the issuer only saw the
                 # recipient-originated messages, and the recipient only saw the
@@ -2348,6 +2450,298 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert helping.nowIso8601() == admitStamp
                 assert recipientHby.db.exns.get(keys=(staleOfferExn.said,)) is None
                 assert recipientHby.db.exns.get(keys=(offerExn.said,)) is not None
+        finally:
+            rgy.close()
+
+
+def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeHelpingClock):
+    """Run the full IPEX flow for a two-node DAG with node-local issuer-auth."""
+    clock = fakeHelpingClock
+
+    kramConfig = {
+        "kram": {
+            "enabled": True,
+            "denials": [],
+            "caches": {
+                "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000],
+            },
+        },
+    }
+    assert helping.nowIso8601() == "2021-01-01T00:00:00.000000+00:00"
+
+    with (openHby(name="ipex-v2-dag-kram-issuer",
+                  base="test",
+                  version=Vrsn_2_0) as issuerHby,
+          openHby(name="ipex-v2-dag-kram-recipient",
+                  base="test",
+                  version=Vrsn_2_0) as recipientHby):
+        issuerHab = issuerHby.makeHab(name="issuer")
+        recipientHab = recipientHby.makeHab(name="recipient")
+        rgy = Regery(hby=issuerHby, name="ipex-v2-dag-kram-two-haberies", temp=True)
+        try:
+            # Build the issuer-owned registry and anchor its inception so the
+            # recipient can later vet the origin node's blind proof group.
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="blind-dag-kram", prefix=issuerHab.pre)
+            rip = rgy.store.event(registry.regk)
+            ripAnc = _anchor(issuerHab, registry, rip, framed=True)
+
+            # The disclosed DAG has a registry-backed origin node that points to
+            # one child node.
+            child = acdcmap(israid=issuerHab.pre,
+                            attribute=dict(d="", role="member"),
+                            iseaid=recipientHab.pre)
+            origin = acdcmap(israid=issuerHab.pre,
+                             regid=registry.regk,
+                             attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                             edge=_edge("holder", child),
+                             iseaid=recipientHab.pre)
+            schema = origin.sad["s"]["$id"]
+
+            issuedBlinder, issued = registrar.issue(registry, acdc=origin, state="issued")
+            issuedAnc = _anchor(issuerHab, registry, issued, framed=False)
+
+            # Rotate after the TEL anchors so the later transferable IPEX
+            # messages sign against a fresh establishment event.
+            issuerRot = issuerHab.rotate(framed=True,
+                                         version=Vrsn_2_0,
+                                         kind=issuerHab.kever.serder.kind,
+                                         gvrsn=Vrsn_2_0)
+
+            recipientRemoteKvy = Kevery(db=recipientHby.db, lax=False, local=False)
+            issuerRemoteKvy = Kevery(db=issuerHby.db, lax=False, local=False)
+
+            # Preload each side with the other side's evidence it will need to
+            # authenticate the later cross-Habery exchanges.
+            recipientIcp = recipientHab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(recipientIcp), kvy=issuerRemoteKvy)
+
+            issuerIcp = issuerHab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerIcp), kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(ripAnc), kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuedAnc),
+                                           framed=False,
+                                           kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerRot), kvy=recipientRemoteKvy)
+
+
+            # Set up each Habery with its IPEX exchanger and recorder
+            issuerRecorder = Recorder()
+            issuerInboundExc = Exchanger(hby=issuerHby, handlers=[])
+            loadHandlers(hby=issuerHby, exc=issuerInboundExc, notifier=issuerRecorder, rgy=rgy)
+
+            recipientRecorder = Recorder()
+            recipientInboundExc = Exchanger(hby=recipientHby, handlers=[])
+            loadHandlers(hby=recipientHby, exc=recipientInboundExc, notifier=recipientRecorder, rgy=rgy)
+
+            with (openCF(name="ipex-v2-dag-kram-issuer", base="test", temp=True) as issuerCf,
+                  openCF(name="ipex-v2-dag-kram-recipient", base="test", temp=True) as recipientCf):
+                issuerCf.put(kramConfig)
+                recipientCf.put(kramConfig)
+
+                # Set up local-send ingest for each Habery so each side can
+                # parse its own outbound messages first without treating them
+                # as true inbound IPEX events.
+                issuerLocalSendExc = Exchanger(hby=issuerHby, handlers=[])
+                recipientLocalSendExc = Exchanger(hby=recipientHby, handlers=[])
+                issuerLocalSendKvy = Kevery(db=issuerHby.db,
+                                            lax=False,
+                                            local=False,
+                                            kramer=Kramer(db=issuerHby.db, cf=issuerCf),
+                                            exc=issuerLocalSendExc)
+                recipientLocalSendKvy = Kevery(db=recipientHby.db,
+                                               lax=False,
+                                               local=False,
+                                               kramer=Kramer(db=recipientHby.db, cf=recipientCf),
+                                               exc=recipientLocalSendExc)
+                issuerInboundKvy = Kevery(db=issuerHby.db,
+                                          lax=False,
+                                          local=False,
+                                          kramer=Kramer(db=issuerHby.db, cf=issuerCf),
+                                          exc=issuerInboundExc)
+                recipientInboundKvy = Kevery(db=recipientHby.db,
+                                             lax=False,
+                                             local=False,
+                                             kramer=Kramer(db=recipientHby.db, cf=recipientCf),
+                                             exc=recipientInboundExc)
+
+                # The recipient opens the thread with one disclose-path list
+                # whose entries describe the one disclosed DAG.
+                applyStamp = helping.nowIso8601()
+                applyExn, applyAtc = ipexApply(hab=recipientHab,
+                                               recp=issuerHab.pre,
+                                               message="Please issue the DAG credential",
+                                               attrs={},
+                                               modifiers=dict(dp=[
+                                                   [schema, "/", []],
+                                                   [schema, "/e/holder", []],
+                                               ]),
+                                               dt=applyStamp)
+                
+                assert applyExn.ked["q"]["dp"] == [
+                    [schema, "/", []],
+                    [schema, "/e/holder", []],
+                ]
+
+                applyMsg = bytearray(applyExn.raw)
+                applyMsg.extend(applyAtc)
+
+                # Feed the apply to the recipient self-ingest pipeline and issuer's real inbound
+                localIms = bytearray(applyMsg)
+                Parser(version=Vrsn_2_0).parse(ims=localIms, kvy=recipientLocalSendKvy)
+                assert localIms == bytearray()
+                inboundIms = bytearray(applyMsg)
+                Parser(version=Vrsn_2_0).parse(ims=inboundIms, kvy=issuerInboundKvy)
+                assert inboundIms == bytearray()
+
+                applyStored, _ = cloneMessage(issuerHby, applyExn.said)
+                assert applyStored is not None
+                assert applyStored.ked["x"] == applyExn.ked["x"]
+
+                # The issuer answers with the full disclosed DAG. Offer uses the
+                # new per-node nest shape but does not yet carry issuer-auth.
+                clock.advance(milliseconds=1)
+                offerStamp = helping.nowIso8601()
+                offerExn, offerAtc = ipexOffer(hab=issuerHab,
+                                               message="Here is the credential DAG",
+                                               origin=origin,
+                                               artifacts=[child],
+                                               apply=applyExn,
+                                               dt=offerStamp)
+                assert offerExn.ked["a"]["o"] == [origin.said]
+
+                offerMsg = bytearray(offerExn.raw)
+                offerMsg.extend(offerAtc)
+
+                localIms = bytearray(offerMsg)
+                Parser(version=Vrsn_2_0).parse(ims=localIms, kvy=issuerLocalSendKvy)
+                assert localIms == bytearray()
+                inboundIms = bytearray(offerMsg)
+                Parser(version=Vrsn_2_0).parse(ims=inboundIms, kvy=recipientInboundKvy)
+                assert inboundIms == bytearray()
+
+                storedOffer, _ = cloneMessage(recipientHby, offerExn.said)
+                assert storedOffer is not None
+                assert storedOffer.ked["x"] == applyExn.ked["x"]
+
+                offerWire = bytearray(serializeMessage(recipientHby, offerExn.said, framed=True))
+                offerResults = Parser(version=Vrsn_2_0).parse(ims=offerWire,
+                                                              framed=False,
+                                                              processive=False)
+                
+                # Assert the nested DAG structure is preserved through the full roundtrip.
+                assert len(offerResults) == 1
+
+                # The offer nests should contain the origin and child nodes in order.
+                assert [nest.serder.said for nest in offerResults[0].nests] == [
+                    origin.said,
+                    child.said,
+                ]
+                assert len(offerResults[0].nests[0].bsqs) == 0
+
+                # The recipient agrees to the disclosed DAG.
+                clock.advance(milliseconds=1)
+                agreeStamp = helping.nowIso8601()
+                agreeExn, agreeAtc = ipexAgree(hab=recipientHab,
+                                               message="I agree to the DAG credential",
+                                               offer=storedOffer,
+                                               dt=agreeStamp)
+
+                agreeMsg = bytearray(agreeExn.raw)
+                agreeMsg.extend(agreeAtc)
+
+                localIms = bytearray(agreeMsg)
+                Parser(version=Vrsn_2_0).parse(ims=localIms, kvy=recipientLocalSendKvy)
+                assert localIms == bytearray()
+                inboundIms = bytearray(agreeMsg)
+                Parser(version=Vrsn_2_0).parse(ims=inboundIms, kvy=issuerInboundKvy)
+                assert inboundIms == bytearray()
+
+                storedAgree, _ = cloneMessage(issuerHby, agreeExn.said)
+                assert storedAgree is not None
+                assert storedAgree.ked["x"] == applyExn.ked["x"]
+
+                # The issuer grants the same two-node DAG, but now the origin
+                # node carries the node-local blind proof group that step 4 vets.
+                clock.advance(milliseconds=1)
+                grantStamp = helping.nowIso8601()
+                grantExn, grantAtc = ipexGrant(hab=issuerHab,
+                                               recp=recipientHab.pre,
+                                               message="Here is the registry-backed DAG disclosure",
+                                               origin=_proofed(origin, issuedBlinder),
+                                               artifacts=[child],
+                                               agree=storedAgree,
+                                               dt=grantStamp)
+                assert grantExn.ked["a"]["o"] == [origin.said]
+
+                grantMsg = bytearray(grantExn.raw)
+                grantMsg.extend(grantAtc)
+
+                localIms = bytearray(grantMsg)
+                Parser(version=Vrsn_2_0).parse(ims=localIms, kvy=issuerLocalSendKvy)
+                assert localIms == bytearray()
+                inboundIms = bytearray(grantMsg)
+                Parser(version=Vrsn_2_0).parse(ims=inboundIms, kvy=recipientInboundKvy)
+                assert inboundIms == bytearray()
+
+                storedGrant, _ = cloneMessage(recipientHby, grantExn.said)
+                assert storedGrant is not None
+                assert storedGrant.ked["x"] == applyExn.ked["x"]
+
+                grantWire = bytearray(serializeMessage(recipientHby, grantExn.said, framed=True))
+                grantResults = Parser(version=Vrsn_2_0).parse(ims=grantWire,
+                                                              framed=False,
+                                                              processive=False)
+                assert grantWire == bytearray()
+                assert len(grantResults) == 1
+                assert [nest.serder.said for nest in grantResults[0].nests] == [
+                    origin.said,
+                    child.said,
+                ]
+                assert len(grantResults[0].nests[0].bsqs) == 1
+                assert len(grantResults[0].nests[1].bsqs) == 0
+
+                # The recipient closes the happy path with admit
+                clock.advance(milliseconds=1)
+                admitStamp = helping.nowIso8601()
+                admitExn, admitAtc = ipexAdmit(hab=recipientHab,
+                                               message="Thanks for the DAG credential",
+                                               grant=storedGrant,
+                                               dt=admitStamp)
+
+                admitMsg = bytearray(admitExn.raw)
+                admitMsg.extend(admitAtc)
+                ims = bytearray(admitMsg)
+                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=issuerInboundKvy)
+                assert ims == bytearray()
+
+                storedAdmit, _ = cloneMessage(issuerHby, admitExn.said)
+                assert storedAdmit is not None
+                assert storedAdmit.ked["x"] == applyExn.ked["x"]
+
+                # A second grant that omits the child nest should now fail the
+                # graph walk even though the origin still carries a valid proof.
+                clock.advance(milliseconds=1)
+                badGrantExn, badGrantAtc = ipexGrant(hab=issuerHab,
+                                                     recp=recipientHab.pre,
+                                                     message="Here is the incomplete DAG",
+                                                     origin=_proofed(origin, issuedBlinder),
+                                                     dt=helping.nowIso8601())
+                badGrantMsg = bytearray(badGrantExn.raw)
+                badGrantMsg.extend(badGrantAtc)
+                Parser(version=Vrsn_2_0).parse(ims=badGrantMsg, kvy=recipientInboundKvy)
+                assert badGrantMsg == bytearray()
+                assert recipientHby.db.exns.get(keys=(badGrantExn.said,)) is None
+
+                assert [(item["r"], item["m"]) for item in issuerRecorder.items] == [
+                    ("/exn/ipex/apply", "Please issue the DAG credential"),
+                    ("/exn/ipex/agree", "I agree to the DAG credential"),
+                    ("/exn/ipex/admit", "Thanks for the DAG credential"),
+                ]
+                assert [(item["r"], item["m"]) for item in recipientRecorder.items] == [
+                    ("/exn/ipex/offer", "Here is the credential DAG"),
+                    ("/exn/ipex/grant", "Here is the registry-backed DAG disclosure"),
+                ]
         finally:
             rgy.close()
 
@@ -2398,8 +2792,7 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                            iseaid=recipient.pre)
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
-            issuedAnc = _anchor(hab, registry, issued, framed=False)
-            issuedAncSerder = _serder(issuedAnc)
+            _anchor(hab, registry, issued, framed=False)
 
             # After the anchors, rotate so the transferable IPEX messages below
             # sign against a fresh establishment event KRAM can verify.
@@ -2412,7 +2805,7 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
             # authenticated and dispatched through the usual handler path.
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             with openCF(name="ipex-v2-offer-kram", base="test", temp=True) as cf:
                 cf.put(kramConfig)
@@ -2446,8 +2839,7 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                 grantExn, grantAtc = ipexGrant(hab=hab,
                                                recp=recipient.pre,
                                                message="Here is the offer-first blind registry disclosure",
-                                               origin=acdc,
-                                               artifacts=[issued, issuedAnc],
+                                               origin=_proofed(acdc, issuedBlinder),
                                                agree=agreeExn,
                                                dt=grantStamp)
                 admitExn, admitAtc = ipexAdmit(hab=recipient,
@@ -2498,8 +2890,8 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                     assert (receiveMs - d - sl) <= mdtMs <= (receiveMs + d)
                     assert xdtMs <= mdtMs <= (xdtMs + xl)
 
-                # Re-serialize the stored grant and confirm the exact nested ACDC,
-                # blind update, and anchor survive the KRAM + exchanger path.
+                # Re-serialize the stored grant and confirm the exact nested ACDC
+                # survives the KRAM + exchanger path.
                 grantMsg = serializeMessage(hby, grantExn.said, framed=True)
                 grantIms = bytearray(grantMsg)
                 grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
@@ -2507,23 +2899,8 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                                                               processive=False)
                 assert grantIms == bytearray()
                 assert len(grantResults) == 1
-                assert [nest.serder.said for nest in grantResults[0].nests] == [
-                    acdc.said,
-                    issued.said,
-                    issuedAncSerder.said,
-                ]
-
-                # The carried blindable update must still unblind to the expected
-                # issued state once pulled back out of the accepted IPEX grant.
-                carriedBup = grantResults[0].nests[1].serder
-                unblinder = Blinder.unblind(said=carriedBup.sad["b"],
-                                            uuid=issuedBlinder.uuid,
-                                            acdc=acdc.said,
-                                            states=["issued", "revoked"])
-                assert unblinder is not None
-                assert unblinder.state == "issued"
-                assert unblinder.acdc == acdc.said
-                assert unblinder.crew == issuedBlinder.crew
+                assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
+                assert len(grantResults[0].nests[0].bsqs) == 1
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -2578,8 +2955,7 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                            iseaid=recipient.pre)
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
-            issuedAnc = _anchor(hab, registry, issued, framed=False)
-            issuedAncSerder = _serder(issuedAnc)
+            _anchor(hab, registry, issued, framed=False)
 
             # After the anchors, rotate so the transferable IPEX messages below
             # sign against a fresh establishment event KRAM can verify.
@@ -2592,7 +2968,7 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
             # authenticated and dispatched through the usual handler path.
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             with openCF(name="ipex-v2-grant-kram", base="test", temp=True) as cf:
                 cf.put(kramConfig)
@@ -2614,8 +2990,7 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
                 grantExn, grantAtc = ipexGrant(hab=hab,
                                                recp=recipient.pre,
                                                message="Grant starts the blind credential flow",
-                                               origin=acdc,
-                                               artifacts=[issued, issuedAnc],
+                                               origin=_proofed(acdc, issuedBlinder),
                                                dt=grantStamp)
                 admitExn, admitAtc = ipexAdmit(hab=recipient,
                                                message="Thanks for the grant-first blind credential",
@@ -2663,8 +3038,8 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
                     assert (receiveMs - d - sl) <= mdtMs <= (receiveMs + d)
                     assert xdtMs <= mdtMs <= (xdtMs + xl)
 
-                # Re-serialize the stored grant and confirm the exact nested ACDC,
-                # blind update, and anchor survive the KRAM + exchanger path.
+                # Re-serialize the stored grant and confirm the exact nested ACDC
+                # survives the KRAM + exchanger path.
                 grantMsg = serializeMessage(hby, grantExn.said, framed=True)
                 grantIms = bytearray(grantMsg)
                 grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
@@ -2672,23 +3047,8 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
                                                               processive=False)
                 assert grantIms == bytearray()
                 assert len(grantResults) == 1
-                assert [nest.serder.said for nest in grantResults[0].nests] == [
-                    acdc.said,
-                    issued.said,
-                    issuedAncSerder.said,
-                ]
-
-                # The carried blindable update must still unblind to the expected
-                # issued state once pulled back out of the accepted IPEX grant.
-                carriedBup = grantResults[0].nests[1].serder
-                unblinder = Blinder.unblind(said=carriedBup.sad["b"],
-                                            uuid=issuedBlinder.uuid,
-                                            acdc=acdc.said,
-                                            states=["issued", "revoked"])
-                assert unblinder is not None
-                assert unblinder.state == "issued"
-                assert unblinder.acdc == acdc.said
-                assert unblinder.crew == issuedBlinder.crew
+                assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
+                assert len(grantResults[0].nests[0].bsqs) == 1
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -2723,8 +3083,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
 
             # Commit an issued blind update first and anchor it before any later lifecycle state exists
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
-            issuedAnc = _anchor(hab, registry, issued, framed=False)
-            issuedAncSerder = _serder(issuedAnc)
+            _anchor(hab, registry, issued, framed=False)
 
             assert rgy.store.seqEvent(registry.regk, 0).said == rip.said
             assert rgy.store.seqEvent(registry.regk, 1).said == issued.said
@@ -2734,7 +3093,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
             # Wire one exchanger with the V2 IPEX handlers, then disclose the issued update first
             recorder = Recorder()
             exc = Exchanger(hby=hby, handlers=[])
-            loadHandlers(hby=hby, exc=exc, notifier=recorder)
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
 
             # First disclose the issued-state credential through one full linear IPEX exchange
             issuedApplyExn, issuedApplyAtc = ipexApply(hab=hab,
@@ -2752,8 +3111,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
             issuedGrantExn, issuedGrantAtc = ipexGrant(hab=hab,
                                                        recp=hab.pre,
                                                        message="Here is the issued blind registry disclosure",
-                                                       origin=acdc,
-                                                       artifacts=[issued, issuedAnc],
+                                                       origin=_proofed(acdc, issuedBlinder),
                                                        agree=issuedAgreeExn)
             issuedAdmitExn, issuedAdmitAtc = ipexAdmit(hab=hab,
                                                        message="Thanks for the issued blind credential",
@@ -2774,7 +3132,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
 
             issuedStoredGrant = hby.db.exns.get(keys=(issuedGrantExn.said,))
             assert issuedStoredGrant.ked["p"] == issuedAgreeExn.said
-            assert issuedStoredGrant.ked["a"]["o"] == acdc.said
+            assert issuedStoredGrant.ked["a"]["o"] == [acdc.said]
             assert "iss" not in issuedStoredGrant.ked["a"]
             assert "anc" not in issuedStoredGrant.ked["a"]
 
@@ -2785,26 +3143,12 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
                                                            processive=False)
             assert issuedIms == bytearray()
             assert len(issuedResults) == 1
-            assert [nest.serder.said for nest in issuedResults[0].nests] == [
-                acdc.said,
-                issued.said,
-                issuedAncSerder.said,
-            ]
-
-            issuedCarriedBup = issuedResults[0].nests[1].serder
-            issuedUnblinder = Blinder.unblind(said=issuedCarriedBup.sad["b"],
-                                              uuid=issuedBlinder.uuid,
-                                              acdc=acdc.said,
-                                              states=["issued", "revoked"])
-            assert issuedUnblinder is not None
-            assert issuedUnblinder.state == "issued"
-            assert issuedUnblinder.acdc == acdc.said
-            assert issuedUnblinder.crew == issuedBlinder.crew
+            assert [nest.serder.said for nest in issuedResults[0].nests] == [acdc.said]
+            assert len(issuedResults[0].nests[0].bsqs) == 1
 
             # Commit a revoked blind update that follows the issued state
             revokedBlinder, revoked = registrar.issue(registry, acdc=acdc, state="revoked")
-            revokedAnc = _anchor(hab, registry, revoked, framed=False)
-            revokedAncSerder = _serder(revokedAnc)
+            _anchor(hab, registry, revoked, framed=False)
 
             # The accepted TEL should now show the full rip -> bup -> bup lifecycle
             assert rgy.store.seqEvent(registry.regk, 0).said == rip.said
@@ -2830,8 +3174,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
             revokedGrantExn, revokedGrantAtc = ipexGrant(hab=hab,
                                                          recp=hab.pre,
                                                          message="Here is the revoked blind registry disclosure",
-                                                         origin=acdc,
-                                                         artifacts=[revoked, revokedAnc],
+                                                         origin=_proofed(acdc, revokedBlinder),
                                                          agree=revokedAgreeExn)
             revokedAdmitExn, revokedAdmitAtc = ipexAdmit(hab=hab,
                                                          message="Thanks for the revoked blind credential",
@@ -2852,7 +3195,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
 
             revokedStoredGrant = hby.db.exns.get(keys=(revokedGrantExn.said,))
             assert revokedStoredGrant.ked["p"] == revokedAgreeExn.said
-            assert revokedStoredGrant.ked["a"]["o"] == acdc.said
+            assert revokedStoredGrant.ked["a"]["o"] == [acdc.said]
             assert "iss" not in revokedStoredGrant.ked["a"]
             assert "anc" not in revokedStoredGrant.ked["a"]
 
@@ -2863,21 +3206,8 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
                                                              processive=False)
             assert revokedIms == bytearray()
             assert len(revokedResults) == 1
-            assert [nest.serder.said for nest in revokedResults[0].nests] == [
-                acdc.said,
-                revoked.said,
-                revokedAncSerder.said,
-            ]
-
-            revokedCarriedBup = revokedResults[0].nests[1].serder
-            revokedUnblinder = Blinder.unblind(said=revokedCarriedBup.sad["b"],
-                                               uuid=revokedBlinder.uuid,
-                                               acdc=acdc.said,
-                                               states=["issued", "revoked"])
-            assert revokedUnblinder is not None
-            assert revokedUnblinder.state == "revoked"
-            assert revokedUnblinder.acdc == acdc.said
-            assert revokedUnblinder.crew == revokedBlinder.crew
+            assert [nest.serder.said for nest in revokedResults[0].nests] == [acdc.said]
+            assert len(revokedResults[0].nests[0].bsqs) == 1
 
             # The notifier should reflect both full disclosures in the order they were sent
             assert [(item["r"], item["m"]) for item in recorder.items] == [

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -647,6 +647,70 @@ def test_ipex_v2_offer_can_name_origin_without_disclosing_the_dag():
         ]
 
 
+def test_ipex_v2_offer_accepts_reachable_partial_metadata_subgraph():
+    """Offer may disclose a reachable metadata subgraph without full closure."""
+    with openHby(name="ipex-v2-offer-partial-subgraph",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+
+        grandchild = acdcmap(israid=holder.pre,
+                             uuid="",
+                             attribute=dict(d="", role="member"))
+        child = acdcmap(israid=holder.pre,
+                        uuid="",
+                        attribute=dict(d="", department="kitchen"),
+                        edge=_edge("member", grandchild))
+        origin = acdcmap(israid=holder.pre,
+                         uuid="",
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("department", child),
+                         iseaid=verifier.pre)
+        schema = origin.sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=verifier,
+                                       recp=holder.pre,
+                                       message="Show me the metadata path",
+                                       attrs={},
+                                       modifiers=dict(dp=[[schema, "/", []],
+                                                           [schema, "/e/department", []]]))
+        # Carry only the disclosed root plus one reachable metadata child.
+        # The child's farther edge to `grandchild` is intentionally omitted.
+        offerExn, offerAtc = ipexOffer(hab=holder,
+                                       recp=verifier.pre,
+                                       message="Here is the partial metadata DAG",
+                                       origin=origin,
+                                       artifacts=[child],
+                                       apply=applyExn)
+
+        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        storedOffer = hby.db.exns.get(keys=(offerExn.said,))
+        assert storedOffer is not None
+        assert storedOffer.ked["a"]["o"] == [origin.said]
+
+        offerWire = bytearray(serializeMessage(hby, offerExn.said, framed=True))
+        offerResults = Parser(version=Vrsn_2_0).parse(ims=offerWire,
+                                                      framed=False,
+                                                      processive=False)
+        assert offerWire == bytearray()
+        assert len(offerResults) == 1
+        assert [nest.serder.said for nest in offerResults[0].nests] == [origin.said, child.said]
+        assert recorder.items == [
+            {"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Show me the metadata path"},
+            {"r": "/exn/ipex/offer", "d": offerExn.said, "m": "Here is the partial metadata DAG"},
+        ]
+
+
 def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
     """Offer DAG nests must describe exactly one reachable metadata graph."""
     with openHby(name="ipex-v2-bad-offer-extra-node",

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -12,7 +12,7 @@ from keri.acdc import (Regery, Registrar, acdcmap, blindate, apply as ipexApply,
                        loadHandlers, offer as ipexOffer, regcept,
                        spurn as ipexSpurn)
 from keri.app import openCF, openHby
-from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Parser,
+from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Noncer, Parser,
                        messagize,
                        SerderKERI, Serdery, Texter, exchange)
 from keri.kering import Colds, sniff
@@ -180,7 +180,7 @@ def test_ipex_v2_builders_parse_happypath():
         assert offerExn.ked["a"]["ax"] == [False]
         assert offerExn.ked["a"]["o"] == [acdc.said]
         assert offerExn.ked["p"] == applyExn.said       # prior
-        assert offerExn.ked["q"]["dp"] == []
+        assert offerExn.ked["q"]["dp"] == applyExn.ked["q"]["dp"]
 
         assert agreeExn.ked["a"]["m"] == "I agree to the offer"
         assert agreeExn.ked["p"] == offerExn.said
@@ -435,27 +435,125 @@ def test_ipex_v2_builders_reject_registry_events_as_disclosed_nodes():
                       artifacts=[rip])
 
 
-def test_ipex_v2_offer_builder_rejects_disclosed_artifacts():
-    """Offer remains metadata-only and rejects any disclosed DAG node artifacts."""
+def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
+    """Offer may carry a metadata DAG and later grant the full disclosed DAG."""
     with openHby(name="ipex-v2-bad-offer-duplicate-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
         holder = hby.makeHab(name="holder")
         verifier = hby.makeHab(name="verifier")
-        acdc = acdcmap(israid=holder.pre,
-                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                       iseaid=holder.pre)
 
-        with pytest.raises(ValueError, match="offer does not disclose DAG nodes"):
-            ipexOffer(hab=holder,
-                      recp=verifier.pre,
-                      message="Here are the terms",
-                      origin=acdc,
-                      artifacts=[acdc])
+        # Build the final disclosed DAG first: the grant will later carry these
+        # full ACDC bodies, including the private attribute values.
+        child = acdcmap(israid=holder.pre,
+                        uuid=Noncer().qb64,
+                        attribute=dict(d="", u=Noncer().qb64, role="member"),
+                        iseaid=verifier.pre)
+        origin = acdcmap(israid=holder.pre,
+                         uuid=Noncer().qb64,
+                         attribute=dict(d="", u=Noncer().qb64, LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         rule=dict(d="", l="Use only for onboarding."),
+                         iseaid=verifier.pre)
+        schema = origin.sad["s"]["$id"]
+
+        # The offer carries metadata variants of those same nodes instead:
+        # top-level `u` is emptied, private sections stay compacted to SAIDs,
+        # and only the root's rule text is disclosed up front.
+        offerChild = acdcmap(israid=holder.pre,
+                             uuid="",
+                             schema=child.sad["s"]["$id"],
+                             attribute=child.sad["a"]["d"])
+        offerOrigin = acdcmap(israid=holder.pre,
+                              uuid="",
+                              schema=origin.sad["s"]["$id"],
+                              attribute=origin.sad["a"]["d"],
+                              edge=_edge("holder", offerChild),
+                              rule=origin.sad["r"])
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=verifier,
+                                       recp=holder.pre,
+                                       message="Please disclose the credential DAG",
+                                       attrs=dict(role="member"),
+                                       modifiers=dict(dp=[[schema, "/", []],
+                                                           [schema, "/e/holder", []]]))
+        offerExn, offerAtc = ipexOffer(hab=holder,
+                                       recp=verifier.pre,
+                                       message="Here are the terms",
+                                       origin=offerOrigin,
+                                       artifacts=[offerChild],
+                                       apply=applyExn)
+        agreeExn, agreeAtc = ipexAgree(hab=verifier,
+                                       message="I agree to the terms",
+                                       offer=offerExn)
+        grantExn, grantAtc = ipexGrant(hab=holder,
+                                       recp=verifier.pre,
+                                       message="Here is the granted credential",
+                                       origin=origin,
+                                       artifacts=[child],
+                                       agree=agreeExn)
+
+        for exn, atc in ((applyExn, applyAtc),
+                         (offerExn, offerAtc),
+                         (agreeExn, agreeAtc),
+                         (grantExn, grantAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        storedOffer = hby.db.exns.get(keys=(offerExn.said,))
+        storedGrant = hby.db.exns.get(keys=(grantExn.said,))
+        assert storedOffer is not None
+        assert storedGrant is not None
+        assert storedOffer.ked["a"]["o"] == [offerOrigin.said]
+        assert storedGrant.ked["a"]["o"] == [origin.said]
+        assert storedOffer.ked["a"]["o"] != storedGrant.ked["a"]["o"]
+        assert storedOffer.ked["q"]["dp"] == [[schema, "/", []],
+                                              [schema, "/e/holder", []]]
+
+        offerWire = bytearray(serializeMessage(hby, offerExn.said, framed=True))
+        offerResults = Parser(version=Vrsn_2_0).parse(ims=offerWire,
+                                                      framed=False,
+                                                      processive=False)
+        assert offerWire == bytearray()
+        assert len(offerResults) == 1
+        assert [nest.serder.said for nest in offerResults[0].nests] == [offerOrigin.said, offerChild.said]
+        assert offerResults[0].nests[0].serder.sad["u"] == ""
+        assert isinstance(offerResults[0].nests[0].serder.sad["a"], str)
+        assert isinstance(offerResults[0].nests[0].serder.sad["r"], dict)
+        assert offerResults[0].nests[0].serder.sad["r"]["l"] == "Use only for onboarding."
+        assert offerResults[0].nests[1].serder.sad["u"] == ""
+        assert isinstance(offerResults[0].nests[1].serder.sad["a"], str)
+
+        grantWire = bytearray(serializeMessage(hby, grantExn.said, framed=True))
+        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantWire,
+                                                      framed=False,
+                                                      processive=False)
+        assert grantWire == bytearray()
+        assert len(grantResults) == 1
+        assert [nest.serder.said for nest in grantResults[0].nests] == [origin.said, child.said]
+        assert grantResults[0].nests[0].serder.sad["u"] != ""
+        assert isinstance(grantResults[0].nests[0].serder.sad["a"], dict)
+        assert grantResults[0].nests[0].serder.sad["a"]["LEI"] == "254900OPPU84GM83MG36"
+        assert grantResults[0].nests[1].serder.sad["u"] != ""
+        assert isinstance(grantResults[0].nests[1].serder.sad["a"], dict)
+        assert grantResults[0].nests[1].serder.sad["a"]["role"] == "member"
+
+        assert [item["r"] for item in recorder.items] == [
+            "/exn/ipex/apply",
+            "/exn/ipex/offer",
+            "/exn/ipex/agree",
+            "/exn/ipex/grant",
+        ]
 
 
 def test_ipex_v2_rejects_offer_with_unexpected_nested_artifacts():
-    """Inbound offer verification rejects any forged nested disclosure payload."""
+    """Inbound offer verification rejects invalid nested payloads."""
     with openHby(name="ipex-v2-bad-offer-tel-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -471,9 +569,8 @@ def test_ipex_v2_rejects_offer_with_unexpected_nested_artifacts():
                          edge=_edge("holder", rip),
                          iseaid=hab.pre)
 
-        # Build a syntactically valid metadata-only offer body, then re-endorse
-        # it with forged nests. Offer must reject any attempt to disclose
-        # payload bodies before grant.
+        # Build a syntactically valid offer body, then re-endorse it with an
+        # invalid nested DAG that points at a TEL event instead of an ACDC node.
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=origin,
@@ -535,6 +632,7 @@ def test_ipex_v2_offer_can_name_origin_without_disclosing_the_dag():
         storedOffer = hby.db.exns.get(keys=(offerExn.said,))
         assert storedOffer is not None
         assert storedOffer.ked["a"]["o"] == [origin.said]
+        assert storedOffer.ked["q"]["dp"] == applyExn.ked["q"]["dp"]
 
         storedOfferMsg = serializeMessage(hby, offerExn.said, framed=True)
         storedOfferIms = bytearray(storedOfferMsg)
@@ -550,8 +648,8 @@ def test_ipex_v2_offer_can_name_origin_without_disclosing_the_dag():
         ]
 
 
-def test_ipex_v2_offer_builder_rejects_multiple_disclosed_artifacts():
-    """Offer rejects any attempt to carry additional disclosed DAG nodes."""
+def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
+    """Offer DAG nests must describe exactly one reachable metadata graph."""
     with openHby(name="ipex-v2-bad-offer-extra-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -567,13 +665,27 @@ def test_ipex_v2_offer_builder_rejects_multiple_disclosed_artifacts():
                          attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                          edge=_edge("holder", child),
                          iseaid=holder.pre)
+        schema = origin.sad["s"]["$id"]
 
-        with pytest.raises(ValueError, match="offer does not disclose DAG nodes"):
-            ipexOffer(hab=holder,
-                      recp=verifier.pre,
-                      message="Here is the overstuffed DAG",
-                      origin=origin,
-                      artifacts=[child, extra])
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexOffer(hab=holder,
+                             recp=verifier.pre,
+                             message="Here is the overstuffed DAG",
+                             origin=origin,
+                             artifacts=[child, extra],
+                             modifiers=dict(dp=[[schema, "/", []],
+                                                 [schema, "/e/holder", []]]))
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
 
 
 def test_ipex_v2_rejects_grant_with_missing_edged_node():
@@ -711,8 +823,8 @@ def test_ipex_v2_rejects_grant_with_unreachable_nested_node():
         assert recorder.items == []
 
 
-def test_ipex_v2_rejects_grant_when_offer_origin_differs():
-    """Grant must disclose the same origin DAG root that the prior offer named."""
+def test_ipex_v2_allows_grant_origin_to_differ_from_offer_origin():
+    """Offer and grant may carry different root SAIDs when offer uses metadata ACDCs."""
     with openHby(name="ipex-v2-offer-metadata-origin",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -761,11 +873,12 @@ def test_ipex_v2_rejects_grant_when_offer_origin_differs():
         assert offerExn.ked["a"]["o"] == [offerMeta.said]
         assert grantExn.ked["a"]["o"] == [grantOrigin.said]
         assert offerExn.ked["a"]["o"] != grantExn.ked["a"]["o"]
-        assert hby.db.exns.get(keys=(grantExn.said,)) is None
+        assert hby.db.exns.get(keys=(grantExn.said,)) is not None
         assert [item["r"] for item in recorder.items] == [
             "/exn/ipex/apply",
             "/exn/ipex/offer",
             "/exn/ipex/agree",
+            "/exn/ipex/grant",
         ]
 
 
@@ -858,7 +971,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         assert storedOffer.ked["a"]["m"] == "Here is the offered credential"
         assert storedOffer.ked["a"]["o"] == [acdc.said]
         assert "acdc" not in storedOffer.ked["a"]
-        assert storedOffer.ked["q"]["dp"] == []
+        assert storedOffer.ked["q"]["dp"] == apply0.ked["q"]["dp"]
         assert storedOffer.ked["p"] == apply0.said
 
         storedOfferMsg = serializeMessage(hby, offer0.said, framed=True)
@@ -1132,7 +1245,7 @@ def test_ipex_v2_rejects_offer_without_dp():
         assert recorder.items == []
 
 
-def test_ipex_v2_rejects_offer_with_missing_origin_attr_without_throwing():
+def test_ipex_v2_accepts_offer_with_missing_origin_attr_without_throwing():
     with openHby(name="ipex-v2-bad-offer-origin",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -1167,8 +1280,10 @@ def test_ipex_v2_rejects_offer_with_missing_origin_attr_without_throwing():
         Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
 
         assert ims == bytearray()
-        assert hby.db.exns.get(keys=(badOffer.said,)) is None
-        assert recorder.items == []
+        stored = hby.db.exns.get(keys=(badOffer.said,))
+        assert stored is not None
+        assert "o" not in stored.ked["a"]
+        assert recorder.items == [{"r": "/exn/ipex/offer", "d": badOffer.said, "m": "Here is the offered credential"}]
 
 
 def test_ipex_v2_rejects_offer_with_nonstring_origin_without_throwing():

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -479,7 +479,7 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
                                        message="Please disclose the credential DAG",
                                        attrs=dict(role="member"),
                                        modifiers=dict(dp=[[[schema, "/", []],
-                                                           [schema, "/e/holder", []]]]))
+                                                           [schema, "/e/holder/_/", []]]]))
         offerExn, offerAtc = ipexOffer(hab=holder,
                                        recp=verifier.pre,
                                        message="Here are the terms",
@@ -513,7 +513,7 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
         assert storedGrant.ked["a"]["o"] == [origin.said]
         assert storedOffer.ked["a"]["o"] != storedGrant.ked["a"]["o"]
         assert storedOffer.ked["q"]["dp"] == [[[schema, "/", []],
-                                              [schema, "/e/holder", []]]]
+                                              [schema, "/e/holder/_/", []]]]
 
         offerWire = bytearray(serializeMessage(hby, offerExn.said, framed=True))
         offerResults = Parser(version=Vrsn_2_0).parse(ims=offerWire,
@@ -678,7 +678,7 @@ def test_ipex_v2_offer_accepts_reachable_partial_metadata_subgraph():
                                        message="Show me the metadata path",
                                        attrs={},
                                        modifiers=dict(dp=[[[schema, "/", []],
-                                                           [schema, "/e/department", []]]]))
+                                                           [schema, "/e/department/_/", []]]]))
         # Carry only the disclosed root plus one reachable metadata child.
         # The child's farther edge to `grandchild` is intentionally omitted.
         offerExn, offerAtc = ipexOffer(hab=holder,
@@ -740,7 +740,7 @@ def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
                              origin=origin,
                              artifacts=[child, extra],
                              modifiers=dict(dp=[[[schema, "/", []],
-                                                 [schema, "/e/holder", []]]]))
+                                                 [schema, "/e/holder/_/", []]]]))
 
         ims = bytearray(exn.raw)
         ims.extend(atc)
@@ -1906,6 +1906,52 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
                       recp=holder.pre,
                       message="Bad disclosure plan nesting",
                       modifiers=dict(dp=[[[[schema, "/", ["a/role"]]]]]))
+        with pytest.raises(ValueError):
+            ipexApply(hab=verifier,
+                      recp=holder.pre,
+                      message="Bad disclosure plan prefix",
+                      modifiers=dict(dp=[[[schema, "/e/holder", ["a/role"]]]]))
+        with pytest.raises(ValueError):
+            ipexApply(hab=verifier,
+                      recp=holder.pre,
+                      message="Bad disclosure plan field entries",
+                      modifiers=dict(dp=[[[schema, "/", [1, {}]]]]))
+
+
+def test_ipex_v2_rejects_inbound_apply_with_malformed_disclosure_path():
+    """Inbound apply verification rejects forged dp entries with invalid field paths."""
+    with openHby(name="ipex-v2-bad-apply-dp",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+        schema = acdcmap(israid=holder.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         iseaid=verifier.pre).sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        badApply = exchange(sender=verifier.pre,
+                            receiver=holder.pre,
+                            xid=Noncer().qb64,
+                            route="/ipex/apply",
+                            modifiers=dict(dp=[[[schema, "/", [1, {}]]]]),
+                            attributes=dict(m="Please disclose the forged plan"),
+                            pvrsn=Vrsn_2_0,
+                            gvrsn=Vrsn_2_0,
+                            kind=verifier.kever.serder.kind)
+        atc = bytearray(verifier.endorse(serder=badApply, framed=False, gvrsn=Vrsn_2_0))
+        del atc[:badApply.size]
+
+        ims = bytearray(badApply.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(badApply.said,)) is None
+        assert recorder.items == []
 
 
 def test_ipex_v2_rejects_third_party_prior_response_without_throwing():
@@ -3190,13 +3236,13 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                                                attrs={},
                                                modifiers=dict(dp=[[
                                                    [schema, "/", []],
-                                                   [schema, "/e/holder", []],
+                                                   [schema, "/e/holder/_/", []],
                                                ]]),
                                                dt=applyStamp)
                 
                 assert applyExn.ked["q"]["dp"] == [[
                     [schema, "/", []],
-                    [schema, "/e/holder", []],
+                    [schema, "/e/holder/_/", []],
                 ]]
 
                 applyMsg = bytearray(applyExn.raw)

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -2037,6 +2037,17 @@ def test_ipex_v2_blindable_registry_roundtrip():
                                                     processive=False)
             assert [nest.serder.said for nest in parsed] == [acdc.said]
             assert len(parsed[0].bsqs) == 1
+            proof = parsed[0].bsqs[0]
+            assert proof[0].qb64 == issuedBlinder.said
+            assert proof[1].nonce == issuedBlinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "issued"
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"])
+            assert unblinder is not None
+            assert unblinder.state == "issued"
 
             # Serializing the whole stored message should round-trip the same
             # nested node and its proof-group attachment section.
@@ -2049,6 +2060,17 @@ def test_ipex_v2_blindable_registry_roundtrip():
             assert len(results) == 1
             assert [nest.serder.said for nest in results[0].nests] == [acdc.said]
             assert len(results[0].nests[0].bsqs) == 1
+            proof = results[0].nests[0].bsqs[0]
+            assert proof[0].qb64 == issuedBlinder.said
+            assert proof[1].nonce == issuedBlinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "issued"
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"])
+            assert unblinder is not None
+            assert unblinder.state == "issued"
         finally:
             rgy.close()
 
@@ -2264,6 +2286,17 @@ def test_ipex_v2_blind_registry_update_roundtrip():
             assert len(results) == 1
             assert [nest.serder.said for nest in results[0].nests] == [acdc.said]
             assert len(results[0].nests[0].bsqs) == 1
+            proof = results[0].nests[0].bsqs[0]
+            assert proof[0].qb64 == blinder.said
+            assert proof[1].nonce == blinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "revoked"
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"])
+            assert unblinder is not None
+            assert unblinder.state == "revoked"
 
             # The notifier should report the accepted linear IPEX exchange in send order
             assert [(item["r"], item["m"]) for item in recorder.items] == [
@@ -2560,6 +2593,17 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
                 assert len(grantResults) == 1
                 assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
                 assert len(grantResults[0].nests[0].bsqs) == 1
+                proof = grantResults[0].nests[0].bsqs[0]
+                assert proof[0].qb64 == issuedBlinder.said
+                assert proof[1].nonce == issuedBlinder.uuid
+                assert proof[2].nonce == acdc.said
+                assert proof[3].text == "issued"
+                unblinder = Blinder.unblind(said=proof[0].qb64,
+                                            uuid=proof[1].nonce,
+                                            acdc=acdc.said,
+                                            states=["issued", "revoked"])
+                assert unblinder is not None
+                assert unblinder.state == "issued"
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -3266,6 +3310,17 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                     child.said,
                 ]
                 assert len(grantResults[0].nests[0].bsqs) == 1
+                proof = grantResults[0].nests[0].bsqs[0]
+                assert proof[0].qb64 == issuedBlinder.said
+                assert proof[1].nonce == issuedBlinder.uuid
+                assert proof[2].nonce == origin.said
+                assert proof[3].text == "issued"
+                unblinder = Blinder.unblind(said=proof[0].qb64,
+                                            uuid=proof[1].nonce,
+                                            acdc=origin.said,
+                                            states=["issued", "revoked"])
+                assert unblinder is not None
+                assert unblinder.state == "issued"
                 assert len(grantResults[0].nests[1].bsqs) == 0
 
                 # The recipient closes the happy path with admit
@@ -3469,6 +3524,17 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                 assert len(grantResults) == 1
                 assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
                 assert len(grantResults[0].nests[0].bsqs) == 1
+                proof = grantResults[0].nests[0].bsqs[0]
+                assert proof[0].qb64 == issuedBlinder.said
+                assert proof[1].nonce == issuedBlinder.uuid
+                assert proof[2].nonce == acdc.said
+                assert proof[3].text == "issued"
+                unblinder = Blinder.unblind(said=proof[0].qb64,
+                                            uuid=proof[1].nonce,
+                                            acdc=acdc.said,
+                                            states=["issued", "revoked"])
+                assert unblinder is not None
+                assert unblinder.state == "issued"
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -3617,6 +3683,17 @@ def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):
                 assert len(grantResults) == 1
                 assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
                 assert len(grantResults[0].nests[0].bsqs) == 1
+                proof = grantResults[0].nests[0].bsqs[0]
+                assert proof[0].qb64 == issuedBlinder.said
+                assert proof[1].nonce == issuedBlinder.uuid
+                assert proof[2].nonce == acdc.said
+                assert proof[3].text == "issued"
+                unblinder = Blinder.unblind(said=proof[0].qb64,
+                                            uuid=proof[1].nonce,
+                                            acdc=acdc.said,
+                                            states=["issued", "revoked"])
+                assert unblinder is not None
+                assert unblinder.state == "issued"
 
                 # Recorder order proves the whole accepted chain actually reached
                 # the IPEX handlers after KRAM let each message through.
@@ -3713,6 +3790,17 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
             assert len(issuedResults) == 1
             assert [nest.serder.said for nest in issuedResults[0].nests] == [acdc.said]
             assert len(issuedResults[0].nests[0].bsqs) == 1
+            proof = issuedResults[0].nests[0].bsqs[0]
+            assert proof[0].qb64 == issuedBlinder.said
+            assert proof[1].nonce == issuedBlinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "issued"
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"])
+            assert unblinder is not None
+            assert unblinder.state == "issued"
 
             # Commit a revoked blind update that follows the issued state
             revokedBlinder, revoked = registrar.issue(registry, acdc=acdc, state="revoked")
@@ -3776,6 +3864,17 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
             assert len(revokedResults) == 1
             assert [nest.serder.said for nest in revokedResults[0].nests] == [acdc.said]
             assert len(revokedResults[0].nests[0].bsqs) == 1
+            proof = revokedResults[0].nests[0].bsqs[0]
+            assert proof[0].qb64 == revokedBlinder.said
+            assert proof[1].nonce == revokedBlinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "revoked"
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"])
+            assert unblinder is not None
+            assert unblinder.state == "revoked"
 
             # The notifier should reflect both full disclosures in the order they were sent
             assert [(item["r"], item["m"]) for item in recorder.items] == [

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -721,6 +721,86 @@ def test_ipex_v2_rejects_grant_with_missing_edged_node():
         assert recorder.items == []
 
 
+def test_ipex_v2_accepts_grant_with_section_level_edge_nonce():
+    """Grant accepts an expanded edge section that carries its own nonce."""
+    with openHby(name="ipex-v2-grant-edge-section-u",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        child = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=dict(d="",
+                                   u=Noncer().qb64,
+                                   holder=dict(d="", n=child.said, o="I2I")),
+                         iseaid=hab.pre)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the expanded edge-section DAG",
+                             origin=origin,
+                             artifacts=[child])
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is not None
+        assert recorder.items == [{"r": "/exn/ipex/grant",
+                                   "d": exn.said,
+                                   "m": "Here is the expanded edge-section DAG"}]
+
+
+def test_ipex_v2_accepts_grant_with_nested_edge_group():
+    """Grant accepts nested edge groups and walks their far-node leaves."""
+    with openHby(name="ipex-v2-grant-edge-group",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        child0 = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", role="member"),
+                         iseaid=hab.pre)
+        child1 = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", department="kitchen"),
+                         iseaid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=dict(d="",
+                                   u=Noncer().qb64,
+                                   either=dict(d="",
+                                               o="OR",
+                                               member=dict(d="", n=child0.said, o="I2I"),
+                                               staff=dict(d="", n=child1.said, o="I2I"))),
+                         iseaid=hab.pre)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the grouped-edge DAG",
+                             origin=origin,
+                             artifacts=[child0, child1])
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is not None
+        assert recorder.items == [{"r": "/exn/ipex/grant",
+                                   "d": exn.said,
+                                   "m": "Here is the grouped-edge DAG"}]
+
+
 def test_ipex_v2_rejects_grant_with_duplicate_disclosed_node():
     """Grant must not carry the same disclosed ACDC node more than once."""
     with openHby(name="ipex-v2-bad-grant-duplicate-node",

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -102,9 +102,11 @@ def _anchor(hab, registry, serder, *, framed=False):
     return anc
 
 
-def _edge(label, node, *, op="I2I", schema=None):
+def _edge(label, node, *, op=None, schema=None):
     """Create a simple edge block that points at another disclosed ACDC node."""
-    target = dict(d="", n=node.said, o=op)
+    target = dict(d="", n=node.said)
+    if op is not None:
+        target["o"] = op
     if schema is not None:
         target["s"] = schema
     return dict(d="", **{label: target})
@@ -568,13 +570,15 @@ def test_ipex_v2_rejects_offer_with_unexpected_nested_artifacts():
                          attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                          edge=_edge("holder", rip),
                          iseaid=hab.pre)
+        schema = origin.sad["s"]["$id"]
 
         # Build a syntactically valid offer body, then re-endorse it with an
         # invalid nested DAG that points at a TEL event instead of an ACDC node.
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=origin,
-                           message="Here is the forged credential DAG")
+                           message="Here is the forged credential DAG",
+                           modifiers=dict(dp=[[[schema, "/", []]]]))
 
         atc = bytearray(hab.endorse(serder=exn,
                                     framed=False,
@@ -802,26 +806,65 @@ def test_ipex_v2_accepts_grant_graph_shape_and_semantics():
                         schemaOrigin,
                         [schemaChild])
 
-        # Case 2: nested edge groups still walk correctly, and leaf operators
-        # are evaluated against the far nodes they point to.
-        memberChild = acdcmap(israid=issuer.pre,
-                              attribute=dict(d="", role="member"),
-                              iseaid=issuer.pre)
-        subjectChild = acdcmap(israid=issuer.pre,
-                               attribute=dict(d="", department="kitchen"),
-                               iseaid=subject.pre)
+        # Case 2: the edge schema allows `s` on a nested edge group. IPEX
+        # interprets that as one shared far-node schema pin for the group's
+        # children unless a leaf provides its own `s`.
+        groupedSchemaMember = acdcmap(israid=issuer.pre,
+                                      attribute=dict(d="", role="member"),
+                                      iseaid=issuer.pre)
+        groupedSchemaStaff = acdcmap(israid=issuer.pre,
+                                     attribute=dict(d="", role="staff"),
+                                     iseaid=issuer.pre)
+        groupedSchemaOrigin = acdcmap(israid=issuer.pre,
+                                      attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                      edge=dict(d="",
+                                                u=Noncer().qb64,
+                                                reports=dict(d="",
+                                                             s=compatSchemer.said,
+                                                             member=dict(d="",
+                                                                         n=groupedSchemaMember.said,
+                                                                         o="I2I"),
+                                                             staff=dict(d="",
+                                                                        n=groupedSchemaStaff.said,
+                                                                        o="I2I"))),
+                                      iseaid=subject.pre)
+        assert_accepted("Here is the grouped-schema DAG",
+                        groupedSchemaOrigin,
+                        [groupedSchemaMember, groupedSchemaStaff])
+
+        # Case 3: a grouped OR succeeds when at least one child edge relation
+        # is satisfied, instead of requiring every branch to pass.
+        orMember = acdcmap(israid=issuer.pre,
+                           attribute=dict(d="", role="member"),
+                           iseaid=issuer.pre)
+        orStaff = acdcmap(israid=issuer.pre,
+                          attribute=dict(d="", department="kitchen"),
+                          iseaid=subject.pre)
         groupedOrigin = acdcmap(israid=issuer.pre,
                                 attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                                 edge=dict(d="",
                                           u=Noncer().qb64,
                                           either=dict(d="",
                                                       o="OR",
-                                                      member=dict(d="", n=memberChild.said, o="I2I"),
-                                                      staff=dict(d="", n=subjectChild.said, o="E1E"))),
+                                                      member=dict(d="", n=orMember.said, o="I2I"),
+                                                      staff=dict(d="", n=orStaff.said, o="I2I"))),
                                 iseaid=subject.pre)
-        assert_accepted("Here is the grouped-edge DAG",
+        assert_accepted("Here is the grouped-OR DAG",
                         groupedOrigin,
-                        [memberChild, subjectChild])
+                        [orMember, orStaff])
+
+        # Case 4: a leaf edge may omit `o`. The V2 edge shape allows that, and
+        # IPEX does not infer an I2I/NI2I default when the operator is absent.
+        noOpChild = acdcmap(israid=issuer.pre,
+                            attribute=dict(d="", role="member"),
+                            iseaid=subject.pre)
+        noOpOrigin = acdcmap(israid=issuer.pre,
+                             attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                             edge=_edge("holder", noOpChild),
+                             iseaid=subject.pre)
+        assert_accepted("Here is the no-operator DAG",
+                        noOpOrigin,
+                        [noOpChild])
 
 
 def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
@@ -951,6 +994,51 @@ def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
         assert_rejected("Here is the DI2I-operator DAG",
                         diOrigin,
                         [diChild])
+
+        # List-valued leaf operators are not supported
+        listOpChild = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", role="member"),
+                              iseaid=issuer.pre)
+        listOpOrigin = acdcmap(israid=issuer.pre,
+                               attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                               edge=_edge("holder", listOpChild, op=["I2I"]),
+                               iseaid=subject.pre)
+        assert_rejected("Here is the list-valued leaf-operator DAG",
+                        listOpOrigin,
+                        [listOpChild])
+
+        # Unknown edge operators are not supported
+        bogusChild = acdcmap(israid=issuer.pre,
+                             attribute=dict(d="", role="member"),
+                             iseaid=issuer.pre)
+        bogusOrigin = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                              edge=_edge("holder", bogusChild, op="BOGUS"),
+                              iseaid=subject.pre)
+        assert_rejected("Here is the unknown-operator DAG",
+                        bogusOrigin,
+                        [bogusChild])
+
+        # An OR group fails when none of its children satisfy the
+        # disclosed relation constraints.
+        orLeft = acdcmap(israid=issuer.pre,
+                         attribute=dict(d="", role="member"),
+                         iseaid=subject.pre)
+        orRight = acdcmap(israid=issuer.pre,
+                          attribute=dict(d="", department="kitchen"),
+                          iseaid=subject.pre)
+        badOrOrigin = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                              edge=dict(d="",
+                                        u=Noncer().qb64,
+                                        either=dict(d="",
+                                                    o="OR",
+                                                    member=dict(d="", n=orLeft.said, o="I2I"),
+                                                    staff=dict(d="", n=orRight.said, o="I2I"))),
+                              iseaid=subject.pre)
+        assert_rejected("Here is the unsatisfied grouped-OR DAG",
+                        badOrOrigin,
+                        [orLeft, orRight])
 
         # A pinned edge schema must either match the far node's own schema or
         # be a different compatible schema that the far node still satisfies.

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -2153,6 +2153,95 @@ def test_ipex_v2_blindable_registry_roundtrip():
             rgy.close()
 
 
+def test_ipex_v2_bound_registry_proof_roundtrip():
+    """Grant a bound blind proof through IPEX and keep it as bsss on the node nest."""
+    with openHby(name="ipex-v2-bound-blindable",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        rgy = Regery(hby=hby, name="ipex-v2-bound-blindable", temp=True)
+        try:
+            # Create and anchor a real registry so the later proof has accepted
+            # TEL evidence to verify against.
+            registrar = Registrar(rgy=rgy)
+            registry = registrar.makeRegistry(name="bound-blindable", prefix=hab.pre)
+            rip = rgy.store.event(registry.regk)
+            _anchor(hab, registry, rip, framed=True)
+
+            # Build a registry-backed ACDC that will be disclosed through the grant.
+            acdc = acdcmap(israid=hab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=hab.pre)
+
+            # Issue a bound blind state so the proof lands in the bsss group
+            # rather than the simpler bsqs group.
+            boundBlinder, issued = registrar.issue(registry,
+                                                   acdc=acdc,
+                                                   state="issued",
+                                                   bound=True,
+                                                   bsn=hab.kever.sn,
+                                                   bd=hab.kever.serder.said)
+            _anchor(hab, registry, issued, framed=False)
+
+            # Wire the normal IPEX verifier path with access to the local Regery.
+            recorder = Recorder()
+            exc = Exchanger(hby=hby, handlers=[])
+            loadHandlers(hby=hby, exc=exc, notifier=recorder, rgy=rgy)
+
+            # Grant the ACDC and carry the bound proof on the same node nest.
+            grantExn, grantAtc = ipexGrant(hab=hab,
+                                           recp=hab.pre,
+                                           message="Bound blindable disclosure",
+                                           origin=_proofed(acdc, boundBlinder))
+
+            # Parse the inbound grant end to end. Successful acceptance proves
+            # the handler can vet bsss-based issuer-auth evidence.
+            ims = bytearray(grantExn.raw)
+            ims.extend(grantAtc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+            assert hby.db.exns.get(keys=(grantExn.said,)) is not None
+
+            # Reload the stored message and confirm the disclosed node still
+            # carries one bound proof group, not a plain blind proof group.
+            msg = serializeMessage(hby, grantExn.said, framed=True)
+            ims = bytearray(msg)
+            results = Parser(version=Vrsn_2_0).parse(ims=ims,
+                                                     framed=False,
+                                                     processive=False)
+            assert ims == bytearray()
+            assert len(results) == 1
+            assert [nest.serder.said for nest in results[0].nests] == [acdc.said]
+            assert len(results[0].nests[0].bsqs) == 0
+            assert len(results[0].nests[0].bsss) == 1
+            proof = results[0].nests[0].bsss[0]
+
+            # These fields are the on-wire bound disclosure tuple:
+            # blid, uuid, transaction ACDC said, state, bound sn, bound said.
+            assert proof[0].qb64 == boundBlinder.said
+            assert proof[1].nonce == boundBlinder.uuid
+            assert proof[2].nonce == acdc.said
+            assert proof[3].text == "issued"
+            assert proof[4].snh == boundBlinder.bnh
+            assert proof[5].nonce == boundBlinder.bd
+            
+            # Unblind from the stored tuple to prove the bsss data round-trips
+            # through IPEX storage and serialization without losing meaning.
+            unblinder = Blinder.unblind(said=proof[0].qb64,
+                                        uuid=proof[1].nonce,
+                                        acdc=acdc.said,
+                                        states=["issued", "revoked"],
+                                        bound=True,
+                                        bounds=[(proof[4].sn, proof[5].nonce)])
+            assert unblinder is not None
+            assert unblinder.state == "issued"
+            assert unblinder.bsn == boundBlinder.bsn
+            assert unblinder.bd == boundBlinder.bd
+        finally:
+            rgy.close()
+
+
 def test_ipex_v2_rejects_registry_backed_grant_without_node_proof_group():
     """A grant with rd must carry exactly one node-local registry proof group."""
     with openHby(name="ipex-v2-missing-node-proof",

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -403,6 +403,44 @@ def test_ipex_v2_grant_carries_multiple_dag_nodes():
         assert "iss" not in storedGrant.ked["a"]
 
 
+def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
+    """Offer must not carry the same disclosed ACDC node more than once."""
+    with openHby(name="ipex-v2-bad-offer-duplicate-node",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+        acdc = acdcmap(israid=holder.pre,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=holder.pre)
+        schema = acdc.sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=verifier,
+                                       recp=holder.pre,
+                                       message="Prove over-21",
+                                       attrs=dict(role="member"),
+                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        offerExn, offerAtc = ipexOffer(hab=holder,
+                                       message="Here are the terms",
+                                       origin=acdc,
+                                       artifacts=[acdc],
+                                       apply=applyExn)
+
+        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        assert hby.db.exns.get(keys=(applyExn.said,)) is not None
+        assert hby.db.exns.get(keys=(offerExn.said,)) is None
+        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+
+
 def test_ipex_v2_rejects_grant_with_missing_edged_node():
     """Grant must include every ACDC node referenced by the origin DAG."""
     with openHby(name="ipex-v2-bad-grant-dangling-edge",
@@ -426,6 +464,39 @@ def test_ipex_v2_rejects_grant_with_missing_edged_node():
                              recp=hab.pre,
                              message="Here is the incomplete DAG",
                              origin=origin)
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
+
+
+def test_ipex_v2_rejects_grant_with_duplicate_disclosed_node():
+    """Grant must not carry the same disclosed ACDC node more than once."""
+    with openHby(name="ipex-v2-bad-grant-duplicate-node",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+        child = acdcmap(israid=hab.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         iseaid=hab.pre)
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        exn, atc = ipexGrant(hab=hab,
+                             recp=hab.pre,
+                             message="Here is the duplicated DAG",
+                             origin=origin,
+                             artifacts=[child, child])
 
         ims = bytearray(exn.raw)
         ims.extend(atc)

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -13,7 +13,7 @@ from keri.acdc import (Regery, Registrar, acdcmap, blindate, apply as ipexApply,
                        spurn as ipexSpurn)
 from keri.app import openCF, openHby
 from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Noncer, Parser,
-                       messagize,
+                       Schemer, messagize,
                        SerderKERI, Serdery, Texter, exchange)
 from keri.kering import Colds, sniff
 from keri.help import helping
@@ -452,7 +452,7 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
         origin = acdcmap(israid=holder.pre,
                          uuid=Noncer().qb64,
                          attribute=dict(d="", u=Noncer().qb64, LEI="254900OPPU84GM83MG36"),
-                         edge=_edge("holder", child),
+                         edge=_edge("holder", child, op="E1E"),
                          rule=dict(d="", l="Use only for onboarding."),
                          iseaid=verifier.pre)
         schema = origin.sad["s"]["$id"]
@@ -468,7 +468,7 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
                               uuid="",
                               schema=origin.sad["s"]["$id"],
                               attribute=origin.sad["a"]["d"],
-                              edge=_edge("holder", offerChild),
+                              edge=_edge("holder", offerChild, op="E1E"),
                               rule=origin.sad["r"])
 
         recorder = Recorder()
@@ -752,219 +752,222 @@ def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
         assert recorder.items == []
 
 
-def test_ipex_v2_rejects_grant_with_missing_edged_node():
-    """Grant must include every ACDC node referenced by the origin DAG."""
-    with openHby(name="ipex-v2-bad-grant-dangling-edge",
+def test_ipex_v2_accepts_grant_graph_shape_and_semantics():
+    """Grant accepts valid edge-group shapes and valid leaf operator/schema semantics."""
+    with openHby(name="ipex-v2-grant-graph-semantics",
                  base="test",
                  version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        registry = regcept(israid=hab.pre)
-        child = acdcmap(israid=hab.pre,
-                        attribute=dict(d="", role="member"),
-                        iseaid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         edge=_edge("holder", child),
-                         iseaid=hab.pre)
+        issuer = hby.makeHab(name="issuer")
+        subject = hby.makeHab(name="subject")
 
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
 
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the incomplete DAG",
-                             origin=origin)
+        def assert_accepted(message, origin, artifacts):
+            exn, atc = ipexGrant(hab=issuer,
+                                 recp=subject.pre,
+                                 message=message,
+                                 origin=origin,
+                                 artifacts=artifacts)
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+            assert hby.db.exns.get(keys=(exn.said,)) is not None
+            assert recorder.items[-1] == {"r": "/exn/ipex/grant",
+                                          "d": exn.said,
+                                          "m": message}
 
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+        # Case 1: an expanded edge section may carry its own nonce, and an edge
+        # schema may name a different but still compatible schema that the far
+        # node satisfies.
+        schemaChild = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", role="member"),
+                              iseaid=issuer.pre)
+        compatSchema = dict(schemaChild.sad["s"])
+        compatSchema["title"] = "ACM Default Schema (compatible grant edge)"
+        compatSchemer = Schemer(sed=compatSchema)
+        hby.db.schema.pin(compatSchemer.said, compatSchemer)
+        schemaOrigin = acdcmap(israid=issuer.pre,
+                               attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                               edge=dict(d="",
+                                         u=Noncer().qb64,
+                                         holder=dict(d="",
+                                                     n=schemaChild.said,
+                                                     o="I2I",
+                                                     s=compatSchemer.said)),
+                               iseaid=subject.pre)
+        assert_accepted("Here is the schema-pinned DAG",
+                        schemaOrigin,
+                        [schemaChild])
 
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is None
-        assert recorder.items == []
+        # Case 2: nested edge groups still walk correctly, and leaf operators
+        # are evaluated against the far nodes they point to.
+        memberChild = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", role="member"),
+                              iseaid=issuer.pre)
+        subjectChild = acdcmap(israid=issuer.pre,
+                               attribute=dict(d="", department="kitchen"),
+                               iseaid=subject.pre)
+        groupedOrigin = acdcmap(israid=issuer.pre,
+                                attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                edge=dict(d="",
+                                          u=Noncer().qb64,
+                                          either=dict(d="",
+                                                      o="OR",
+                                                      member=dict(d="", n=memberChild.said, o="I2I"),
+                                                      staff=dict(d="", n=subjectChild.said, o="E1E"))),
+                                iseaid=subject.pre)
+        assert_accepted("Here is the grouped-edge DAG",
+                        groupedOrigin,
+                        [memberChild, subjectChild])
 
 
-def test_ipex_v2_accepts_grant_with_section_level_edge_nonce():
-    """Grant accepts an expanded edge section that carries its own nonce."""
-    with openHby(name="ipex-v2-grant-edge-section-u",
+def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
+    """Grant rejects malformed graph closure and violated leaf edge semantics."""
+    with openHby(name="ipex-v2-bad-grant-graph-semantics",
                  base="test",
                  version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        child = acdcmap(israid=hab.pre,
-                        attribute=dict(d="", role="member"),
-                        iseaid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         edge=dict(d="",
-                                   u=Noncer().qb64,
-                                   holder=dict(d="", n=child.said, o="I2I")),
-                         iseaid=hab.pre)
+        issuer = hby.makeHab(name="issuer")
+        subject = hby.makeHab(name="subject")
 
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
 
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the expanded edge-section DAG",
-                             origin=origin,
-                             artifacts=[child])
+        baseChild = acdcmap(israid=issuer.pre,
+                            attribute=dict(d="", role="member"),
+                            iseaid=issuer.pre)
+        incompatSchema = dict(baseChild.sad["s"])
+        incompatSchema["title"] = "ACM Default Schema (incompatible grant edge)"
+        incompatSchema["required"] = list(dict.fromkeys([*incompatSchema["required"], "z"]))
+        incompatSchemer = Schemer(sed=incompatSchema)
+        hby.db.schema.pin(incompatSchemer.said, incompatSchemer)
 
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+        def assert_rejected(message, origin, artifacts=None):
+            before = len(recorder.items)
+            exn, atc = ipexGrant(hab=issuer,
+                                 recp=subject.pre,
+                                 message=message,
+                                 origin=origin,
+                                 artifacts=artifacts)
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+            assert hby.db.exns.get(keys=(exn.said,)) is None
+            assert len(recorder.items) == before
 
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is not None
-        assert recorder.items == [{"r": "/exn/ipex/grant",
-                                   "d": exn.said,
-                                   "m": "Here is the expanded edge-section DAG"}]
+        # Missing referenced node: the walk is not closed.
+        missingChild = acdcmap(israid=issuer.pre,
+                               attribute=dict(d="", role="member"),
+                               iseaid=issuer.pre)
+        missingOrigin = acdcmap(israid=issuer.pre,
+                                attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                edge=_edge("holder", missingChild),
+                                iseaid=subject.pre)
+        assert_rejected("Here is the incomplete DAG", missingOrigin)
 
+        # Duplicate disclosed node: one DAG node must not appear twice.
+        duplicateChild = acdcmap(israid=issuer.pre,
+                                 attribute=dict(d="", role="member"),
+                                 iseaid=issuer.pre)
+        duplicateOrigin = acdcmap(israid=issuer.pre,
+                                  attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                  edge=_edge("holder", duplicateChild),
+                                  iseaid=subject.pre)
+        assert_rejected("Here is the duplicated DAG",
+                        duplicateOrigin,
+                        [duplicateChild, duplicateChild])
 
-def test_ipex_v2_accepts_grant_with_nested_edge_group():
-    """Grant accepts nested edge groups and walks their far-node leaves."""
-    with openHby(name="ipex-v2-grant-edge-group",
-                 base="test",
-                 version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        child0 = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", role="member"),
-                         iseaid=hab.pre)
-        child1 = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", department="kitchen"),
-                         iseaid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         edge=dict(d="",
-                                   u=Noncer().qb64,
-                                   either=dict(d="",
-                                               o="OR",
-                                               member=dict(d="", n=child0.said, o="I2I"),
-                                               staff=dict(d="", n=child1.said, o="I2I"))),
-                         iseaid=hab.pre)
+        # Compacted edge section is not walkable.
+        compactOrigin = acdcmap(israid=issuer.pre,
+                                attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                iseaid=subject.pre)
+        compactSad = dict(compactOrigin.sad)
+        compactSad["e"] = regcept(israid=issuer.pre).said
+        assert_rejected("Here is the compacted DAG",
+                        type(compactOrigin)(sad=compactSad, makify=True))
 
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+        # Extra carried node must still be reachable from the origin.
+        reachableChild = acdcmap(israid=issuer.pre,
+                                 attribute=dict(d="", role="member"),
+                                 iseaid=issuer.pre)
+        extraChild = acdcmap(israid=issuer.pre,
+                             attribute=dict(d="", department="kitchen"),
+                             iseaid=subject.pre)
+        extraOrigin = acdcmap(israid=issuer.pre,
+                              attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                              edge=_edge("holder", reachableChild),
+                              iseaid=subject.pre)
+        assert_rejected("Here is the overstuffed DAG",
+                        extraOrigin,
+                        [reachableChild, extraChild])
 
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the grouped-edge DAG",
-                             origin=origin,
-                             artifacts=[child0, child1])
+        # I2I requires the near issuer to equal the far issuee.
+        wrongI2IChild = acdcmap(israid=issuer.pre,
+                                attribute=dict(d="", role="member"),
+                                iseaid=subject.pre)
+        wrongI2IOrigin = acdcmap(israid=issuer.pre,
+                                 attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                 edge=_edge("holder", wrongI2IChild, op="I2I"),
+                                 iseaid=subject.pre)
+        assert_rejected("Here is the I2I-violating DAG",
+                        wrongI2IOrigin,
+                        [wrongI2IChild])
 
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+        # E1E requires the near and far nodes to target the same issuee.
+        wrongE1EChild = acdcmap(israid=issuer.pre,
+                                attribute=dict(d="", department="kitchen"),
+                                iseaid=issuer.pre)
+        wrongE1EOrigin = acdcmap(israid=issuer.pre,
+                                 attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                 edge=_edge("holder", wrongE1EChild, op="E1E"),
+                                 iseaid=subject.pre)
+        assert_rejected("Here is the E1E-violating DAG",
+                        wrongE1EOrigin,
+                        [wrongE1EChild])
 
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is not None
-        assert recorder.items == [{"r": "/exn/ipex/grant",
-                                   "d": exn.said,
-                                   "m": "Here is the grouped-edge DAG"}]
+        # Unsupported leaf operators fail closed instead of being treated as no-op.
+        notChild = acdcmap(israid=issuer.pre,
+                           attribute=dict(d="", role="member"),
+                           iseaid=issuer.pre)
+        notOrigin = acdcmap(israid=issuer.pre,
+                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                            edge=_edge("holder", notChild, op="NOT"),
+                            iseaid=subject.pre)
+        assert_rejected("Here is the NOT-operator DAG",
+                        notOrigin,
+                        [notChild])
 
+        diChild = acdcmap(israid=issuer.pre,
+                          attribute=dict(d="", role="member"),
+                          iseaid=issuer.pre)
+        diOrigin = acdcmap(israid=issuer.pre,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           edge=_edge("holder", diChild, op="DI2I"),
+                           iseaid=subject.pre)
+        assert_rejected("Here is the DI2I-operator DAG",
+                        diOrigin,
+                        [diChild])
 
-def test_ipex_v2_rejects_grant_with_duplicate_disclosed_node():
-    """Grant must not carry the same disclosed ACDC node more than once."""
-    with openHby(name="ipex-v2-bad-grant-duplicate-node",
-                 base="test",
-                 version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        child = acdcmap(israid=hab.pre,
-                        attribute=dict(d="", role="member"),
-                        iseaid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         edge=_edge("holder", child),
-                         iseaid=hab.pre)
-
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the duplicated DAG",
-                             origin=origin,
-                             artifacts=[child, child])
-
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
-
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is None
-        assert recorder.items == []
-
-
-def test_ipex_v2_rejects_grant_with_nonwalkable_compact_edges():
-    """Grant rejects ACDCs whose edge block is compacted to a non-walkable value."""
-    with openHby(name="ipex-v2-bad-grant-compact-edge",
-                 base="test",
-                 version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        registry = regcept(israid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         iseaid=hab.pre)
-        sad = dict(origin.sad)
-        sad["e"] = regcept(israid=hab.pre).said
-        compactOrigin = type(origin)(sad=sad, makify=True)
-
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the compacted DAG",
-                             origin=compactOrigin)
-
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
-
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is None
-        assert recorder.items == []
-
-
-def test_ipex_v2_rejects_grant_with_unreachable_nested_node():
-    """Grant must not carry extra nested ACDCs outside the origin DAG."""
-    with openHby(name="ipex-v2-bad-grant-extra-node",
-                 base="test",
-                 version=Vrsn_2_0) as hby:
-        hab = hby.makeHab(name="test")
-        registry = regcept(israid=hab.pre)
-        child = acdcmap(israid=hab.pre,
-                        attribute=dict(d="", role="member"),
-                        iseaid=hab.pre)
-        extra = acdcmap(israid=hab.pre,
-                        attribute=dict(d="", department="kitchen"),
-                        iseaid=hab.pre)
-        origin = acdcmap(israid=hab.pre,
-                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                         edge=_edge("holder", child),
-                         iseaid=hab.pre)
-
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        exn, atc = ipexGrant(hab=hab,
-                             recp=hab.pre,
-                             message="Here is the overstuffed DAG",
-                             origin=origin,
-                             artifacts=[child, extra])
-
-        ims = bytearray(exn.raw)
-        ims.extend(atc)
-        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
-
-        assert ims == bytearray()
-        assert hby.db.exns.get(keys=(exn.said,)) is None
-        assert recorder.items == []
+        # A pinned edge schema must either match the far node's own schema or
+        # be a different compatible schema that the far node still satisfies.
+        badSchemaChild = acdcmap(israid=issuer.pre,
+                                 attribute=dict(d="", role="member"),
+                                 iseaid=issuer.pre)
+        badSchemaOrigin = acdcmap(israid=issuer.pre,
+                                  attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                                  edge=dict(d="",
+                                            holder=dict(d="",
+                                                        n=badSchemaChild.said,
+                                                        o="I2I",
+                                                        s=incompatSchemer.said)),
+                                  iseaid=subject.pre)
+        assert_rejected("Here is the incompatible-schema DAG",
+                        badSchemaOrigin,
+                        [badSchemaChild])
 
 
 def test_ipex_v2_allows_grant_origin_to_differ_from_offer_origin():
@@ -3172,7 +3175,7 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
             origin = acdcmap(israid=issuerHab.pre,
                              regid=registry.regk,
                              attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
-                             edge=_edge("holder", child),
+                             edge=_edge("holder", child, op="E1E"),
                              iseaid=recipientHab.pre)
             schema = origin.sad["s"]["$id"]
 

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -441,6 +441,92 @@ def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
         assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
 
 
+def test_ipex_v2_rejects_offer_with_missing_edged_node():
+    """Offer must include every disclosed ACDC node referenced by the origin DAG."""
+    with openHby(name="ipex-v2-bad-offer-dangling-edge",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+        child = acdcmap(israid=holder.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=holder.pre)
+        origin = acdcmap(israid=holder.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         iseaid=holder.pre)
+        schema = origin.sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=verifier,
+                                       recp=holder.pre,
+                                       message="Prove over-21",
+                                       attrs=dict(role="member"),
+                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        offerExn, offerAtc = ipexOffer(hab=holder,
+                                       message="Here is the incomplete DAG",
+                                       origin=origin,
+                                       apply=applyExn)
+
+        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        assert hby.db.exns.get(keys=(applyExn.said,)) is not None
+        assert hby.db.exns.get(keys=(offerExn.said,)) is None
+        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+
+
+def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
+    """Offer must not carry extra nested ACDCs outside the disclosed origin DAG."""
+    with openHby(name="ipex-v2-bad-offer-extra-node",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+        child = acdcmap(israid=holder.pre,
+                        attribute=dict(d="", role="member"),
+                        iseaid=holder.pre)
+        extra = acdcmap(israid=holder.pre,
+                        attribute=dict(d="", department="kitchen"),
+                        iseaid=holder.pre)
+        origin = acdcmap(israid=holder.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", child),
+                         iseaid=holder.pre)
+        schema = origin.sad["s"]["$id"]
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        applyExn, applyAtc = ipexApply(hab=verifier,
+                                       recp=holder.pre,
+                                       message="Prove over-21",
+                                       attrs=dict(role="member"),
+                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        offerExn, offerAtc = ipexOffer(hab=holder,
+                                       message="Here is the overstuffed DAG",
+                                       origin=origin,
+                                       artifacts=[child, extra],
+                                       apply=applyExn)
+
+        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
+        assert hby.db.exns.get(keys=(applyExn.said,)) is not None
+        assert hby.db.exns.get(keys=(offerExn.said,)) is None
+        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+
+
 def test_ipex_v2_rejects_grant_with_missing_edged_node():
     """Grant must include every ACDC node referenced by the origin DAG."""
     with openHby(name="ipex-v2-bad-grant-dangling-edge",

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -228,7 +228,7 @@ def test_ipex_v2_builders_parse_happypath():
         assert offerResult.serder.ked["r"] == "/ipex/offer"
         assert offerResult.serder.ked["a"] == offerExn.ked["a"]
         assert offerResult.serder.ked["p"] == applyExn.said
-        assert [nest.serder.said for nest in offerResult.nests] == [acdc.said]
+        assert offerResult.nests == []
 
         # Agree
         agreeIms = bytearray(agreeExn.raw)
@@ -415,7 +415,7 @@ def test_ipex_v2_builders_reject_registry_events_as_disclosed_nodes():
                        iseaid=holder.pre)
         rip = regcept(israid=holder.pre)
 
-        with pytest.raises(ValueError, match="disclosed ACDC nodes"):
+        with pytest.raises(ValueError, match="disclosed ACDC node"):
             ipexOffer(hab=holder,
                       recp=verifier.pre,
                       message="Here is the bad offer",
@@ -435,8 +435,8 @@ def test_ipex_v2_builders_reject_registry_events_as_disclosed_nodes():
                       artifacts=[rip])
 
 
-def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
-    """Offer must not carry the same disclosed ACDC node more than once."""
+def test_ipex_v2_offer_builder_rejects_disclosed_artifacts():
+    """Offer remains metadata-only and rejects any disclosed DAG node artifacts."""
     with openHby(name="ipex-v2-bad-offer-duplicate-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -445,36 +445,17 @@ def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
         acdc = acdcmap(israid=holder.pre,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=holder.pre)
-        schema = acdc.sad["s"]["$id"]
 
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        applyExn, applyAtc = ipexApply(hab=verifier,
-                                       recp=holder.pre,
-                                       message="Prove over-21",
-                                       attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
-        offerExn, offerAtc = ipexOffer(hab=holder,
-                                       message="Here are the terms",
-                                       origin=acdc,
-                                       artifacts=[acdc],
-                                       apply=applyExn)
-
-        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
-            ims = bytearray(exn.raw)
-            ims.extend(atc)
-            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
-            assert ims == bytearray()
-
-        assert hby.db.exns.get(keys=(applyExn.said,)) is not None
-        assert hby.db.exns.get(keys=(offerExn.said,)) is None
-        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+        with pytest.raises(ValueError, match="offer does not disclose DAG nodes"):
+            ipexOffer(hab=holder,
+                      recp=verifier.pre,
+                      message="Here are the terms",
+                      origin=acdc,
+                      artifacts=[acdc])
 
 
-def test_ipex_v2_rejects_offer_with_registry_event_nested_as_dag_node():
-    """Inbound offer verification must reject TEL events masquerading as DAG nodes."""
+def test_ipex_v2_rejects_offer_with_unexpected_nested_artifacts():
+    """Inbound offer verification rejects any forged nested disclosure payload."""
     with openHby(name="ipex-v2-bad-offer-tel-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -490,8 +471,9 @@ def test_ipex_v2_rejects_offer_with_registry_event_nested_as_dag_node():
                          edge=_edge("holder", rip),
                          iseaid=hab.pre)
 
-        # Build a syntactically valid offer body, then re-endorse it with a
-        # forged nested `rip` so the handler has to reject it as a non-node.
+        # Build a syntactically valid metadata-only offer body, then re-endorse
+        # it with forged nests. Offer must reject any attempt to disclose
+        # payload bodies before grant.
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=origin,
@@ -513,8 +495,8 @@ def test_ipex_v2_rejects_offer_with_registry_event_nested_as_dag_node():
         assert recorder.items == []
 
 
-def test_ipex_v2_rejects_offer_with_missing_edged_node():
-    """Offer must include every disclosed ACDC node referenced by the origin DAG."""
+def test_ipex_v2_offer_can_name_origin_without_disclosing_the_dag():
+    """Offer may name a DAG origin SAID without carrying any disclosed node nests."""
     with openHby(name="ipex-v2-bad-offer-dangling-edge",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -539,7 +521,7 @@ def test_ipex_v2_rejects_offer_with_missing_edged_node():
                                        attrs=dict(role="member"),
                                        modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
         offerExn, offerAtc = ipexOffer(hab=holder,
-                                       message="Here is the incomplete DAG",
+                                       message="Here are the terms",
                                        origin=origin,
                                        apply=applyExn)
 
@@ -550,12 +532,26 @@ def test_ipex_v2_rejects_offer_with_missing_edged_node():
             assert ims == bytearray()
 
         assert hby.db.exns.get(keys=(applyExn.said,)) is not None
-        assert hby.db.exns.get(keys=(offerExn.said,)) is None
-        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+        storedOffer = hby.db.exns.get(keys=(offerExn.said,))
+        assert storedOffer is not None
+        assert storedOffer.ked["a"]["o"] == [origin.said]
+
+        storedOfferMsg = serializeMessage(hby, offerExn.said, framed=True)
+        storedOfferIms = bytearray(storedOfferMsg)
+        storedOfferResults = Parser(version=Vrsn_2_0).parse(ims=storedOfferIms,
+                                                            framed=False,
+                                                            processive=False)
+        assert storedOfferIms == bytearray()
+        assert len(storedOfferResults) == 1
+        assert storedOfferResults[0].nests == []
+        assert recorder.items == [
+            {"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"},
+            {"r": "/exn/ipex/offer", "d": offerExn.said, "m": "Here are the terms"},
+        ]
 
 
-def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
-    """Offer must not carry extra nested ACDCs outside the disclosed origin DAG."""
+def test_ipex_v2_offer_builder_rejects_multiple_disclosed_artifacts():
+    """Offer rejects any attempt to carry additional disclosed DAG nodes."""
     with openHby(name="ipex-v2-bad-offer-extra-node",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -571,32 +567,13 @@ def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
                          attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                          edge=_edge("holder", child),
                          iseaid=holder.pre)
-        schema = origin.sad["s"]["$id"]
 
-        recorder = Recorder()
-        exc = Exchanger(hby=hby, handlers=[])
-        loadHandlers(hby=hby, exc=exc, notifier=recorder)
-
-        applyExn, applyAtc = ipexApply(hab=verifier,
-                                       recp=holder.pre,
-                                       message="Prove over-21",
-                                       attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
-        offerExn, offerAtc = ipexOffer(hab=holder,
-                                       message="Here is the overstuffed DAG",
-                                       origin=origin,
-                                       artifacts=[child, extra],
-                                       apply=applyExn)
-
-        for exn, atc in ((applyExn, applyAtc), (offerExn, offerAtc)):
-            ims = bytearray(exn.raw)
-            ims.extend(atc)
-            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
-            assert ims == bytearray()
-
-        assert hby.db.exns.get(keys=(applyExn.said,)) is not None
-        assert hby.db.exns.get(keys=(offerExn.said,)) is None
-        assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+        with pytest.raises(ValueError, match="offer does not disclose DAG nodes"):
+            ipexOffer(hab=holder,
+                      recp=verifier.pre,
+                      message="Here is the overstuffed DAG",
+                      origin=origin,
+                      artifacts=[child, extra])
 
 
 def test_ipex_v2_rejects_grant_with_missing_edged_node():
@@ -735,7 +712,7 @@ def test_ipex_v2_rejects_grant_with_unreachable_nested_node():
 
 
 def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
-    """Offer can carry a metadata DAG whose origin differs from the later grant origin."""
+    """Offer can name metadata origin SAID that differs from the later grant origin."""
     with openHby(name="ipex-v2-offer-metadata-origin",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -785,7 +762,7 @@ def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
         assert offerExn.ked["a"]["o"] == [offerMeta.said]
         assert grantExn.ked["a"]["o"] == [grantOrigin.said]
         assert offerExn.ked["a"]["o"] != grantExn.ked["a"]["o"]
-        assert [nest.serder.said for nest in offerResults[0].nests] == [offerMeta.said]
+        assert offerResults[0].nests == []
         assert [nest.serder.said for nest in grantResults[0].nests] == [grantOrigin.said]
 
 
@@ -888,7 +865,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
                                                             processive=False)
         assert storedOfferIms == bytearray()
         assert len(storedOfferResults) == 1
-        assert [nest.serder.said for nest in storedOfferResults[0].nests] == [acdc.said]
+        assert storedOfferResults[0].nests == []
 
         storedAgree = hby.db.exns.get(keys=(agree0.said,))
         assert storedAgree.ked["a"]["m"] == "I agree to the offer"
@@ -1051,7 +1028,7 @@ def test_ipex_v2_nontransferable_nested_artifacts():
         assert offerIms == bytearray()
         assert len(offerResults) == 1
         offerResult = offerResults[0]
-        assert [nest.serder.said for nest in offerResult.nests] == [acdc.said]
+        assert offerResult.nests == []
 
         # Parse Grant for assertions
         grantIms = bytearray(grantExn.raw)
@@ -1133,8 +1110,7 @@ def test_ipex_v2_rejects_offer_without_dp():
 
         atc = bytearray(hab.endorse(serder=badOffer,
                                     framed=False,
-                                    gvrsn=Vrsn_2_0,
-                                    nests=[_nest(acdc)]))
+                                    gvrsn=Vrsn_2_0))
         del atc[:badOffer.size]
 
         # Rebuild the tampered wire message with the malformed signed body.
@@ -1179,8 +1155,7 @@ def test_ipex_v2_rejects_offer_with_missing_origin_attr_without_throwing():
 
         atc = bytearray(hab.endorse(serder=badOffer,
                                     framed=False,
-                                    gvrsn=Vrsn_2_0,
-                                    nests=[_nest(acdc)]))
+                                    gvrsn=Vrsn_2_0))
         del atc[:badOffer.size]
 
         ims = bytearray(badOffer.raw)
@@ -1219,8 +1194,7 @@ def test_ipex_v2_rejects_offer_with_nonstring_origin_without_throwing():
 
         atc = bytearray(hab.endorse(serder=badOffer,
                                     framed=False,
-                                    gvrsn=Vrsn_2_0,
-                                    nests=[_nest(acdc)]))
+                                    gvrsn=Vrsn_2_0))
         del atc[:badOffer.size]
 
         ims = bytearray(badOffer.raw)
@@ -1233,7 +1207,7 @@ def test_ipex_v2_rejects_offer_with_nonstring_origin_without_throwing():
         assert recorder.items == []
 
 
-def test_ipex_v2_rejects_offer_without_origin_nested_artifact():
+def test_ipex_v2_rejects_offer_with_forged_nested_artifact():
     with openHby(name="ipex-v2-bad-offer-origin-nest",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -1254,7 +1228,6 @@ def test_ipex_v2_rejects_offer_without_origin_nested_artifact():
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=origin,
-                           artifacts=[sibling],
                            message="Here is the offered credential")
 
         atc = bytearray(hab.endorse(serder=exn,
@@ -2827,14 +2800,13 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                 assert applyStored is not None
                 assert applyStored.ked["x"] == applyExn.ked["x"]
 
-                # The issuer answers with the full disclosed DAG. Offer uses the
-                # new per-node nest shape but does not yet carry issuer-auth.
+                # The issuer answers with metadata only. Offer names the origin
+                # SAID but does not yet disclose any ACDC node bodies.
                 clock.advance(milliseconds=1)
                 offerStamp = helping.nowIso8601()
                 offerExn, offerAtc = ipexOffer(hab=issuerHab,
                                                message="Here is the credential DAG",
                                                origin=origin,
-                                               artifacts=[child],
                                                apply=applyExn,
                                                dt=offerStamp)
                 assert offerExn.ked["a"]["o"] == [origin.said]
@@ -2858,17 +2830,13 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                                                               framed=False,
                                                               processive=False)
                 
-                # Assert the nested DAG structure is preserved through the full roundtrip.
+                # Offer remains metadata-only through the full roundtrip.
                 assert len(offerResults) == 1
 
-                # The offer nests should contain the origin and child nodes in order.
-                assert [nest.serder.said for nest in offerResults[0].nests] == [
-                    origin.said,
-                    child.said,
-                ]
-                assert len(offerResults[0].nests[0].bsqs) == 0
+                assert offerResults[0].nests == []
 
-                # The recipient agrees to the disclosed DAG.
+                # The recipient agrees to the proposed disclosure, and the
+                # later grant carries the actual DAG nodes.
                 clock.advance(milliseconds=1)
                 agreeStamp = helping.nowIso8601()
                 agreeExn, agreeAtc = ipexAgree(hab=recipientHab,

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -403,6 +403,38 @@ def test_ipex_v2_grant_carries_multiple_dag_nodes():
         assert "iss" not in storedGrant.ked["a"]
 
 
+def test_ipex_v2_builders_reject_registry_events_as_disclosed_nodes():
+    """Offer/grant builders must reject TEL events in disclosed DAG node slots."""
+    with openHby(name="ipex-v2-bad-node-builder",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        holder = hby.makeHab(name="holder")
+        verifier = hby.makeHab(name="verifier")
+        acdc = acdcmap(israid=holder.pre,
+                       attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                       iseaid=holder.pre)
+        rip = regcept(israid=holder.pre)
+
+        with pytest.raises(ValueError, match="disclosed ACDC nodes"):
+            ipexOffer(hab=holder,
+                      recp=verifier.pre,
+                      message="Here is the bad offer",
+                      origin=rip)
+
+        with pytest.raises(ValueError, match="disclosed ACDC nodes"):
+            ipexGrant(hab=holder,
+                      recp=verifier.pre,
+                      message="Here is the bad grant",
+                      origin=rip)
+
+        with pytest.raises(ValueError, match="disclosed ACDC nodes"):
+            ipexGrant(hab=holder,
+                      recp=verifier.pre,
+                      message="Here is the bad grant artifact",
+                      origin=acdc,
+                      artifacts=[rip])
+
+
 def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
     """Offer must not carry the same disclosed ACDC node more than once."""
     with openHby(name="ipex-v2-bad-offer-duplicate-node",
@@ -439,6 +471,46 @@ def test_ipex_v2_rejects_offer_with_duplicate_disclosed_node():
         assert hby.db.exns.get(keys=(applyExn.said,)) is not None
         assert hby.db.exns.get(keys=(offerExn.said,)) is None
         assert recorder.items == [{"r": "/exn/ipex/apply", "d": applyExn.said, "m": "Prove over-21"}]
+
+
+def test_ipex_v2_rejects_offer_with_registry_event_nested_as_dag_node():
+    """Inbound offer verification must reject TEL events masquerading as DAG nodes."""
+    with openHby(name="ipex-v2-bad-offer-tel-node",
+                 base="test",
+                 version=Vrsn_2_0) as hby:
+        hab = hby.makeHab(name="test")
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        rip = regcept(israid=hab.pre)
+        origin = acdcmap(israid=hab.pre,
+                         attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                         edge=_edge("holder", rip),
+                         iseaid=hab.pre)
+
+        # Build a syntactically valid offer body, then re-endorse it with a
+        # forged nested `rip` so the handler has to reject it as a non-node.
+        exn, _ = ipexOffer(hab=hab,
+                           recp=hab.pre,
+                           origin=origin,
+                           message="Here is the forged credential DAG")
+
+        atc = bytearray(hab.endorse(serder=exn,
+                                    framed=False,
+                                    gvrsn=Vrsn_2_0,
+                                    nests=[_nest(origin), _nest(rip)]))
+        del atc[:exn.size]
+
+        ims = bytearray(exn.raw)
+        ims.extend(atc)
+
+        Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+        assert ims == bytearray()
+        assert hby.db.exns.get(keys=(exn.said,)) is None
+        assert recorder.items == []
 
 
 def test_ipex_v2_rejects_offer_with_missing_edged_node():

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -711,13 +711,16 @@ def test_ipex_v2_rejects_grant_with_unreachable_nested_node():
         assert recorder.items == []
 
 
-def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
-    """Offer can name metadata origin SAID that differs from the later grant origin."""
+def test_ipex_v2_rejects_grant_when_offer_origin_differs():
+    """Grant must disclose the same origin DAG root that the prior offer named."""
     with openHby(name="ipex-v2-offer-metadata-origin",
                  base="test",
                  version=Vrsn_2_0) as hby:
         hab = hby.makeHab(name="test")
-        registry = regcept(israid=hab.pre)
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
         offerMeta = acdcmap(israid=hab.pre,
                             attribute=dict(d="", rules="club-entry"),
                             iseaid=hab.pre)
@@ -725,45 +728,45 @@ def test_ipex_v2_offer_metadata_origin_can_differ_from_grant_origin():
                               attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                               iseaid=hab.pre)
         schema = grantOrigin.sad["s"]["$id"]
-        applyExn, _ = ipexApply(hab=hab,
-                                recp=hab.pre,
-                                message="Please issue a credential",
-                                attrs=dict(role="member"),
-                                modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        applyExn, applyAtc = ipexApply(hab=hab,
+                                       recp=hab.pre,
+                                       message="Please issue a credential",
+                                       attrs=dict(role="member"),
+                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
         offerExn, offerAtc = ipexOffer(hab=hab,
                                        message="Here is the metadata offer",
                                        origin=offerMeta,
                                        apply=applyExn)
-        agreeExn, _ = ipexAgree(hab=hab,
-                                message="I agree to the metadata offer",
-                                offer=offerExn)
+        agreeExn, agreeAtc = ipexAgree(hab=hab,
+                                       message="I agree to the metadata offer",
+                                       offer=offerExn)
+
+        for exn, atc in ((applyExn, applyAtc),
+                         (offerExn, offerAtc),
+                         (agreeExn, agreeAtc)):
+            ims = bytearray(exn.raw)
+            ims.extend(atc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+            assert ims == bytearray()
+
         grantExn, grantAtc = ipexGrant(hab=hab,
                                        recp=hab.pre,
                                        message="Here is the granted credential",
                                        origin=grantOrigin,
                                        agree=agreeExn)
-
-        offerIms = bytearray(offerExn.raw)
-        offerIms.extend(offerAtc)
-        offerResults = Parser(version=Vrsn_2_0).parse(ims=offerIms,
-                                                      framed=False,
-                                                      processive=False)
-        assert offerIms == bytearray()
-        assert len(offerResults) == 1
-
         grantIms = bytearray(grantExn.raw)
         grantIms.extend(grantAtc)
-        grantResults = Parser(version=Vrsn_2_0).parse(ims=grantIms,
-                                                      framed=False,
-                                                      processive=False)
+        Parser(version=Vrsn_2_0).parse(ims=grantIms, framed=False, exc=exc)
         assert grantIms == bytearray()
-        assert len(grantResults) == 1
-
         assert offerExn.ked["a"]["o"] == [offerMeta.said]
         assert grantExn.ked["a"]["o"] == [grantOrigin.said]
         assert offerExn.ked["a"]["o"] != grantExn.ked["a"]["o"]
-        assert offerResults[0].nests == []
-        assert [nest.serder.said for nest in grantResults[0].nests] == [grantOrigin.said]
+        assert hby.db.exns.get(keys=(grantExn.said,)) is None
+        assert [item["r"] for item in recorder.items] == [
+            "/exn/ipex/apply",
+            "/exn/ipex/offer",
+            "/exn/ipex/agree",
+        ]
 
 
 def test_ipex_v2_dispatch_linear_and_spurn():

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -418,7 +418,8 @@ def test_ipex_v2_builders_reject_registry_events_as_disclosed_nodes():
             ipexOffer(hab=holder,
                       recp=verifier.pre,
                       message="Here is the bad offer",
-                      origin=rip)
+                      origin=rip,
+                      modifiers=dict(dp=[[[acdc.sad["s"]["$id"], "/", []]]]))
 
         with pytest.raises(ValueError, match="disclosed ACDC nodes"):
             ipexGrant(hab=holder,
@@ -1190,13 +1191,20 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         with pytest.raises(ValueError):
             ipexOffer(hab=hab, message="Bare offer without receiver", origin=acdc)
 
+        with pytest.raises(ValueError):
+            ipexOffer(hab=hab,
+                      message="Bare offer without disclosure plan",
+                      origin=acdc,
+                      recp=hab.pre)
+
         # Build a bare offer with the committed origin and explicit receiver;
-        # the starter generates its own xid and still supports a valid spurn
-        # against it.
+        # the starter generates its own xid once it is also given the explicit
+        # disclosure plan that an unsolicited offer now requires.
         offer1, offer1Atc = ipexOffer(hab=hab,
                                       message="Bare offer for spurn path",
                                       origin=acdc,
-                                      recp=hab.pre)
+                                      recp=hab.pre,
+                                      modifiers=dict(dp=[[[acdc.sad["s"]["$id"], "/", []]]]))
         assert offer1.ked["x"] != ""
         spurn2, spurn2Atc = ipexSpurn(hab=hab,
                                       message="I reject this offer",
@@ -1356,13 +1364,15 @@ def test_ipex_v2_rejects_offer_without_dp():
         acdc = acdcmap(israid=hab.pre,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
+        schema = acdc.sad["s"]["$id"]
 
         # Build a normal offer first, then remove q.dp to prove the V2 handler
         # fails closed on the required disclosure-plan field.
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=acdc,
-                           message="Here is the offered credential")
+                           message="Here is the offered credential",
+                           modifiers=dict(dp=[[[schema, "/", []]]]))
         sad = dict(exn.ked)
         sad["q"] = {}
         badOffer = SerderKERI(sad=sad, makify=True, verify=False)
@@ -1402,11 +1412,13 @@ def test_ipex_v2_accepts_offer_with_missing_origin_attr_without_throwing():
         acdc = acdcmap(israid=hab.pre,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
+        schema = acdc.sad["s"]["$id"]
 
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=acdc,
-                           message="Here is the offered credential")
+                           message="Here is the offered credential",
+                           modifiers=dict(dp=[[[schema, "/", []]]]))
         sad = dict(exn.ked)
         sad["a"] = dict(exn.ked["a"])
         sad["a"].pop("o")
@@ -1443,11 +1455,13 @@ def test_ipex_v2_rejects_offer_with_nonstring_origin_without_throwing():
         acdc = acdcmap(israid=hab.pre,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                        iseaid=hab.pre)
+        schema = acdc.sad["s"]["$id"]
 
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=acdc,
-                           message="Here is the offered credential")
+                           message="Here is the offered credential",
+                           modifiers=dict(dp=[[[schema, "/", []]]]))
         sad = dict(exn.ked)
         sad["a"] = dict(exn.ked["a"])
         sad["a"]["o"] = 123
@@ -1485,11 +1499,13 @@ def test_ipex_v2_rejects_offer_with_forged_nested_artifact():
         sibling = acdcmap(israid=hab.pre,
                           attribute=dict(d="", rules="club-entry"),
                           iseaid=hab.pre)
+        schema = origin.sad["s"]["$id"]
 
         exn, _ = ipexOffer(hab=hab,
                            recp=hab.pre,
                            origin=origin,
-                           message="Here is the offered credential")
+                           message="Here is the offered credential",
+                           modifiers=dict(dp=[[[schema, "/", []]]]))
 
         atc = bytearray(hab.endorse(serder=exn,
                                     framed=False,
@@ -1715,7 +1731,8 @@ def test_ipex_v2_responders_set_receiver():
         bootExn, _ = ipexOffer(hab=holder,
                                message="Opening offer",
                                origin=acdc,
-                               recp=verifier.pre)
+                               recp=verifier.pre,
+                               modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         assert bootExn.ked["p"] == ""
         assert bootExn.ked["ri"] == verifier.pre
         assert bootExn.ked["x"] != ""
@@ -1844,18 +1861,30 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
         # Offer-first flows reject a starter with no recipient.
         with pytest.raises(ValueError):
             ipexOffer(hab=holder, message="Bare offer", origin=acdc)
-        # Supplying the origin plus recipient is enough for an offer-first opener.
-        bareOffer, _ = ipexOffer(hab=holder, message="Bare offer", origin=acdc, recp=verifier.pre)
+        with pytest.raises(ValueError):
+            ipexOffer(hab=holder,
+                      message="Bare offer",
+                      origin=acdc,
+                      recp=verifier.pre)
+        # Supplying the origin plus recipient and explicit dp is enough for an
+        # offer-first opener.
+        bareOffer, _ = ipexOffer(hab=holder,
+                                 message="Bare offer",
+                                 origin=acdc,
+                                 recp=verifier.pre,
+                                 modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         assert bareOffer.ked["p"] == ""
         assert bareOffer.ked["ri"] == verifier.pre
         assert bareOffer.ked["x"] != ""
         assert bareOffer.ked["a"]["o"] == [acdc.said]
+        assert bareOffer.ked["q"]["dp"] == [[[schema, "/", ["a/role"]]]]
         # Supplying xid directly is no longer supported at all.
         with pytest.raises(TypeError):
             ipexOffer(hab=holder,
                       message="Bare offer",
                       origin=acdc,
                       recp=verifier.pre,
+                      modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
                       xid="E" * 44)
         # Grant-first flows follow the same auto-generated-xid rule.
         bareGrant, _ = ipexGrant(hab=holder,
@@ -3460,6 +3489,7 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                            regid=registry.regk,
                            attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
                            iseaid=recipient.pre)
+            schema = acdc.sad["s"]["$id"]
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
             _anchor(hab, registry, issued, framed=False)
 
@@ -3500,6 +3530,7 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                                                message="Offer starts the blind credential flow",
                                                origin=acdc,
                                                recp=recipient.pre,
+                                               modifiers=dict(dp=[[[schema, "/", []]]]),
                                                dt=offerStamp)
                 agreeExn, agreeAtc = ipexAgree(hab=recipient,
                                                message="I agree to the offer-first credential",

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -131,7 +131,7 @@ def test_ipex_v2_builders_parse_happypath():
                                           recp=hab.pre,
                                           message="Please issue a credential",
                                           attrs=dict(role="member", ax=[False]),
-                                          modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                          modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
 
         # Build Offer message chained to apply 
         offerExn, offerAtc = ipexOffer(hab=hab,
@@ -173,7 +173,7 @@ def test_ipex_v2_builders_parse_happypath():
         # Assert fields
         assert applyExn.ked["a"]["m"] == "Please issue a credential"    # message
         assert applyExn.ked["a"]["ax"] == [False]
-        assert applyExn.ked["q"]["dp"] == [[schema, "/", ["a/role"]]]
+        assert applyExn.ked["q"]["dp"] == [[[schema, "/", ["a/role"]]]]
 
         assert offerExn.ked["a"]["m"] == "Here is the offered credential"
         assert offerExn.ked["a"]["ax"] == [False]
@@ -314,7 +314,7 @@ def test_ipex_v2_accepts_empty_ax_list_as_unanchored():
                                        recp=hab.pre,
                                        message="Please issue a credential",
                                        attrs=dict(role="member", ax=[]),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                       modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offerExn, offerAtc = ipexOffer(hab=hab,
                                        message="Here is the offered credential",
                                        origin=acdc,
@@ -478,8 +478,8 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
                                        recp=holder.pre,
                                        message="Please disclose the credential DAG",
                                        attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", []],
-                                                           [schema, "/e/holder", []]]))
+                                       modifiers=dict(dp=[[[schema, "/", []],
+                                                           [schema, "/e/holder", []]]]))
         offerExn, offerAtc = ipexOffer(hab=holder,
                                        recp=verifier.pre,
                                        message="Here are the terms",
@@ -512,8 +512,8 @@ def test_ipex_v2_offer_builder_accepts_metadata_dag_nodes():
         assert storedOffer.ked["a"]["o"] == [offerOrigin.said]
         assert storedGrant.ked["a"]["o"] == [origin.said]
         assert storedOffer.ked["a"]["o"] != storedGrant.ked["a"]["o"]
-        assert storedOffer.ked["q"]["dp"] == [[schema, "/", []],
-                                              [schema, "/e/holder", []]]
+        assert storedOffer.ked["q"]["dp"] == [[[schema, "/", []],
+                                              [schema, "/e/holder", []]]]
 
         offerWire = bytearray(serializeMessage(hby, offerExn.said, framed=True))
         offerResults = Parser(version=Vrsn_2_0).parse(ims=offerWire,
@@ -615,7 +615,7 @@ def test_ipex_v2_offer_can_name_origin_without_disclosing_the_dag():
                                        recp=holder.pre,
                                        message="Prove over-21",
                                        attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                       modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offerExn, offerAtc = ipexOffer(hab=holder,
                                        message="Here are the terms",
                                        origin=origin,
@@ -677,8 +677,8 @@ def test_ipex_v2_offer_accepts_reachable_partial_metadata_subgraph():
                                        recp=holder.pre,
                                        message="Show me the metadata path",
                                        attrs={},
-                                       modifiers=dict(dp=[[schema, "/", []],
-                                                           [schema, "/e/department", []]]))
+                                       modifiers=dict(dp=[[[schema, "/", []],
+                                                           [schema, "/e/department", []]]]))
         # Carry only the disclosed root plus one reachable metadata child.
         # The child's farther edge to `grandchild` is intentionally omitted.
         offerExn, offerAtc = ipexOffer(hab=holder,
@@ -739,8 +739,8 @@ def test_ipex_v2_rejects_offer_with_unreachable_nested_node():
                              message="Here is the overstuffed DAG",
                              origin=origin,
                              artifacts=[child, extra],
-                             modifiers=dict(dp=[[schema, "/", []],
-                                                 [schema, "/e/holder", []]]))
+                             modifiers=dict(dp=[[[schema, "/", []],
+                                                 [schema, "/e/holder", []]]]))
 
         ims = bytearray(exn.raw)
         ims.extend(atc)
@@ -987,7 +987,7 @@ def test_ipex_v2_allows_grant_origin_to_differ_from_offer_origin():
                                        recp=hab.pre,
                                        message="Please issue a credential",
                                        attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                       modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offerExn, offerAtc = ipexOffer(hab=hab,
                                        message="Here is the metadata offer",
                                        origin=offerMeta,
@@ -1046,7 +1046,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
                                         recp=hab.pre,
                                         message="Please issue a credential",
                                         attrs=dict(role="member"),
-                                        modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                        modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offer0, offer0Atc = ipexOffer(hab=hab,
                                       message="Here is the offered credential",
                                       origin=acdc,
@@ -1083,7 +1083,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         assert storedApply is not None
         assert storedApply.ked["a"]["m"] == "Please issue a credential"
         assert storedApply.ked["a"]["role"] == "member"
-        assert storedApply.ked["q"]["dp"] == [[schema, "/", ["a/role"]]]
+        assert storedApply.ked["q"]["dp"] == [[[schema, "/", ["a/role"]]]]
 
         # Parse the rest of the chain
         offer0Ims = bytearray(offer0.raw)
@@ -1264,7 +1264,7 @@ def test_ipex_v2_nontransferable_nested_artifacts():
                                        recp=hab.pre,
                                        message="Please issue a credential",
                                        attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                       modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offerExn, offerAtc = ipexOffer(hab=hab,
                                        message="Here is the offered credential",
                                        origin=acdc,
@@ -1672,7 +1672,7 @@ def test_ipex_v2_responders_set_receiver():
                                 recp=holder.pre,
                                 message="Prove over-21",
                                 attrs=dict(role="member"),
-                                modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         assert applyExn.ked["i"] == verifier.pre
         assert applyExn.ked["ri"] == holder.pre
 
@@ -1751,7 +1751,7 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
                                 recp=holder.pre,
                                 message="Prove over-21",
                                 attrs=dict(role="member"),
-                                modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         # Continue with the valid holder response that derives its receiver and xid from the apply.
         offerExn, _ = ipexOffer(hab=holder,
                                 message="Here are the terms",
@@ -1836,7 +1836,7 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
                       recp=holder.pre,
                       message="Bad xid",
                       attrs=dict(role="member"),
-                      modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+                      modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
                       xid="F" * 44)
 
         # Set 4: every flow starter still needs a recipient, but now generates
@@ -1871,16 +1871,17 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
                       recp="",
                       message="Missing receiver",
                       attrs=dict(role="member"),
-                      modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                      modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         # Apply now generates xid internally when the caller omits it.
         bareApply, _ = ipexApply(hab=verifier,
                                  recp=holder.pre,
                                  message="Generated xid",
                                  attrs=dict(role="member"),
-                                 modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                 modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         assert bareApply.ked["p"] == ""
         assert bareApply.ked["ri"] == holder.pre
         assert bareApply.ked["x"] != ""
+        assert bareApply.ked["q"]["dp"] == [[[schema, "/", ["a/role"]]]]
 
         # Set 5: apply still enforces its own disclosure-plan contract after starter fields pass.
         # Even with recp present and xid auto-generated, apply still requires an explicit disclosure plan.
@@ -1898,8 +1899,13 @@ def test_ipex_v2_builders_reject_prior_party_mismatches_and_caller_xid():
         with pytest.raises(ValueError):
             ipexApply(hab=verifier,
                       recp=holder.pre,
+                      message="Flat disclosure plan is no longer accepted",
+                      modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+        with pytest.raises(ValueError):
+            ipexApply(hab=verifier,
+                      recp=holder.pre,
                       message="Bad disclosure plan nesting",
-                      modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
+                      modifiers=dict(dp=[[[[schema, "/", ["a/role"]]]]]))
 
 
 def test_ipex_v2_rejects_third_party_prior_response_without_throwing():
@@ -1925,7 +1931,7 @@ def test_ipex_v2_rejects_third_party_prior_response_without_throwing():
                                        recp=holder.pre,
                                        message="Prove over-21",
                                        attrs=dict(role="member"),
-                                       modifiers=dict(dp=[[schema, "/", ["a/role"]]]))
+                                       modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]))
         offerExn, offerAtc = ipexOffer(hab=holder,
                                        message="Here are the terms",
                                        origin=acdc,
@@ -2089,6 +2095,80 @@ def test_ipex_v2_rejects_registry_backed_grant_without_node_proof_group():
             rgy.close()
 
 
+def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
+    """Recipient keeps a registry-backed grant retryable until TEL evidence is loaded."""
+    with (openHby(name="ipex-v2-proof-escrow-issuer",
+                  base="test",
+                  version=Vrsn_2_0) as issuerHby,
+          openHby(name="ipex-v2-proof-escrow-recipient",
+                  base="test",
+                  version=Vrsn_2_0) as recipientHby):
+        issuerHab = issuerHby.makeHab(name="issuer")
+        recipientHab = recipientHby.makeHab(name="recipient")
+        issuerRgy = Regery(hby=issuerHby, name="ipex-v2-proof-escrow-issuer", temp=True)
+        recipientRgy = Regery(hby=recipientHby, name="ipex-v2-proof-escrow-recipient", temp=True)
+        try:
+            registrar = Registrar(rgy=issuerRgy)
+            registry = registrar.makeRegistry(name="proof-escrow", prefix=issuerHab.pre)
+            rip = issuerRgy.store.event(registry.regk)
+            ripAnc = _anchor(issuerHab, registry, rip, framed=True)
+
+            acdc = acdcmap(israid=issuerHab.pre,
+                           regid=registry.regk,
+                           attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
+                           iseaid=recipientHab.pre)
+            issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
+            issuedAnc = _anchor(issuerHab, registry, issued, framed=False)
+
+            recipientRemoteKvy = Kevery(db=recipientHby.db, lax=False, local=False)
+            Parser(version=Vrsn_2_0).parse(
+                ims=bytearray(issuerHab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)),
+                kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(ripAnc), kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuedAnc),
+                                           framed=False,
+                                           kvy=recipientRemoteKvy)
+
+            recorder = Recorder()
+            exc = Exchanger(hby=recipientHby, handlers=[])
+            loadHandlers(hby=recipientHby, exc=exc, notifier=recorder, rgy=recipientRgy)
+
+            grantExn, grantAtc = ipexGrant(hab=issuerHab,
+                                           recp=recipientHab.pre,
+                                           message="Waiting on observer TEL",
+                                           origin=_proofed(acdc, issuedBlinder))
+
+            ims = bytearray(grantExn.raw)
+            ims.extend(grantAtc)
+            Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
+
+            assert ims == bytearray()
+            assert recipientHby.db.exns.get(keys=(grantExn.said,)) is None
+            assert recipientHby.db.epse.get(keys=(grantExn.said,)) is not None
+            assert recorder.items == []
+            assert list(exc.cues) == [dict(kin="proof", said=grantExn.said)]
+
+            # Simulate the disclosee learning the issuer's TEL later, for
+            # example by fetching it from observers after the first grant parse.
+            recipientRgy.store.accept(registry.regk, 0, rip)
+            recipientRgy.store.accept(registry.regk, 1, issued)
+
+            exc.processEscrow()
+
+            assert recipientHby.db.exns.get(keys=(grantExn.said,)) is not None
+            assert recipientHby.db.epse.get(keys=(grantExn.said,)) is None
+            assert recorder.items == [
+                {"r": "/exn/ipex/grant", "d": grantExn.said, "m": "Waiting on observer TEL"},
+            ]
+            assert list(exc.cues) == [
+                dict(kin="proof", said=grantExn.said),
+                dict(kin="saved", said=grantExn.said),
+            ]
+        finally:
+            recipientRgy.close()
+            issuerRgy.close()
+
+
 def test_ipex_v2_blind_registry_update_roundtrip():
     """Grant a blind ``bup`` registry update through a full linear V2 IPEX exchange."""
     with openHby(name="ipex-v2-blind-registry",
@@ -2134,7 +2214,7 @@ def test_ipex_v2_blind_registry_update_roundtrip():
                                            recp=hab.pre,
                                            message="Please issue the blind credential",
                                            attrs=dict(flow="blind"),
-                                           modifiers=dict(dp=[[schema, "/", []]]))
+                                           modifiers=dict(dp=[[[schema, "/", []]]]))
             offerExn, offerAtc = ipexOffer(hab=hab,
                                            message="Here is the blind credential",
                                            origin=acdc,
@@ -2288,7 +2368,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram(fakeHelpingClock):
                                                recp=hab.pre,
                                                message="Please issue the blind credential",
                                                attrs={},
-                                               modifiers=dict(dp=[[schema, "/", []]]),
+                                               modifiers=dict(dp=[[[schema, "/", []]]]),
                                                dt=applyStamp)
                 applyReceiveMs = helping.fromIso8601(helping.nowIso8601()).timestamp() * 1000
 
@@ -2656,7 +2736,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                                                recp=issuerHab.pre,
                                                message="Please issue the blind credential",
                                                attrs={},
-                                               modifiers=dict(dp=[[schema, "/", []]]),
+                                               modifiers=dict(dp=[[[schema, "/", []]]]),
                                                dt=applyStamp)
                 applyReceiveMs = helping.fromIso8601(helping.nowIso8601()).timestamp() * 1000
 
@@ -3064,16 +3144,16 @@ def test_ipex_v2_two_node_registry_dag_roundtrip_through_kram_two_haberies(fakeH
                                                recp=issuerHab.pre,
                                                message="Please issue the DAG credential",
                                                attrs={},
-                                               modifiers=dict(dp=[
+                                               modifiers=dict(dp=[[
                                                    [schema, "/", []],
                                                    [schema, "/e/holder", []],
-                                               ]),
+                                               ]]),
                                                dt=applyStamp)
                 
-                assert applyExn.ked["q"]["dp"] == [
+                assert applyExn.ked["q"]["dp"] == [[
                     [schema, "/", []],
                     [schema, "/e/holder", []],
-                ]
+                ]]
 
                 applyMsg = bytearray(applyExn.raw)
                 applyMsg.extend(applyAtc)
@@ -3588,7 +3668,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
                                                        recp=hab.pre,
                                                        message="Please issue the issued blind credential",
                                                        attrs=None,
-                                                       modifiers=dict(dp=[[schema, "/", []]]))
+                                                       modifiers=dict(dp=[[[schema, "/", []]]]))
             issuedOfferExn, issuedOfferAtc = ipexOffer(hab=hab,
                                                        message="Here is the issued blind credential",
                                                        origin=acdc,
@@ -3651,7 +3731,7 @@ def test_ipex_v2_successive_blind_registry_updates_roundtrip():
                                                          recp=hab.pre,
                                                          message="Please issue the revoked blind credential",
                                                          attrs=dict(flow="revoked"),
-                                                         modifiers=dict(dp=[[schema, "/", []]]))
+                                                         modifiers=dict(dp=[[[schema, "/", []]]]))
             revokedOfferExn, revokedOfferAtc = ipexOffer(hab=hab,
                                                          message="Here is the revoked blind credential",
                                                          origin=acdc,

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -868,7 +868,7 @@ def test_ipex_v2_accepts_grant_graph_shape_and_semantics():
 
 
 def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
-    """Grant rejects malformed graph closure and violated leaf edge semantics."""
+    """Grant rejects malformed graph closure and false leaf edge semantics."""
     with openHby(name="ipex-v2-bad-grant-graph-semantics",
                  base="test",
                  version=Vrsn_2_0) as hby:
@@ -878,6 +878,7 @@ def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
+        handler = exc.routes["/ipex/grant"]
 
         baseChild = acdcmap(israid=issuer.pre,
                             attribute=dict(d="", role="member"),
@@ -972,7 +973,8 @@ def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
                         wrongE1EOrigin,
                         [wrongE1EChild])
 
-        # Unsupported leaf operators fail closed instead of being treated as no-op.
+        # Recognized but unevaluated operators are well-formed leaves whose
+        # relation is unsatisfied, instead of malformed graph input.
         notChild = acdcmap(israid=issuer.pre,
                            attribute=dict(d="", role="member"),
                            iseaid=issuer.pre)
@@ -983,6 +985,10 @@ def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
         assert_rejected("Here is the NOT-operator DAG",
                         notOrigin,
                         [notChild])
+        assert handler._evaluateLeafEdge(notOrigin.sad["e"]["holder"],
+                                         nodes={notChild.said: {"serder": notChild}},
+                                         nserder=notOrigin,
+                                         inheritedSchema=None) is False
 
         diChild = acdcmap(israid=issuer.pre,
                           attribute=dict(d="", role="member"),
@@ -994,6 +1000,10 @@ def test_ipex_v2_rejects_invalid_grant_graph_shape_and_semantics():
         assert_rejected("Here is the DI2I-operator DAG",
                         diOrigin,
                         [diChild])
+        assert handler._evaluateLeafEdge(diOrigin.sad["e"]["holder"],
+                                         nodes={diChild.said: {"serder": diChild}},
+                                         nserder=diOrigin,
+                                         inheritedSchema=None) is False
 
         # List-valued leaf operators are not supported
         listOpChild = acdcmap(israid=issuer.pre,

--- a/tests/acdc/test_regeventing.py
+++ b/tests/acdc/test_regeventing.py
@@ -418,6 +418,38 @@ def test_V15_acdc_rd_mismatch_refused():
         assert 'rd' in str(ex.value)
 
 
+def test_acdc_issuer_mismatch_refused():
+    """ACDC whose issuer does not match the registry's issuer is refused."""
+    with habbing.openHby(name="v15b", temp=True, version=Vrsn_2_0) as hby:
+
+        # Build two local identifiers so the registry and the presented ACDC
+        # can intentionally disagree about who the issuer is.
+        issuer = hby.makeHab(name="issuer", version=Vrsn_2_0)
+        stranger = hby.makeHab(name="stranger", version=Vrsn_2_0)
+
+        # The registry is genuinely controlled and anchored by `issuer`.
+        ripper = makeRegistry(issuer, stamp=STAMP0)
+
+        # The presented ACDC points at that registry but falsely claims that a
+        # different issuer created the credential body.
+        acdc = acdcmap(israid=stranger.pre,
+                       regid=ripper.said,
+                       attribute=dict(d='', name="Sunspot College", level="gold"))
+
+        # Build a real blinded update whose td commits to this ACDC SAID, so
+        # the only thing wrong is the issuer mismatch.
+        blinder, bup = makeUpdate(ripper.said, ripper.said, acdc.said,
+                                  'issued', sn=1, stamp=STAMP1)
+        anchor(issuer, bup)
+
+        # Verification must reject the presentation because the ACDC's `i`
+        # does not match the issuer that incepted the registry.
+        with pytest.raises(kering.MisbindingError) as ex:
+            vet(rip=ripper, updates=[bup], db=hby.db, acdc=acdc,
+                blinder=blinder)
+        assert 'issuer' in str(ex.value)
+
+
 def test_V16_rdless_acdc_oneway_binding():
     """V16: an rd-less ACDC whose chain td matches verifies, and the verdict
     names the one-directional binding (registry->ACDC only)."""
@@ -608,6 +640,7 @@ if __name__ == "__main__":
     test_V13_seal_reference_without_seal_retryable()
     test_V14_substitution_sibling_registry_refused()
     test_V15_acdc_rd_mismatch_refused()
+    test_V15b_acdc_issuer_mismatch_refused()
     test_V16_rdless_acdc_oneway_binding()
     test_V16b_blinded_head_undisclosed_binds_nothing()
     test_V18_equal_n_duplicity_both_orders()

--- a/tests/acdc/test_regeventing.py
+++ b/tests/acdc/test_regeventing.py
@@ -720,7 +720,7 @@ if __name__ == "__main__":
     test_V12_smt_root_anchor_refused_by_name()
     test_V13_seal_reference_without_seal_retryable()
     test_V14_substitution_sibling_registry_refused()
-    test_V15_acdc_rd_mismatch_refused()
+    test_acdc_issuer_mismatch_refused()
     test_V15b_acdc_issuer_mismatch_refused()
     test_V16_rdless_acdc_oneway_binding()
     test_V16b_blinded_head_undisclosed_binds_nothing()


### PR DESCRIPTION
This PR updates V2 IPEX message handling to use the single-DAG wire shape discussed for v1.1, so disclosed ACDC nodes travel as per-node nested substreams and `grant` verification can walk the disclosed origin graph

It also wires in verifier-side registry issuer-auth checks for registry-backed disclosed nodes by validating the node-local proof group against locally available TEL/KEL evidence.

- `q.dp` round-trips as a list of disclosure-path entries, e.g. `[[schema, "/", []]]`
- `a.o` round-trips as a one-element origin SAID list
- `a.ax` is accepted and round-tripped as an optional list field on `apply`, `offer`, and `grant`
- single-DAG only is enforced for `o`; multi-DAG is for a later task

- `grant()` now treat `origin` + `artifacts` as disclosed ACDC DAG nodes
- each disclosed node is emitted as its own nested `BodyWithAttachmentGroup`
- the first nest is always the origin node named by `a.o[0]`
- issuer-auth proof material now lives on the node’s attachment section

- `IpexHandler.verify()` was refactored into staged helpers for readability
- `grant` verification now:
  - validates origin nest shape
  - builds a `said -> nest` map
  - BFS walks `e` edges from `a.o[0]`
  - rejects dangling edge references
  - rejects malformed or compact non-walkable edge shapes
  - rejects extra unreachable disclosed nests

- added `_verifyIssuerAuthNode()` to enforce node-local verifier checks for disclosed registry-backed ACDCs
- when a disclosed node has top-level `rd`, the handler now expects a node-local blind proof group and vets it with `regeventing.vet(...)`
- `loadHandlers(...)` now accepts optional `rgy` so IPEX handlers can reuse an injected registry manager

- updated `serializeParsedSubstream()` so parsed blind proof groups reserialize correctly when accepted IPEX messages are stored and replayed