### PR TITLE
Pin gleif_hio 0.6.20rc3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
                         'cbor2>=5.6.2',
                         'multidict>=6.0.5',
                         'ordered-set>=4.1.0',
-                        'gleif_hio==0.6.20rc2',
+                        'gleif_hio==0.6.20rc3',
                         'multicommand==1.0.0',
                         'jsonschema>=4.21.1',
                         'falcon>=3.1.3',

--- a/src/keri/app/directing.py
+++ b/src/keri/app/directing.py
@@ -6,6 +6,7 @@ keri.app.directing module
 simple direct mode demo support classes
 """
 import itertools
+from hio import hioing
 from hio.base import doing
 
 from .. import help, kering
@@ -704,7 +705,14 @@ class Reactant(doing.DoDoer):
             msg: Bytes to queue on the connection.
             label: Optional description included in the log entry.
         """
-        self.remoter.tx(msg)  # send to remote
+        try:
+            self.remoter.tx(msg)  # send to remote
+        except hioing.TransmitClosedError as ex:
+            error = self.remoter.error if self.remoter.error is not None else ex
+            logger.error("Server %s could not queue %s after transmit cutoff; "
+                         "rejected=%d: %s",
+                         self.hab.name, label, len(msg), error)
+            return
         logger.info("Server %s: sent %s:\n%d\n\n", self.hab.name,
                     label, len(msg))
 

--- a/tests/app/test_directing.py
+++ b/tests/app/test_directing.py
@@ -473,9 +473,11 @@ def test_directant_tx_cutoff_accounts_for_unsent_response(
         )
 
         assert alice.pre in bob.kevers  # Final receive must still process the request.
-        assert remoter.txbs  # Receipt remains queued because send is terminal.
+        assert not remoter.txbs  # HIO rejects output once send is terminal.
+        assert remoter.error is not None
         assert any("after transmit cutoff" in error for error in errors)  # expose terminal reason
-        assert any(f"txbs={len(remoter.txbs)}" in error for error in errors)  # account for unsent bytes
+        assert any("rejected=" in error and "rejected=0" not in error
+                   for error in errors), errors  # account for rejected bytes
         assert ca not in directant.rants
     finally:
         doist.exit()
@@ -522,7 +524,7 @@ def test_directant_response_drain_stops_at_absolute_deadline(
         # Second recurrence advances output and refreshes only HIO's timer.
         doist.recur()
         assert directant.drainStops[ca] == drainStop  # Partial sends cannot extend drain.
-        assert remoter.tymer.remaining > transportRemaining  # HIO timer did refresh.
+        assert remoter.tymer.remaining == transportRemaining  # Restarted from current time.
 
         recurUntil(
             doist,


### PR DESCRIPTION
## Summary

- pin the published `gleif_hio` 0.6.20rc3 release candidate
- contain the `TransmitClosedError` exposed by the production witness `Reactant` cutoff path and log the rejected response byte count locally after rc3 leaves `txbs` empty
- update the existing `Directant` timer assertion for restart from current time

## Boundaries

This includes only the dependency bump and compatibility changes required by the two production-relevant `Directant` regressions. It does not add connection-level pending state; change the demo-only `Director` or `Reactor`, the currently unowned `Indirector`, or regular Messenger outcomes; add retries; bump the KERIpy package version; or change unrelated lifecycle behavior.

The existing `tests/demo/test_demo.py::test_run_bob_eve_demo` remains red under rc3 because its demo-only `Reactor` sends after the client transmit side has closed; that behavior is deliberately outside this PR.

Fixes #1645