### PR TITLE
fix: read witness AIDs from config mapping

### DIFF
--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -121,7 +121,7 @@ def runWitness(name="witness", base="", alias="witness", bran="", tcp=5631, http
     if configFile is not None:
         cf = configing.Configer(name=configFile, headDirPath=configDir, temp=False, reopen=True, clear=False)
 
-    aids = cf.get("aids", default=None) if cf is not None else None
+    aids = cf.get().get("aids") if cf is not None else None
 
     hby = None
     try:

--- a/tests/app/cli/test_kli_commands.py
+++ b/tests/app/cli/test_kli_commands.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import socket
 
 import multicommand
 import pytest
@@ -11,7 +12,7 @@ from keri.kering import ValidationError, AuthError
 from keri import core, help
 from keri.core import coring
 
-from keri.app import directing, habbing
+from keri.app import configing, directing, habbing
 
 from keri.app.cli import commands
 from keri.app.cli.common import existing
@@ -348,6 +349,40 @@ def test_launch_normalizes_loglevel(monkeypatch):
     args.handler(args)  # -> launch(args)
 
     assert help.ogler.level == logging.DEBUG
+
+
+def test_run_witness_reads_configured_aids(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    aids = ["BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha"]
+    cf = configing.Configer(name="witness", headDirPath=str(tmp_path), temp=False)
+    cf.put(dict(aids=aids))
+    cf.close()
+
+    spy_aids = {}
+    setup_witness = witness_start.indirecting.setupWitness
+
+    # Wrap setupWitness to spy on the "aids" val it configures"
+    def spy_setupWitness(**kwa):
+        doers = setup_witness(**kwa)
+        receiptEnd = next(doer for doer in doers
+                          if isinstance(doer, witness_start.indirecting.ReceiptEnd))
+        spy_aids["aids"] = receiptEnd.aids
+        return doers
+
+    # inject spy
+    monkeypatch.setattr(witness_start.indirecting, "setupWitness", spy_setupWitness)
+
+    with socket.socket() as tcpServer, socket.socket() as httpServer:
+        tcpServer.bind(("", 0))
+        httpServer.bind(("", 0))
+        tcp = tcpServer.getsockname()[1]
+        http = httpServer.getsockname()[1]
+
+    witness_start.runWitness(name="witness-aids", alias="wit", tcp=tcp, http=http,
+                             expire=0.125, configDir=str(tmp_path), configFile="witness")
+
+    assert spy_aids["aids"] == aids
 
 
 def test_run_failure_is_logged_and_hby_closed(helpers, monkeypatch):


### PR DESCRIPTION
## Summary

- read the complete mapping returned by `Configer.get()` before selecting optional `aids`
- forward configured witness restrictions to `setupWitness()`
- exercise happy-path `runWitness()` with actual KERI stores, witness endpoints, servers, controller, and scheduler, then inspect the real `ReceiptEnd`
- allocate distinct unprivileged HTTP and TCP ports so the real-server test is portable to Linux CI

## Tests

- focused: `1 passed in 1.95s`
- complete `tests/app/cli/test_kli_commands.py`: `11 passed in 10.74s`
- `git diff --check`: passed