### PR TITLE
Avoid scheduling messengers for completed receipts

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -410,6 +410,14 @@ class WitnessReceiptor(doing.DoDoer):
 
                 dgkey = dbing.dgKey(ser.preb, ser.saidb)
 
+                # Check before scheduling messenger children so a completed
+                # request does not leak no-work doers on resubmission.
+                wigs = hab.db.getWigs(dgkey)
+                completed = len(wigs) == len(wits)
+                if completed and not self.force:
+                    self.cues.push(evt)
+                    continue
+
                 witers = []
                 for wit in wits:
                     auth = self.auths[wit] if wit in self.auths else None
@@ -417,10 +425,7 @@ class WitnessReceiptor(doing.DoDoer):
                     witers.append(witer)
                     self.extend([witer])
 
-                # Check to see if we already have all the receipts we need for this event
-                wigs = hab.db.getWigs(dgkey)
-                completed = len(wigs) == len(wits)
-                if len(wigs) != len(wits):  # We have all the receipts, skip
+                if len(wigs) != len(wits):  # Send only when receipts are incomplete
                     for idx, witer in enumerate(witers):
                         wit = wits[idx]
 
@@ -440,11 +445,6 @@ class WitnessReceiptor(doing.DoDoer):
                         if len(wigs) == len(wits):
                             break
                         _ = yield tock
-
-                # If we started with all our receipts, exit unless told to force resubmit of all receipts
-                if completed and not self.force:
-                    self.cues.push(evt)
-                    continue
 
                 # generate all rct msgs to send to all witnesses
                 awigers = [indexing.Siger(qb64b=bytes(wig)) for wig in wigs]


### PR DESCRIPTION
## Summary

- check stored witness receipts before constructing or scheduling Messenger children
- immediately emit the existing completion cue for an already-complete non-forced request
- preserve forced resubmission and zero-witness behavior

## Boundary

This changes only the no-work fast path. It does not change transport completion, error, timeout, retry, or witness-threshold semantics.

## Related issues

This is in the same resource-lifecycle defect family as #1652 and #1501, and removes one source of unnecessary scheduled polling work relevant to #1504.

WebOfTrust/keria#450 and WebOfTrust/keria#232 report broader downstream CPU and memory symptoms. This change can remove a contributing source only when an already-complete, non-forced witness-receipt request is queued again; it does not establish or claim resolution of either KERIA issue.
