### PR TITLE
Fix #1654: Admit TCP stream payloads

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -1075,6 +1075,7 @@ def streamMessengerFrom(hab, pre, urls, msg, headers=None):
     elif kering.Schemes.tcp in urls:
         url = urls[kering.Schemes.tcp]
         witer = TCPStreamMessenger(hab=hab, wit=pre, url=url)
+        witer.msgs.append(bytearray(msg))
     else:
         raise kering.ConfigurationError(f"unable to find a valid endpoint for witness {pre}")
 

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -66,29 +66,17 @@ def test_http_messengers_read_state_after_client_service():
             doist.exit()
 
 
-def test_stream_messenger_from_admits_tcp_payload(monkeypatch):
-    class FakeTCPStreamMessenger:
-        def __init__(self, *, hab, wit, url):
-            self.hab = hab
-            self.wit = wit
-            self.url = url
-            self.msgs = []
+def test_stream_messenger_from_admits_tcp_payload():
+    with habbing.openHab(name="tcp-stream-payload", temp=True) as (_, hab):
+        msg = hab.makeOwnInception()
+        messenger = agenting.streamMessengerFrom(
+            hab=hab,
+            pre=hab.pre,
+            urls={kering.Schemes.tcp: "tcp://127.0.0.1:5631"},
+            msg=msg,
+        )
 
-    monkeypatch.setattr(agenting, "TCPStreamMessenger",
-                        FakeTCPStreamMessenger)
-
-    payload = b"tcp stream payload"
-    messenger = agenting.streamMessengerFrom(
-        hab="hab",
-        pre="witness",
-        urls={kering.Schemes.tcp: "tcp://127.0.0.1:5631"},
-        msg=payload,
-    )
-
-    assert messenger.hab == "hab"
-    assert messenger.wit == "witness"
-    assert messenger.url == "tcp://127.0.0.1:5631"
-    assert messenger.msgs == [bytearray(payload)]
+        assert list(messenger.msgs) == [bytearray(msg)]
 
 
 def test_receiptor_tocks_are_generator_local():

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -66,6 +66,31 @@ def test_http_messengers_read_state_after_client_service():
             doist.exit()
 
 
+def test_stream_messenger_from_admits_tcp_payload(monkeypatch):
+    class FakeTCPStreamMessenger:
+        def __init__(self, *, hab, wit, url):
+            self.hab = hab
+            self.wit = wit
+            self.url = url
+            self.msgs = []
+
+    monkeypatch.setattr(agenting, "TCPStreamMessenger",
+                        FakeTCPStreamMessenger)
+
+    payload = b"tcp stream payload"
+    messenger = agenting.streamMessengerFrom(
+        hab="hab",
+        pre="witness",
+        urls={kering.Schemes.tcp: "tcp://127.0.0.1:5631"},
+        msg=payload,
+    )
+
+    assert messenger.hab == "hab"
+    assert messenger.wit == "witness"
+    assert messenger.url == "tcp://127.0.0.1:5631"
+    assert messenger.msgs == [bytearray(payload)]
+
+
 def test_receiptor_tocks_are_generator_local():
     with habbing.openHby(name="receiptor-generator-tocks", temp=True) as hby:
         receiptor = agenting.Receiptor(hby=hby)


### PR DESCRIPTION
Fixes #1654.

## Summary

- enqueue the supplied payload when `streamMessengerFrom` selects TCP
- add a regression test that forces the TCP-only branch and verifies queue admission

## Rationale

`streamMessengerFrom` accepts the message to transmit, and its HTTP branch passes that message directly to `HTTPStreamMessenger`. The TCP branch instead created a `TCPStreamMessenger` with an empty queue and discarded the supplied message. Because an empty queue is valid constructor state, this raised no error: the send loop simply waited for work and transmitted nothing.

Existing coverage did not expose the defect. HTTP and HTTPS take precedence whenever either endpoint is advertised, KERIA agents advertise HTTP endpoints, and witness configurations commonly advertise HTTP alongside TCP. Other TCP tests exercise `messengerFrom`, whose callers enqueue messages separately, rather than this stream factory.

## Testing

- `tests/app/test_agenting.py::test_stream_messenger_from_admits_tcp_payload`
- `git diff --check`
