### PR TITLE
fix: resolve WitnessPublisher lifecycle bugs (#1652)

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -653,9 +653,9 @@ class WitnessPublisher(doing.DoDoer):
             cues (Deck): completed request cues.
         """
         self.hby = hby
-        self.posted = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.cues = cues if cues is not None else decking.Deck()
+        self.witers = []
         super(WitnessPublisher, self).__init__(
             doers=[doing.doify(self.sendDo,
                                tock=hby.tocks["witnessPublisher"])], **kwa)
@@ -671,7 +671,6 @@ class WitnessPublisher(doing.DoDoer):
         while True:
             while self.msgs:
                 evt = self.msgs.popleft()
-                self.posted += 1
                 pre = evt["pre"]
                 msg = evt["msg"]
 
@@ -681,21 +680,22 @@ class WitnessPublisher(doing.DoDoer):
                 hab = self.hby.habs[pre]
                 wits = hab.kever.wits
 
-                witers = []
                 for wit in wits:
                     witer = messenger(hab, wit)
-                    witers.append(witer)
+                    self.witers.append(witer)
                     witer.msgs.append(bytearray(msg))  # make a copy so everyone munges their own
                     self.extend([witer])
 
                     _ = (yield tock)
 
-                while witers:
-                    witer = witers.pop()
+                while self.witers:
+                    witer = self.witers[0]
                     while not witer.idle:
                         _ = (yield tock)
 
-                self.remove(witers)
+                    self.remove([witer])
+                    self.witers.remove(witer)
+
                 self.cues.push(evt)
 
                 yield tock
@@ -717,7 +717,7 @@ class WitnessPublisher(doing.DoDoer):
 
     @property
     def idle(self):
-        return len(self.msgs) == 0 and self.posted == len(self.cues)
+        return not self.msgs and not self.witers
 
 
 class TCPMessenger(doing.DoDoer):

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -97,6 +97,60 @@ def test_receiptor_tocks_are_generator_local():
         query.close()
 
 
+def test_witness_publisher_idle_tracks_queued_and_active_work(monkeypatch):
+    with habbing.openHby(name="publisher-lifecycle", temp=True) as hby:
+        wit = hby.makeHab(name="witness", transferable=False)
+        hab = hby.makeHab(name="controller", transferable=True,
+                          wits=[wit.pre])
+
+        # Replace the HTTP/TCP transport so this test isolates the publisher's
+        # child-Doer lifecycle management.
+        class FakeMessenger(doing.Doer):
+            def __init__(self, wit):
+                super().__init__()
+                self.wit = wit
+                self.msgs = []
+
+            @property
+            def idle(self):
+                return not self.msgs
+
+        messenger = FakeMessenger(wit.pre)
+        monkeypatch.setattr(agenting, "messenger",
+                            lambda hab, wit: messenger)
+
+        publisher = agenting.WitnessPublisher(hby=hby)
+        evt = dict(pre=hab.pre, said=hab.pre,
+                   msg=hab.makeOwnInception())
+        publisher.msgs.append(evt)
+
+        # The queued event is pending work before a messenger is scheduled.
+        assert not publisher.idle
+
+        doist = doing.Doist(tock=0.03125, limit=1.0,
+                            doers=[publisher])
+        doist.enter()
+        try:
+            # The first recurrence transfers the event to an active child.
+            doist.recur()
+            assert messenger in publisher.witers
+            assert not publisher.idle
+
+            # Simulate transport drain so the next recurrence removes the child.
+            messenger.msgs.clear()
+            doist.recur()
+
+            assert publisher.idle
+            assert list(publisher.cues) == [evt]
+            assert messenger not in publisher.doers
+
+            # Completion cues are consumable output, not lifecycle state.
+            publisher.cues.popleft()
+            assert publisher.idle
+        finally:
+            doist.exit()
+
+
 def test_witness_receiptor(seeder):
     with habbing.openHby(name="wan", salt=core.Salter(raw=b'wann-the-witness').qb64) as wanHby, \
             habbing.openHby(name="wil", salt=core.Salter(raw=b'will-the-witness').qb64) as wilHby, \


### PR DESCRIPTION
## Summary

- Track queued work and active witness messenger children directly.
- Remove and close each completed messenger before reporting the publisher idle.
- Cover queued, active, completed, and consumed-cue states with a regression test.

Fixes #1652.

## Rationale

The previous `idle` check compared the monotonic `posted` count with the current length of `cues`. That was not reliable lifecycle state: completion cues are consumable, so removing a cue could make an inactive publisher appear permanently busy; `posted` was incremented immediately after dequeue, before habitat validation, so a skipped request could be counted without ever producing a cue; and the local messenger list was emptied before `remove()` received it, leaving completed child doers scheduled even when the counters reported idle.

This change makes the lifecycle explicit. `msgs` represents work waiting to start, `witers` represents messenger children still owned by the publisher, and `cues` remains only a completion-notification channel. The publisher is idle only when both queued and active work are absent, independent of whether completion cues have been consumed.

This is local lifecycle accounting: completion still means each child messenger reached its own idle boundary, not that a remote witness durably stored or processed the message.

## Related Issues

The following issues may be affected, but this PR does not completely resolve or close them:

- [WebOfTrust/keripy#1501](https://github.com/WebOfTrust/keripy/issues/1501): directly related. This PR decouples `WitnessPublisher.idle` from cue retention and removes completed messenger children, but it does not bound or drain `WitnessPublisher.cues` or `Receiptor.cues`.
- [WebOfTrust/keripy#1504](https://github.com/WebOfTrust/keripy/issues/1504): removing leaked children reduces unnecessary scheduled doers, but this PR does not add idle backoff.
- [WebOfTrust/keripy#814](https://github.com/WebOfTrust/keripy/issues/814): active messenger state is now represented accurately, but this PR adds no witness timeout, retry, or failure semantics.
- [WebOfTrust/keria#450](https://github.com/WebOfTrust/keria/issues/450): cleanup may reduce CPU and memory accumulation during repeated issuance and revocation, but no KERIA long-run test establishes how much of that issue it explains.
- [WebOfTrust/keria#232](https://github.com/WebOfTrust/keria/issues/232): cleanup may reduce idle scheduling caused by retained messenger children, while the documented tock, escrow, and logging contributors remain outside this PR.
- [WebOfTrust/keria#433](https://github.com/WebOfTrust/keria/issues/433): this PR improves in-memory lifecycle ownership but does not add durable queues, restart recovery, or replay.
- [WebOfTrust/keria#200](https://github.com/WebOfTrust/keria/issues/200): this PR changes local publisher idleness only; it does not change long-running operation dependency or witness-receipt completion semantics.

## Testing

- `tests/app/test_agenting.py`: 6 passed