### PR TITLE
Add durable IPEX stores

### DIFF
--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -998,9 +998,9 @@ class IpexHandler:
                        invalid=False):
         """Select verified non-sender evidence accepted by this IPEX route.
 
-        A grant retains cryptographically valid evidence without assigning it
-        an ACDC or DAG role. Invalid grant evidence is discarded. Other verbs
-        reject non-sender evidence.
+        The caller removes invalid attachments before this method runs. A grant
+        retains the valid subset without assigning it an ACDC or DAG role.
+        Other verbs reject non-sender evidence or any invalid attachment.
         """
         tsgs = tsgs if tsgs is not None else []
         cigars = cigars if cigars is not None else []
@@ -1008,6 +1008,8 @@ class IpexHandler:
 
         verb = serder.ked["r"].rsplit("/", 1)[-1]
         if verb == Ipex.grant:
+            # Grant evidence is optional, so retain the valid subset despite
+            # invalid extras.
             return tsgs, cigars, sourceSeals
 
         if tsgs or cigars or sourceSeals or invalid:

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -994,6 +994,27 @@ class IpexHandler:
 
         return True
 
+    def verifyEvidence(self, serder, *, tsgs=None, cigars=None, sourceSeals=None,
+                       invalid=False):
+        """Select verified non-sender evidence accepted by this IPEX route.
+
+        A grant retains cryptographically valid evidence without assigning it
+        an ACDC or DAG role. Invalid grant evidence is discarded. Other verbs
+        reject non-sender evidence.
+        """
+        tsgs = tsgs if tsgs is not None else []
+        cigars = cigars if cigars is not None else []
+        sourceSeals = sourceSeals if sourceSeals is not None else []
+
+        verb = serder.ked["r"].rsplit("/", 1)[-1]
+        if verb == Ipex.grant:
+            return tsgs, cigars, sourceSeals
+
+        if tsgs or cigars or sourceSeals or invalid:
+            return None
+
+        return [], [], []
+
     def response(self, serder):
         """Look up the recorded response to a prior IPEX exchange.
 

--- a/src/keri/acdc/ipexing.py
+++ b/src/keri/acdc/ipexing.py
@@ -940,17 +940,16 @@ class IpexHandler:
             bsqs = nest.get("bsqs", []) if isinstance(nest, dict) else nest.bsqs
             bsss = nest.get("bsss", []) if isinstance(nest, dict) else nest.bsss
 
-            # The parser gives us primitive tuples. Rebuild those as the
-            # canonical BlindState / BoundState data records before handing
-            # them back to Blinder.
+            # Reparse the proof with Blinder's canonical casts. The parser
+            # supplies a Diger for d, but Blinder uses a Noncer with .nonce.
             proofs = []
             for proof in bsqs:
-                data = proof if isinstance(proof, BlindState) else BlindState(*proof)
-                proofs.append(Blinder(data=data))
+                proofs.append(Blinder(clan=BlindState,
+                                      qb64=b''.join(item.qb64b for item in proof)))
 
             for proof in bsss:
-                data = proof if isinstance(proof, BoundState) else BoundState(*proof)
-                proofs.append(Blinder(data=data))
+                proofs.append(Blinder(clan=BoundState,
+                                      qb64=b''.join(item.qb64b for item in proof)))
 
             # The proof group must disclose exactly one blinded state for the registry's root event.
             if len(proofs) != 1:

--- a/src/keri/core/eventing.py
+++ b/src/keri/core/eventing.py
@@ -4789,10 +4789,12 @@ class Kevery:
             case Ilks.exn:
                 cigars = kwa.get('cigars', [])
                 tsgs = kwa.get('tsgs', [])
-                if not (cigars or tsgs):
+                sscs = kwa.get('sscs', [])
+                ssts = kwa.get('ssts', [])
+                if not (cigars or tsgs or sscs or ssts):
                     raise ValidationError(
                         f"Missing attached exchanger "
-                        f"signatures for msg={serder.pretty()}")
+                        f"authentication for msg={serder.pretty()}")
                 if exc is None:
                     raise ValidationError(
                         f"No exchanger to process so "

--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -500,11 +500,7 @@ class Kramer:
             return AuthTypes.AttachedSignatureMultiKey, False
 
         if hasSealRef and hasSigs:
-            try:
-                sealValid = self._validateSenderSeal(
-                    msg, senderId, kwa)
-            except MissingSenderKeyStateError:
-                sealValid = False
+            sealValid = self._validateSenderSeal(msg, senderId, kwa)
 
             if sealValid:
                 return AuthTypes.AttachedSealReference, True
@@ -728,6 +724,21 @@ class Kramer:
             sigers=vsigers,
             stale_tsgs=stale_tsgs)
 
+    def _cueMissingSenderKeyState(self, senderId, sn, error):
+        """Request the exact sender KEL event required by a seal reference."""
+        self.cues.append({
+            "kin": "keystate",
+            "aid": senderId,
+            "sn": sn,
+        })
+        logger.info(
+            "Cueing keystate retrieval: missing key state in seal reference "
+            "for sender=%s, sn=%s, error=%s",
+            senderId,
+            sn,
+            error,
+        )
+
     def _validateSenderSeal(self, msg, senderId, kwa):
         """Validate seal reference attachments against sender's KEL.
 
@@ -752,7 +763,8 @@ class Kramer:
 
         Raises:
             MissingSenderKeyStateError: when a referenced event is not
-                found in the sender's KEL (caller should drop + cue)
+                found in the sender's KEL; queues the exact missing event
+                before raising so the caller can drop the message
         """
         # Build list of (number, diger) candidates to check.
         # sscs first (implicit sender KEL ref), then sender-matching ssts.
@@ -774,8 +786,10 @@ class Kramer:
         sdig = self.db.kels.getLast(keys=prefixer.qb64b, on=number.sn)
 
         if sdig is None:
-            raise MissingSenderKeyStateError(
+            error = MissingSenderKeyStateError(
                 f"Event at sn={number.sn} not in KEL for sender {senderId}")
+            self._cueMissingSenderKeyState(senderId, number.sn, error)
+            raise error
 
         # Verify the event SAID matches the seal reference
         if bytes(sdig, "utf-8") != diger.qb64b:
@@ -784,8 +798,10 @@ class Kramer:
         # Fetch the actual event
         evtSerder = self.db.evts.get(keys=(prefixer.qb64b, bytes(sdig, "utf-8")))
         if evtSerder is None:
-            raise MissingSenderKeyStateError(
+            error = MissingSenderKeyStateError(
                 f"Event data missing for sender {senderId} at sn={number.sn}")
+            self._cueMissingSenderKeyState(senderId, number.sn, error)
+            raise error
 
         # Search event's seal list for a seal whose 'd' field matches msg SAID
         for seal in (evtSerder.seals or []):
@@ -834,6 +850,7 @@ class Kramer:
             if kever is None:
                 self.db.kramULGS.add(key, prefixer)
                 continue
+            self.db.kramULGS.rem(keys=key, val=prefixer)
             number = Number(sn=kever.lastEst.s)
             diger = Diger(qb64=kever.lastEst.d)
             for siger in sigers:
@@ -908,7 +925,8 @@ class Kramer:
 
         After threshold is satisfied on a later delivery, ``kwa`` reflects only
         that parse; ``kramPMKS`` and non-auth attachment DBs hold the union of
-        state accumulated across deliveries.
+        state accumulated across deliveries. The caller removes that partial
+        state after this method copies it into the accepted delivery.
 
         Parameters:
             partialKey (tuple): ``(AID, MID)`` escrow key
@@ -1117,7 +1135,12 @@ class Kramer:
 
                 # "Both attached" case, try seal validation first
                 if hasSealRef and hasSigs:
-                    if self._validateSenderSeal(msg, senderId, kwa):
+                    try:
+                        sealValidated = self._validateSenderSeal(
+                            msg, senderId, kwa)
+                    except MissingSenderKeyStateError:
+                        return None
+                    if sealValidated:
                         # Seal valid -> treat as seal auth -> idempotent drop
                         return None
                     # Seal invalid -> fall through to signature auth below
@@ -1131,13 +1154,6 @@ class Kramer:
                 # Reached from both "pure sig multi-key" and
                 # "both attached with invalid seal, multi-key" paths.
 
-                # Verify attached sigs using type-appropriate dispatch
-                sigResult = self._verifyAttachedSigs(
-                    msg=msg, senderId=senderId, kever=kever, kwa=kwa)
-
-                if not sigResult.verified:
-                    return None  # no valid sigs in this delivery
-
                 # Key state change detection:
                 # Compare stored key state ref against current kever state
                 currentKeyState = (Number(num=kever.lastEst.s),
@@ -1147,7 +1163,20 @@ class Kramer:
                     storedSn, storedSaid = storedKeyState
                     if (storedSn.num != currentKeyState[0].num or
                             storedSaid.qb64 != currentKeyState[1].qb64):
+                        # Keep the timeliness cache to block this stale SAID.
+                        self.db.kramPMKM.rem(key)
+                        self.db.kramPMKS.rem(key)
+                        self.db.kramPMSK.rem(key)
+                        self._remNonAuthAttachments(key)
                         return None  # drop, key state changed
+
+                # Verify attached sigs using type-appropriate dispatch only
+                # after confirming that the accumulated pool is still usable.
+                sigResult = self._verifyAttachedSigs(
+                    msg=msg, senderId=senderId, kever=kever, kwa=kwa)
+
+                if not sigResult.verified:
+                    return None  # no valid sigs in this delivery
 
                 # Idempotently accumulate newly verified signatures
                 existingSigs = self.db.kramPMKS.get(key)
@@ -1183,6 +1212,12 @@ class Kramer:
                         if msg.ilk == Ilks.exn:
                             self._setVerifiedSenderTsg(
                                 senderId, kever, allSigs, kwa)
+                        # The cache remains as the replay marker. Partial state
+                        # is no longer retryable after the accepted handoff.
+                        self.db.kramPMKM.rem(key)
+                        self.db.kramPMKS.rem(key)
+                        self.db.kramPMSK.rem(key)
+                        self._remNonAuthAttachments(key)
                         return msg
 
                 # Threshold not satisfied, message remains pending
@@ -1209,8 +1244,11 @@ class Kramer:
 
                 # Resolve auth type before timeliness check per spec.
                 # Ensures "both attached" fallback to multi-key gets long lag.
-                authType, sealValidated = self._resolveAuthType(
-                    msg, kwa, kever, hasSealRef, hasSigs, senderId)
+                try:
+                    authType, sealValidated = self._resolveAuthType(
+                        msg, kwa, kever, hasSealRef, hasSigs, senderId)
+                except MissingSenderKeyStateError:
+                    return None
 
                 # Select lag values based on resolved auth type
                 d = cacheTypeRecord.d
@@ -1238,20 +1276,7 @@ class Kramer:
                         try:
                             sealValidated = self._validateSenderSeal(
                                 msg, senderId, kwa)
-                        except MissingSenderKeyStateError as e:
-                            logger.info("Missing sender key state for "
-                                        "%s: %s", senderId, e)
-                            # Append the cue for the keystate retrieval notification including the senderID and the sn
-                            self.cues.append({
-                                "kin": "keystate",
-                                "aid": senderId,
-                                "sn": kever.sn,
-                            })
-                            logger.info(
-                                "Cueing keystate retrieval: missing key state in seal reference for sender=%s, current_sn=%s, error=%s",
-                                senderId,
-                                kever.sn,
-                            )
+                        except MissingSenderKeyStateError:
                             return None
                         if not sealValidated:
                             return None
@@ -1357,7 +1382,12 @@ class Kramer:
 
                 # "Both attached" case, try seal validation first
                 if hasSealRef and hasSigs:
-                    if self._validateSenderSeal(msg, senderId, kwa):
+                    try:
+                        sealValidated = self._validateSenderSeal(
+                            msg, senderId, kwa)
+                    except MissingSenderKeyStateError:
+                        return None
+                    if sealValidated:
                         # Seal valid -> treat as seal auth -> idempotent drop
                         return None
                     # Seal invalid -> fall through to signature auth below
@@ -1371,13 +1401,6 @@ class Kramer:
                 # Reached from both "pure sig multi-key" and
                 # "both attached with invalid seal, multi-key" paths.
 
-                # Verify attached sigs using type-appropriate dispatch
-                sigResult = self._verifyAttachedSigs(
-                    msg=msg, senderId=senderId, kever=kever, kwa=kwa)
-
-                if not sigResult.verified:
-                    return None  # no valid sigs in this delivery
-
                 # Key state change detection:
                 # Compare stored key state ref against current kever state.
                 # Partial dbs use (AID.MID) key per spec, not (AID.XID.MID).
@@ -1388,7 +1411,20 @@ class Kramer:
                     storedSn, storedSaid = storedKeyState
                     if (storedSn.num != currentKeyState[0].num or
                             storedSaid.qb64 != currentKeyState[1].qb64):
+                        # Keep the timeliness cache to block this stale SAID.
+                        self.db.kramPMKM.rem(partialKey)
+                        self.db.kramPMKS.rem(partialKey)
+                        self.db.kramPMSK.rem(partialKey)
+                        self._remNonAuthAttachments(partialKey)
                         return None  # drop, key state changed
+
+                # Verify attached sigs using type-appropriate dispatch only
+                # after confirming that the accumulated pool is still usable.
+                sigResult = self._verifyAttachedSigs(
+                    msg=msg, senderId=senderId, kever=kever, kwa=kwa)
+
+                if not sigResult.verified:
+                    return None  # no valid sigs in this delivery
 
                 # Idempotently accumulate newly verified signatures
                 existingSigs = self.db.kramPMKS.get(partialKey)
@@ -1424,6 +1460,12 @@ class Kramer:
                         if msg.ilk == Ilks.exn:
                             self._setVerifiedSenderTsg(
                                 senderId, kever, allSigs, kwa)
+                        # The cache remains as the replay marker. Partial state
+                        # is no longer retryable after the accepted handoff.
+                        self.db.kramPMKM.rem(partialKey)
+                        self.db.kramPMKS.rem(partialKey)
+                        self.db.kramPMSK.rem(partialKey)
+                        self._remNonAuthAttachments(partialKey)
                         return msg
 
                 # Threshold not satisfied, message remains pending
@@ -1449,8 +1491,11 @@ class Kramer:
                         f"Sender KEL unavailable for {senderId}")
 
                 # Resolve auth type before timeliness check per spec.
-                authType, sealValidated = self._resolveAuthType(
-                    msg, kwa, kever, hasSealRef, hasSigs, senderId)
+                try:
+                    authType, sealValidated = self._resolveAuthType(
+                        msg, kwa, kever, hasSealRef, hasSigs, senderId)
+                except MissingSenderKeyStateError:
+                    return None
 
                 d = cacheTypeRecord.d
                 if authType == AuthTypes.AttachedSignatureMultiKey:
@@ -1515,20 +1560,7 @@ class Kramer:
                             try:
                                 sealValidated = self._validateSenderSeal(
                                     msg, senderId, kwa)
-                            except MissingSenderKeyStateError as e:
-                                logger.info("Missing sender key state for "
-                                            "%s: %s", senderId, e)
-                                # Append the cue for the keystate retrieval notification including the senderID and the sn
-                                self.cues.append({
-                                    "kin": "keystate",
-                                    "aid": senderId,
-                                    "sn": kever.sn,
-                                })
-                                logger.info(
-                                    "Cueing keystate retrieval: missing key state in seal reference for sender=%s, current_sn=%s, error=%s",
-                                    senderId,
-                                    kever.sn,
-                                )
+                            except MissingSenderKeyStateError:
                                 return None
                             if not sealValidated:
                                 return None

--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -709,6 +709,14 @@ class Kramer:
             raw=msg.raw, sigers=poolSigers, verfers=kever.verfers)
         verified = {s.qb64 for s in vsigers}
         self._scrubFailedVerification(senderId, kever, kwa, verified)
+        if msg.ilk == Ilks.exn and vsigers:
+            tsgs = [tsg for tsg in kwa.get('tsgs', [])
+                    if tsg[0].qb64 != senderId]
+            tsgs.insert(0, (kever.prefixer,
+                            Number(sn=kever.lastEst.s),
+                            Diger(qb64=kever.lastEst.d),
+                            list(vsigers)))
+            kwa['tsgs'] = tsgs
 
         return SigVerifyResult(
             verified=True if vsigers else False,
@@ -785,7 +793,7 @@ class Kramer:
         """Idempotently store non-authenticator attachments for a partially
         signed multi-key message pending threshold satisfaction.
 
-        Handles parser kwa attachment keys except lsgs, essrs, sscs, and
+        Handles parser kwa attachment keys except essrs, sscs, and
         sender-matching ssts. Seal couples (sscs) and source triples whose
         prefix is the message sender are anchoring-seal-reference material
         for this AID and are not stored here. Only ssts whose prefix differs
@@ -794,8 +802,11 @@ class Kramer:
 
         Sender-addressed tsgs quads are not written to kramTSGS (they are
         authenticator material, not non-auth forwarding); other prefixers'
-        tsgs are stored. The live kwa dict is not mutated by this method;
-        signature scrubbing may already have run in _verifyAttachedSigs.
+        tsgs are stored. A foreign last-establishment signature group is
+        resolved to that endorser's current establishment event at receipt
+        and stored in the same explicit form. The live kwa dict is not
+        mutated by this method; signature scrubbing may already have run in
+        _verifyAttachedSigs.
 
         Parameters:
             key (tuple): (AID, MID) partial db key
@@ -809,6 +820,20 @@ class Kramer:
                 continue
             for siger in sigers:
                 self.db.kramTSGS.add(key, (prefixer, number, diger, siger))
+        for prefixer, sigers in kwa.get('lsgs', []):
+            if prefixer.qb64 == senderId:
+                continue
+            kever = self.db.kevers.get(prefixer.qb64)
+            if kever is None:
+                self.db.kramULGS.add(key, prefixer)
+                continue
+            number = Number(sn=kever.lastEst.s)
+            diger = Diger(qb64=kever.lastEst.d)
+            for siger in sigers:
+                self.db.kramTSGS.add(key, (prefixer, number, diger, siger))
+        for cigar in kwa.get('cigars', []):
+            if cigar.verfer.qb64 != senderId:
+                self.db.kramCIGS.add(key, (cigar.verfer, cigar))
         for prefixer, number, diger in kwa.get('ssts', []):
             if prefixer.qb64 != senderId:
                 self.db.kramSSTS.add(key, (prefixer, number, diger))
@@ -834,6 +859,8 @@ class Kramer:
         """
         self.db.kramTRQS.rem(key)
         self.db.kramTSGS.rem(key)
+        self.db.kramULGS.rem(key)
+        self.db.kramCIGS.rem(key)
         self.db.kramSSCS.rem(key)
         self.db.kramSSTS.rem(key)
         self.db.kramFRCS.rem(key)
@@ -919,6 +946,17 @@ class Kramer:
         else:
             kwa.pop('tsgs', None)
 
+        ulgsEsc = list(self.db.kramULGS.get(partialKey) or [])
+        kwa['ulgs'] = self._dedupeAttachmentItems(
+            ulgsEsc + kwa.get('ulgs', []))
+
+        cigarsEsc = []
+        for verfer, cigar in self.db.kramCIGS.get(partialKey) or []:
+            cigar.verfer = verfer
+            cigarsEsc.append(cigar)
+        kwa['cigars'] = self._dedupeAttachmentItems(
+            cigarsEsc + kwa.get('cigars', []))
+
         sstsEsc = list(self.db.kramSSTS.get(partialKey) or [])
         kwa['ssts'] = self._dedupeAttachmentItems(
             sstsEsc + kwa.get('ssts', []))
@@ -947,8 +985,8 @@ class Kramer:
         kwa['tmqs'] = self._dedupeAttachmentItems(
             tmqsEsc + kwa.get('tmqs', []))
 
-        for name in ('trqs', 'ssts', 'frcs', 'tdcs', 'ptds', 'bsqs', 'bsss',
-                     'tmqs'):
+        for name in ('trqs', 'ulgs', 'cigars', 'ssts', 'frcs', 'tdcs', 'ptds',
+                     'bsqs', 'bsss', 'tmqs'):
             if not kwa.get(name):
                 kwa.pop(name, None)
 
@@ -1124,8 +1162,9 @@ class Kramer:
                     if storedKeyState is None:
                         self.db.kramPMSK.pin(key, currentKeyState)
 
-                    # Store non-auth attachments alongside new sigs
-                    self._storeNonAuthAttachments(key, senderId, kwa)
+                # A repeated valid sender signature may carry new non-auth
+                # attachments. Preserve them even when the signature exists.
+                self._storeNonAuthAttachments(key, senderId, kwa)
 
                 # Check threshold using current kever's tholder
                 allSigs = existingSigs + newSigs
@@ -1134,6 +1173,14 @@ class Kramer:
 
                     if kever.tholder.satisfy(indices=sigIndices):
                         self._rehydrateKwaFromEscrow(key, senderId, kwa)
+                        if msg.ilk == Ilks.exn:
+                            tsgs = [tsg for tsg in kwa.get('tsgs', [])
+                                    if tsg[0].qb64 != senderId]
+                            tsgs.insert(0, (kever.prefixer,
+                                            Number(sn=kever.lastEst.s),
+                                            Diger(qb64=kever.lastEst.d),
+                                            list(allSigs)))
+                            kwa['tsgs'] = tsgs
                         return msg
 
                 # Threshold not satisfied, message remains pending
@@ -1206,6 +1253,10 @@ class Kramer:
                             return None
                         if not sealValidated:
                             return None
+
+                    if hasSigs and msg.ilk == Ilks.exn:
+                        self._verifyAttachedSigs(
+                            msg=msg, senderId=senderId, kever=kever, kwa=kwa)
 
                     # Create cache and accept
                     mcr = MsgCacheRecord(
@@ -1357,8 +1408,9 @@ class Kramer:
                     if storedKeyState is None:
                         self.db.kramPMSK.pin(partialKey, currentKeyState)
 
-                    # Store non-auth attachments alongside new sigs
-                    self._storeNonAuthAttachments(partialKey, senderId, kwa)
+                # A repeated valid sender signature may carry new non-auth
+                # attachments. Preserve them even when the signature exists.
+                self._storeNonAuthAttachments(partialKey, senderId, kwa)
 
                 # Check threshold using current kever's tholder
                 allSigs = existingSigs + newSigs
@@ -1367,6 +1419,14 @@ class Kramer:
 
                     if kever.tholder.satisfy(indices=sigIndices):
                         self._rehydrateKwaFromEscrow(partialKey, senderId, kwa)
+                        if msg.ilk == Ilks.exn:
+                            tsgs = [tsg for tsg in kwa.get('tsgs', [])
+                                    if tsg[0].qb64 != senderId]
+                            tsgs.insert(0, (kever.prefixer,
+                                            Number(sn=kever.lastEst.s),
+                                            Diger(qb64=kever.lastEst.d),
+                                            list(allSigs)))
+                            kwa['tsgs'] = tsgs
                         return msg
 
                 # Threshold not satisfied, message remains pending
@@ -1475,6 +1535,10 @@ class Kramer:
                                 return None
                             if not sealValidated:
                                 return None
+
+                        if hasSigs and msg.ilk == Ilks.exn:
+                            self._verifyAttachedSigs(
+                                msg=msg, senderId=senderId, kever=kever, kwa=kwa)
 
                         # Create txn cache and accept
                         mcr = TxnMsgCacheRecord(

--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -627,6 +627,17 @@ class Kramer:
             if not kwa['tsgs']:
                 kwa.pop('tsgs', None)
 
+    @staticmethod
+    def _setVerifiedSenderTsg(senderId, kever, sigers, kwa):
+        """Replace sender groups with one verified last-establishment group."""
+        tsgs = [tsg for tsg in kwa.get('tsgs', [])
+                if tsg[0].qb64 != senderId]
+        tsgs.insert(0, (kever.prefixer,
+                        Number(sn=kever.lastEst.s),
+                        Diger(qb64=kever.lastEst.d),
+                        list(sigers)))
+        kwa['tsgs'] = tsgs
+
     def _verifyAttachedSigs(self, *, msg, senderId, kever, kwa):
         """Verify attached signatures using cigar gate then oset pooling.
 
@@ -710,13 +721,7 @@ class Kramer:
         verified = {s.qb64 for s in vsigers}
         self._scrubFailedVerification(senderId, kever, kwa, verified)
         if msg.ilk == Ilks.exn and vsigers:
-            tsgs = [tsg for tsg in kwa.get('tsgs', [])
-                    if tsg[0].qb64 != senderId]
-            tsgs.insert(0, (kever.prefixer,
-                            Number(sn=kever.lastEst.s),
-                            Diger(qb64=kever.lastEst.d),
-                            list(vsigers)))
-            kwa['tsgs'] = tsgs
+            self._setVerifiedSenderTsg(senderId, kever, vsigers, kwa)
 
         return SigVerifyResult(
             verified=True if vsigers else False,
@@ -804,9 +809,11 @@ class Kramer:
         authenticator material, not non-auth forwarding); other prefixers'
         tsgs are stored. A foreign last-establishment signature group is
         resolved to that endorser's current establishment event at receipt
-        and stored in the same explicit form. The live kwa dict is not
-        mutated by this method; signature scrubbing may already have run in
-        _verifyAttachedSigs.
+        and stored in the same explicit form. This freezes the establishment
+        reference so a later endorser rotation before the sender reaches its
+        signature threshold does not reinterpret the escrowed signatures. The
+        live kwa dict is not mutated by this method; signature scrubbing may
+        already have run in _verifyAttachedSigs.
 
         Parameters:
             key (tuple): (AID, MID) partial db key
@@ -1174,13 +1181,8 @@ class Kramer:
                     if kever.tholder.satisfy(indices=sigIndices):
                         self._rehydrateKwaFromEscrow(key, senderId, kwa)
                         if msg.ilk == Ilks.exn:
-                            tsgs = [tsg for tsg in kwa.get('tsgs', [])
-                                    if tsg[0].qb64 != senderId]
-                            tsgs.insert(0, (kever.prefixer,
-                                            Number(sn=kever.lastEst.s),
-                                            Diger(qb64=kever.lastEst.d),
-                                            list(allSigs)))
-                            kwa['tsgs'] = tsgs
+                            self._setVerifiedSenderTsg(
+                                senderId, kever, allSigs, kwa)
                         return msg
 
                 # Threshold not satisfied, message remains pending
@@ -1420,13 +1422,8 @@ class Kramer:
                     if kever.tholder.satisfy(indices=sigIndices):
                         self._rehydrateKwaFromEscrow(partialKey, senderId, kwa)
                         if msg.ilk == Ilks.exn:
-                            tsgs = [tsg for tsg in kwa.get('tsgs', [])
-                                    if tsg[0].qb64 != senderId]
-                            tsgs.insert(0, (kever.prefixer,
-                                            Number(sn=kever.lastEst.s),
-                                            Diger(qb64=kever.lastEst.d),
-                                            list(allSigs)))
-                            kwa['tsgs'] = tsgs
+                            self._setVerifiedSenderTsg(
+                                senderId, kever, allSigs, kwa)
                         return msg
 
                 # Threshold not satisfied, message remains pending

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -580,6 +580,14 @@ class Baser(LMDBer):
             subkey 'essrs.'
             Multiple values per key.
 
+        .ests is named subDB instance of CatCesrIoSetSuber
+            (klas=(Number, Diger)) for resolved exchange source seals.
+            subkey 'ests.'
+            Key: exchange message SAID and sealing AID.
+            Value: sealing KEL event sequence number and SAID.
+            Multiple values per key are allowed. The exchange message in
+            ``exns`` remains the acceptance marker.
+
         .chas is named subDB instance of CesrIoSetSuber (klas=Diger) for
             accepted signed 12-word challenge response exn messages. Keyed by
             prefix of signer.
@@ -790,6 +798,23 @@ class Baser(LMDBer):
             parser kwa key 'tsgs'.
             Multiple values per key stored as ordered set (duplicates ignored).
             Entries persist until removed by the KRAM pruner.
+
+        .kramULGS is named subDB instance of CesrIoSetSuber (klas=Prefixer) for
+            foreign last signature groups that KRAM could not resolve when a
+            partial message was received.
+            subkey 'ulgs.'
+            DB is keyed by (AID, MID): sender identifier prefix plus message SAID.
+            Values identify unresolved foreign signer prefixes. Multiple values
+            per key are allowed and entries persist until removed by the KRAM
+            pruner.
+
+        .kramCIGS is named subDB instance of CatCesrIoSetSuber
+            (klas=(Verfer, Cigar)) for foreign nontransferable signatures on
+            partially signed multi-key messages.
+            subkey 'cigs.'
+            DB is keyed by (AID, MID): sender identifier prefix plus message SAID.
+            Multiple values per key are allowed and entries persist until removed
+            by the KRAM pruner.
 
         .kramSSCS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key first seen seal couple attachments from issuing or
@@ -1105,6 +1130,10 @@ class Baser(LMDBer):
 
         self.essrs = subing.CesrIoSetSuber(db=self, subkey="essrs.", klas=coring.Texter)
 
+        # resolved exchange source seals indexed by message and sealing AID
+        self.ests = subing.CatCesrIoSetSuber(db=self, subkey="ests.",
+                                             klas=(coring.Number, coring.Diger))
+
         # accepted signed 12-word challenge response exn messages keys by prefix of signer
         # TODO: clean
         self.chas = subing.CesrIoSetSuber(db=self, subkey='chas.', klas=coring.Diger)
@@ -1300,6 +1329,14 @@ class Baser(LMDBer):
         self.kramTSGS = subing.CatCesrIoSetSuber(db=self, subkey='tsgs.',
                                                   klas=(coring.Prefixer, coring.Number,
                                                         coring.Diger, indexing.Siger))
+
+        # ulgs: foreign last signature groups unresolved at receipt
+        self.kramULGS = subing.CesrIoSetSuber(db=self, subkey='ulgs.',
+                                             klas=coring.Prefixer)
+
+        # cigs: foreign nontransferable signatures (verfer, cigar)
+        self.kramCIGS = subing.CatCesrIoSetSuber(
+            db=self, subkey='cigs.', klas=(coring.Verfer, coring.Cigar))
 
         # sscs: first seen seal couples (number, diger) issuing or delegating
         self.kramSSCS = subing.CatCesrIoSetSuber(db=self, subkey='sscs.',
@@ -1584,11 +1621,15 @@ class Baser(LMDBer):
                 # This is the list of set based databases that are not created as part of event processing.
                 # for now we are just copying them from self to copy without worrying about being able to
                 # reprocess them.  We need a more secure method in the future
-                sets = ["esigs", "ecigs", "epath", "enst", "chas", "reps", "wkas", "meids", "maids"]
+                evidence = ["esigs", "ecigs", "epath", "enst", "essrs", "ests"]
+                accepted = {said for (said,), _ in self.exns.getTopItemIter()}
+                sets = evidence + ["chas", "reps", "wkas", "meids", "maids"]
                 for name in sets:
                     srcdb = getattr(self, name)
                     cpydb = getattr(copy, name)
                     for keys, val in srcdb.getTopItemIter():
+                        if name in evidence and keys[0] not in accepted:
+                            continue
                         cpydb.add(keys=keys, val=val)
 
                 # Copy imgs (blinded media for remote identifiers)

--- a/src/keri/db/basing.py
+++ b/src/keri/db/basing.py
@@ -787,7 +787,8 @@ class Baser(LMDBer):
             Value is (Prefixer, Number, Diger, Siger) tuple. Sourced from
             parser kwa key 'trqs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramTSGS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key trans last sig group attachments. Each group is
@@ -797,7 +798,8 @@ class Baser(LMDBer):
             Value is (Prefixer, Number, Diger, Siger) tuple. Sourced from
             parser kwa key 'tsgs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramULGS is named subDB instance of CesrIoSetSuber (klas=Prefixer) for
             foreign last signature groups that KRAM could not resolve when a
@@ -805,16 +807,18 @@ class Baser(LMDBer):
             subkey 'ulgs.'
             DB is keyed by (AID, MID): sender identifier prefix plus message SAID.
             Values identify unresolved foreign signer prefixes. Multiple values
-            per key are allowed and entries persist until removed by the KRAM
-            pruner.
+            per key are allowed.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramCIGS is named subDB instance of CatCesrIoSetSuber
             (klas=(Verfer, Cigar)) for foreign nontransferable signatures on
             partially signed multi-key messages.
             subkey 'cigs.'
             DB is keyed by (AID, MID): sender identifier prefix plus message SAID.
-            Multiple values per key are allowed and entries persist until removed
-            by the KRAM pruner.
+            Multiple values per key are allowed.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramSSCS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key first seen seal couple attachments from issuing or
@@ -823,7 +827,8 @@ class Baser(LMDBer):
             DB is keyed by (AID, MID): sender identifier prefix plus message SAID
             Value is (Number, Diger) tuple. Sourced from parser kwa key 'sscs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramSSTS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key source seal triple attachments from issued or
@@ -833,7 +838,8 @@ class Baser(LMDBer):
             Value is (Prefixer, Number, Diger) tuple. Sourced from parser kwa
             key 'ssts'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramFRCS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key first seen replay couple attachments.
@@ -841,7 +847,8 @@ class Baser(LMDBer):
             DB is keyed by (AID, MID): sender identifier prefix plus message SAID
             Value is (Number, Dater) tuple. Sourced from parser kwa key 'frcs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramTDCS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key typed digest seal couple attachments.
@@ -849,7 +856,8 @@ class Baser(LMDBer):
             DB is keyed by (AID, MID): sender identifier prefix plus message SAID
             Value is (Verser, Diger) tuple. Sourced from parser kwa key 'tdcs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramPTDS is named subDB instance of IoSetSuber for KRAM partially signed
             multi-key pathed stream attachments.
@@ -858,7 +866,8 @@ class Baser(LMDBer):
             Value is raw bytes of pathed CESR stream. Sourced from parser kwa
             key 'ptds'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramBSQS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key blind state quadruple attachments.
@@ -867,7 +876,8 @@ class Baser(LMDBer):
             Value is (Diger, Noncer, Noncer, Labeler) tuple. Sourced from
             parser kwa key 'bsqs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramBSSS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key bound state sextuple attachments.
@@ -876,7 +886,8 @@ class Baser(LMDBer):
             Value is (Diger, Noncer, Noncer, Labeler, Number, Noncer) tuple.
             Sourced from parser kwa key 'bsss'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
         .kramTMQS is named subDB instance of CatCesrIoSetSuber for KRAM partially
             signed multi-key type media quadruple attachments.
@@ -885,7 +896,8 @@ class Baser(LMDBer):
             Value is (Diger, Noncer, Labeler, Texter) tuple. Sourced from
             parser kwa key 'tmqs'.
             Multiple values per key stored as ordered set (duplicates ignored).
-            Entries persist until removed by the KRAM pruner.
+            KRAM removes entries after it forwards the message, detects a sender
+            key-state change, or prunes the incomplete message.
 
     Properties:
         kevers (statedict): read through cache of kevers of states for KELs in db

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -74,7 +74,12 @@ class Exchanger:
             cigars (list): of Cigar instances of attached non-trans sigs
             ptds (list[bytes]): pathed Cesr Streams
             essrs (list[Texter]): ESSR streams as Texters
-            kwa: optional source seals and parsed V2 nested substreams
+            kwa (dict): optional parsed attachment groups:
+                nests contains parsed V2 nested substreams
+                lsgs contains last-establishment signature groups
+                ulgs contains unresolved foreign signer prefixes
+                sscs contains sender-implied source seal couples
+                ssts contains explicit source seal triples
 
         Returns:
             bool | None: ``True`` when the exchange verified and was persisted,
@@ -113,6 +118,9 @@ class Exchanger:
 
         evidenceVerifier = getattr(behavior, "verifyEvidence", None)
         if senderTsgs and evidenceVerifier is None:
+            # Routes without an evidence policy preserve the existing
+            # TSG-over-cigar precedence. A sender TSG causes all cigars to be
+            # ignored.
             senderCigars = []
             extraCigars = []
         else:
@@ -129,6 +137,8 @@ class Exchanger:
         validSenderTsgs = []
         validSenderCigars = []
         if validSenderSourceSeals:
+            # A valid sender seal authenticates the EXN. Retain only valid
+            # optional sender TSGs and do not fail on invalid ones.
             validSenderTsgs, _, _, _ = verifyAttachments(
                 hby=self.hby, serder=serder, tsgs=senderTsgs)
 
@@ -175,6 +185,8 @@ class Exchanger:
                 validSenderCigars.append(cigar)
 
         elif not validSenderSourceSeals:
+            # Do not escrow unsupported foreign-only evidence as missing sender
+            # authentication on routes without an evidence policy.
             if (evidenceVerifier is None and
                     (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
                 msg = (f"Skipped evidence not from aid={sender} route={route} "
@@ -193,6 +205,9 @@ class Exchanger:
             logger.debug("Exchange message body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
 
+        # A sender authenticated above may still carry unsupported foreign
+        # evidence, which routes without an evidence policy must reject before
+        # persistence.
         if (evidenceVerifier is None and
                 (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
             msg = (f"Skipped evidence not from aid={sender} route={route} "
@@ -974,7 +989,11 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
 
 
 def verify(hby, serder):
-    """Verify stored authentication and endorsements for an exchange message.
+    """Verify all stored authentication and evidence for an exchange message.
+
+    Any invalid stored attachment fails verification. Source seals are
+    verified but omitted from the legacy two-item return tuple;
+    ``serializeMessage`` reloads them for wire reconstruction.
 
     Parameters:
         hby (Habery): database environment from which to verify message
@@ -1021,7 +1040,7 @@ def verify(hby, serder):
         sourceSeals=sourceSeals,
     )
     if invalid:
-        msg = f"Invalid stored authentication for evt = {serder.said}"
+        msg = f"Invalid stored authentication or evidence for evt = {serder.said}"
         logger.info(msg)
         logger.debug("Exn Body=\n%s\n", serder.pretty())
         raise MissingSignatureError(msg)

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -60,6 +60,26 @@ class Exchanger:
 
         self.routes[handler.resource] = handler
 
+    def _raiseMissingKeyState(self, serder, missing):
+        """Request missing KEL events and reject the current exchange."""
+        seen = set()
+        for prefixer, number in missing:
+            sn = number.snh if number is not None else None
+            key = (prefixer.qb64, sn)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            query = dict(r="logs", pre=prefixer.qb64)
+            if sn is not None:
+                query["sn"] = sn
+            self.cues.append(dict(kin="query", q=query))
+
+        msg = f"Missing key state for attached evidence on evt={serder.said}"
+        logger.info(msg)
+        logger.debug("Exchange message body=\n%s\n", serder.pretty())
+        raise MissingSignatureError(msg)
+
     def processEvent(self, serder, tsgs=None, cigars=None, ptds=None, essrs=None, **kwa):
         """ Process one serder event with attached indexed signatures representing a Peer to Peer exchange message.
 
@@ -131,15 +151,18 @@ class Exchanger:
         if evidenceVerifier is None:
             extraSourceSeals = []
 
-        _, _, validSenderSourceSeals, _ = verifyAttachments(
+        (_, _, validSenderSourceSeals, _,
+         missingSenderSourceSeals) = verifyAttachments(
             hby=self.hby, serder=serder, sourceSeals=senderSourceSeals)
+        if missingSenderSourceSeals:
+            self._raiseMissingKeyState(serder, missingSenderSourceSeals)
 
         validSenderTsgs = []
         validSenderCigars = []
         if validSenderSourceSeals:
             # A valid sender seal authenticates the EXN. Retain only valid
             # optional sender TSGs and do not fail on invalid ones.
-            validSenderTsgs, _, _, _ = verifyAttachments(
+            validSenderTsgs, _, _, _, _ = verifyAttachments(
                 hby=self.hby, serder=serder, tsgs=senderTsgs)
 
         elif senderTsgs:
@@ -219,15 +242,18 @@ class Exchanger:
         (validExtraTsgs,
          validExtraCigars,
          validExtraSourceSeals,
-         invalidExtra) = verifyAttachments(
+         invalidExtra,
+         missingExtra) = verifyAttachments(
              hby=self.hby,
              serder=serder,
              tsgs=extraTsgs,
              lsgs=extraLsgs,
              cigars=extraCigars,
              sourceSeals=extraSourceSeals,
-             unresolved=bool(unresolvedLsgs),
+             unresolved=unresolvedLsgs,
          )
+        if missingExtra:
+            self._raiseMissingKeyState(serder, missingExtra)
 
         e = Pather(parts=["e"])
 
@@ -909,7 +935,7 @@ def nesting(paths, acc, val):
 
 
 def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
-                      sourceSeals=None, unresolved=False):
+                      sourceSeals=None, unresolved=None):
     """Cryptographically verify exchange authentication attachments.
 
     Parameters:
@@ -919,21 +945,25 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
         lsgs (list): transferable signature groups without establishment references
         cigars (list): non-transferable signatures
         sourceSeals (list): source seal triples
-        unresolved (bool): True if an attachment could not be reconstructed
+        unresolved (list): signer prefixes whose attachments could not be
+            reconstructed without their KEL
 
     Returns:
         tuple: Valid transferable signature groups, non-transferable signatures,
-            source seal triples, and an invalid attachment flag.
+            source seal triples, an invalid attachment flag, and missing KEL
+            coordinates.
     """
     tsgs = list(tsgs or [])
     lsgs = lsgs or []
     cigars = cigars or []
     sourceSeals = sourceSeals or []
-    invalid = unresolved
+    unresolved = unresolved or []
+    invalid = False
+    missing = [(prefixer, None) for prefixer in unresolved]
 
     for prefixer, sigers in lsgs:
         if prefixer.qb64 not in hby.kevers:
-            invalid = True
+            missing.append((prefixer, None))
             continue
 
         kever = hby.kevers[prefixer.qb64]
@@ -944,8 +974,22 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
 
     validTsgs = []
     for prefixer, number, diger, sigers in tsgs:
-        if (prefixer.qb64 not in hby.kevers or
-                hby.kevers[prefixer.qb64].sn < number.sn):
+        if not prefixer.transferable:
+            invalid = True
+            continue
+
+        sdig = hby.db.kels.getLast(keys=prefixer.qb64b, on=number.sn)
+        if sdig is None:
+            missing.append((prefixer, number))
+            continue
+
+        aserder = hby.db.evts.get(
+            keys=(prefixer.qb64b, bytes(sdig, "utf-8")))
+        if aserder is None:
+            missing.append((prefixer, number))
+            continue
+
+        if sdig != diger.qb64:
             invalid = True
             continue
 
@@ -974,9 +1018,22 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
 
     validSourceSeals = []
     for prefixer, number, diger in sourceSeals:
+        if not prefixer.transferable:
+            invalid = True
+            continue
+
         sdig = hby.db.kels.getLast(keys=prefixer.qb64b, on=number.sn)
-        aserder = hby.db.evts.get(keys=(prefixer.qb64b, diger.qb64b))
-        if (sdig != diger.qb64 or aserder is None or
+        if sdig is None:
+            missing.append((prefixer, number))
+            continue
+
+        aserder = hby.db.evts.get(
+            keys=(prefixer.qb64b, bytes(sdig, "utf-8")))
+        if aserder is None:
+            missing.append((prefixer, number))
+            continue
+
+        if (sdig != diger.qb64 or
                 not any(isinstance(seal, dict) and
                         seal.get("d") == serder.said
                         for seal in aserder.seals or [])):
@@ -985,7 +1042,7 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
 
         validSourceSeals.append((prefixer, number, diger))
 
-    return validTsgs, validCigars, validSourceSeals, invalid
+    return validTsgs, validCigars, validSourceSeals, invalid, missing
 
 
 def verify(hby, serder):
@@ -1032,14 +1089,14 @@ def verify(hby, serder):
         cigar.verfer = verfer
         cigars.append(cigar)
 
-    tsgs, cigars, sourceSeals, invalid = verifyAttachments(
+    tsgs, cigars, sourceSeals, invalid, missing = verifyAttachments(
         hby=hby,
         serder=serder,
         tsgs=tsgs,
         cigars=cigars,
         sourceSeals=sourceSeals,
     )
-    if invalid:
+    if invalid or missing:
         msg = f"Invalid stored authentication or evidence for evt = {serder.said}"
         logger.info(msg)
         logger.debug("Exn Body=\n%s\n", serder.pretty())

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -10,12 +10,11 @@ from hio.help import decking, ogler
 
 from ..kering import (Vrsn_1_0, Vrsn_2_0, Ilks,
                       Kinds, Version, versify,
-                      ValidationError, MissingChainError,
-                      MissingSignatureError)
-from ..core import (Counter, Pather, Dater, Diger,
+                      ValidationError, MissingChainError, MissingSignatureError)
+from ..core import (Counter, Pather, Dater, Diger, Number,
                     Prefixer, Seqner, Saider,
-                    Noncer, Sadder, Serder, SerderKERI, Texter,
-                    Saids, Codens, BlindState, BoundState, FirstSeen, Parser,
+                    Serder, SerderKERI, Texter,
+                    Saids, Codens, BlindState, BoundState, FirstSeen, SealEvent, Parser,
                     messagize,
                     verifySigs)
 from ..db import fetchTsgs
@@ -75,7 +74,7 @@ class Exchanger:
             cigars (list): of Cigar instances of attached non-trans sigs
             ptds (list[bytes]): pathed Cesr Streams
             essrs (list[Texter]): ESSR streams as Texters
-            kwa: optional parsed V2 nested substreams under ``nests``
+            kwa: optional source seals and parsed V2 nested substreams
 
         Returns:
             bool | None: ``True`` when the exchange verified and was persisted,
@@ -89,20 +88,56 @@ class Exchanger:
         route = serder.ked["r"]
         sender = serder.ked["i"]
         nests = kwa.get("nests")
-
+        lsgs = list(kwa.get("lsgs", []))
+        unresolvedLsgs = list(kwa.get("ulgs", []))
+        sscs = kwa.get("sscs", [])
+        ssts = kwa.get("ssts", [])
 
         behavior = self.routes[route] if route in self.routes else None
-        if tsgs:
-            for prefixer, snumber, sdiger, sigers in tsgs:  # iterate over each tsg
-                if sender != prefixer.qb64:  # sig not by aid
-                    msg = (f"Skipped signature not from aid = "
-                           f"{sender}, from {prefixer.qb64} on exn msg = {serder.said}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+        tsgs = list(tsgs or [])
+        cigars = list(cigars or [])
 
+        # A seal couple implies the sender AID. Store both attachment forms as
+        # an explicit sealing AID and historical event reference.
+        sourceSeals = [(Prefixer(qb64=sender), number, diger)
+                       for number, diger in sscs]
+        sourceSeals.extend(ssts)
+
+        senderTsgs = [tsg for tsg in tsgs if tsg[0].qb64 == sender]
+        extraTsgs = [tsg for tsg in tsgs if tsg[0].qb64 != sender]
+        extraLsgs = [lsg for lsg in lsgs if lsg[0].qb64 != sender]
+        senderSourceSeals = [seal for seal in sourceSeals
+                             if seal[0].qb64 == sender]
+        extraSourceSeals = [seal for seal in sourceSeals
+                            if seal[0].qb64 != sender]
+
+        evidenceVerifier = getattr(behavior, "verifyEvidence", None)
+        if senderTsgs and evidenceVerifier is None:
+            senderCigars = []
+            extraCigars = []
+        else:
+            senderCigars = [cigar for cigar in cigars
+                            if cigar.verfer.qb64 == sender]
+            extraCigars = [cigar for cigar in cigars
+                           if cigar.verfer.qb64 != sender]
+        if evidenceVerifier is None:
+            extraSourceSeals = []
+
+        _, _, validSenderSourceSeals, _ = verifyAttachments(
+            hby=self.hby, serder=serder, sourceSeals=senderSourceSeals)
+
+        validSenderTsgs = []
+        validSenderCigars = []
+        if validSenderSourceSeals:
+            validSenderTsgs, _, _, _ = verifyAttachments(
+                hby=self.hby, serder=serder, tsgs=senderTsgs)
+
+        elif senderTsgs:
+            for tsg in senderTsgs:
+                prefixer, snumber, sdiger, sigers = tsg
                 if prefixer.qb64 not in self.kevers or self.kevers[prefixer.qb64].sn < snumber.sn:
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=ptds,
+                                          cigars=cigars, sourceSeals=sourceSeals,
                                           nests=nests):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=snumber.snh)))
                     msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
@@ -110,12 +145,12 @@ class Exchanger:
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
-                # Verify the signatures are valid and that the signature threshold as of the signing event is met
-                tholder, verfers = self.hby.db.resolveVerifiers(pre=prefixer.qb64, sn=snumber.sn, dig=sdiger.qb64)
-                _, indices = verifySigs(serder.raw, sigers, verfers)
-
-                if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
+                tholder, verfers = self.hby.db.resolveVerifiers(
+                    pre=prefixer.qb64, sn=snumber.sn, dig=sdiger.qb64)
+                vsigers, indices = verifySigs(serder.raw, sigers, verfers)
+                if not tholder.satisfy(indices):
                     if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=ptds,
+                                          cigars=cigars, sourceSeals=sourceSeals,
                                           nests=nests):
                         self.cues.append(dict(kin="query", q=dict(r="logs", pre=prefixer.qb64, sn=snumber.snh)))
                     msg = (f"Not enough signatures in idx={indices} route={route} "
@@ -124,30 +159,60 @@ class Exchanger:
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
 
-        elif cigars:
-            for cigar in cigars:
-                if sender != cigar.verfer.qb64:  # cig not by aid
-                    msg = (f"Skipped cig not from aid={sender} route={route} "
-                           f"for exn evt = {serder.said} receiver={serder.ked.get('rp', '')}")
-                    logger.info(msg)
-                    logger.debug("Exchange message body=\n%s\n", serder.pretty())
-                    raise MissingSignatureError(msg)
+                validSenderTsgs.append(
+                    (prefixer, snumber, sdiger, vsigers))
 
-                if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
+        elif senderCigars:
+            for cigar in senderCigars:
+                if (cigar.verfer.transferable or
+                        not cigar.verfer.verify(cigar.raw, serder.raw)):
                     msg = (f"Failure satisfying exn on cigs for {cigar} route={route} "
                            f"for evt = {serder.said} receiver={serder.ked.get('rp', '')}")
                     logger.info(msg)
                     logger.debug("Exchange message body=\n%s\n", serder.pretty())
                     raise MissingSignatureError(msg)
-        else:
-            self.escrowPSEvent(serder=serder, tsgs=[], pathed=ptds,
+
+                validSenderCigars.append(cigar)
+
+        elif not validSenderSourceSeals:
+            if (evidenceVerifier is None and
+                    (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
+                msg = (f"Skipped evidence not from aid={sender} route={route} "
+                       f"for exn evt={serder.said}")
+                logger.info(msg)
+                logger.debug("Exchange message body=\n%s\n", serder.pretty())
+                raise MissingSignatureError(msg)
+
+            self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=ptds,
+                               cigars=cigars, sourceSeals=sourceSeals,
                                nests=nests)
             msg = (
-                f"Failure satisfying exn, no cigs or sigs for evt = {serder.said} "
+                f"Failure satisfying exn, no sender authentication for evt = {serder.said} "
                 f"on route {route} receiver = {serder.ked.get('rp', '')}")
             logger.info(msg)
             logger.debug("Exchange message body=\n%s\n", serder.pretty())
             raise MissingSignatureError(msg)
+
+        if (evidenceVerifier is None and
+                (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
+            msg = (f"Skipped evidence not from aid={sender} route={route} "
+                   f"for exn evt={serder.said}")
+            logger.info(msg)
+            logger.debug("Exchange message body=\n%s\n", serder.pretty())
+            raise MissingSignatureError(msg)
+
+        (validExtraTsgs,
+         validExtraCigars,
+         validExtraSourceSeals,
+         invalidExtra) = verifyAttachments(
+             hby=self.hby,
+             serder=serder,
+             tsgs=extraTsgs,
+             lsgs=extraLsgs,
+             cigars=extraCigars,
+             sourceSeals=extraSourceSeals,
+             unresolved=bool(unresolvedLsgs),
+         )
 
         e = Pather(parts=["e"])
 
@@ -180,13 +245,14 @@ class Exchanger:
         try:
             if not behavior.verify(serder=serder, **kwa):
                 logger.error("exn event for route %s failed behavior verification. said=%s", route, serder.said)
-                logger.debug(f"Event=\n%s\n", serder.pretty())
+                logger.debug("Event=\n%s\n", serder.pretty())
                 return False
         except MissingChainError as ex:
             # Registry-backed IPEX grants may arrive before the disclosee has
             # fetched the issuer's TEL history from observers. Keep those
             # messages in exchange escrow and cue the app to fetch proof data.
-            if self.escrowPSEvent(serder=serder, tsgs=tsgs or [], pathed=ptds,
+            if self.escrowPSEvent(serder=serder, tsgs=tsgs, pathed=ptds,
+                                  cigars=cigars, sourceSeals=sourceSeals,
                                   nests=nests):
                 self.cues.append(dict(kin="proof", said=serder.said))
             logger.info("Escrowed exchange awaiting proof evidence: said=%s reason=%s",
@@ -198,8 +264,30 @@ class Exchanger:
             logger.debug("Behavior for %s missing or does not have verify for said %s", route, serder.said)
             logger.debug("Exn Event Body=\n%s\n", serder.pretty())
 
+        if evidenceVerifier is None:
+            acceptedExtras = ([], [], [])
+        else:
+            acceptedExtras = evidenceVerifier(
+                serder=serder,
+                tsgs=validExtraTsgs,
+                cigars=validExtraCigars,
+                sourceSeals=validExtraSourceSeals,
+                invalid=invalidExtra,
+            )
+            if acceptedExtras is None:
+                logger.error("exn evidence for route %s failed behavior verification. said=%s",
+                             route, serder.said)
+                logger.debug("Exn Event Body=\n%s\n", serder.pretty())
+                return
+
+        acceptedTsgs, acceptedCigars, acceptedSourceSeals = acceptedExtras
+        tsgs = validSenderTsgs + acceptedTsgs
+        cigars = validSenderCigars + acceptedCigars
+        sourceSeals = validSenderSourceSeals + acceptedSourceSeals
+
         # Always persist events
-        self.logEvent(serder, ptds, tsgs, cigars, essrs, nests=nests)
+        self.logEvent(serder, ptds, tsgs, cigars, essrs,
+                      sourceSeals=sourceSeals, nests=nests)
         self.cues.append(dict(kin="saved", said=serder.said))
 
         # Execute any behavior specific handling, not sure if this should be different than verify
@@ -215,21 +303,32 @@ class Exchanger:
         """ Process all escrows for `exn` messages"""
         self.processEscrowPartialSigned()
 
-    def escrowPSEvent(self, serder, tsgs, pathed, nests=None):
+    def escrowPSEvent(self, serder, tsgs, pathed, cigars=None,
+                      sourceSeals=None, nests=None):
         """ Escrow event that does not have enough signatures.
 
         Parameters:
             serder (Serder): instance of event
             tsgs (list): quadlet of prefixer seqner, saider, sigers
             pathed (list): list of bytes of attached paths
+            cigars (list | None): nontransferable signatures to preserve
+            sourceSeals (list | None): source seal triples to preserve
             nests (list | None): parsed V2 nested substreams to preserve
 
         """
         dig = serder.said
-        for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
-            quadkeys = (serder.said, prefixer.qb64, f"{seqner.sn:032x}", ssaider.qb64)
+        cigars = cigars or []
+        sourceSeals = sourceSeals or []
+        for prefixer, seqner, ssaider, sigers in tsgs:
+            quadkeys = (serder.said, prefixer.qb64,
+                        f"{seqner.sn:032x}", ssaider.qb64)
             for siger in sigers:
                 self.hby.db.esigs.add(keys=quadkeys, val=siger)
+        for cigar in cigars:
+            self.hby.db.ecigs.add(keys=(dig,), val=(cigar.verfer, cigar))
+        for prefixer, number, diger in sourceSeals:
+            self.hby.db.ests.add(keys=(serder.said, prefixer.qb64),
+                                 val=(number, diger))
 
         self.hby.db.epsd.put(keys=(dig,), val=Dater())
         self.hby.db.epath.pin(keys=(dig,), vals=[bytes(p) for p in pathed])
@@ -241,6 +340,11 @@ class Exchanger:
     def processEscrowPartialSigned(self):
         """ Process escrow of partially signed messages"""
         for (dig,), serder in self.hby.db.epse.getTopItemIter():
+            if self.hby.db.exns.get(keys=(dig,)) is not None:
+                self.hby.db.epse.rem(dig)
+                self.hby.db.epsd.rem(dig)
+                continue
+
             try:
                 tsgs = []
                 klases = (Prefixer, Seqner, Saider)
@@ -276,21 +380,50 @@ class Exchanger:
 
                 pathed = [bytearray(p.encode("utf-8")) for p in self.hby.db.epath.get(keys=(dig,))]
                 essrs = [texter for texter in self.hby.db.essrs.get(keys=(dig,))]
+                cigars = []
+                for verfer, cigar in self.hby.db.ecigs.get(keys=(dig,)):
+                    cigar.verfer = verfer
+                    cigars.append(cigar)
+                sourceSeals = []
+                for keys, (number, diger) in self.hby.db.ests.getTopItemIter(
+                        keys=(dig, "")):
+                    sourceSeals.append((Prefixer(qb64=keys[1]), number, diger))
                 nests = loadParsedNestedSubstreams(self.hby, dig)
 
-                result = self.processEvent(serder=serder, tsgs=tsgs, ptds=pathed,
-                                           essrs=essrs, nests=nests)
+                # The same stores hold escrowed and accepted evidence. Remove
+                # the temporary branches so processEvent writes back only the
+                # evidence that passes current verification and policy.
+                self.hby.db.esigs.trim(keys=(dig, ""))
+                self.hby.db.ecigs.rem(keys=(dig,))
+                self.hby.db.ests.trim(keys=(dig, ""))
+                result = self.processEvent(serder=serder, tsgs=tsgs, cigars=cigars,
+                                  ptds=pathed,
+                                  essrs=essrs, ssts=sourceSeals, nests=nests)
 
             except MissingSignatureError as ex:
+                for prefixer, seqner, ssaider, sigers in tsgs:
+                    quadkeys = (serder.said, prefixer.qb64,
+                                f"{seqner.sn:032x}", ssaider.qb64)
+                    for siger in sigers:
+                        self.hby.db.esigs.add(keys=quadkeys, val=siger)
+                for cigar in cigars:
+                    self.hby.db.ecigs.add(
+                        keys=(serder.said,), val=(cigar.verfer, cigar))
+                for prefixer, number, diger in sourceSeals:
+                    self.hby.db.ests.add(
+                        keys=(serder.said, prefixer.qb64),
+                        val=(number, diger))
                 if logger.isEnabledFor(logging.TRACE):
                     logger.trace("Exchange partially signed unescrow failed: %s\n", ex.args[0])
-                    logger.debug(f"Event body=\n%s\n", serder.pretty())
+                    logger.debug("Event body=\n%s\n", serder.pretty())
             except Exception as ex:
                 saved = self.hby.db.exns.get(keys=(dig,)) is not None
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)
-                self.hby.db.esigs.rem(dig)
                 if not saved:
+                    self.hby.db.esigs.trim(keys=(dig, ""))
+                    self.hby.db.ecigs.rem(keys=(dig,))
+                    self.hby.db.ests.trim(keys=(dig, ""))
                     self.hby.db.epath.rem(keys=(dig,))
                     self.hby.db.enst.rem(keys=(dig,))
                 if logger.isEnabledFor(logging.DEBUG):
@@ -306,8 +439,10 @@ class Exchanger:
                 saved = self.hby.db.exns.get(keys=(dig,)) is not None
                 self.hby.db.epse.rem(dig)
                 self.hby.db.epsd.rem(dig)
-                self.hby.db.esigs.rem(dig)
                 if not saved:
+                    self.hby.db.esigs.trim(keys=(dig, ""))
+                    self.hby.db.ecigs.rem(keys=(dig,))
+                    self.hby.db.ests.trim(keys=(dig, ""))
                     self.hby.db.epath.rem(keys=(dig,))
                     self.hby.db.enst.rem(keys=(dig,))
                     logger.info("Exchanger unescrow rejected exchange: said=%s", serder.said)
@@ -315,32 +450,50 @@ class Exchanger:
                 logger.info("Exchanger unescrow succeeded in valid exchange: creder=%s", serder.said)
                 logger.debug("Event=\n%s\n", serder.pretty())
 
-    def logEvent(self, serder, pathed=None, tsgs=None, cigars=None, essrs=None, nests=None):
+    def logEvent(self, serder, pathed=None, tsgs=None, cigars=None, essrs=None,
+                 sourceSeals=None, nests=None):
         dig = serder.said
         pdig = serder.ked['p']
         pathed = pathed or []
         tsgs = tsgs or []
         cigars = cigars or []
         essrs = essrs or []
+        sourceSeals = sourceSeals or []
 
-        for prefixer, seqner, ssaider, sigers in tsgs:  # iterate over each tsg
-            quadkeys = (serder.said, prefixer.qb64, f"{seqner.sn:032x}", ssaider.qb64)
+        escrowed = (self.hby.db.exns.get(keys=(dig,)) is None and
+                    self.hby.db.epse.get(keys=(dig,)) is not None)
+        if escrowed:
+            self.hby.db.esigs.trim(keys=(dig, ""))
+            self.hby.db.ecigs.rem(keys=(dig,))
+            self.hby.db.ests.trim(keys=(dig, ""))
+            self.hby.db.epath.rem(keys=(dig,))
+            self.hby.db.enst.rem(keys=(dig,))
+
+        for prefixer, seqner, ssaider, sigers in tsgs:
+            quadkeys = (serder.said, prefixer.qb64,
+                        f"{seqner.sn:032x}", ssaider.qb64)
             for siger in sigers:
                 self.hby.db.esigs.add(keys=quadkeys, val=siger)
         for cigar in cigars:
             self.hby.db.ecigs.add(keys=(dig,), val=(cigar.verfer, cigar))
 
-        diger = Diger(qb64=serder.said)
+        exnDiger = Diger(qb64=serder.said)
         self.hby.db.epath.pin(keys=(dig,), vals=[bytes(p) for p in pathed])
         if nests:
             self.hby.db.enst.pin(keys=(dig,),
                                  vals=[bytes(serializeParsedSubstream(nest)) for nest in nests])
         for texter in essrs:
             self.hby.db.essrs.add(keys=(dig,), val=texter)
+        for prefixer, number, diger in sourceSeals:
+            self.hby.db.ests.add(keys=(serder.said, prefixer.qb64),
+                                 val=(number, diger))
         if pdig:
-            self.hby.db.erpy.pin(keys=(pdig,), val=diger)
+            self.hby.db.erpy.pin(keys=(pdig,), val=exnDiger)
 
         self.hby.db.exns.put(keys=(dig,), val=serder)
+        if escrowed:
+            self.hby.db.epse.rem(dig)
+            self.hby.db.epsd.rem(dig)
 
     def lead(self, hab, said):
         """ Determines is current member represented by hab is the lead of an exn message
@@ -682,21 +835,27 @@ def serializeMessage(hby, said, framed=False):
     tsgs, cigars = verify(hby=hby, serder=exn)
     pathed = hby.db.epath.get(keys=(exn.said,))
     nests = hby.db.enst.get(keys=(exn.said,))
+    sourceSeals = []
+    for keys, (number, diger) in hby.db.ests.getTopItemIter(keys=(exn.said, "")):
+        _, pre = keys
+        sourceSeals.append(SealEvent(i=Prefixer(qb64=pre), s=number, d=diger))
 
     if exn.pvrsn.major >= Vrsn_2_0.major and not pathed:
         return messagize(serder=exn,
                          tsgs=tsgs or None,
                          cigars=cigars or None,
+                         bonds=sourceSeals or None,
                          nests=[bytearray(nest.encode("utf-8") if hasattr(nest, "encode") else nest)
                                 for nest in nests] or None,
                          framed=framed,
                          gvrsn=exn.gvrsn if exn.gvrsn else exn.pvrsn)
 
     aims = bytearray()
-    if tsgs or cigars:
+    if tsgs or cigars or sourceSeals:
         # Authenticator attachments via messagize; framed=True so we can append
         # pathed embeds after (pathed material is outside messagize support).
         full = messagize(exn, tsgs=tsgs or None, cigars=cigars or None,
+                         bonds=sourceSeals or None,
                          framed=True, gvrsn=Vrsn_1_0)
         aims.extend(full[exn.size:])
 
@@ -734,15 +893,96 @@ def nesting(paths, acc, val):
         return acc
 
 
+def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
+                      sourceSeals=None, unresolved=False):
+    """Cryptographically verify exchange authentication attachments.
+
+    Parameters:
+        hby (Habery): database environment with signer key state
+        serder (Serder): exchange message signed or sealed by the attachments
+        tsgs (list): transferable signature groups with establishment references
+        lsgs (list): transferable signature groups without establishment references
+        cigars (list): non-transferable signatures
+        sourceSeals (list): source seal triples
+        unresolved (bool): True if an attachment could not be reconstructed
+
+    Returns:
+        tuple: Valid transferable signature groups, non-transferable signatures,
+            source seal triples, and an invalid attachment flag.
+    """
+    tsgs = list(tsgs or [])
+    lsgs = lsgs or []
+    cigars = cigars or []
+    sourceSeals = sourceSeals or []
+    invalid = unresolved
+
+    for prefixer, sigers in lsgs:
+        if prefixer.qb64 not in hby.kevers:
+            invalid = True
+            continue
+
+        kever = hby.kevers[prefixer.qb64]
+        tsgs.append((prefixer,
+                     Number(sn=kever.lastEst.s),
+                     Diger(qb64=kever.lastEst.d),
+                     sigers))
+
+    validTsgs = []
+    for prefixer, number, diger, sigers in tsgs:
+        if (prefixer.qb64 not in hby.kevers or
+                hby.kevers[prefixer.qb64].sn < number.sn):
+            invalid = True
+            continue
+
+        try:
+            tholder, verfers = hby.db.resolveVerifiers(
+                pre=prefixer.qb64, sn=number.sn, dig=diger.qb64)
+        except ValidationError:
+            invalid = True
+            continue
+
+        vsigers, indices = verifySigs(serder.raw, sigers, verfers)
+        if not tholder.satisfy(indices):
+            invalid = True
+            continue
+
+        validTsgs.append((prefixer, number, diger, vsigers))
+
+    validCigars = []
+    for cigar in cigars:
+        if (cigar.verfer.transferable or
+                not cigar.verfer.verify(cigar.raw, serder.raw)):
+            invalid = True
+            continue
+
+        validCigars.append(cigar)
+
+    validSourceSeals = []
+    for prefixer, number, diger in sourceSeals:
+        sdig = hby.db.kels.getLast(keys=prefixer.qb64b, on=number.sn)
+        aserder = hby.db.evts.get(keys=(prefixer.qb64b, diger.qb64b))
+        if (sdig != diger.qb64 or aserder is None or
+                not any(isinstance(seal, dict) and
+                        seal.get("d") == serder.said
+                        for seal in aserder.seals or [])):
+            invalid = True
+            continue
+
+        validSourceSeals.append((prefixer, number, diger))
+
+    return validTsgs, validCigars, validSourceSeals, invalid
+
+
 def verify(hby, serder):
-    """  Verify that the signatures in the database are valid for the provided exn
+    """Verify stored authentication and endorsements for an exchange message.
 
     Parameters:
         hby (Habery): database environment from which to verify message
         serder (Serder): exn serder to load and verify signatures for
 
     Returns:
-        bool: True means threshold satisfyig signatures were loaded and verified successfully"""
+        tuple: Transferable signature groups and non-transferable signatures.
+    """
     tsgs = []
     klases = (Prefixer, Seqner, Saider)
     args = ("qb64", "snh", "qb64")
@@ -762,36 +1002,39 @@ def verify(hby, serder):
         prefixer, seqner, saider = helping.klasify(sers=old, klases=klases, args=args)
         tsgs.append((prefixer, seqner, saider, sigers))
 
-    accepted = False
-    for prefixer, seqner, ssaider, sigers in tsgs:
-        if prefixer.qb64 not in hby.kevers or hby.kevers[prefixer.qb64].sn < seqner.sn:
-            msg = f"Unable to find sender {prefixer.qb64} in kevers for evt = {serder.said}"
-            logger.info(msg)
-            logger.debug("Exn Body=\n%s\n", serder.pretty())
-            raise MissingSignatureError(msg)
+    sourceSeals = []
+    for keys, (number, diger) in hby.db.ests.getTopItemIter(
+            keys=(serder.said, "")):
+        _, pre = keys
+        sourceSeals.append((Prefixer(qb64=pre), number, diger))
 
-        # Verify the signatures are valid and that the signature threshold as of the signing event is met
-        tholder, verfers = hby.db.resolveVerifiers(pre=prefixer.qb64, sn=seqner.sn, dig=ssaider.qb64)
-        _, indices = verifySigs(serder.raw, sigers, verfers)
+    cigars = []
+    for verfer, cigar in hby.db.ecigs.get(keys=(serder.said,)):
+        cigar.verfer = verfer
+        cigars.append(cigar)
 
-        if not tholder.satisfy(indices):  # We still don't have all the sigers, need to escrow
-            msg = f"Not enough signatures in idx={indices} for evt = {serder.said}"
-            logger.info(msg)
-            logger.debug("Exn Body=\n%s\n", serder.pretty())
-            raise MissingSignatureError(msg)
-        accepted = True
+    tsgs, cigars, sourceSeals, invalid = verifyAttachments(
+        hby=hby,
+        serder=serder,
+        tsgs=tsgs,
+        cigars=cigars,
+        sourceSeals=sourceSeals,
+    )
+    if invalid:
+        msg = f"Invalid stored authentication for evt = {serder.said}"
+        logger.info(msg)
+        logger.debug("Exn Body=\n%s\n", serder.pretty())
+        raise MissingSignatureError(msg)
 
-    cigars = hby.db.ecigs.get(keys=(serder.said,))
-    for cigar in cigars:
-        if not cigar.verfer.verify(cigar.raw, serder.raw):  # cig not verify
-            msg = f"Failure satisfying exn on cigs for {cigar} for evt = {serder.said}"
-            logger.info(msg)
-            logger.debug("Exn Body=\n%s\n", serder.pretty())
-            raise MissingSignatureError(msg)
-        accepted = True
+    authenticated = any(prefixer.qb64 == serder.pre
+                        for prefixer, _, _, _ in tsgs)
+    authenticated |= any(cigar.verfer.qb64 == serder.pre
+                         for cigar in cigars)
+    authenticated |= any(prefixer.qb64 == serder.pre
+                         for prefixer, _, _ in sourceSeals)
 
-    if not accepted:
-        msg = f"No valid signatures stored for evt = {serder.said}"
+    if not authenticated:
+        msg = f"No valid sender authentication stored for evt = {serder.said}"
         logger.info(msg)
         logger.debug("Exn Body=\n%s\n", serder.pretty())
         raise MissingSignatureError(msg)

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -282,9 +282,31 @@ class Exchanger:
             if not diger.verify(ser=essr):
                 raise ValidationError(f"essr diger={diger.qb64} is invalid against content")
 
+        if evidenceVerifier is None:
+            acceptedExtras = ([], [], [])
+        else:
+            acceptedExtras = evidenceVerifier(
+                serder=serder,
+                tsgs=validExtraTsgs,
+                cigars=validExtraCigars,
+                sourceSeals=validExtraSourceSeals,
+                invalid=invalidExtra,
+            )
+            if acceptedExtras is None:
+                logger.error("exn evidence for route %s failed behavior verification. said=%s",
+                             route, serder.said)
+                logger.debug("Exn Event Body=\n%s\n", serder.pretty())
+                return False
+
+        acceptedTsgs, acceptedCigars, acceptedSourceSeals = acceptedExtras
+        tsgs = validSenderTsgs + acceptedTsgs
+        cigars = validSenderCigars + acceptedCigars
+        sourceSeals = validSenderSourceSeals + acceptedSourceSeals
+
         # Perform behavior specific verification, think IPEX chaining requirements
+        verifier = getattr(behavior, "verify", None)
         try:
-            if not behavior.verify(serder=serder, **kwa):
+            if verifier is not None and not verifier(serder=serder, **kwa):
                 logger.error("exn event for route %s failed behavior verification. said=%s", route, serder.said)
                 logger.debug("Event=\n%s\n", serder.pretty())
                 return False
@@ -300,31 +322,6 @@ class Exchanger:
                         serder.said, ex)
             logger.debug("Exchange message body=\n%s\n", serder.pretty())
             return None
-
-        except AttributeError:
-            logger.debug("Behavior for %s missing or does not have verify for said %s", route, serder.said)
-            logger.debug("Exn Event Body=\n%s\n", serder.pretty())
-
-        if evidenceVerifier is None:
-            acceptedExtras = ([], [], [])
-        else:
-            acceptedExtras = evidenceVerifier(
-                serder=serder,
-                tsgs=validExtraTsgs,
-                cigars=validExtraCigars,
-                sourceSeals=validExtraSourceSeals,
-                invalid=invalidExtra,
-            )
-            if acceptedExtras is None:
-                logger.error("exn evidence for route %s failed behavior verification. said=%s",
-                             route, serder.said)
-                logger.debug("Exn Event Body=\n%s\n", serder.pretty())
-                return
-
-        acceptedTsgs, acceptedCigars, acceptedSourceSeals = acceptedExtras
-        tsgs = validSenderTsgs + acceptedTsgs
-        cigars = validSenderCigars + acceptedCigars
-        sourceSeals = validSenderSourceSeals + acceptedSourceSeals
 
         # Always persist events
         self.logEvent(serder, ptds, tsgs, cigars, essrs,
@@ -438,8 +435,8 @@ class Exchanger:
                 self.hby.db.ecigs.rem(keys=(dig,))
                 self.hby.db.ests.trim(keys=(dig, ""))
                 result = self.processEvent(serder=serder, tsgs=tsgs, cigars=cigars,
-                                  ptds=pathed,
-                                  essrs=essrs, ssts=sourceSeals, nests=nests)
+                                           ptds=pathed,
+                                           essrs=essrs, ssts=sourceSeals, nests=nests)
 
             except MissingSignatureError as ex:
                 for prefixer, seqner, ssaider, sigers in tsgs:

--- a/src/keri/peer/exchanging.py
+++ b/src/keri/peer/exchanging.py
@@ -122,6 +122,23 @@ class Exchanger:
         tsgs = list(tsgs or [])
         cigars = list(cigars or [])
 
+        # Freeze foreign last-establishment references before sender escrow
+        # can return, so replay retains the evidence and its original keys.
+        missing = [(prefixer, None) for prefixer in unresolvedLsgs]
+        for prefixer, sigers in lsgs:
+            if prefixer.qb64 == sender:
+                continue
+            kever = self.kevers.get(prefixer.qb64)
+            if kever is None:
+                missing.append((prefixer, None))
+                continue
+            tsgs.append((prefixer,
+                         Number(sn=kever.lastEst.s),
+                         Diger(qb64=kever.lastEst.d),
+                         sigers))
+        if missing:
+            self._raiseMissingKeyState(serder, missing)
+
         # A seal couple implies the sender AID. Store both attachment forms as
         # an explicit sealing AID and historical event reference.
         sourceSeals = [(Prefixer(qb64=sender), number, diger)
@@ -130,7 +147,6 @@ class Exchanger:
 
         senderTsgs = [tsg for tsg in tsgs if tsg[0].qb64 == sender]
         extraTsgs = [tsg for tsg in tsgs if tsg[0].qb64 != sender]
-        extraLsgs = [lsg for lsg in lsgs if lsg[0].qb64 != sender]
         senderSourceSeals = [seal for seal in sourceSeals
                              if seal[0].qb64 == sender]
         extraSourceSeals = [seal for seal in sourceSeals
@@ -211,7 +227,7 @@ class Exchanger:
             # Do not escrow unsupported foreign-only evidence as missing sender
             # authentication on routes without an evidence policy.
             if (evidenceVerifier is None and
-                    (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
+                    (extraTsgs or extraCigars)):
                 msg = (f"Skipped evidence not from aid={sender} route={route} "
                        f"for exn evt={serder.said}")
                 logger.info(msg)
@@ -232,7 +248,7 @@ class Exchanger:
         # evidence, which routes without an evidence policy must reject before
         # persistence.
         if (evidenceVerifier is None and
-                (extraTsgs or extraLsgs or extraCigars or unresolvedLsgs)):
+                (extraTsgs or extraCigars)):
             msg = (f"Skipped evidence not from aid={sender} route={route} "
                    f"for exn evt={serder.said}")
             logger.info(msg)
@@ -247,10 +263,8 @@ class Exchanger:
              hby=self.hby,
              serder=serder,
              tsgs=extraTsgs,
-             lsgs=extraLsgs,
              cigars=extraCigars,
              sourceSeals=extraSourceSeals,
-             unresolved=unresolvedLsgs,
          )
         if missingExtra:
             self._raiseMissingKeyState(serder, missingExtra)
@@ -355,6 +369,9 @@ class Exchanger:
 
         """
         dig = serder.said
+        if self.hby.db.exns.get(keys=(dig,)) is not None:
+            return False
+
         cigars = cigars or []
         sourceSeals = sourceSeals or []
         for prefixer, seqner, ssaider, sigers in tsgs:
@@ -931,19 +948,16 @@ def nesting(paths, acc, val):
         return acc
 
 
-def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
-                      sourceSeals=None, unresolved=None):
+def verifyAttachments(hby, serder, *, tsgs=None, cigars=None,
+                      sourceSeals=None):
     """Cryptographically verify exchange authentication attachments.
 
     Parameters:
         hby (Habery): database environment with signer key state
         serder (Serder): exchange message signed or sealed by the attachments
         tsgs (list): transferable signature groups with establishment references
-        lsgs (list): transferable signature groups without establishment references
         cigars (list): non-transferable signatures
         sourceSeals (list): source seal triples
-        unresolved (list): signer prefixes whose attachments could not be
-            reconstructed without their KEL
 
     Returns:
         tuple: Valid transferable signature groups, non-transferable signatures,
@@ -951,23 +965,10 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
             coordinates.
     """
     tsgs = list(tsgs or [])
-    lsgs = lsgs or []
     cigars = cigars or []
     sourceSeals = sourceSeals or []
-    unresolved = unresolved or []
     invalid = False
-    missing = [(prefixer, None) for prefixer in unresolved]
-
-    for prefixer, sigers in lsgs:
-        if prefixer.qb64 not in hby.kevers:
-            missing.append((prefixer, None))
-            continue
-
-        kever = hby.kevers[prefixer.qb64]
-        tsgs.append((prefixer,
-                     Number(sn=kever.lastEst.s),
-                     Diger(qb64=kever.lastEst.d),
-                     sigers))
+    missing = []
 
     validTsgs = []
     for prefixer, number, diger, sigers in tsgs:
@@ -986,7 +987,7 @@ def verifyAttachments(hby, serder, *, tsgs=None, lsgs=None, cigars=None,
             missing.append((prefixer, number))
             continue
 
-        if sdig != diger.qb64:
+        if sdig != diger.qb64 or not aserder.estive:
             invalid = True
             continue
 

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -1155,7 +1155,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             recp=hab.pre,
             message="Foreign evidence is not allowed on apply",
             attrs=dict(role="member"),
-            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+            modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
         )
 
         def group(signer, serder):
@@ -1177,7 +1177,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             recp=hab.pre,
             message="Foreign cigar is not allowed on apply",
             attrs=dict(role="member"),
-            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+            modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
         )
         validForeignCigar = cigarEndorser.sign(
             ser=rejectedCigarApply.raw, indexed=False)
@@ -1192,7 +1192,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             recp=hab.pre,
             message="Invalid foreign cigar is not allowed on apply",
             attrs=dict(role="member"),
-            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+            modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
         )
         invalidForeignCigar = cigarEndorser.sign(
             ser=b"different exchange message", indexed=False)
@@ -1207,7 +1207,7 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             recp=hab.pre,
             message="Unresolved foreign signer is not allowed on apply",
             attrs=dict(role="member"),
-            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+            modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
         )
         with pytest.raises(MissingSignatureError):
             exc.processEvent(unresolvedApply,
@@ -2461,7 +2461,9 @@ def test_ipex_v2_rejects_registry_backed_grant_without_node_proof_group():
             rgy.close()
 
 
-def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
+@pytest.mark.parametrize("senderSeal", [False, True])
+@pytest.mark.parametrize("validProof", [False, True])
+def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives(senderSeal, validProof):
     """Recipient keeps a registry-backed grant retryable until TEL evidence is loaded."""
     with (openHby(name="ipex-v2-proof-escrow-issuer",
                   base="test",
@@ -2471,6 +2473,7 @@ def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
                   version=Vrsn_2_0) as recipientHby):
         issuerHab = issuerHby.makeHab(name="issuer")
         recipientHab = recipientHby.makeHab(name="recipient")
+        endorserHab = recipientHby.makeHab(name="endorser", transferable=False)
         issuerRgy = Regery(hby=issuerHby, name="ipex-v2-proof-escrow-issuer", temp=True)
         recipientRgy = Regery(hby=recipientHby, name="ipex-v2-proof-escrow-recipient", temp=True)
         try:
@@ -2499,13 +2502,31 @@ def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
             exc = Exchanger(hby=recipientHby, handlers=[])
             loadHandlers(hby=recipientHby, exc=exc, notifier=recorder, rgy=recipientRgy)
 
-            grantExn, grantAtc = ipexGrant(hab=issuerHab,
+            node = acdc if validProof else acdcmap(
+                israid=issuerHab.pre, regid=registry.regk,
+                attribute=dict(d="", LEI="different credential"),
+                iseaid=recipientHab.pre)
+            grantExn, _ = ipexGrant(hab=issuerHab,
                                            recp=recipientHab.pre,
                                            message="Waiting on observer TEL",
-                                           origin=_proofed(acdc, issuedBlinder))
+                                           origin=_proofed(node, issuedBlinder))
 
-            ims = bytearray(grantExn.raw)
-            ims.extend(grantAtc)
+            anchorHab = issuerHab if senderSeal else recipientHab
+            anchor = anchorHab.interact(data=[dict(d=grantExn.said)],
+                                        framed=True, gvrsn=Vrsn_2_0)
+            if senderSeal:
+                Parser(version=Vrsn_2_0).parse(ims=bytearray(anchor),
+                                               kvy=recipientRemoteKvy)
+            seal = SealEvent(i=anchorHab.pre, s=f"{anchorHab.kever.sn:x}",
+                             d=anchorHab.kever.serder.said)
+            signers = [recipientHab] if senderSeal else [issuerHab, recipientHab]
+            tsgs = [(hab.kever.prefixer, Number(num=hab.kever.lastEst.s),
+                     Diger(qb64=hab.kever.lastEst.d), hab.sign(ser=grantExn.raw))
+                    for hab in signers]
+            cigars = endorserHab.sign(ser=grantExn.raw, indexed=False)
+            ims = messagize(grantExn, tsgs=tsgs, cigars=cigars, bonds=[seal],
+                             nests=[_nest(_proofed(node, issuedBlinder))],
+                             framed=False, gvrsn=Vrsn_2_0)
             Parser(version=Vrsn_2_0).parse(ims=ims, framed=False, exc=exc)
 
             assert ims == bytearray()
@@ -2514,12 +2535,46 @@ def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
             assert recorder.items == []
             assert list(exc.cues) == [dict(kin="proof", said=grantExn.said)]
 
+            # Retry twice before the TEL arrives. Each pass must retain every
+            # direct authentication factor and the node-local proof.
+            for _ in range(2):
+                exc.processEscrow()
+                assert recipientHby.db.exns.get(keys=(grantExn.said,)) is None
+                assert recipientHby.db.epse.get(keys=(grantExn.said,)) is not None
+                assert list(recipientHby.db.erpy.getTopItemIter()) == []
+                assert recorder.items == []
+                assert list(exc.cues) == [dict(kin="proof", said=grantExn.said)]
+                assert len(list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, "")))) == len(signers)
+                assert len(recipientHby.db.ecigs.get(keys=(grantExn.said,))) == 1
+                assert len(recipientHby.db.ests.get(
+                    keys=(grantExn.said, anchorHab.pre))) == 1
+                assert len(recipientHby.db.enst.get(keys=(grantExn.said,))) == 1
+
             # Simulate the disclosee learning the issuer's TEL later, for
             # example by fetching it from observers after the first grant parse.
             recipientRgy.store.accept(registry.regk, 0, rip)
             recipientRgy.store.accept(registry.regk, 1, issued)
 
             exc.processEscrow()
+
+            if not validProof:
+                # Once TEL evidence is available, the proof for a different
+                # credential is a permanent refusal. Remove all escrow rows.
+                assert recipientHby.db.exns.get(keys=(grantExn.said,)) is None
+                assert list(recipientHby.db.erpy.getTopItemIter()) == []
+                assert recipientHby.db.epse.get(keys=(grantExn.said,)) is None
+                assert recipientHby.db.epsd.get(keys=(grantExn.said,)) is None
+                assert list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, ""))) == []
+                assert recipientHby.db.ecigs.get(keys=(grantExn.said,)) == []
+                assert list(recipientHby.db.ests.getTopItemIter(
+                    keys=(grantExn.said, ""))) == []
+                assert recipientHby.db.epath.get(keys=(grantExn.said,)) == []
+                assert recipientHby.db.enst.get(keys=(grantExn.said,)) == []
+                assert recorder.items == []
+                assert list(exc.cues) == [dict(kin="proof", said=grantExn.said)]
+                return
 
             assert recipientHby.db.exns.get(keys=(grantExn.said,)) is not None
             assert recipientHby.db.epse.get(keys=(grantExn.said,)) is None
@@ -2530,6 +2585,19 @@ def test_ipex_v2_escrows_registry_backed_grant_until_tel_evidence_arrives():
                 dict(kin="proof", said=grantExn.said),
                 dict(kin="saved", said=grantExn.said),
             ]
+            with reopenDB(db=recipientHby.db, reuse=True):
+                wire = serializeMessage(recipientHby, grantExn.said, framed=True)
+                replay, = Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(wire), framed=True, processive=False)
+                assert {prefixer.qb64 for prefixer, _, _, _ in replay.tsgs} == {
+                    hab.pre for hab in signers}
+                assert [(cigar.verfer.qb64, cigar.qb64) for cigar in replay.cigars] == [
+                    (endorserHab.pre, cigars[0].qb64)]
+                assert [(prefixer.qb64, number.sn, diger.qb64)
+                        for prefixer, number, diger in replay.ssts] == [
+                    (anchorHab.pre, anchorHab.kever.sn, anchorHab.kever.serder.said)]
+                assert [nest.serder.said for nest in replay.nests] == [acdc.said]
+                assert len(replay.nests[0].bsqs) == 1
         finally:
             recipientRgy.close()
             issuerRgy.close()
@@ -3446,8 +3514,7 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                     hab=issuerHab,
                     recp=recipientHab.pre,
                     message="Here is the blind registry disclosure",
-                    origin=acdc,
-                    artifacts=[issued, issuedAnc],
+                    origin=_proofed(acdc, issuedBlinder),
                     agree=storedAgree,
                     dt=grantStamp,
                 )
@@ -3722,13 +3789,16 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                     ] == beforeSeals
                     assert recipientRecorder.items == beforeItems
 
-                # Pull the carried blindable update back out of the stored grant
-                # and prove it still unblinds to the expected issued state.
+                # Resolve the replayed node's proof against the recipient's
+                # accepted TEL. The grant carries the node-local proof, while
+                # the recipient's registry store supplies the update history.
                 assert len(replay.nests[0].bsqs) == 1
+                said, uuid, _, _ = replay.nests[0].bsqs[0]
+                assert said.qb64 == issuedBlinder.blid
                 carriedBup = recipientRgy.store.seqEvent(registry.regk, 1)
                 unblinder = Blinder.unblind(said=carriedBup.sad["b"],
-                                            uuid=issuedBlinder.uuid,
-                                            acdc=acdc.said,
+                                            uuid=uuid.nonce,
+                                            acdc=replay.nests[0].serder.said,
                                             states=["issued", "revoked"])
                 assert unblinder is not None
                 assert unblinder.state == "issued"
@@ -4272,15 +4342,9 @@ def test_ipex_v2_nested_signature_does_not_authenticate_outer_grant(
         sender = hby.makeHab(name="sender")
         recipient = hby.makeHab(name="recipient")
 
-        nested = exchange(
-            sender=sender.pre,
-            receiver=recipient.pre,
-            route="/test/nested-auth",
-            attributes=dict(m="valid nested sender signature"),
-            pvrsn=Vrsn_2_0,
-            gvrsn=Vrsn_2_0,
-            kind=Kinds.json,
-        )
+        nested = acdcmap(israid=sender.pre,
+                         attribute=dict(d="", role="member"),
+                         iseaid=recipient.pre)
         nestedTsgs = [(
             sender.kever.prefixer,
             Number(sn=sender.kever.lastEst.s),

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -17,7 +17,7 @@ from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Noncer,
                        Diger, Number, SealEvent, SerderKERI, Serdery, Texter,
                        exchange, messagize)
 from keri.db import reopenDB
-from keri.kering import Colds, sniff
+from keri.kering import Colds, MissingSignatureError, sniff
 from keri.help import helping
 from keri.peer import Exchanger, cloneMessage, serializeMessage
 
@@ -1209,12 +1209,17 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             attrs=dict(role="member"),
             modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
         )
-        exc.processEvent(unresolvedApply,
-                         tsgs=[group(hab, unresolvedApply)],
-                         ulgs=[endorser.kever.prefixer])
+        with pytest.raises(MissingSignatureError):
+            exc.processEvent(unresolvedApply,
+                             tsgs=[group(hab, unresolvedApply)],
+                             ulgs=[endorser.kever.prefixer])
         assert hby.db.exns.get(keys=(unresolvedApply.said,)) is None
         assert list(hby.db.esigs.getTopItemIter(
             keys=(unresolvedApply.said, ""))) == []
+        assert exc.cues.popleft() == dict(
+            kin="query",
+            q=dict(r="logs", pre=endorser.pre),
+        )
         assert recorder.items == []
 
         # Build a happy path chain: apply -> offer -> agree -> grant -> admit
@@ -3392,6 +3397,108 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 ims = bytearray(secondGrant)
                 Parser(version=Vrsn_2_0).parse(ims=ims, kvy=recipientKvy)
                 assert ims == bytearray()
+                assert recipientHby.db.exns.get(keys=(grantExn.said,)) is None
+                assert any(cue.get("kin") == "query" and
+                           cue["q"] == dict(r="logs",
+                                            pre=unknownEndorserHab.pre)
+                           for cue in recipientExc.cues)
+                assert recipientHby.db.kramPMKM.get(keys=partialKey) is None
+                assert recipientHby.db.kramPMKS.get(keys=partialKey) == []
+                assert recipientHby.db.kramPMSK.get(keys=partialKey) is None
+                assert recipientHby.db.kramTSGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramULGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramCIGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramSSTS.get(keys=partialKey) == []
+
+                unknownEndorserIcp = unknownEndorserHab.msgOwnEvent(
+                    sn=0, framed=True, gvrsn=Vrsn_2_0)
+                Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(unknownEndorserIcp),
+                    kvy=recipientRemoteKvy)
+                recipientExc.cues.clear()
+
+                # KRAM keeps the accepted SAID in its replay cache, so even a
+                # complete same-SAID delivery cannot retry downstream handling.
+                sameSaidReplay = messagize(
+                    grantExn,
+                    sigers=[senderSigs[0], senderSigs[2]],
+                    tsgs=[sigGroup(endorserHab, endorserSigs)],
+                    lsgs=[(recipientHab.kever.prefixer, recipientSigs),
+                          (unknownEndorserHab.kever.prefixer,
+                           unknownEndorserSigs)],
+                    cigars=endorserCigars,
+                    bonds=[validSeal, invalidSeal],
+                    nests=nests,
+                    framed=False,
+                    gvrsn=Vrsn_2_0,
+                )
+                ims = bytearray(sameSaidReplay)
+                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=recipientKvy)
+                assert ims == bytearray()
+                assert recipientHby.db.exns.get(
+                    keys=(grantExn.said,)) is None
+
+                # A protocol retry is a fresh message: the later datetime
+                # produces a new SAID and every signer authenticates those bytes.
+                clock.advance(milliseconds=1)
+                grantStamp = helping.nowIso8601()
+                retryGrantExn, _ = ipexGrant(
+                    hab=issuerHab,
+                    recp=recipientHab.pre,
+                    message="Here is the blind registry disclosure",
+                    origin=acdc,
+                    artifacts=[issued, issuedAnc],
+                    agree=storedAgree,
+                    dt=grantStamp,
+                )
+                grantReceiveMs = helping.fromIso8601(
+                    helping.nowIso8601()).timestamp() * 1000
+
+                retryEndorserAnchor = endorserHab.interact(
+                    data=[dict(d=retryGrantExn.said)],
+                    framed=True,
+                    version=Vrsn_2_0,
+                    gvrsn=Vrsn_2_0,
+                )
+                Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(retryEndorserAnchor),
+                    kvy=recipientRemoteKvy)
+
+                senderSigs = issuerHab.sign(
+                    ser=retryGrantExn.raw, indexed=True)
+                endorserSigs = endorserHab.sign(
+                    ser=retryGrantExn.raw, indexed=True)
+                endorserCigars = cigarEndorserHab.sign(
+                    ser=retryGrantExn.raw, indexed=False)
+                recipientSigs = recipientHab.sign(
+                    ser=retryGrantExn.raw, indexed=True)
+                unknownEndorserSigs = unknownEndorserHab.sign(
+                    ser=retryGrantExn.raw, indexed=True)
+                validSeal = SealEvent(
+                    i=endorserHab.pre,
+                    s=f"{endorserHab.kever.sn:x}",
+                    d=endorserHab.kever.serder.said,
+                )
+
+                retryGrant = messagize(
+                    retryGrantExn,
+                    sigers=[senderSigs[0], senderSigs[2]],
+                    tsgs=[sigGroup(endorserHab, endorserSigs)],
+                    lsgs=[(recipientHab.kever.prefixer, recipientSigs),
+                          (unknownEndorserHab.kever.prefixer,
+                           unknownEndorserSigs)],
+                    cigars=endorserCigars,
+                    bonds=[validSeal, invalidSeal],
+                    nests=nests,
+                    framed=False,
+                    gvrsn=Vrsn_2_0,
+                )
+                ims = bytearray(retryGrant)
+                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=recipientKvy)
+                assert ims == bytearray()
+
+                grantExn = retryGrantExn
+                partialKey = (issuerHab.pre, grantExn.said)
 
                 # Preserve the issuer's outbound prior so it can validate the
                 # recipient's admit at the end of the real IPEX sequence.
@@ -3421,8 +3528,8 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert len(senderRows) == 2
                 assert len(endorserRows) == 1
                 assert len(recipientRows) == 1
-                assert list(recipientHby.db.esigs.getTopItemIter(
-                    keys=(grantExn.said, unknownEndorserHab.pre, ""))) == []
+                assert len(list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, unknownEndorserHab.pre, "")))) == 1
                 storedCigars = recipientHby.db.ecigs.get(
                     keys=(grantExn.said,))
                 assert [(verfer.qb64, cigar.qb64)
@@ -4145,6 +4252,91 @@ def test_ipex_v2_offer_starts_flow_with_xid_through_kram(fakeHelpingClock):
                 ]
         finally:
             rgy.close()
+
+
+def test_ipex_v2_nested_signature_does_not_authenticate_outer_grant(
+        fakeHelpingClock):
+    """A valid nested signature cannot satisfy outer grant KRAM auth."""
+    kramConfig = {
+        "kram": {
+            "enabled": True,
+            "denials": [],
+            "caches": {
+                "~": [1000, 5000, 60000, 300000, 5000, 60000, 300000],
+            },
+        },
+    }
+
+    with openHby(name="ipex-v2-nested-auth", base="test",
+                 version=Vrsn_2_0) as hby:
+        sender = hby.makeHab(name="sender")
+        recipient = hby.makeHab(name="recipient")
+
+        nested = exchange(
+            sender=sender.pre,
+            receiver=recipient.pre,
+            route="/test/nested-auth",
+            attributes=dict(m="valid nested sender signature"),
+            pvrsn=Vrsn_2_0,
+            gvrsn=Vrsn_2_0,
+            kind=Kinds.json,
+        )
+        nestedTsgs = [(
+            sender.kever.prefixer,
+            Number(sn=sender.kever.lastEst.s),
+            Diger(qb64=sender.kever.lastEst.d),
+            sender.sign(ser=nested.raw, indexed=True),
+        )]
+        nestedMsg = messagize(
+            serder=nested,
+            tsgs=nestedTsgs,
+            framed=False,
+            gvrsn=Vrsn_2_0,
+        )
+
+        grantExn, _ = ipexGrant(
+            hab=sender,
+            recp=recipient.pre,
+            message="Nested evidence cannot authenticate this grant",
+            origin=nestedMsg,
+        )
+        invalidOuterTsgs = [(
+            sender.kever.prefixer,
+            Number(sn=sender.kever.lastEst.s),
+            Diger(qb64=sender.kever.lastEst.d),
+            sender.sign(ser=b"different outer grant", indexed=True),
+        )]
+        invalidOuterGrant = messagize(
+            serder=grantExn,
+            tsgs=invalidOuterTsgs,
+            nests=[_nest(nestedMsg)],
+            framed=False,
+            gvrsn=Vrsn_2_0,
+        )
+
+        recorder = Recorder()
+        exc = Exchanger(hby=hby, handlers=[])
+        loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        with openCF(name="ipex-v2-nested-auth-kram", base="test",
+                    temp=True) as cf:
+            cf.put(kramConfig)
+            kvy = Kevery(db=hby.db,
+                         lax=False,
+                         local=False,
+                         kramer=Kramer(db=hby.db, cf=cf),
+                         exc=exc)
+            ims = bytearray(invalidOuterGrant)
+            Parser(version=Vrsn_2_0).parse(ims=ims, kvy=kvy)
+            assert ims == bytearray()
+
+        assert hby.db.exns.get(keys=(grantExn.said,)) is None
+        assert list(hby.db.esigs.getTopItemIter(
+            keys=(grantExn.said, ""))) == []
+        assert hby.db.enst.get(keys=(grantExn.said,)) == []
+        assert hby.db.kramTMSC.get(
+            keys=(sender.pre, grantExn.ked["x"], grantExn.said)) is None
+        assert recorder.items == []
 
 
 def test_ipex_v2_grant_starts_flow_with_xid_through_kram(fakeHelpingClock):

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -1172,6 +1172,31 @@ def test_ipex_v2_dispatch_linear_and_spurn():
             keys=(rejectedApply.said, ""))) == []
         assert recorder.items == []
 
+        # Foreign last-establishment groups must still reach route policy
+        # after the sender's signatures have accumulated in exchange escrow.
+        partialSender = hby.makeHab(name="partial-sender", isith="2", icount=3)
+        partialApply, _ = ipexApply(
+            hab=partialSender, recp=hab.pre,
+            message="Foreign evidence remains forbidden after escrow",
+            attrs=dict(role="member"),
+            modifiers=dict(dp=[[[schema, "/", ["a/role"]]]]),
+        )
+        senderGroup = group(partialSender, partialApply)
+        endorserGroup = group(endorser, partialApply)
+        for index in (0, 1):
+            with pytest.raises(MissingSignatureError):
+                exc.processEvent(
+                    partialApply,
+                    tsgs=[(*senderGroup[:3], [senderGroup[3][index]])],
+                    lsgs=[(endorser.kever.prefixer, endorserGroup[3])]
+                         if index == 0 else [],
+                )
+        exc.processEscrow()
+        assert hby.db.exns.get(keys=(partialApply.said,)) is None
+        assert hby.db.epse.get(keys=(partialApply.said,)) is None
+        assert recorder.items == []
+        exc.cues.clear()
+
         rejectedCigarApply, _ = ipexApply(
             hab=hab,
             recp=hab.pre,
@@ -3550,7 +3575,13 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 retryGrant = messagize(
                     retryGrantExn,
                     sigers=[senderSigs[0], senderSigs[2]],
-                    tsgs=[sigGroup(endorserHab, endorserSigs)],
+                    # An interaction is a valid source seal but cannot supply
+                    # establishment keys for an optional signature group.
+                    tsgs=[sigGroup(endorserHab, endorserSigs),
+                          (endorserHab.kever.prefixer,
+                           Number(sn=endorserHab.kever.sn),
+                           Diger(qb64=endorserHab.kever.serder.said),
+                           endorserSigs)],
                     lsgs=[(recipientHab.kever.prefixer, recipientSigs),
                           (unknownEndorserHab.kever.prefixer,
                            unknownEndorserSigs)],

--- a/tests/acdc/test_ipexing.py
+++ b/tests/acdc/test_ipexing.py
@@ -7,14 +7,16 @@ from datetime import timedelta
 
 import pytest
 from keri import Kinds, Vrsn_2_0
-from keri.acdc import (Regery, Registrar, acdcmap, blindate, apply as ipexApply, admit as ipexAdmit,
+from keri.acdc import (Regery, Registrar, acdcmap, blindate,
+                       apply as ipexApply, admit as ipexAdmit,
                        agree as ipexAgree, grant as ipexGrant,
                        loadHandlers, offer as ipexOffer, regcept,
                        spurn as ipexSpurn)
 from keri.app import openCF, openHby
-from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Noncer, Parser,
-                       Schemer, messagize,
-                       SerderKERI, Serdery, Texter, exchange)
+from keri.core import (Blinder, Codens, Counter, GenDex, Kevery, Kramer, Noncer, Parser, Schemer,
+                       Diger, Number, SealEvent, SerderKERI, Serdery, Texter,
+                       exchange, messagize)
+from keri.db import reopenDB
 from keri.kering import Colds, sniff
 from keri.help import helping
 from keri.peer import Exchanger, cloneMessage, serializeMessage
@@ -1132,6 +1134,9 @@ def test_ipex_v2_dispatch_linear_and_spurn():
     with openHby(name="ipex-v2-dispatch",
                  base="test") as hby:
         hab = hby.makeHab(name="test")
+        endorser = hby.makeHab(name="endorser")
+        cigarEndorser = hby.makeHab(name="cigar-endorser",
+                                    transferable=False)
         registry = regcept(israid=hab.pre)
         acdc = acdcmap(israid=hab.pre,
                        attribute=dict(d="", LEI="254900OPPU84GM83MG36"),
@@ -1142,6 +1147,75 @@ def test_ipex_v2_dispatch_linear_and_spurn():
         recorder = Recorder()
         exc = Exchanger(hby=hby, handlers=[])
         loadHandlers(hby=hby, exc=exc, notifier=recorder)
+
+        # Non-grant IPEX routes reject otherwise valid foreign evidence before
+        # any durable exchange rows are written.
+        rejectedApply, _ = ipexApply(
+            hab=hab,
+            recp=hab.pre,
+            message="Foreign evidence is not allowed on apply",
+            attrs=dict(role="member"),
+            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+        )
+
+        def group(signer, serder):
+            return (signer.kever.prefixer,
+                    Number(sn=signer.kever.lastEst.s),
+                    Diger(qb64=signer.kever.lastEst.d),
+                    signer.sign(ser=serder.raw, indexed=True))
+
+        exc.processEvent(rejectedApply,
+                         tsgs=[group(hab, rejectedApply),
+                               group(endorser, rejectedApply)])
+        assert hby.db.exns.get(keys=(rejectedApply.said,)) is None
+        assert list(hby.db.esigs.getTopItemIter(
+            keys=(rejectedApply.said, ""))) == []
+        assert recorder.items == []
+
+        rejectedCigarApply, _ = ipexApply(
+            hab=hab,
+            recp=hab.pre,
+            message="Foreign cigar is not allowed on apply",
+            attrs=dict(role="member"),
+            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+        )
+        validForeignCigar = cigarEndorser.sign(
+            ser=rejectedCigarApply.raw, indexed=False)
+        exc.processEvent(rejectedCigarApply,
+                         tsgs=[group(hab, rejectedCigarApply)],
+                         cigars=validForeignCigar)
+        assert hby.db.exns.get(keys=(rejectedCigarApply.said,)) is None
+        assert hby.db.ecigs.get(keys=(rejectedCigarApply.said,)) == []
+
+        invalidCigarApply, _ = ipexApply(
+            hab=hab,
+            recp=hab.pre,
+            message="Invalid foreign cigar is not allowed on apply",
+            attrs=dict(role="member"),
+            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+        )
+        invalidForeignCigar = cigarEndorser.sign(
+            ser=b"different exchange message", indexed=False)
+        exc.processEvent(invalidCigarApply,
+                         tsgs=[group(hab, invalidCigarApply)],
+                         cigars=invalidForeignCigar)
+        assert hby.db.exns.get(keys=(invalidCigarApply.said,)) is None
+        assert hby.db.ecigs.get(keys=(invalidCigarApply.said,)) == []
+
+        unresolvedApply, _ = ipexApply(
+            hab=hab,
+            recp=hab.pre,
+            message="Unresolved foreign signer is not allowed on apply",
+            attrs=dict(role="member"),
+            modifiers=dict(dp=[[schema, "/", ["a/role"]]]),
+        )
+        exc.processEvent(unresolvedApply,
+                         tsgs=[group(hab, unresolvedApply)],
+                         ulgs=[endorser.kever.prefixer])
+        assert hby.db.exns.get(keys=(unresolvedApply.said,)) is None
+        assert list(hby.db.esigs.getTopItemIter(
+            keys=(unresolvedApply.said, ""))) == []
+        assert recorder.items == []
 
         # Build a happy path chain: apply -> offer -> agree -> grant -> admit
         apply0, apply0Atc = ipexApply(hab=hab,
@@ -2933,6 +3007,10 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                   base="test",
                   version=Vrsn_2_0) as recipientHby):
         issuerHab = issuerHby.makeHab(name="issuer")
+        endorserHab = issuerHby.makeHab(name="endorser")
+        cigarEndorserHab = issuerHby.makeHab(name="cigar-endorser",
+                                             transferable=False)
+        unknownEndorserHab = issuerHby.makeHab(name="unknown-endorser")
         recipientHab = recipientHby.makeHab(name="recipient")
         issuerRgy = Regery(hby=issuerHby,
                            name="ipex-v2-blind-registry-kram-two-haberies-issuer",
@@ -2960,13 +3038,14 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
             issuedBlinder, issued = registrar.issue(registry, acdc=acdc, state="issued")
             issuedAnc = _anchor(issuerHab, registry, issued, framed=False)
 
-            # Rotate after the TEL anchors so the later IPEX exchanges sign
-            # against a fresh establishment event KRAM can authenticate.
+            # Establish the single current key used by the offer flow while
+            # committing to the 2-of-3 key state used by the later grant.
             issuerRot = issuerHab.rotate(framed=True,
+                                         nsith="2",
+                                         ncount=3,
                                          version=Vrsn_2_0,
                                          kind=issuerHab.kever.serder.kind,
                                          gvrsn=Vrsn_2_0)
-
 
             recipientRemoteKvy = Kevery(db=recipientHby.db, lax=False, local=False)
             issuerRemoteKvy = Kevery(db=issuerHby.db, lax=False, local=False)
@@ -2981,11 +3060,16 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
             # verify the registry artifacts referenced by the later grant.
             issuerIcp = issuerHab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerIcp), kvy=recipientRemoteKvy)
+            endorserIcp = endorserHab.msgOwnEvent(sn=0, framed=True,
+                                                  gvrsn=Vrsn_2_0)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserIcp),
+                                           kvy=recipientRemoteKvy)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(ripAnc), kvy=recipientRemoteKvy)
             Parser(version=Vrsn_2_0).parse(ims=bytearray(issuedAnc),
                                            framed=False,
                                            kvy=recipientRemoteKvy)
-            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerRot), kvy=recipientRemoteKvy)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(issuerRot),
+                                           kvy=recipientRemoteKvy)
 
             # Simulate observer retrieval by preloading the issuer's TEL chain
             # into the recipient's local Regery before the grant is verified.
@@ -3212,23 +3296,114 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 # The issuer now grants the disclosed credential node.
                 clock.advance(milliseconds=500)
                 grantStamp = helping.nowIso8601()
-                grantExn, grantAtc = ipexGrant(hab=issuerHab,
-                                               recp=recipientHab.pre,
-                                               message="Here is the blind registry disclosure",
-                                               origin=_proofed(acdc, issuedBlinder),
-                                               agree=storedAgree,
-                                               dt=grantStamp)
+                issuerGrantRot = issuerHab.rotate(
+                    framed=True,
+                    version=Vrsn_2_0,
+                    kind=issuerHab.kever.serder.kind,
+                    gvrsn=Vrsn_2_0,
+                )
+                Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(issuerGrantRot), kvy=recipientRemoteKvy)
+                grantExn, _ = ipexGrant(hab=issuerHab,
+                                        recp=recipientHab.pre,
+                                        message="Here is the blind registry disclosure",
+                                        origin=_proofed(acdc, issuedBlinder),
+                                        agree=storedAgree,
+                                        dt=grantStamp)
                 grantReceiveMs = helping.fromIso8601(helping.nowIso8601()).timestamp() * 1000
-                # Persist the outbound grant locally on the issuer side before
-                # sending it across so the issuer still has its own prior chain.
-                grantExnMsg = bytearray(grantExn.raw)
-                grantExnMsg.extend(grantAtc)
 
-                ims = bytearray(grantExnMsg)
-                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=issuerSelfKvy)
-                assert ims == bytearray()
-                ims = bytearray(grantExnMsg)
+                # A distinct transferable AID endorses the grant with both a
+                # signature group and a KEL event that seals the grant SAID.
+                endorserAnchor = endorserHab.interact(
+                    data=[dict(d=grantExn.said)],
+                    framed=True,
+                    version=Vrsn_2_0,
+                    gvrsn=Vrsn_2_0,
+                )
+                Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(endorserAnchor), kvy=recipientRemoteKvy)
+
+                senderSigs = issuerHab.sign(ser=grantExn.raw, indexed=True)
+                endorserSigs = endorserHab.sign(ser=grantExn.raw,
+                                                indexed=True)
+                endorserCigars = cigarEndorserHab.sign(
+                    ser=grantExn.raw, indexed=False)
+                recipientSigs = recipientHab.sign(ser=grantExn.raw,
+                                                  indexed=True)
+                unknownEndorserSigs = unknownEndorserHab.sign(
+                    ser=grantExn.raw, indexed=True)
+                grantEstSn = issuerHab.kever.lastEst.s
+                grantEstSaid = issuerHab.kever.lastEst.d
+
+                def sigGroup(hab, sigers):
+                    return (hab.kever.prefixer,
+                            Number(sn=hab.kever.lastEst.s),
+                            Diger(qb64=hab.kever.lastEst.d),
+                            sigers)
+
+                validSeal = SealEvent(i=endorserHab.pre,
+                                      s=f"{endorserHab.kever.sn:x}",
+                                      d=endorserHab.kever.serder.said)
+                invalidSeal = SealEvent(i=recipientHab.pre,
+                                        s=f"{recipientHab.kever.sn:x}",
+                                        d=recipientHab.kever.serder.said)
+                nests = [_nest(_proofed(acdc, issuedBlinder))]
+
+                # Deliver a 2-of-3 sender signature threshold in two parser
+                # passes. KRAM must pool the bare sigers and rehydrate the
+                # optional evidence from the first pass. The recipient's
+                # foreign last-establishment group is present only in this
+                # partial delivery and must survive escrow in explicit form.
+                firstGrant = messagize(
+                    grantExn,
+                    sigers=[senderSigs[0]],
+                    tsgs=[sigGroup(endorserHab, endorserSigs)],
+                    lsgs=[(recipientHab.kever.prefixer, recipientSigs),
+                          (unknownEndorserHab.kever.prefixer,
+                           unknownEndorserSigs)],
+                    cigars=endorserCigars,
+                    bonds=[validSeal, invalidSeal],
+                    nests=nests,
+                    framed=False,
+                    gvrsn=Vrsn_2_0,
+                )
+                ims = bytearray(firstGrant)
                 Parser(version=Vrsn_2_0).parse(ims=ims, kvy=recipientKvy)
+                assert ims == bytearray()
+                assert recipientHby.db.exns.get(keys=(grantExn.said,)) is None
+
+                partialKey = (issuerHab.pre, grantExn.said)
+                assert len(recipientHby.db.kramPMKS.get(keys=partialKey)) == 1
+                assert len(recipientHby.db.kramTSGS.get(keys=partialKey)) == 2
+                assert [prefixer.qb64 for prefixer in
+                        recipientHby.db.kramULGS.get(keys=partialKey)] == [
+                    unknownEndorserHab.pre,
+                ]
+                assert len(recipientHby.db.kramCIGS.get(keys=partialKey)) == 1
+                assert len(recipientHby.db.kramSSTS.get(keys=partialKey)) == 2
+
+                secondGrant = messagize(
+                    grantExn,
+                    sigers=[senderSigs[2]],
+                    nests=nests,
+                    framed=False,
+                    gvrsn=Vrsn_2_0,
+                )
+                ims = bytearray(secondGrant)
+                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=recipientKvy)
+                assert ims == bytearray()
+
+                # Preserve the issuer's outbound prior so it can validate the
+                # recipient's admit at the end of the real IPEX sequence.
+                issuerGrant = messagize(
+                    grantExn,
+                    tsgs=[sigGroup(issuerHab, senderSigs)],
+                    nests=nests,
+                    framed=False,
+                    gvrsn=Vrsn_2_0,
+                )
+                ims = bytearray(issuerGrant)
+                Parser(version=Vrsn_2_0).parse(ims=ims, kvy=issuerSelfKvy)
                 assert ims == bytearray()
 
                 # The recipient stores this grant locally so the final admit can
@@ -3236,6 +3411,40 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 storedGrant, _ = cloneMessage(recipientHby, grantExn.said)
                 assert storedGrant is not None
                 assert storedGrant.ked["x"] == applyExn.ked["x"]
+
+                senderRows = list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, issuerHab.pre, "")))
+                endorserRows = list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, endorserHab.pre, "")))
+                recipientRows = list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, recipientHab.pre, "")))
+                assert len(senderRows) == 2
+                assert len(endorserRows) == 1
+                assert len(recipientRows) == 1
+                assert list(recipientHby.db.esigs.getTopItemIter(
+                    keys=(grantExn.said, unknownEndorserHab.pre, ""))) == []
+                storedCigars = recipientHby.db.ecigs.get(
+                    keys=(grantExn.said,))
+                assert [(verfer.qb64, cigar.qb64)
+                        for verfer, cigar in storedCigars] == [
+                    (cigarEndorserHab.pre, endorserCigars[0].qb64),
+                ]
+
+                validSeals = recipientHby.db.ests.get(
+                    keys=(grantExn.said, endorserHab.pre))
+                invalidSeals = recipientHby.db.ests.get(
+                    keys=(grantExn.said, recipientHab.pre))
+                assert [(number.sn, diger.qb64)
+                        for number, diger in validSeals] == [
+                    (endorserHab.kever.sn, endorserHab.kever.serder.said),
+                ]
+                assert invalidSeals == []
+                assert not any(cue.get("kin") == "query"
+                               for cue in recipientExc.cues)
+
+                response = recipientHby.db.erpy.get(
+                    keys=(grantExn.ked["p"],))
+                assert response.qb64 == grantExn.said
 
                 grantCache = recipientHby.db.kramTMSC.get(
                     keys=(issuerHab.pre, applyExn.ked["x"], grantExn.said))
@@ -3281,18 +3490,143 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 assert (admitReceiveMs - d - sl) <= admitMdtMs <= (admitReceiveMs + d)
                 assert admitXdtMs <= admitMdtMs <= (admitXdtMs + xl)
 
-                # Re-serialize the stored grant from the recipient side to prove
-                # the nested ACDC survived the full cross-Habery KRAM plus
-                # exchanger path unchanged.
-                grantMsg = serializeMessage(recipientHby, grantExn.said, framed=True)
-                grantWire = bytearray(grantMsg)
-                grantResults = Parser(version=Vrsn_2_0).parse(ims=grantWire,
-                                                              framed=False,
-                                                              processive=False)
-                assert grantWire == bytearray()
-                assert len(grantResults) == 1
-                assert [nest.serder.said for nest in grantResults[0].nests] == [acdc.said]
-                assert len(grantResults[0].nests[0].bsqs) == 1
+                # Move the sender to a later establishment event after the
+                # grant is accepted. Durable replay must still verify the
+                # grant against the historical event that supplied its keys.
+                issuerPostGrantRot = issuerHab.rotate(
+                    framed=True,
+                    version=Vrsn_2_0,
+                    kind=issuerHab.kever.serder.kind,
+                    gvrsn=Vrsn_2_0,
+                )
+                Parser(version=Vrsn_2_0).parse(
+                    ims=bytearray(issuerPostGrantRot), kvy=recipientRemoteKvy)
+                assert recipientHby.kevers[issuerHab.pre].lastEst.s > grantEstSn
+
+                # Run the production prune path after the exchange cache
+                # expires. It must remove only KRAM's temporary rows.
+                pruneMs = (int(helping.fromIso8601(
+                    grantCache.xdt).timestamp() * 1000) + grantCache.pxl + 1)
+                assert recipientKvy.kramer._pruneExchanges(rdt_ms=pruneMs)
+                assert recipientHby.db.kramTMSC.get(
+                    keys=(issuerHab.pre, applyExn.ked["x"], grantExn.said)) is None
+                assert recipientHby.db.kramPMKM.get(keys=partialKey) is None
+                assert recipientHby.db.kramPMKS.get(keys=partialKey) == []
+                assert recipientHby.db.kramTSGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramULGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramCIGS.get(keys=partialKey) == []
+                assert recipientHby.db.kramSSTS.get(keys=partialKey) == []
+
+                # Close and reopen the receiver database before replay. The
+                # durable generic evidence and nested streams must survive both
+                # KRAM pruning and an LMDB lifecycle boundary.
+                with reopenDB(db=recipientHby.db, reuse=True):
+                    grantMsg = serializeMessage(recipientHby,
+                                                grantExn.said,
+                                                framed=True)
+                    grantWire = bytearray(grantMsg)
+                    grantResults = Parser(version=Vrsn_2_0).parse(
+                        ims=grantWire, framed=False, processive=False)
+                    assert grantWire == bytearray()
+                    assert len(grantResults) == 1
+
+                    replay = grantResults[0]
+                    replayGroups = {
+                        prefixer.qb64: (number, diger, sigers)
+                        for prefixer, number, diger, sigers in replay.tsgs
+                    }
+                    number, diger, sigers = replayGroups[issuerHab.pre]
+                    assert (number.sn, diger.qb64, len(sigers)) == (
+                        grantEstSn,
+                        grantEstSaid,
+                        2,
+                    )
+                    number, diger, sigers = replayGroups[endorserHab.pre]
+                    assert (number.sn, diger.qb64, len(sigers)) == (
+                        endorserHab.kever.lastEst.s,
+                        endorserHab.kever.lastEst.d,
+                        1,
+                    )
+                    number, diger, sigers = replayGroups[recipientHab.pre]
+                    assert (number.sn, diger.qb64, len(sigers)) == (
+                        recipientHab.kever.lastEst.s,
+                        recipientHab.kever.lastEst.d,
+                        1,
+                    )
+                    assert [(prefixer.qb64, number.sn, diger.qb64)
+                            for prefixer, number, diger in replay.ssts] == [
+                        (endorserHab.pre,
+                         endorserHab.kever.sn,
+                         endorserHab.kever.serder.said),
+                    ]
+                    assert [(cigar.verfer.qb64, cigar.qb64)
+                            for cigar in replay.cigars] == [
+                        (cigarEndorserHab.pre, endorserCigars[0].qb64),
+                    ]
+                    assert [nest.serder.said for nest in replay.nests] == [
+                        acdc.said,
+                    ]
+                    assert recipientHby.db.exns.get(
+                        keys=(staleOfferExn.said,)) is None
+                    assert recipientHby.db.exns.get(
+                        keys=(offerExn.said,)) is not None
+
+                    # Process the reconstructed message again after KRAM
+                    # pruning. The replay may refresh temporary KRAM state,
+                    # but it must not duplicate durable evidence or notify the
+                    # route handler a second time.
+                    beforeSenderRows = [
+                        (keys, siger.qb64)
+                        for keys, siger in recipientHby.db.esigs.getTopItemIter(
+                            keys=(grantExn.said, issuerHab.pre, ""))
+                    ]
+                    beforeEndorserRows = [
+                        (keys, siger.qb64)
+                        for keys, siger in recipientHby.db.esigs.getTopItemIter(
+                            keys=(grantExn.said, endorserHab.pre, ""))
+                    ]
+                    beforeSeals = [
+                        (keys, number.qb64, diger.qb64)
+                        for keys, (number, diger) in
+                        recipientHby.db.ests.getTopItemIter(
+                            keys=(grantExn.said, ""))
+                    ]
+                    beforeItems = list(recipientRecorder.items)
+
+                    replayWire = bytearray(grantMsg)
+                    Parser(version=Vrsn_2_0).parse(
+                        ims=replayWire, framed=True, kvy=recipientKvy)
+                    assert replayWire == bytearray()
+                    assert [
+                        (keys, siger.qb64)
+                        for keys, siger in recipientHby.db.esigs.getTopItemIter(
+                            keys=(grantExn.said, issuerHab.pre, ""))
+                    ] == beforeSenderRows
+                    assert [
+                        (keys, siger.qb64)
+                        for keys, siger in recipientHby.db.esigs.getTopItemIter(
+                            keys=(grantExn.said, endorserHab.pre, ""))
+                    ] == beforeEndorserRows
+                    assert [
+                        (keys, number.qb64, diger.qb64)
+                        for keys, (number, diger) in
+                        recipientHby.db.ests.getTopItemIter(
+                            keys=(grantExn.said, ""))
+                    ] == beforeSeals
+                    assert recipientRecorder.items == beforeItems
+
+                # Pull the carried blindable update back out of the stored grant
+                # and prove it still unblinds to the expected issued state.
+                assert len(replay.nests[0].bsqs) == 1
+                carriedBup = recipientRgy.store.seqEvent(registry.regk, 1)
+                unblinder = Blinder.unblind(said=carriedBup.sad["b"],
+                                            uuid=issuedBlinder.uuid,
+                                            acdc=acdc.said,
+                                            states=["issued", "revoked"])
+                assert unblinder is not None
+                assert unblinder.state == "issued"
+                assert unblinder.acdc == acdc.said
+                assert unblinder.crew == issuedBlinder.crew
 
                 # Recorder contents should show the issuer only saw the
                 # recipient-originated messages, and the recipient only saw the
@@ -3310,8 +3644,6 @@ def test_ipex_v2_blind_registry_update_roundtrip_through_kram_two_haberies(fakeH
                 # Recovery here means the stale offer never landed, the retry did
                 # land, and the fake clock advanced cleanly from apply to admit.
                 assert helping.nowIso8601() == admitStamp
-                assert recipientHby.db.exns.get(keys=(staleOfferExn.said,)) is None
-                assert recipientHby.db.exns.get(keys=(offerExn.said,)) is not None
         finally:
             recipientRgy.close()
             issuerRgy.close()

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -921,11 +921,13 @@ def test_asmk(mockHelpingNowUTC):
             kwa["serder"] = msg2
             kvy.processMsg(kwa)
 
-            # Partials persist until pruner cleans up (not deleted on threshold)
-            assert receiverHby.db.kramPMKM.get(keys=(senderHab.pre, msg2.said)) is not None
-            kramPMKS = receiverHby.db.kramPMKS.get(keys=(senderHab.pre, msg2.said))
-            assert len(kramPMKS) >= 2
-            assert receiverHby.db.kramPMSK.get(keys=(senderHab.pre, msg2.said)) is not None
+            # Threshold completion clears partial state but keeps the replay cache.
+            assert receiverHby.db.kramPMKM.get(
+                keys=(senderHab.pre, msg2.said)) is None
+            assert receiverHby.db.kramPMKS.get(
+                keys=(senderHab.pre, msg2.said)) == []
+            assert receiverHby.db.kramPMSK.get(
+                keys=(senderHab.pre, msg2.said)) is None
 
             # Assert that downstream dispatch occurred via cue gen
             assert len(kvy.cues) > 0
@@ -981,7 +983,7 @@ def test_asmk(mockHelpingNowUTC):
             # Assert both sigs pooled, 2 of 3 threshold met
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg4.said))
             assert cache is not None
-            # Partials persist until pruner cleans up (not deleted on threshold)
+            # Immediate threshold satisfaction creates no partial state.
             assert receiverHby.db.kramPMKM.get(keys=(senderHab.pre, msg4.said)) is None
 
             kvy.cues.clear()
@@ -1004,17 +1006,19 @@ def test_asmk(mockHelpingNowUTC):
             rotMsg = senderHab.rotate(framed=True, version=V2, kind=Kinds.cesr, gvrsn=V2)
             Parser(version=V2).parse(ims=bytearray(rotMsg), kvy=crossKvy)
 
-            # Second sig uses new keys post-rotation
-            newSigers = senderHab.mgr.sign(ser=msg5.raw,
-                                           verfers=senderHab.kever.verfers,
-                                           indexed=True)
+            # A captured old-key delivery must still trigger key-state cleanup.
+            # The current key state is authoritative even though this signature
+            # no longer verifies against it.
+            kvy.processMsg(dict(serder=msg5,
+                                lsgs=[(prefixer, [allSigers2f[2]])]))
 
-            # Second delivery with new-key sig — key state mismatch detected
-            kvy.processMsg(dict(serder=msg5, lsgs=[(prefixer, [newSigers[2]])]))
-
-            # Assert accumulation invalidated by key state change -> returns None
-            # The partial DB entries still exist (should we be wiping these here?)
-            # No cue generated
+            # The old-key partials are unusable, so only the replay cache remains.
+            assert receiverHby.db.kramPMKM.get(
+                keys=(senderHab.pre, msg5.said)) is None
+            assert receiverHby.db.kramPMKS.get(
+                keys=(senderHab.pre, msg5.said)) == []
+            assert receiverHby.db.kramPMSK.get(
+                keys=(senderHab.pre, msg5.said)) is None
             assert len(kvy.cues) == 0
 
             kvy.cues.clear()
@@ -1062,10 +1066,10 @@ def test_asr(mockHelpingNowUTC):
 
     Covers: valid seal via sscs, valid seal via ssts, non-matching ssts
     fallback to sig auth, invalid seal (no matching digest), missing KEL event,
-    missing KEL with sscs + lsgs falls back to assk, invalid seal + valid sigs
-    (multi-key) falls back to asmk, valid seal + valid sigs (sscs) resolves to
-    asr, invalid seal (wrong digest) + single-key sigs falls back to assk,
-    valid seal + invalid sigs resolves to asr (sigs irrelevant).
+    missing KEL with sscs + lsgs drops until KEL retry, invalid seal + valid
+    sigs (multi-key) falls back to asmk, valid seal + valid sigs (sscs)
+    resolves to asr, invalid seal (wrong digest) + single-key sigs falls back
+    to assk, valid seal + invalid sigs resolves to asr (sigs irrelevant).
     """
 
     # Step 1: Setup
@@ -1265,12 +1269,12 @@ def test_asr(mockHelpingNowUTC):
             cue = kvy.cues.popleft()
             assert cue['kin'] == "keystate"
             assert cue['aid'] == senderHab.pre
-            assert cue['sn'] == 2
+            assert cue['sn'] == 999
 
             kvy.cues.clear()
 
 
-            # Step 7: Missing KEL with sscs + lsgs falls back to sig auth
+            # Step 7: Missing KEL with sscs + lsgs drops until KEL retry
 
             msg6 = query(pre=senderHab.pre,
                                   route="ksn",
@@ -1278,19 +1282,35 @@ def test_asr(mockHelpingNowUTC):
                                   stamp=stamp,
                                   pvrsn=Vrsn_2_0)
 
-            sscs = [(Seqner(sn=999), Saider(qb64=ixnSaid))]
+            ixnMsg = senderHab.interact(data=[dict(d=msg6.said)], framed=True,
+                                        version=V2, kind=Kinds.cesr, gvrsn=V2)
+            ixnSn = senderHab.kever.sn
+            ixnSaid = senderHab.kever.serder.said
+            sscs = [(Seqner(sn=ixnSn), Saider(qb64=ixnSaid))]
             sigers = senderHab.mgr.sign(ser=msg6.raw,
                                         verfers=senderHab.kever.verfers,
                                         indexed=True)
             kwa = dict(sscs=sscs, lsgs=[(prefixer, sigers)])
 
-            # falls back to assk
             kwa["serder"] = msg6
             kvy.processMsg(kwa)
 
             cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg6.said))
-            assert cache is not None  # accepted via sig fallback
-            assert cache.ml == 5000  # short lag (assk)
+            assert cache is None
+            cue = kvy.cues.popleft()
+            assert cue['kin'] == "keystate"
+            assert cue['aid'] == senderHab.pre
+            assert cue['sn'] == ixnSn
+
+            Parser(version=V2).parse(ims=bytearray(ixnMsg), kvy=crossKvy)
+            kvy.processMsg(dict(serder=msg6,
+                                sscs=sscs,
+                                lsgs=[(prefixer, sigers)]))
+
+            cache = receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg6.said))
+            assert cache is not None
+            assert cache.ml == 5000  # short lag (asr)
+            kvy.cues.clear()
 
 
             # Step 8: Valid seal (sscs) + valid sigs resolves to asr (seal takes priority)
@@ -1385,10 +1405,12 @@ def test_asr(mockHelpingNowUTC):
             kvy.processMsg(dict(serder=msg7, sscs=sscs,
                                         lsgs=[(mkPrefixer, [allSigers[1]])]))
 
-            # Partials persist until pruner cleans up (not deleted on threshold)
-            assert receiverHby.db.kramPMKM.get(keys=(mkHab.pre, msg7.said)) is not None
-            kramPMKS = receiverHby.db.kramPMKS.get(keys=(mkHab.pre, msg7.said))
-            assert len(kramPMKS) >= 2
+            assert receiverHby.db.kramPMKM.get(
+                keys=(mkHab.pre, msg7.said)) is None
+            assert receiverHby.db.kramPMKS.get(
+                keys=(mkHab.pre, msg7.said)) == []
+            assert receiverHby.db.kramPMSK.get(
+                keys=(mkHab.pre, msg7.said)) is None
 
             kvy.cues.clear()
 
@@ -1682,10 +1704,55 @@ def test_transactioned(mockHelpingNowUTC):
                 kwa["serder"] = mkExn
                 kvy.processMsg(kwa)
 
-            # Partials persist until pruner cleans up (not deleted on threshold)
-            assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
-            kramPMKS = receiverHby.db.kramPMKS.get(keys=partialKey)
-            assert len(kramPMKS) >= 2
+            assert receiverHby.db.kramPMKM.get(keys=partialKey) is None
+            assert receiverHby.db.kramPMKS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPMSK.get(keys=partialKey) is None
+
+            # An invalid same-SAID delivery cannot erase a valid pending pool.
+            rotateExn = exchange(sender=mkHab.pre,
+                                 receiver=receiverHab.pre,
+                                 xid=mkXip.said,
+                                 route="/test/exchange",
+                                 attributes=dict(n='rotation cleanup'),
+                                 stamp=stamp,
+                                 **EXN_KWA)
+            oldKeySigers = mkHab.mgr.sign(
+                ser=rotateExn.raw,
+                verfers=mkHab.kever.verfers,
+                indexed=True)
+            rotatePartialKey = (mkHab.pre, rotateExn.said)
+            assert kramer.kramit(
+                rotateExn,
+                dict(lsgs=[(mkPrefixer, [oldKeySigers[0]])])) is None
+
+            invalidSigers = skHab.mgr.sign(
+                ser=rotateExn.raw,
+                verfers=skHab.kever.verfers,
+                indexed=True)
+            assert kramer.kramit(
+                rotateExn,
+                dict(lsgs=[(mkPrefixer, invalidSigers)])) is None
+            assert receiverHby.db.kramPMKM.get(
+                keys=rotatePartialKey) is not None
+            assert len(receiverHby.db.kramPMKS.get(
+                keys=rotatePartialKey)) == 1
+
+            # Once the sender rotates, even an old-key replay clears the stale
+            # pool while the transaction cache continues to block this SAID.
+            mkRot = mkHab.rotate(framed=True, version=V2, kind=Kinds.cesr,
+                                 gvrsn=V2)
+            Parser(version=V2).parse(ims=bytearray(mkRot), kvy=crossKvy)
+            assert kramer.kramit(
+                rotateExn,
+                dict(lsgs=[(mkPrefixer, [oldKeySigers[2]])])) is None
+            assert receiverHby.db.kramPMKM.get(
+                keys=rotatePartialKey) is None
+            assert receiverHby.db.kramPMKS.get(
+                keys=rotatePartialKey) == []
+            assert receiverHby.db.kramPMSK.get(
+                keys=rotatePartialKey) is None
+            assert receiverHby.db.kramTMSC.get(
+                keys=(mkHab.pre, mkXip.said, rotateExn.said)) is not None
 
 
             # Step 8: exc happy path
@@ -1950,8 +2017,9 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
     ssts with a different prefix are stored like other non-auth attachments.
 
     Covers: trqs, tsgs, foreign-prefix ssts, frcs, tdcs, ptds, bsqs, bsss,
-    tmqs on partial delivery, idempotency on re-delivery, persistence after
-    threshold met. sscs and sender-matching ssts remain only on the message.
+    tmqs on partial delivery, idempotency on re-delivery, and removal after
+    threshold completion. sscs and sender-matching ssts remain only on the
+    message.
     """
 
     salt1 = Salter(raw=b'0123456789abcdef').qb64
@@ -2089,8 +2157,7 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
             assert len(receiverHby.db.kramTMQS.get(keys=partialKey)) == 1
 
 
-            # Second delivery with 2nd sig meets threshold
-            # Non-auth attachments should persist (pruner responsibility)
+            # Second delivery with 2nd sig meets threshold.
 
             kwa2 = dict(lsgs=[(prefixer, [allSigers[2]])],
                         trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
@@ -2104,17 +2171,19 @@ def test_non_auth_attachments_stored(mockHelpingNowUTC):
             cue = kvy.cues.popleft()
             assert cue["kin"] == "reply"
 
-            # Non-auth attachments persist (pruner cleans up, not kramit)
+            assert receiverHby.db.kramPMKM.get(keys=partialKey) is None
+            assert receiverHby.db.kramPMKS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPMSK.get(keys=partialKey) is None
             assert receiverHby.db.kramSSCS.get(keys=partialKey) == []
-            assert len(receiverHby.db.kramTRQS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTSGS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramSSTS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramFRCS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTDCS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramPTDS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramBSQS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramBSSS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTMQS.get(keys=partialKey)) >= 1
+            assert receiverHby.db.kramTRQS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTSGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramSSTS.get(keys=partialKey) == []
+            assert receiverHby.db.kramFRCS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTDCS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPTDS.get(keys=partialKey) == []
+            assert receiverHby.db.kramBSQS.get(keys=partialKey) == []
+            assert receiverHby.db.kramBSSS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTMQS.get(keys=partialKey) == []
 
     """Done Test"""
 
@@ -2228,8 +2297,20 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
             assert len(kwa2['bsss']) == 1
             assert len(kwa2['tmqs']) == 1
 
-            escrow = kramer.db.kramPMKS.get(keys=partialKey)
-            assert {s.index for s in escrow} == {0, 2}
+            assert kramer.db.kramPMKM.get(keys=partialKey) is None
+            assert kramer.db.kramPMKS.get(keys=partialKey) == []
+            assert kramer.db.kramPMSK.get(keys=partialKey) is None
+            assert kramer.db.kramTRQS.get(keys=partialKey) == []
+            assert kramer.db.kramTSGS.get(keys=partialKey) == []
+            assert kramer.db.kramULGS.get(keys=partialKey) == []
+            assert kramer.db.kramCIGS.get(keys=partialKey) == []
+            assert kramer.db.kramSSTS.get(keys=partialKey) == []
+            assert kramer.db.kramFRCS.get(keys=partialKey) == []
+            assert kramer.db.kramTDCS.get(keys=partialKey) == []
+            assert kramer.db.kramPTDS.get(keys=partialKey) == []
+            assert kramer.db.kramBSQS.get(keys=partialKey) == []
+            assert kramer.db.kramBSSS.get(keys=partialKey) == []
+            assert kramer.db.kramTMQS.get(keys=partialKey) == []
 
     """Done Test"""
 
@@ -2932,7 +3013,7 @@ def test_cue_ks_non_transactioned(mockHelpingNowUTC):
             cue = kvy.cues.popleft()
             assert cue['kin'] == "keystate"
             assert cue['aid'] == kownSenderHab.pre
-            assert cue['sn'] == 0
+            assert cue['sn'] == 999
             kvy.cues.clear()
 
 
@@ -3065,7 +3146,25 @@ def test_cue_ks_transactioned(mockHelpingNowUTC):
             cue = kvy.cues.popleft()
             assert cue['kin'] == "keystate"
             assert cue['aid'] == kownSenderHab.pre
-            assert cue['sn'] == 0
+            assert cue['sn'] == 999
+            kvy.cues.clear()
+
+            # A valid signature does not bypass the missing seal KEL event.
+            knownPrefixer = Prefixer(qb64=kownSenderHab.pre)
+            sigers = kownSenderHab.mgr.sign(
+                ser=xip.raw,
+                verfers=kownSenderHab.kever.verfers,
+                indexed=True)
+            result = kramer.kramit(
+                xip, dict(sscs=sscs, lsgs=[(knownPrefixer, sigers)]))
+            assert result is None
+            assert receiverHby.db.kramTMSC.get(
+                keys=(kownSenderHab.pre, xip.said, xip.said)) is None
+
+            cue = kvy.cues.popleft()
+            assert cue['kin'] == "keystate"
+            assert cue['aid'] == kownSenderHab.pre
+            assert cue['sn'] == 999
             kvy.cues.clear()
 
 
@@ -5211,7 +5310,7 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
             assert receiverHby.db.kramBSSS.get(keys=partialKey) == []
             assert receiverHby.db.kramTMQS.get(keys=partialKey) == []
 
-            # Happy path, attachments pruned after threshold is met
+            # Happy path, partial state removed when threshold is met
             stamp = helping.nowIso8601()
             prefixer = Prefixer(qb64=senderHab.pre)
 
@@ -5311,7 +5410,6 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
             assert len(kvy.cues) == 0
 
             # Second delivery with 2nd sig meets threshold
-            # Non-auth attachments should persist (pruner responsibility)
 
             kwa2 = dict(lsgs=[(prefixer, [allSigers[2]])],
                         trqs=trqs, tsgs=tsgs, sscs=sscs, ssts=ssts,
@@ -5325,17 +5423,19 @@ def test_pruning_messages_multi_key(fakeHelpingClock):
             cue = kvy.cues.popleft()
             assert cue["kin"] == "reply"
 
-            # Non-auth attachments persist (not sscs)
+            assert receiverHby.db.kramPMKM.get(keys=partialKey) is None
+            assert receiverHby.db.kramPMKS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPMSK.get(keys=partialKey) is None
             assert receiverHby.db.kramSSCS.get(keys=partialKey) == []
-            assert len(receiverHby.db.kramTRQS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTSGS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramSSTS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramFRCS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTDCS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramPTDS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramBSQS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramBSSS.get(keys=partialKey)) >= 1
-            assert len(receiverHby.db.kramTMQS.get(keys=partialKey)) >= 1
+            assert receiverHby.db.kramTRQS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTSGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramSSTS.get(keys=partialKey) == []
+            assert receiverHby.db.kramFRCS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTDCS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPTDS.get(keys=partialKey) == []
+            assert receiverHby.db.kramBSQS.get(keys=partialKey) == []
+            assert receiverHby.db.kramBSSS.get(keys=partialKey) == []
+            assert receiverHby.db.kramTMQS.get(keys=partialKey) == []
 
             # Advance time past pruning window
             pml = cache.pml/1000 # convert pml to seconds

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -18,7 +18,7 @@ from keri.kering import (KramConfigurationError, MissingAuthAttachmentError,
 from keri.core import (Kramer, SerderKERI, Kevery, Pruner, Salter,
                        Parser, Seqner, Saider, Prefixer, Diger,
                        Dater, Noncer, Number, Verser, Labeler, Texter,
-                       AuthTypes, exchange, exchept, reply, query)
+                       AuthTypes, exchange, exchept, reply, query, verifySigs)
 
 from keri.app import openHby, openCF
 from keri.db import openDB
@@ -2240,9 +2240,9 @@ def test_repeated_sender_signature_preserves_new_non_auth_attachments(
         mockHelpingNowUTC, transactioned):
     """A repeated valid sender signature may carry new non-auth evidence.
 
-    Preserve that evidence in both partial multi-signature cache paths so a
-    later threshold-satisfying delivery can rehydrate it for downstream
-    verification.
+    Preserve a foreign last-establishment signature group in both partial
+    multi-signature cache paths. Freeze its establishment coordinates so an
+    endorser rotation before threshold completion does not reinterpret it.
     """
 
     salt1 = Salter(raw=b'0123456789abcdef').qb64
@@ -2293,10 +2293,7 @@ def test_repeated_sender_signature_preserves_new_non_auth_attachments(
 
             senderSigs = senderHab.sign(ser=msg.raw, indexed=True)
             endorserSigs = endorserHab.sign(ser=msg.raw, indexed=True)
-            endorserTsg = (endorserHab.kever.prefixer,
-                           Number(sn=endorserHab.kever.lastEst.s),
-                           Diger(qb64=endorserHab.kever.lastEst.d),
-                           endorserSigs)
+            endorserEst = endorserHab.kever.lastEst
             partialKey = (senderHab.pre, msg.said)
 
             assert kramer.kramit(
@@ -2306,13 +2303,33 @@ def test_repeated_sender_signature_preserves_new_non_auth_attachments(
             assert kramer.kramit(
                 msg,
                 dict(sigers=[senderSigs[0]],
-                     tsgs=[endorserTsg])) is None
-            assert len(kramer.db.kramTSGS.get(keys=partialKey)) == 1
+                     lsgs=[(endorserHab.kever.prefixer,
+                            endorserSigs)])) is None
+            escrowedTsgs = kramer.db.kramTSGS.get(keys=partialKey)
+            assert [(prefixer.qb64, number.sn, diger.qb64)
+                    for prefixer, number, diger, _ in escrowedTsgs] == [
+                (endorserHab.pre, endorserEst.s, endorserEst.d),
+            ]
+
+            endorserRot = endorserHab.rotate(
+                framed=True, version=V2, kind=Kinds.cesr, gvrsn=V2)
+            Parser(version=V2).parse(ims=bytearray(endorserRot),
+                                     kvy=crossKvy)
+            assert receiverHby.kevers[endorserHab.pre].lastEst.s > endorserEst.s
 
             final = dict(sigers=[senderSigs[2]])
             assert kramer.kramit(msg, final) is not None
-            assert any(prefixer.qb64 == endorserHab.pre
-                       for prefixer, _, _, _ in final['tsgs'])
+            endorserTsg = next(
+                tsg for tsg in final['tsgs']
+                if tsg[0].qb64 == endorserHab.pre)
+            prefixer, number, diger, sigers = endorserTsg
+            assert (prefixer.qb64, number.sn, diger.qb64) == (
+                endorserHab.pre, endorserEst.s, endorserEst.d)
+
+            tholder, verfers = receiverHby.db.resolveVerifiers(
+                pre=prefixer.qb64, sn=number.sn, dig=diger.qb64)
+            _, indices = verifySigs(msg.raw, sigers, verfers)
+            assert tholder.satisfy(indices)
 
     """Done Test"""
 

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -2134,6 +2134,10 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
 
         senderHab = senderHby.makeHab(name="rehSender", isith='2', icount=3,
                                       transferable=True, version=V2, kind=Kinds.cesr)
+        unknownHab = senderHby.makeHab(name="rehUnknown", isith='1', icount=1,
+                                       transferable=True, version=V2, kind=Kinds.cesr)
+        cigarHab = senderHby.makeHab(name="rehCigar", isith='1', icount=1,
+                                     transferable=False, version=V2, kind=Kinds.cesr)
         receiverHab = receiverHby.makeHab(name="rehReceiver", isith='1', icount=1,
                                           transferable=True, version=V2, kind=Kinds.cesr)
 
@@ -2165,6 +2169,8 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
             saider = Saider(qb64=senderKever.serder.said)
             diger = Diger(ser=msg.raw)
             otherPrefixer = Prefixer(qb64=receiverHab.pre)
+            unknownSigers = unknownHab.sign(ser=msg.raw, indexed=True)
+            foreignCigars = cigarHab.sign(ser=msg.raw, indexed=False)
 
             trqs = [(prefixer, seqner, saider, allSigers[0])]
             tsgs = [(otherPrefixer, seqner, saider, [allSigers[0]])]
@@ -2185,7 +2191,9 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
             texter = Texter(text='application/json')
             tmqs = [(diger, noncer0, labeler, texter)]
 
-            kwa = dict(lsgs=[(prefixer, [allSigers[0]])],
+            kwa = dict(lsgs=[(prefixer, [allSigers[0]]),
+                              (unknownHab.kever.prefixer, unknownSigers)],
+                       cigars=foreignCigars,
                        trqs=trqs, tsgs=tsgs, ssts=ssts,
                        frcs=frcs, tdcs=tdcs, ptds=ptds,
                        bsqs=bsqs, bsss=bsss, tmqs=tmqs)
@@ -2193,6 +2201,12 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
             r1 = kramer.kramit(msg, kwa)
             assert r1 is None
             assert len(kramer.db.kramPMKS.get(keys=partialKey)) == 1
+            assert [pre.qb64 for pre in
+                    kramer.db.kramULGS.get(keys=partialKey)] == [unknownHab.pre]
+            assert [(verfer.qb64, cigar.qb64) for verfer, cigar in
+                    kramer.db.kramCIGS.get(keys=partialKey)] == [
+                (cigarHab.pre, foreignCigars[0].qb64),
+            ]
 
             kwa2 = dict(lsgs=[(prefixer, [allSigers[2]])])
             r2 = kramer.kramit(msg, kwa2)
@@ -2201,6 +2215,11 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
             assert {s.index for s in kwa2['sigers']} == {0, 2}
             assert len(kwa2['trqs']) == 1
             assert len(kwa2['tsgs']) == 1
+            assert [pre.qb64 for pre in kwa2['ulgs']] == [unknownHab.pre]
+            assert [(cigar.verfer.qb64, cigar.qb64)
+                    for cigar in kwa2['cigars']] == [
+                (cigarHab.pre, foreignCigars[0].qb64),
+            ]
             assert len(kwa2['ssts']) == 1
             assert len(kwa2['frcs']) == 1
             assert len(kwa2['tdcs']) == 1
@@ -2211,6 +2230,89 @@ def test_multisig_kwa_rehydration_after_threshold(mockHelpingNowUTC):
 
             escrow = kramer.db.kramPMKS.get(keys=partialKey)
             assert {s.index for s in escrow} == {0, 2}
+
+    """Done Test"""
+
+
+@pytest.mark.parametrize("transactioned", [False, True],
+                         ids=["message-cache", "transaction-cache"])
+def test_repeated_sender_signature_preserves_new_non_auth_attachments(
+        mockHelpingNowUTC, transactioned):
+    """A repeated valid sender signature may carry new non-auth evidence.
+
+    Preserve that evidence in both partial multi-signature cache paths so a
+    later threshold-satisfying delivery can rehydrate it for downstream
+    verification.
+    """
+
+    salt1 = Salter(raw=b'0123456789abcdef').qb64
+    salt2 = Salter(raw=b'0123456789abcdeg').qb64
+
+    with (openHby(name="repeatSender", base="test", salt=salt1) as senderHby,
+          openHby(name="repeatReceiver", base="test", salt=salt2) as receiverHby):
+
+        senderHab = senderHby.makeHab(name="repeatSender", isith='2', icount=3,
+                                      transferable=True, version=V2,
+                                      kind=Kinds.cesr)
+        endorserHab = senderHby.makeHab(name="repeatEndorser", version=V2,
+                                        kind=Kinds.cesr)
+        receiverHab = receiverHby.makeHab(name="repeatReceiver", version=V2,
+                                          kind=Kinds.cesr)
+
+        crossKvy = Kevery(db=receiverHby.db, lax=False, local=False)
+        for hab in (senderHab, endorserHab):
+            msg = hab.msgOwnEvent(sn=0, framed=True, gvrsn=V2)
+            Parser(version=V2).parse(ims=bytearray(msg), kvy=crossKvy)
+
+        with openCF(name="repeatKram", base="test") as cf:
+            cf.put(KRAM_INTEGRATION_CONFIG)
+            kramer = Kramer(db=receiverHby.db, cf=cf)
+            stamp = helping.nowIso8601()
+
+            if transactioned:
+                opener = exchept(sender=senderHab.pre,
+                                  receiver=receiverHab.pre,
+                                  route="/test/exchange",
+                                  stamp=stamp, **EXN_KWA)
+                openerSigs = senderHab.sign(ser=opener.raw, indexed=True)
+                assert kramer.kramit(
+                    opener, dict(sigers=openerSigs)) is not None
+                msg = exchange(sender=senderHab.pre,
+                               receiver=receiverHab.pre,
+                               xid=opener.said,
+                               route="/test/exchange",
+                               attributes=dict(m="repeat evidence"),
+                               stamp=stamp, **EXN_KWA)
+            else:
+                msg = query(pre=senderHab.pre,
+                            route="ksn",
+                            query=dict(i=senderHab.pre,
+                                       src=senderHab.pre),
+                            stamp=stamp,
+                            pvrsn=Vrsn_2_0)
+
+            senderSigs = senderHab.sign(ser=msg.raw, indexed=True)
+            endorserSigs = endorserHab.sign(ser=msg.raw, indexed=True)
+            endorserTsg = (endorserHab.kever.prefixer,
+                           Number(sn=endorserHab.kever.lastEst.s),
+                           Diger(qb64=endorserHab.kever.lastEst.d),
+                           endorserSigs)
+            partialKey = (senderHab.pre, msg.said)
+
+            assert kramer.kramit(
+                msg, dict(sigers=[senderSigs[0]])) is None
+            assert len(kramer.db.kramPMKS.get(keys=partialKey)) == 1
+
+            assert kramer.kramit(
+                msg,
+                dict(sigers=[senderSigs[0]],
+                     tsgs=[endorserTsg])) is None
+            assert len(kramer.db.kramTSGS.get(keys=partialKey)) == 1
+
+            final = dict(sigers=[senderSigs[2]])
+            assert kramer.kramit(msg, final) is not None
+            assert any(prefixer.qb64 == endorserHab.pre
+                       for prefixer, _, _, _ in final['tsgs'])
 
     """Done Test"""
 
@@ -2269,6 +2371,8 @@ def test_non_auth_attachments_empty_kwa(mockHelpingNowUTC):
             # All non-auth attachment dbs empty
             assert receiverHby.db.kramTRQS.get(keys=partialKey) == []
             assert receiverHby.db.kramTSGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramULGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramCIGS.get(keys=partialKey) == []
             assert receiverHby.db.kramSSCS.get(keys=partialKey) == []
             assert receiverHby.db.kramSSTS.get(keys=partialKey) == []
             assert receiverHby.db.kramFRCS.get(keys=partialKey) == []
@@ -2282,7 +2386,7 @@ def test_non_auth_attachments_empty_kwa(mockHelpingNowUTC):
 
 
 def test_rem_non_auth_attachments(mockHelpingNowUTC):
-    """Test _remNonAuthAttachments clears all ten non-auth dbs for a key."""
+    """Test _remNonAuthAttachments clears all non-auth dbs for a key."""
 
     salt1 = Salter(raw=b'0123456789abcdef').qb64
     salt2 = Salter(raw=b'0123456789abcdeg').qb64
@@ -2323,11 +2427,15 @@ def test_rem_non_auth_attachments(mockHelpingNowUTC):
             saider = Saider(qb64=senderKever.serder.said)
             diger = Diger(ser=msg.raw)
 
-            # Populate all ten non-auth dbs directly
+            # Populate all non-auth dbs directly
             receiverHby.db.kramTRQS.add(keys=partialKey,
                                     val=(prefixer, seqner, saider, allSigers[0]))
             receiverHby.db.kramTSGS.add(keys=partialKey,
                                     val=(prefixer, seqner, saider, allSigers[0]))
+            receiverHby.db.kramULGS.add(keys=partialKey, val=prefixer)
+            cigar = senderHab.sign(ser=msg.raw, indexed=False)[0]
+            receiverHby.db.kramCIGS.add(
+                keys=partialKey, val=(cigar.verfer, cigar))
             receiverHby.db.kramSSCS.add(keys=partialKey, val=(seqner, saider))
             receiverHby.db.kramSSTS.add(keys=partialKey, val=(prefixer, seqner, saider))
 
@@ -2358,6 +2466,8 @@ def test_rem_non_auth_attachments(mockHelpingNowUTC):
             # Confirm all populated
             assert len(receiverHby.db.kramTRQS.get(keys=partialKey)) == 1
             assert len(receiverHby.db.kramTSGS.get(keys=partialKey)) == 1
+            assert len(receiverHby.db.kramULGS.get(keys=partialKey)) == 1
+            assert len(receiverHby.db.kramCIGS.get(keys=partialKey)) == 1
             assert len(receiverHby.db.kramSSCS.get(keys=partialKey)) == 1
             assert len(receiverHby.db.kramSSTS.get(keys=partialKey)) == 1
             assert len(receiverHby.db.kramFRCS.get(keys=partialKey)) == 1
@@ -2370,9 +2480,11 @@ def test_rem_non_auth_attachments(mockHelpingNowUTC):
             # Call _remNonAuthAttachments
             kramer._remNonAuthAttachments(partialKey)
 
-            # All ten cleared
+            # All cleared
             assert receiverHby.db.kramTRQS.get(keys=partialKey) == []
             assert receiverHby.db.kramTSGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramULGS.get(keys=partialKey) == []
+            assert receiverHby.db.kramCIGS.get(keys=partialKey) == []
             assert receiverHby.db.kramSSCS.get(keys=partialKey) == []
             assert receiverHby.db.kramSSTS.get(keys=partialKey) == []
             assert receiverHby.db.kramFRCS.get(keys=partialKey) == []

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -6080,10 +6080,14 @@ def test_tsgs_current_when_latest_event_is_non_establishment(mockHelpingNowUTC):
             assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
             assert [s.index for s in receiverHby.db.kramPMKS.get(keys=partialKey)] == [0]
 
-            assert kramer.intake(mkMsg, delivered([allSigers[1]])) is not None, \
+            kwa = delivered([allSigers[1]])
+            assert kramer.intake(mkMsg, kwa) is not None, \
                 "the second endorsement meets the threshold and releases the message"
-            assert sorted(s.index for s in
-                          receiverHby.db.kramPMKS.get(keys=partialKey)) == [0, 1]
+            assert sorted(s.index for s in kwa['sigers']) == [0, 1]
+            assert receiverHby.db.kramPMKM.get(keys=partialKey) is None
+            assert receiverHby.db.kramPMKS.get(keys=partialKey) == []
+            assert receiverHby.db.kramPMSK.get(keys=partialKey) is None
+            assert receiverHby.db.kramMSGC.get(keys=partialKey) is not None
 
 
 def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC):
@@ -6119,13 +6123,12 @@ def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC
             cf.put(KRAM_INTEGRATION_CONFIG)
             kramer = Kramer(db=receiverHby.db, cf=cf)
 
-            def deliver(hab, msg, chosen):
+            def delivered(hab, chosen):
                 """One member's endorsement, naming the sender's current est event."""
                 kever = receiverHby.db.kevers[hab.pre]
-                return kramer.intake(msg, dict(tsgs=[(Prefixer(qb64=hab.pre),
-                                                      Number(num=kever.lastEst.s),
-                                                      Diger(qb64=kever.lastEst.d),
-                                                      chosen)]))
+                return dict(tsgs=[(Prefixer(qb64=hab.pre),
+                                   Number(num=kever.lastEst.s),
+                                   Diger(qb64=kever.lastEst.d), chosen)])
 
             stamp = helping.nowIso8601()
 
@@ -6138,7 +6141,7 @@ def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC
                 indexed=True)
             key = (senderHab.pre, msg.said)
 
-            assert deliver(senderHab, msg, [sigers[0]]) is None
+            assert kramer.intake(msg, delivered(senderHab, [sigers[0]])) is None
             assert [s.index for s in receiverHby.db.kramPMKS.get(key)] == [0]
 
             Parser(version=V2).parse(
@@ -6149,9 +6152,14 @@ def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC
             assert anchored.sner.num == 1 and anchored.serder.ilk == Ilks.ixn
             assert anchored.lastEst.s == 0
 
-            assert deliver(senderHab, msg, [sigers[1]]) is not None, \
+            kwa = delivered(senderHab, [sigers[1]])
+            assert kramer.intake(msg, kwa) is not None, \
                 "anchoring changes no key, so the second endorsement still counts"
-            assert sorted(s.index for s in receiverHby.db.kramPMKS.get(key)) == [0, 1]
+            assert sorted(s.index for s in kwa['sigers']) == [0, 1]
+            assert receiverHby.db.kramPMKM.get(key) is None
+            assert receiverHby.db.kramPMKS.get(key) == []
+            assert receiverHby.db.kramPMSK.get(key) is None
+            assert receiverHby.db.kramMSGC.get(key) is not None
 
             # A rotation between deliveries: the keys did change, so the escrow drops.
             rotMsg = query(pre=rotHab.pre, route="ksn",
@@ -6162,7 +6170,7 @@ def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC
                 indexed=True)
             rotKey = (rotHab.pre, rotMsg.said)
 
-            assert deliver(rotHab, rotMsg, [rotSigers[0]]) is None
+            assert kramer.intake(rotMsg, delivered(rotHab, [rotSigers[0]])) is None
             assert [s.index for s in receiverHby.db.kramPMKS.get(rotKey)] == [0]
 
             Parser(version=V2).parse(
@@ -6171,6 +6179,9 @@ def test_partial_multisig_survives_an_anchor_during_collection(mockHelpingNowUTC
                 kvy=crossKvy)
             assert receiverHby.db.kevers[rotHab.pre].lastEst.s == 1
 
-            assert deliver(rotHab, rotMsg, [rotSigers[1]]) is None, \
+            assert kramer.intake(rotMsg, delivered(rotHab, [rotSigers[1]])) is None, \
                 "rotating invalidates what was gathered under the old keys"
-            assert [s.index for s in receiverHby.db.kramPMKS.get(rotKey)] == [0]
+            assert receiverHby.db.kramPMKM.get(rotKey) is None
+            assert receiverHby.db.kramPMKS.get(rotKey) == []
+            assert receiverHby.db.kramPMSK.get(rotKey) is None
+            assert receiverHby.db.kramMSGC.get(rotKey) is not None

--- a/tests/db/test_basing.py
+++ b/tests/db/test_basing.py
@@ -14,14 +14,14 @@ import pytest
 import lmdb
 from hio.base import doing
 
-from keri.kering import Kinds, Ilks, versify
+from keri.kering import Kinds, Ilks, Vrsn_2_0, versify
 from keri.app import openHby
 from keri.core import (Seqner, Diger, Number, Kever, Serder,
                        Signer, Siger, Salter, Dater, Prefixer,
-                       Cigar, Seqner, Saider, Noncer, Labeler,
+                       Verfer, Cigar, Saider, Noncer, Labeler,
                        Texter, SerderKERI, StateEstEvent,
                        IdrDex, MtrDex, NumDex,
-                       incept, rotate, interact, rotate)
+                       exchange, incept, rotate, interact)
 
 from keri.core import state as eventState
 from keri.db import (Baser, BaserDoer, Baser, SerderSuber,
@@ -68,6 +68,12 @@ def test_baser():
     # (the v1.3.5 bug fixed in PR #1538).
     assert isinstance(baser.essrs, CesrIoSetSuber)
     assert baser.essrs.klas is Texter
+    assert isinstance(baser.ests, CatCesrIoSetSuber)
+    assert baser.ests.klas == (Number, Diger)
+    assert isinstance(baser.kramULGS, CesrIoSetSuber)
+    assert baser.kramULGS.klas is Prefixer
+    assert isinstance(baser.kramCIGS, CatCesrIoSetSuber)
+    assert baser.kramCIGS.klas == (Verfer, Cigar)
 
     baser.close(clear=True)
     assert not os.path.exists(baser.path)
@@ -1908,7 +1914,40 @@ def test_clean_baser():
         state = natHab.db.states.get(keys=natHab.pre)  # Serder instance
         assert state.s == '6'
         assert state.f == '6'
-        assert natHab.db.env.stat()['entries'] <= 102 #68
+        assert natHab.db.env.stat()['entries'] <= 105 #68
+
+        grant = exchange(sender=natHab.pre,
+                         route="/test/grant",
+                         attributes=dict(m="accepted evidence"),
+                         version=Vrsn_2_0,
+                         kind=Kinds.json)
+        assert natHab.db.exns.put(keys=(grant.said,), val=grant)
+        endorser = natHab.pre
+        sourceSeal = (Number(sn=natHab.kever.sn),
+                      Diger(qb64=natHab.kever.serder.said))
+        assert natHab.db.ests.add(keys=(grant.said, endorser), val=sourceSeal)
+
+        pending = exchange(sender=natHab.pre,
+                           route="/test/pending",
+                           attributes=dict(m="temporary evidence"),
+                           version=Vrsn_2_0,
+                           kind=Kinds.json)
+        pendingSiger = natHab.sign(ser=pending.raw, indexed=True)[0]
+        pendingKeys = (pending.said, natHab.pre,
+                       f"{natHab.kever.lastEst.s:032x}",
+                       natHab.kever.lastEst.d)
+        assert natHab.db.esigs.add(keys=pendingKeys, val=pendingSiger)
+        signer = Signer(transferable=False,
+                        seed=b'fedcba9876543210fedcba9876543210')
+        pendingCigar = signer.sign(ser=pending.raw)
+        assert natHab.db.ecigs.add(
+            keys=(pending.said,), val=(signer.verfer, pendingCigar))
+        assert natHab.db.epath.add(keys=(pending.said,), val=b"pending-path")
+        assert natHab.db.enst.add(keys=(pending.said,), val=b"pending-nest")
+        assert natHab.db.essrs.add(
+            keys=(pending.said,), val=Texter(text="pending-essr"))
+        assert natHab.db.ests.add(
+            keys=(pending.said, endorser), val=sourceSeal)
 
         # test reopenDB with reuse  (because temp)
         with reopenDB(db=natHab.db, reuse=True):
@@ -1918,11 +1957,16 @@ def test_clean_baser():
             assert ldig == natHab.kever.serder.saidb
             serder = natHab.db.evts.get(keys=(natHab.pre, ldig))
             assert serder.said == natHab.kever.serder.said
-            assert natHab.db.env.stat()['entries'] <= 102 #68
+            assert natHab.db.env.stat()['entries'] <= 105 #68
 
             # verify name pre kom in db
             data = natHab.db.habs.get(keys=natHab.pre)
             assert data.hid == natHab.pre
+
+            seals = natHab.db.ests.get(keys=(grant.said, endorser))
+            assert [(number.sn, diger.qb64) for number, diger in seals] == [
+                (sourceSeal[0].sn, sourceSeal[1].qb64)
+            ]
 
             # add garbage event to corrupt database
             badsrdr = rotate(pre=natHab.pre,
@@ -1983,6 +2027,19 @@ def test_clean_baser():
             # verify name pre kom in db
             data = natHab.db.habs.get(keys=natHab.pre)
             assert data.hid == natHab.pre
+
+            seals = natHab.db.ests.get(keys=(grant.said, endorser))
+            assert [(number.sn, diger.qb64) for number, diger in seals] == [
+                (sourceSeal[0].sn, sourceSeal[1].qb64)
+            ]
+            assert list(natHab.db.esigs.getTopItemIter(
+                keys=(pending.said, ""))) == []
+            assert natHab.db.ecigs.get(keys=(pending.said,)) == []
+            assert natHab.db.epath.get(keys=(pending.said,)) == []
+            assert natHab.db.enst.get(keys=(pending.said,)) == []
+            assert natHab.db.essrs.get(keys=(pending.said,)) == []
+            assert natHab.db.ests.get(
+                keys=(pending.said, endorser)) == []
 
 
     assert not os.path.exists(hby.ks.path)

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -424,6 +424,56 @@ def test_source_seal_couple_round_trips_as_resolved_triple(mockHelpingNowUTC):
             (sender.pre, sourceSeal[1].sn, sourceSeal[2].qb64),
         ]
 
+        sealPreferred = exchange(
+            sender=sender.pre,
+            route="/test/seal-source",
+            attributes=dict(m="valid seal with invalid sender signature"),
+            **kwa,
+        )
+        anchor = sender.interact(data=[dict(d=sealPreferred.said)],
+                                 framed=True,
+                                 gvrsn=Vrsn_2_0,
+                                 **kwa)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(anchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        sourceSeal = (sender.kever.prefixer,
+                      Number(sn=sender.kever.sn),
+                      Diger(qb64=sender.kever.serder.said))
+        invalidSenderTsg = (
+            sender.kever.prefixer,
+            Number(sn=sender.kever.lastEst.s),
+            Diger(qb64=sender.kever.lastEst.d),
+            sender.sign(ser=b"different exchange message", indexed=True),
+        )
+        exchanger.processEvent(sealPreferred,
+                               tsgs=[invalidSenderTsg],
+                               ssts=[sourceSeal])
+
+        assert receiverHby.db.exns.get(
+            keys=(sealPreferred.said,)) is not None
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(sealPreferred.said, sender.pre, ""))) == []
+        assert [(number.sn, diger.qb64)
+                for number, diger in receiverHby.db.ests.get(
+                    keys=(sealPreferred.said, sender.pre))] == [
+            (sourceSeal[1].sn, sourceSeal[2].qb64),
+        ]
+        verify(receiverHby, sealPreferred)
+
+        replay = Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(serializeMessage(receiverHby,
+                                           sealPreferred.said,
+                                           framed=True)),
+            framed=True,
+            processive=False,
+        )[0]
+        assert replay.tsgs == []
+        assert [(prefixer.qb64, number.sn, diger.qb64)
+                for prefixer, number, diger in replay.ssts] == [
+            (sender.pre, sourceSeal[1].sn, sourceSeal[2].qb64),
+        ]
+
 
 def test_non_ipex_rejects_non_sender_evidence(mockHelpingNowUTC):
     """Non-IPEX routes keep the existing sender-only evidence contract."""
@@ -577,6 +627,47 @@ def test_non_ipex_rejects_non_sender_evidence(mockHelpingNowUTC):
                            tsgs=[group(endorser, foreignOnly.raw)])
         with pytest.raises(MissingSignatureError):
             verify(receiverHby, foreignOnly)
+
+
+def test_verify_fails_closed_on_invalid_stored_evidence(mockHelpingNowUTC):
+    """Invalid optional evidence makes an accepted stored EXN unverifiable."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+    with openHab(name="stored-sender", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="stored-endorser", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (_, endorser), \
+            openHab(name="stored-receiver", base="test",
+                    salt=b'fedcba9876543210', **kwa) as (receiverHby, _):
+        for hab in (sender, endorser):
+            msg = hab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(msg),
+                                           kvy=receiverHby.kvy,
+                                           local=True)
+
+        exn = exchange(sender=sender.pre,
+                       route="/test/stored-evidence",
+                       attributes=dict(m="invalid stored evidence"),
+                       **kwa)
+
+        def group(hab, sigers):
+            return (hab.kever.prefixer,
+                    Number(sn=hab.kever.lastEst.s),
+                    Diger(qb64=hab.kever.lastEst.d),
+                    sigers)
+
+        senderGroup = group(
+            sender, sender.sign(ser=exn.raw, indexed=True))
+        invalidEndorserGroup = group(
+            endorser,
+            endorser.sign(ser=b"different exchange message", indexed=True),
+        )
+        Exchanger(hby=receiverHby, handlers=[]).logEvent(
+            exn, tsgs=[senderGroup, invalidEndorserGroup])
+
+        with pytest.raises(MissingSignatureError):
+            verify(receiverHby, exn)
+        with pytest.raises(MissingSignatureError):
+            serializeMessage(receiverHby, exn.said, framed=True)
 
 
 def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC):

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -557,15 +557,20 @@ def test_non_ipex_rejects_non_sender_evidence(mockHelpingNowUTC):
                              Diger(qb64=sender.kever.serder.said))
         queryCueCount = sum(cue.get("kin") == "query"
                             for cue in exchanger.cues)
-        exchanger.processEvent(
-            signedWithMissingSeal,
-            tsgs=[group(sender, signedWithMissingSeal.raw)],
-            ssts=[missingSenderSeal],
-        )
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                signedWithMissingSeal,
+                tsgs=[group(sender, signedWithMissingSeal.raw)],
+                ssts=[missingSenderSeal],
+            )
         assert receiverHby.db.exns.get(
-            keys=(signedWithMissingSeal.said,)).said == signedWithMissingSeal.said
+            keys=(signedWithMissingSeal.said,)) is None
         assert sum(cue.get("kin") == "query"
-                   for cue in exchanger.cues) == queryCueCount
+                   for cue in exchanger.cues) == queryCueCount + 1
+        assert any(cue.get("kin") == "query" and
+                   cue["q"] == dict(r="logs", pre=sender.pre,
+                                    sn=missingSenderSeal[1].snh)
+                   for cue in exchanger.cues)
         assert receiverHby.db.ests.get(
             keys=(signedWithMissingSeal.said, sender.pre)) == []
 
@@ -627,6 +632,148 @@ def test_non_ipex_rejects_non_sender_evidence(mockHelpingNowUTC):
                            tsgs=[group(endorser, foreignOnly.raw)])
         with pytest.raises(MissingSignatureError):
             verify(receiverHby, foreignOnly)
+
+
+def test_missing_foreign_key_state_requests_kel_before_persistence(
+        mockHelpingNowUTC):
+    """Missing endorser KEL state drops the EXN until a complete retry."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+
+    class EvidenceHandler:
+        resource = "/test/missing-evidence-state"
+
+        @staticmethod
+        def verify(serder, **kwa):
+            return True
+
+        @staticmethod
+        def verifyEvidence(serder, *, tsgs=None, cigars=None, sourceSeals=None,
+                           invalid=False):
+            if invalid:
+                return None
+            return tsgs or [], cigars or [], sourceSeals or []
+
+        @staticmethod
+        def handle(serder, **kwa):
+            return None
+
+    with openHab(name="missing-state-sender", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="missing-state-endorser", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (_, endorser), \
+            openHab(name="missing-state-receiver", base="test",
+                    salt=b'fedcba9876543210', **kwa) as (receiverHby, _):
+        senderIcp = sender.msgOwnEvent(sn=0, framed=True,
+                                       gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(senderIcp),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+
+        exchanger = Exchanger(hby=receiverHby,
+                              handlers=[EvidenceHandler()])
+
+        def group(hab, serder):
+            return (hab.kever.prefixer,
+                    Number(sn=hab.kever.lastEst.s),
+                    Diger(qb64=hab.kever.lastEst.d),
+                    hab.sign(ser=serder.raw, indexed=True))
+
+        missingTsg = exchange(
+            sender=sender.pre,
+            route=EvidenceHandler.resource,
+            attributes=dict(m="missing endorser establishment event"),
+            **kwa,
+        )
+        senderGroup = group(sender, missingTsg)
+        endorserGroup = group(endorser, missingTsg)
+
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                missingTsg, tsgs=[senderGroup, endorserGroup])
+
+        assert receiverHby.db.exns.get(keys=(missingTsg.said,)) is None
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(missingTsg.said, endorser.pre, ""))) == []
+        assert receiverHby.db.epse.get(keys=(missingTsg.said,)) is None
+        assert any(cue.get("kin") == "query" and
+                   cue["q"] == dict(r="logs", pre=endorser.pre,
+                                    sn=endorserGroup[1].snh)
+                   for cue in exchanger.cues)
+
+        endorserIcp = endorser.msgOwnEvent(sn=0, framed=True,
+                                           gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserIcp),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        exchanger.cues.clear()
+        exchanger.processEvent(
+            missingTsg, tsgs=[senderGroup, endorserGroup])
+        assert receiverHby.db.exns.get(keys=(missingTsg.said,)) is not None
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(missingTsg.said, endorser.pre, "")))) == 1
+
+        invalidTsg = exchange(
+            sender=sender.pre,
+            route=EvidenceHandler.resource,
+            attributes=dict(m="known invalid endorser evidence"),
+            **kwa,
+        )
+        invalidEndorserGroup = (
+            endorser.kever.prefixer,
+            Number(sn=endorser.kever.lastEst.s),
+            Diger(qb64=sender.kever.lastEst.d),
+            endorser.sign(ser=invalidTsg.raw, indexed=True),
+        )
+        exchanger.cues.clear()
+        exchanger.processEvent(
+            invalidTsg, tsgs=[group(sender, invalidTsg),
+                               invalidEndorserGroup])
+        assert receiverHby.db.exns.get(keys=(invalidTsg.said,)) is None
+        assert not any(cue.get("kin") == "query" for cue in exchanger.cues)
+
+        missingSeal = exchange(
+            sender=sender.pre,
+            route=EvidenceHandler.resource,
+            attributes=dict(m="missing endorser anchor event"),
+            **kwa,
+        )
+        senderGroup = group(sender, missingSeal)
+        endorserAnchor = endorser.interact(
+            data=[dict(d=missingSeal.said)],
+            framed=True,
+            gvrsn=Vrsn_2_0,
+            **kwa,
+        )
+        sourceSeal = (endorser.kever.prefixer,
+                      Number(sn=endorser.kever.sn),
+                      Diger(qb64=endorser.kever.serder.said))
+
+        exchanger.cues.clear()
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                missingSeal, tsgs=[senderGroup], ssts=[sourceSeal])
+
+        assert receiverHby.db.exns.get(keys=(missingSeal.said,)) is None
+        assert receiverHby.db.ests.get(
+            keys=(missingSeal.said, endorser.pre)) == []
+        assert receiverHby.db.epse.get(keys=(missingSeal.said,)) is None
+        assert any(cue.get("kin") == "query" and
+                   cue["q"] == dict(r="logs", pre=endorser.pre,
+                                    sn=sourceSeal[1].snh)
+                   for cue in exchanger.cues)
+
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserAnchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        exchanger.cues.clear()
+        exchanger.processEvent(
+            missingSeal, tsgs=[senderGroup], ssts=[sourceSeal])
+        assert receiverHby.db.exns.get(keys=(missingSeal.said,)) is not None
+        assert [(number.sn, diger.qb64)
+                for number, diger in receiverHby.db.ests.get(
+                    keys=(missingSeal.said, endorser.pre))] == [
+            (sourceSeal[1].sn, sourceSeal[2].qb64),
+        ]
 
 
 def test_verify_fails_closed_on_invalid_stored_evidence(mockHelpingNowUTC):

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -9,17 +9,19 @@ import pysodium
 import pytest
 
 from keri import Kinds, Vrsn_1_0, Vrsn_2_0
-from keri.core import (Salter, Counter, Texter,
+from keri.kering import MissingSignatureError
+from keri.core import (Salter, Counter, Dater, Texter, Kevery, Kramer,
                        Diger, Prefixer, Number,
-                       SerderKERI, Parser, messagize,
+                       SealSource, SerderKERI, Parser, messagize,
                        MtrDex, Codens, exchange)
 
 from keri.app import (Notifier, Counselor, Multiplexor,
-                      openHab, openHby,
+                      openCF, openHab, openHby,
                       multisigInceptExn, multisigRotateExn)
 from keri.app.grouping import loadHandlers
 
-from keri.peer import Exchanger, nesting, specialExchange, serializeMessage
+from keri.peer import (Exchanger, nesting, serializeMessage, specialExchange,
+                       verify)
 from keri.vdr import incept
 
 TEST_VERSION = Vrsn_1_0
@@ -290,6 +292,605 @@ def test_serialize_message_round_trips_stored_nested_substreams(mockHelpingNowUT
 
         # The child inside the rebuilt message should be the same child that was originally sent
         assert parsed[0].nests[0].serder.said == inner.said
+
+
+def test_source_seal_couple_round_trips_as_resolved_triple(mockHelpingNowUTC):
+    """Durable replay makes the implicit sender of a seal couple explicit."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+    with openHab(name="seal-source", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="seal-receiver", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (receiverHby, _):
+        Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(sender.msgOwnEvent(sn=0,
+                                             framed=True,
+                                             gvrsn=Vrsn_2_0)),
+            kvy=receiverHby.kvy,
+            local=True,
+        )
+        exn = exchange(sender=sender.pre,
+                       route="/test/seal-source",
+                       attributes=dict(m="sealed exchange"),
+                       **kwa)
+        anchor = sender.interact(data=[dict(d=exn.said)],
+                                 framed=True,
+                                 gvrsn=Vrsn_2_0,
+                                 **kwa)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(anchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+
+        number = Number(sn=sender.kever.sn)
+        diger = Diger(qb64=sender.kever.serder.said)
+        assert receiverHby.db.kels.getLast(
+            keys=sender.kever.prefixer.qb64b, on=number.sn) == diger.qb64
+        anchorSerder = receiverHby.db.evts.get(
+            keys=(sender.kever.prefixer.qb64b, diger.qb64b))
+        assert anchorSerder is not None
+        assert anchorSerder.seals == [dict(d=exn.said)]
+        msg = messagize(exn,
+                        bonds=[SealSource(s=number, d=diger)],
+                        framed=True,
+                        gvrsn=Vrsn_2_0)
+        exchanger = Exchanger(hby=receiverHby, handlers=[])
+        receiverHby.kvy.kramer = None
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(msg),
+                                       framed=True,
+                                       kvy=receiverHby.kvy,
+                                       exc=exchanger)
+
+        assert [(snumber.sn, sdiger.qb64)
+                for snumber, sdiger in receiverHby.db.ests.get(
+                    keys=(exn.said, sender.pre))] == [
+            (number.sn, diger.qb64),
+        ]
+        assert receiverHby.db.exns.get(keys=(exn.said,)) is not None
+
+        replay = Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(serializeMessage(receiverHby, exn.said,
+                                           framed=True)),
+            framed=True,
+            processive=False,
+        )[0]
+        assert replay.sscs == []
+        assert [(prefixer.qb64, snumber.sn, sdiger.qb64)
+                for prefixer, snumber, sdiger in replay.ssts] == [
+            (sender.pre, number.sn, diger.qb64),
+        ]
+
+        signed = exchange(sender=sender.pre,
+                          route="/test/seal-source",
+                          attributes=dict(m="signed and sealed exchange"),
+                          **kwa)
+        anchor = sender.interact(data=[dict(d=signed.said)],
+                                 framed=True,
+                                 gvrsn=Vrsn_2_0,
+                                 **kwa)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(anchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        sourceSeal = (sender.kever.prefixer,
+                      Number(sn=sender.kever.sn),
+                      Diger(qb64=sender.kever.serder.said))
+        senderSigs = sender.sign(ser=signed.raw, indexed=True)
+        msg = messagize(
+            signed,
+            lsgs=[(sender.kever.prefixer, senderSigs)],
+            bonds=[SealSource(s=sourceSeal[1], d=sourceSeal[2])],
+            framed=True,
+            gvrsn=Vrsn_2_0,
+        )
+        config = {
+            "kram": {
+                "enabled": True,
+                "denials": [],
+                "caches": {
+                    "~": [1000, 5000, 60000, 300000,
+                          5000, 60000, 300000],
+                },
+            },
+        }
+        with openCF(name="signed-seal-kram", base="test", temp=True) as cf:
+            cf.put(config)
+            kvy = Kevery(db=receiverHby.db,
+                         lax=False,
+                         local=False,
+                         kramer=Kramer(db=receiverHby.db, cf=cf),
+                         exc=exchanger)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(msg), kvy=kvy)
+
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(signed.said, sender.pre, "")))) == 1
+        assert [(snumber.sn, sdiger.qb64)
+                for snumber, sdiger in receiverHby.db.ests.get(
+                    keys=(signed.said, sender.pre))] == [
+            (sourceSeal[1].sn, sourceSeal[2].qb64),
+        ]
+        verify(receiverHby, signed)
+
+        replay = Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(serializeMessage(receiverHby, signed.said,
+                                           framed=True)),
+            framed=True,
+            processive=False,
+        )[0]
+        assert [(prefixer.qb64, snumber.sn, sdiger.qb64, len(sigers))
+                for prefixer, snumber, sdiger, sigers in replay.tsgs] == [
+            (sender.pre, sender.kever.lastEst.s,
+             sender.kever.lastEst.d, len(senderSigs)),
+        ]
+        assert [(prefixer.qb64, snumber.sn, sdiger.qb64)
+                for prefixer, snumber, sdiger in replay.ssts] == [
+            (sender.pre, sourceSeal[1].sn, sourceSeal[2].qb64),
+        ]
+
+
+def test_non_ipex_rejects_non_sender_evidence(mockHelpingNowUTC):
+    """Non-IPEX routes keep the existing sender-only evidence contract."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+    with openHab(name="extra-sender", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="extra-endorser", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (_, endorser), \
+            openHab(name="extra-unknown", base="test",
+                    salt=b'0123456789abcdeg', **kwa) as (_, unknown), \
+            openHab(name="extra-receiver", base="test",
+                    salt=b'fedcba9876543210', **kwa) as (receiverHby, _):
+        for hab in (sender, endorser):
+            msg = hab.msgOwnEvent(sn=0, framed=True, gvrsn=Vrsn_2_0)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(msg),
+                                           kvy=receiverHby.kvy,
+                                           local=True)
+
+        def group(hab, ser):
+            return (hab.kever.prefixer,
+                    Number(sn=hab.kever.lastEst.s),
+                    Diger(qb64=hab.kever.lastEst.d),
+                    hab.sign(ser=ser, indexed=True))
+
+        exchanger = Exchanger(hby=receiverHby, handlers=[])
+        ordinary = exchange(sender=sender.pre,
+                            route="/test/ordinary",
+                            attributes=dict(m="ordinary"),
+                            **kwa)
+        exchanger.processEvent(ordinary,
+                               tsgs=[group(sender, ordinary.raw)])
+        assert receiverHby.db.exns.get(keys=(ordinary.said,)).said == ordinary.said
+
+        transferableCigar = exchange(
+            sender=sender.pre,
+            route="/test/ordinary",
+            attributes=dict(m="transferable cigar"),
+            **kwa,
+        )
+        senderCigars = sender.sign(ser=transferableCigar.raw, indexed=False)
+        assert senderCigars[0].verfer.transferable
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(transferableCigar, cigars=senderCigars)
+        assert receiverHby.db.exns.get(keys=(transferableCigar.said,)) is None
+
+        mixed = exchange(sender=sender.pre,
+                         route="/test/ordinary",
+                         attributes=dict(m="mixed sender evidence"),
+                         **kwa)
+        ignoredCigars = endorser.sign(ser=b"different exchange message",
+                                      indexed=False)
+        exchanger.processEvent(mixed,
+                               tsgs=[group(sender, mixed.raw)],
+                               cigars=ignoredCigars)
+        assert receiverHby.db.exns.get(keys=(mixed.said,)).said == mixed.said
+        assert receiverHby.db.ecigs.get(keys=(mixed.said,)) == []
+
+        mixedSeal = exchange(sender=sender.pre,
+                             route="/test/ordinary",
+                             attributes=dict(m="mixed source seal"),
+                             **kwa)
+        foreignSeal = (endorser.kever.prefixer,
+                       Number(sn=endorser.kever.sn),
+                       Diger(qb64=endorser.kever.serder.said))
+        exchanger.processEvent(mixedSeal,
+                               tsgs=[group(sender, mixedSeal.raw)],
+                               ssts=[foreignSeal])
+        assert receiverHby.db.exns.get(
+            keys=(mixedSeal.said,)).said == mixedSeal.said
+        assert receiverHby.db.ests.get(
+            keys=(mixedSeal.said, endorser.pre)) == []
+
+        signedWithMissingSeal = exchange(
+            sender=sender.pre,
+            route="/test/ordinary",
+            attributes=dict(m="authenticated with missing sender seal"),
+            **kwa,
+        )
+        missingSenderSeal = (sender.kever.prefixer,
+                             Number(sn=sender.kever.sn + 1),
+                             Diger(qb64=sender.kever.serder.said))
+        queryCueCount = sum(cue.get("kin") == "query"
+                            for cue in exchanger.cues)
+        exchanger.processEvent(
+            signedWithMissingSeal,
+            tsgs=[group(sender, signedWithMissingSeal.raw)],
+            ssts=[missingSenderSeal],
+        )
+        assert receiverHby.db.exns.get(
+            keys=(signedWithMissingSeal.said,)).said == signedWithMissingSeal.said
+        assert sum(cue.get("kin") == "query"
+                   for cue in exchanger.cues) == queryCueCount
+        assert receiverHby.db.ests.get(
+            keys=(signedWithMissingSeal.said, sender.pre)) == []
+
+        withExtra = exchange(sender=sender.pre,
+                             route="/test/ordinary",
+                             attributes=dict(m="foreign evidence"),
+                             **kwa)
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                withExtra,
+                tsgs=[group(sender, withExtra.raw),
+                      group(endorser, withExtra.raw)],
+            )
+
+        assert receiverHby.db.exns.get(keys=(withExtra.said,)) is None
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(withExtra.said, endorser.pre, "")
+        )) == []
+
+        missingSender = exchange(sender=unknown.pre,
+                                 route="/test/ordinary",
+                                 attributes=dict(m="missing sender state"),
+                                 **kwa)
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                missingSender,
+                tsgs=[group(unknown, missingSender.raw),
+                      group(endorser, missingSender.raw)],
+            )
+        assert any(cue.get("kin") == "query" and
+                   cue["q"]["pre"] == unknown.pre
+                   for cue in exchanger.cues)
+
+        unknownIcp = unknown.msgOwnEvent(sn=0, framed=True,
+                                         gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(unknownIcp),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        exchanger.processEscrow()
+        assert receiverHby.db.exns.get(keys=(missingSender.said,)) is None
+
+        unsupportedOnly = exchange(sender=sender.pre,
+                                   route="/test/ordinary",
+                                   attributes=dict(m="foreign only input"),
+                                   **kwa)
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                unsupportedOnly,
+                tsgs=[group(endorser, unsupportedOnly.raw)],
+            )
+        assert receiverHby.db.epse.get(
+            keys=(unsupportedOnly.said,)) is None
+
+        foreignOnly = exchange(sender=sender.pre,
+                               route="/test/ordinary",
+                               attributes=dict(m="foreign only"),
+                               **kwa)
+        exchanger.logEvent(foreignOnly,
+                           tsgs=[group(endorser, foreignOnly.raw)])
+        with pytest.raises(MissingSignatureError):
+            verify(receiverHby, foreignOnly)
+
+
+def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC):
+    """Exchanger escrow rows do not bypass evidence selection on replay."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+
+    class EvidenceHandler:
+        resource = "/test/evidence"
+
+        @staticmethod
+        def verify(serder, **kwa):
+            return True
+
+        @staticmethod
+        def verifyEvidence(serder, *, tsgs=None, cigars=None, sourceSeals=None,
+                           invalid=False):
+            return tsgs or [], cigars or [], sourceSeals or []
+
+        @staticmethod
+        def handle(serder, **kwa):
+            return None
+
+    with openHab(name="escrow-sender", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="escrow-endorser", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (_, endorser), \
+            openHab(name="escrow-cigar", base="test",
+                    salt=b'0123456789abcdeg', transferable=False,
+                    **kwa) as (_, cigarEndorser), \
+            openHab(name="escrow-receiver", base="test",
+                    salt=b'fedcba9876543210', **kwa) as (receiverHby, receiver):
+        endorserIcp = endorser.msgOwnEvent(sn=0, framed=True,
+                                           gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserIcp),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+
+        exchanger = Exchanger(hby=receiverHby,
+                              handlers=[EvidenceHandler()])
+        exn = exchange(sender=sender.pre,
+                       route=EvidenceHandler.resource,
+                       attributes=dict(m="escrow evidence"),
+                       **kwa)
+
+        def group(hab, sigers):
+            return (hab.kever.prefixer,
+                    Number(sn=hab.kever.lastEst.s),
+                    Diger(qb64=hab.kever.lastEst.d),
+                    sigers)
+
+        senderGroup = group(sender, sender.sign(ser=exn.raw, indexed=True))
+        endorserGroup = group(
+            endorser,
+            endorser.sign(ser=exn.raw, indexed=True),
+        )
+        invalidGroup = group(
+            receiver,
+            receiver.sign(ser=b"different exchange message", indexed=True),
+        )
+        validCigar = cigarEndorser.sign(ser=exn.raw, indexed=False)
+        invalidCigar = cigarEndorser.sign(
+            ser=b"different exchange message", indexed=False)
+
+        endorserAnchor = endorser.interact(
+            data=[dict(d=exn.said)],
+            framed=True,
+            version=Vrsn_2_0,
+            gvrsn=Vrsn_2_0,
+        )
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserAnchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        validSeal = (endorser.kever.prefixer,
+                     Number(sn=endorser.kever.sn),
+                     Diger(qb64=endorser.kever.serder.said))
+        invalidSeal = (receiver.kever.prefixer,
+                       Number(sn=receiver.kever.sn),
+                       Diger(qb64=receiver.kever.serder.said))
+
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(exn,
+                                   tsgs=[senderGroup, endorserGroup,
+                                         invalidGroup],
+                                   cigars=validCigar + invalidCigar,
+                                   ssts=[validSeal, invalidSeal])
+
+        assert receiverHby.db.epse.get(keys=(exn.said,)) is not None
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, endorser.pre, "")))) == 1
+        assert len(receiverHby.db.ecigs.get(keys=(exn.said,))) == 2
+
+        senderIcp = sender.msgOwnEvent(sn=0, framed=True,
+                                       gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(senderIcp),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        exchanger.processEscrow()
+
+        assert receiverHby.db.exns.get(keys=(exn.said,)) is not None
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, sender.pre, "")))) == 1
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, endorser.pre, "")))) == 1
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, receiver.pre, ""))) == []
+
+        sourceSeals = receiverHby.db.ests.get(
+            keys=(exn.said, endorser.pre))
+        assert [(number.sn, diger.qb64)
+                for number, diger in sourceSeals] == [
+            (endorser.kever.sn, endorser.kever.serder.said),
+        ]
+        assert receiverHby.db.ests.get(
+            keys=(exn.said, receiver.pre)) == []
+        assert [(verfer.qb64, cigar.qb64)
+                for verfer, cigar in receiverHby.db.ecigs.get(
+                    keys=(exn.said,))] == [
+            (cigarEndorser.pre, validCigar[0].qb64),
+        ]
+
+        serialized = serializeMessage(receiverHby, exn.said, framed=True)
+        assert serialized is not None
+        parsed = Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(serialized), framed=True, processive=False)
+        replayGroups = {prefixer.qb64: (number, diger, sigers)
+                        for prefixer, number, diger, sigers
+                        in parsed[0].tsgs}
+        number, diger, sigers = replayGroups[endorser.pre]
+        assert (number.sn, diger.qb64, len(sigers)) == (
+            endorser.kever.lastEst.s,
+            endorser.kever.lastEst.d,
+            1,
+        )
+        assert [(prefixer.qb64, number.sn, diger.qb64)
+                for prefixer, number, diger in parsed[0].ssts] == [
+            (endorser.pre, endorser.kever.sn, endorser.kever.serder.said),
+        ]
+        assert [(cigar.verfer.qb64, cigar.qb64)
+                for cigar in parsed[0].cigars] == [
+            (cigarEndorser.pre, validCigar[0].qb64),
+        ]
+
+        historical = exchange(sender=sender.pre,
+                              route=EvidenceHandler.resource,
+                              attributes=dict(m="historical endorsement"),
+                              **kwa)
+        historicalEst = endorser.kever.lastEst
+        historicalSigs = endorser.sign(ser=historical.raw, indexed=True)
+        endorserRot = endorser.rotate(framed=True,
+                                     gvrsn=Vrsn_2_0,
+                                     **kwa)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserRot),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        exchanger.processEvent(
+            historical,
+            tsgs=[group(sender, sender.sign(ser=historical.raw,
+                                            indexed=True)),
+                  (endorser.kever.prefixer,
+                   Number(sn=historicalEst.s),
+                   Diger(qb64=historicalEst.d),
+                   historicalSigs)],
+        )
+        assert receiverHby.db.exns.get(keys=(historical.said,)) is not None
+        historicalRows = list(receiverHby.db.esigs.getTopItemIter(
+            keys=(historical.said, endorser.pre, "")))
+        assert len(historicalRows) == 1
+        assert historicalRows[0][0][2:] == (
+            f"{historicalEst.s:032x}",
+            historicalEst.d,
+        )
+        historicalReplay = Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(serializeMessage(receiverHby,
+                                           historical.said,
+                                           framed=True)),
+            framed=True,
+            processive=False,
+        )[0]
+        historicalGroups = {
+            prefixer.qb64: (number, diger, sigers)
+            for prefixer, number, diger, sigers in historicalReplay.tsgs
+        }
+        number, diger, sigers = historicalGroups[endorser.pre]
+        assert (number.sn, diger.qb64, len(sigers)) == (
+            historicalEst.s,
+            historicalEst.d,
+            1,
+        )
+
+        fallback = exchange(sender=sender.pre,
+                            route=EvidenceHandler.resource,
+                            attributes=dict(m="signature fallback"),
+                            **kwa)
+        fallbackSigs = endorser.sign(ser=fallback.raw, indexed=True)
+        exchanger.processEvent(
+            fallback,
+            tsgs=[group(sender, sender.sign(ser=fallback.raw,
+                                            indexed=True))],
+            lsgs=[(endorser.kever.prefixer, fallbackSigs)],
+            ssts=[validSeal],
+        )
+        fallbackRows = list(receiverHby.db.esigs.getTopItemIter(
+            keys=(fallback.said, endorser.pre, "")))
+        assert len(fallbackRows) == 1
+        assert fallbackRows[0][0][2:] == (
+            f"{endorser.kever.lastEst.s:032x}",
+            endorser.kever.lastEst.d,
+        )
+        assert receiverHby.db.ests.get(
+            keys=(fallback.said, endorser.pre)) == []
+
+
+def test_complete_redelivery_replaces_temporary_evidence(mockHelpingNowUTC):
+    """A complete redelivery cannot promote evidence from an older PSE row."""
+    kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
+
+    class EvidenceHandler:
+        resource = "/test/redelivery-evidence"
+
+        @staticmethod
+        def verify(serder, **kwa):
+            return True
+
+        @staticmethod
+        def verifyEvidence(serder, *, tsgs=None, cigars=None, sourceSeals=None,
+                           invalid=False):
+            return tsgs or [], cigars or [], sourceSeals or []
+
+        @staticmethod
+        def handle(serder, **kwa):
+            return None
+
+    with openHab(name="redelivery-sender", base="test",
+                 salt=b'0123456789abcdef', **kwa) as (_, sender), \
+            openHab(name="redelivery-endorser", base="test",
+                    salt=b'abcdef0123456789', **kwa) as (_, endorser), \
+            openHab(name="redelivery-cigar", base="test",
+                    salt=b'0123456789abcdeg', transferable=False,
+                    **kwa) as (_, cigarEndorser), \
+            openHab(name="redelivery-receiver", base="test",
+                    salt=b'fedcba9876543210', **kwa) as (receiverHby, _):
+        Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(endorser.msgOwnEvent(
+                sn=0, framed=True, gvrsn=Vrsn_2_0)),
+            kvy=receiverHby.kvy,
+            local=True,
+        )
+
+        exchanger = Exchanger(hby=receiverHby,
+                              handlers=[EvidenceHandler()])
+        exn = exchange(sender=sender.pre,
+                       route=EvidenceHandler.resource,
+                       attributes=dict(m="complete redelivery"),
+                       **kwa)
+
+        def group(hab):
+            return (hab.kever.prefixer,
+                    Number(sn=hab.kever.lastEst.s),
+                    Diger(qb64=hab.kever.lastEst.d),
+                    hab.sign(ser=exn.raw, indexed=True))
+
+        senderGroup = group(sender)
+        endorserGroup = group(endorser)
+        foreignCigars = cigarEndorser.sign(ser=exn.raw, indexed=False)
+        endorserAnchor = endorser.interact(
+            data=[dict(d=exn.said)], framed=True, gvrsn=Vrsn_2_0, **kwa)
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserAnchor),
+                                       kvy=receiverHby.kvy,
+                                       local=True)
+        foreignSeal = (endorser.kever.prefixer,
+                       Number(sn=endorser.kever.sn),
+                       Diger(qb64=endorser.kever.serder.said))
+
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(exn,
+                                   tsgs=[senderGroup, endorserGroup],
+                                   cigars=foreignCigars,
+                                   ssts=[foreignSeal])
+
+        assert receiverHby.db.epse.get(keys=(exn.said,)) is not None
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, endorser.pre, "")))) == 1
+        assert len(receiverHby.db.ecigs.get(keys=(exn.said,))) == 1
+        assert len(receiverHby.db.ests.get(
+            keys=(exn.said, endorser.pre))) == 1
+
+        Parser(version=Vrsn_2_0).parse(
+            ims=bytearray(sender.msgOwnEvent(
+                sn=0, framed=True, gvrsn=Vrsn_2_0)),
+            kvy=receiverHby.kvy,
+            local=True,
+        )
+        exchanger.processEvent(exn, tsgs=[senderGroup])
+
+        assert receiverHby.db.exns.get(keys=(exn.said,)) is not None
+        assert receiverHby.db.epse.get(keys=(exn.said,)) is None
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, sender.pre, "")))) == 1
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, endorser.pre, ""))) == []
+        assert receiverHby.db.ecigs.get(keys=(exn.said,)) == []
+        assert receiverHby.db.ests.get(
+            keys=(exn.said, endorser.pre)) == []
+        verify(receiverHby, exn)
+
+        before = serializeMessage(receiverHby, exn.said, framed=True)
+        receiverHby.db.epse.put(keys=(exn.said,), val=exn)
+        receiverHby.db.epsd.put(
+            keys=(exn.said,),
+            val=Dater(dts="2021-01-01T00:00:00.000000+00:00"),
+        )
+        exchanger.processEscrow()
+        assert receiverHby.db.epse.get(keys=(exn.said,)) is None
+        assert serializeMessage(receiverHby, exn.said, framed=True) == before
 
 
 def test_v2_multisig_incept_escrow_replay_then_rotation_anchors_in_kel(mockHelpingNowUTC):

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -817,7 +817,8 @@ def test_verify_fails_closed_on_invalid_stored_evidence(mockHelpingNowUTC):
             serializeMessage(receiverHby, exn.said, framed=True)
 
 
-def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC):
+@pytest.mark.parametrize("verificationError", [False, True])
+def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verificationError):
     """Exchanger escrow rows do not bypass evidence selection on replay."""
     kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
 
@@ -826,6 +827,8 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC):
 
         @staticmethod
         def verify(serder, **kwa):
+            if verificationError:
+                raise AttributeError("verifier failure")
             return True
 
         @staticmethod
@@ -912,6 +915,23 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC):
                                        kvy=receiverHby.kvy,
                                        local=True)
         exchanger.processEscrow()
+
+        if verificationError:
+            # A verifier error must not be treated as an absent verifier,
+            # either during escrow replay or on a fresh complete delivery.
+            with pytest.raises(AttributeError, match="verifier failure"):
+                exchanger.processEvent(exn, tsgs=[senderGroup, endorserGroup],
+                                       cigars=validCigar, ssts=[validSeal])
+            assert receiverHby.db.exns.get(keys=(exn.said,)) is None
+            assert receiverHby.db.epse.get(keys=(exn.said,)) is None
+            assert receiverHby.db.epsd.get(keys=(exn.said,)) is None
+            assert list(receiverHby.db.esigs.getTopItemIter(
+                keys=(exn.said, ""))) == []
+            assert receiverHby.db.ecigs.get(keys=(exn.said,)) == []
+            assert list(receiverHby.db.ests.getTopItemIter(
+                keys=(exn.said, ""))) == []
+            assert not any(cue.get("kin") == "saved" for cue in exchanger.cues)
+            return
 
         assert receiverHby.db.exns.get(keys=(exn.said,)) is not None
         assert len(list(receiverHby.db.esigs.getTopItemIter(

--- a/tests/peer/test_exchanging.py
+++ b/tests/peer/test_exchanging.py
@@ -12,7 +12,7 @@ from keri import Kinds, Vrsn_1_0, Vrsn_2_0
 from keri.kering import MissingSignatureError
 from keri.core import (Salter, Counter, Dater, Texter, Kevery, Kramer,
                        Diger, Prefixer, Number,
-                       SealSource, SerderKERI, Parser, messagize,
+                       SealEvent, SealSource, SerderKERI, Parser, messagize,
                        MtrDex, Codens, exchange)
 
 from keri.app import (Notifier, Counselor, Multiplexor,
@@ -665,9 +665,6 @@ def test_missing_foreign_key_state_requests_kel_before_persistence(
                     salt=b'fedcba9876543210', **kwa) as (receiverHby, _):
         senderIcp = sender.msgOwnEvent(sn=0, framed=True,
                                        gvrsn=Vrsn_2_0)
-        Parser(version=Vrsn_2_0).parse(ims=bytearray(senderIcp),
-                                       kvy=receiverHby.kvy,
-                                       local=True)
 
         exchanger = Exchanger(hby=receiverHby,
                               handlers=[EvidenceHandler()])
@@ -686,6 +683,21 @@ def test_missing_foreign_key_state_requests_kel_before_persistence(
         )
         senderGroup = group(sender, missingTsg)
         endorserGroup = group(endorser, missingTsg)
+
+        # Neither KEL is known. Do not lose the unresolved endorsement by
+        # putting only the sender's signatures in exchange escrow.
+        with pytest.raises(MissingSignatureError):
+            exchanger.processEvent(
+                missingTsg, tsgs=[senderGroup],
+                lsgs=[(endorser.kever.prefixer, endorserGroup[3])])
+        assert receiverHby.db.epse.get(keys=(missingTsg.said,)) is None
+        assert list(receiverHby.db.esigs.getTopItemIter(
+            keys=(missingTsg.said, ""))) == []
+        assert exchanger.cues.popleft() == dict(
+            kin="query", q=dict(r="logs", pre=endorser.pre))
+
+        Parser(version=Vrsn_2_0).parse(ims=bytearray(senderIcp),
+                                       kvy=receiverHby.kvy, local=True)
 
         with pytest.raises(MissingSignatureError):
             exchanger.processEvent(
@@ -818,7 +830,9 @@ def test_verify_fails_closed_on_invalid_stored_evidence(mockHelpingNowUTC):
 
 
 @pytest.mark.parametrize("verificationError", [False, True])
-def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verificationError):
+@pytest.mark.parametrize("lastEstGroup", [False, True])
+def test_escrow_replay_persists_only_verified_evidence(
+        mockHelpingNowUTC, verificationError, lastEstGroup):
     """Exchanger escrow rows do not bypass evidence selection on replay."""
     kwa = dict(version=Vrsn_2_0, kind=Kinds.json)
 
@@ -899,8 +913,10 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verifi
 
         with pytest.raises(MissingSignatureError):
             exchanger.processEvent(exn,
-                                   tsgs=[senderGroup, endorserGroup,
-                                         invalidGroup],
+                                   tsgs=[senderGroup, invalidGroup] +
+                                        ([] if lastEstGroup else [endorserGroup]),
+                                   lsgs=[(endorser.kever.prefixer, endorserGroup[3])]
+                                        if lastEstGroup else [],
                                    cigars=validCigar + invalidCigar,
                                    ssts=[validSeal, invalidSeal])
 
@@ -908,6 +924,11 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verifi
         assert len(list(receiverHby.db.esigs.getTopItemIter(
             keys=(exn.said, endorser.pre, "")))) == 1
         assert len(receiverHby.db.ecigs.get(keys=(exn.said,))) == 2
+
+        if lastEstGroup:
+            endorserRot = endorser.rotate(framed=True, gvrsn=Vrsn_2_0, **kwa)
+            Parser(version=Vrsn_2_0).parse(ims=bytearray(endorserRot),
+                                           kvy=receiverHby.kvy, local=True)
 
         senderIcp = sender.msgOwnEvent(sn=0, framed=True,
                                        gvrsn=Vrsn_2_0)
@@ -945,7 +966,7 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verifi
             keys=(exn.said, endorser.pre))
         assert [(number.sn, diger.qb64)
                 for number, diger in sourceSeals] == [
-            (endorser.kever.sn, endorser.kever.serder.said),
+            (validSeal[1].sn, validSeal[2].qb64),
         ]
         assert receiverHby.db.ests.get(
             keys=(exn.said, receiver.pre)) == []
@@ -964,13 +985,13 @@ def test_escrow_replay_persists_only_verified_evidence(mockHelpingNowUTC, verifi
                         in parsed[0].tsgs}
         number, diger, sigers = replayGroups[endorser.pre]
         assert (number.sn, diger.qb64, len(sigers)) == (
-            endorser.kever.lastEst.s,
-            endorser.kever.lastEst.d,
+            endorserGroup[1].sn,
+            endorserGroup[2].qb64,
             1,
         )
         assert [(prefixer.qb64, number.sn, diger.qb64)
                 for prefixer, number, diger in parsed[0].ssts] == [
-            (endorser.pre, endorser.kever.sn, endorser.kever.serder.said),
+            (endorser.pre, validSeal[1].sn, validSeal[2].qb64),
         ]
         assert [(cigar.verfer.qb64, cigar.qb64)
                 for cigar in parsed[0].cigars] == [
@@ -1141,6 +1162,24 @@ def test_complete_redelivery_replaces_temporary_evidence(mockHelpingNowUTC):
         verify(receiverHby, exn)
 
         before = serializeMessage(receiverHby, exn.said, framed=True)
+        # A rejected wire delivery must not change accepted evidence.
+        invalidSenderGroup = (*senderGroup[:3],
+                              sender.sign(ser=b"different message", indexed=True))
+        invalidSeal = (endorser.kever.prefixer, Number(sn=0), endorserGroup[2])
+        invalidCigars = cigarEndorser.sign(ser=b"different message", indexed=False)
+        replay = messagize(exn, tsgs=[invalidSenderGroup],
+                            cigars=invalidCigars, bonds=[SealEvent(*invalidSeal)],
+                            framed=True, gvrsn=Vrsn_2_0)
+        Parser(version=Vrsn_2_0).parse(ims=replay, kvy=receiverHby.kvy,
+                                       exc=exchanger)
+        assert receiverHby.db.epse.get(keys=(exn.said,)) is None
+        assert serializeMessage(receiverHby, exn.said, framed=True) == before
+        assert len(list(receiverHby.db.esigs.getTopItemIter(
+            keys=(exn.said, "")))) == 1
+        assert receiverHby.db.ecigs.get(keys=(exn.said,)) == []
+        assert list(receiverHby.db.ests.getTopItemIter(
+            keys=(exn.said, ""))) == []
+
         receiverHby.db.epse.put(keys=(exn.said,), val=exn)
         receiverHby.db.epsd.put(
             keys=(exn.said,),


### PR DESCRIPTION
This PR adds durable stores for IPEX messages and endorsements.

After KRAM deletes its temporary records, the receiver cannot find all the evidence it accepted with a grant.

This change:

- stores sender and endorser signatures by message and signer
- stores source seal references by message and signer
- keeps nested attachments after KRAM deletes its temporary records
- rebuilds and checks stored messages after restart
- tests partial signatures, repeat delivery, key rotation, cleanup, and restart

Added improvements after meeting discussion:

- check all attached evidence before saving the message
- check sender authentication separately from nested grant attachments
- verify non-sender endorsements against each endorser's AID and KEL
- drop the message and request the required KEL event when key state is missing
- remove temporary signatures and attachments after forwarding the message
- keep the KRAM replay record so the same SAID cannot be processed again
- require retries to use a new datetime, SAID, signatures, and attachments
- remove stale partial signatures when the sender rotates
- update the KRAM store documentation to describe its cleanup behavior
- test missing KEL recovery, replay prevention, rotation, and evidence persistence
