### PR TITLE
Fix messenger idle accounting

### DIFF
--- a/src/keri/app/agenting.py
+++ b/src/keri/app/agenting.py
@@ -721,7 +721,11 @@ class WitnessPublisher(doing.DoDoer):
 
 
 class TCPMessenger(doing.DoDoer):
-    """Send outbound CESR messages to a witness via TCP and parse inbound receipts."""
+    """Send outbound CESR messages to a witness via TCP and parse inbound receipts.
+
+    ``sent`` is a consumable notification queue, so lifecycle accounting is
+    kept separately in ``msgs`` and ``messageInProgress``.
+    """
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, **kwa):
         """Initialize TCP messenger with queues and parser wiring.
@@ -736,7 +740,7 @@ class TCPMessenger(doing.DoDoer):
         self.hab = hab
         self.wit = wit
         self.url = url
-        self.posted = 0
+        self.messageInProgress = False
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = sent if sent is not None else decking.Deck()
         self.parser = None
@@ -770,7 +774,7 @@ class TCPMessenger(doing.DoDoer):
                 yield tock
 
             msg = self.msgs.popleft()
-            self.posted += 1
+            self.messageInProgress = True
 
             client.tx(msg)  # send to connected remote
 
@@ -778,6 +782,7 @@ class TCPMessenger(doing.DoDoer):
                 yield tock
 
             self.sent.append(msg)
+            self.messageInProgress = False
             yield tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
@@ -792,11 +797,17 @@ class TCPMessenger(doing.DoDoer):
 
     @property
     def idle(self):
-        return len(self.sent) == self.posted
+        return not self.msgs and not self.messageInProgress
 
 
 class TCPStreamMessenger(doing.DoDoer):
-    """Stream a CESR message to a witness via TCP and parse inbound receipts."""
+    """Stream a CESR message to a witness via TCP and parse inbound receipts.
+
+    ``sent`` is a consumable notification queue, so lifecycle accounting is
+    kept separately in ``msgs`` and ``messageInProgress``. This messenger
+    remains recurrent after a successful send; terminal stream lifecycle is a
+    separate transport concern.
+    """
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, **kwa):
         """Initialize TCP stream messenger with queues and parser wiring.
@@ -811,7 +822,7 @@ class TCPStreamMessenger(doing.DoDoer):
         self.hab = hab
         self.wit = wit
         self.url = url
-        self.posted = 0
+        self.messageInProgress = False
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = sent if sent is not None else decking.Deck()
         self.parser = None
@@ -848,7 +859,7 @@ class TCPStreamMessenger(doing.DoDoer):
                 yield tock
 
             msg = self.msgs.popleft()
-            self.posted += 1
+            self.messageInProgress = True
 
             client.tx(msg)  # send to connected remote
 
@@ -856,6 +867,7 @@ class TCPStreamMessenger(doing.DoDoer):
                 yield tock
 
             self.sent.append(msg)
+            self.messageInProgress = False
             yield tock
 
     def msgDo(self, tymth=None, tock=0.0, **opts):
@@ -870,11 +882,15 @@ class TCPStreamMessenger(doing.DoDoer):
 
     @property
     def idle(self):
-        return len(self.sent) == self.posted
+        return not self.msgs and not self.messageInProgress
 
 
 class HTTPMessenger(doing.DoDoer):
-    """Send CESR messages to a witness over HTTP and capture responses."""
+    """Send CESR messages to a witness over HTTP and capture responses.
+
+    ``sent`` is a consumable response-notification queue, so outstanding
+    requests are tracked separately in ``pending``.
+    """
 
     def __init__(self, hab, wit, url, msgs=None, sent=None, doers=None, auth=None, **kwa):
         """Initialize HTTP messenger with queues and optional auth.
@@ -889,7 +905,7 @@ class HTTPMessenger(doing.DoDoer):
         """
         self.hab = hab
         self.wit = wit
-        self.posted = 0
+        self.pending = 0
         self.msgs = msgs if msgs is not None else decking.Deck()
         self.sent = sent if sent is not None else decking.Deck()
         self.parser = None
@@ -924,7 +940,7 @@ class HTTPMessenger(doing.DoDoer):
             if self.auth is not None:
                 headers["Authorization"] = self.auth
 
-            self.posted += httping.streamCESRRequests(client=self.client, dest=self.wit, ims=msg, headers=headers)
+            self.pending += httping.streamCESRRequests(client=self.client, dest=self.wit, ims=msg, headers=headers)
             while self.client.requests:
                 yield tock
 
@@ -939,12 +955,13 @@ class HTTPMessenger(doing.DoDoer):
             while self.client.responses:
                 rep = self.client.respond()
                 self.sent.append(rep)
+                self.pending -= 1
                 yield
             yield
 
     @property
     def idle(self):
-        return len(self.msgs) == 0 and self.posted == len(self.sent)
+        return not self.msgs and self.pending == 0
 
 
 class HTTPStreamMessenger(doing.DoDoer):

--- a/tests/app/test_agenting.py
+++ b/tests/app/test_agenting.py
@@ -5,8 +5,12 @@ tests.app.agenting module
 """
 import time
 
+import falcon
+import pytest
+
 from hio.base import doing, tyming
 from hio.core import http
+from hio.core.tcp import serving
 
 from keri import kering, core
 from keri.core import coring, serdering
@@ -77,6 +81,112 @@ def test_stream_messenger_from_admits_tcp_payload():
         )
 
         assert list(messenger.msgs) == [bytearray(msg)]
+
+
+@pytest.mark.parametrize("klas", [agenting.TCPMessenger,
+                                  agenting.TCPStreamMessenger])
+def test_tcp_messenger_accounts_for_real_delivery(klas):
+    with habbing.openHby(name="sender", temp=True) as senderHby, \
+            habbing.openHby(name="receiver", temp=True) as receiverHby:
+        senderHab = senderHby.makeHab(name="sender")
+        receiverHab = receiverHby.makeHab(name="receiver",
+                                          transferable=False)
+
+        server = serving.Server(host="127.0.0.1", port=0)
+        assert server.reopen()
+        server.eha = server.ha
+        messenger = klas(hab=senderHab,
+                         wit=receiverHab.pre,
+                         url=f"tcp://127.0.0.1:{server.ha[1]}")
+        msg = bytearray(senderHab.makeOwnEvent(sn=0))
+
+        # Queuing work must make the messenger non-idle before scheduling starts.
+        assert messenger.idle
+        messenger.msgs.append(msg)
+        assert not messenger.idle
+
+        doist = doing.Doist(tock=0.01,
+                            limit=1.0,
+                            doers=[serving.ServerDoer(server=server),
+                                   directing.Directant(hab=receiverHab,
+                                                       server=server),
+                                   messenger])
+        doist.enter()
+        try:
+            deadline = doist.tyme + doist.limit
+
+            # Advance until the message leaves the queue but is still being sent.
+            while (not messenger.messageInProgress and
+                   doist.tyme < deadline):
+                doist.recur()
+                time.sleep(doist.tock)
+
+            assert messenger.messageInProgress
+            assert not messenger.idle
+
+            # Continue through local transmission and parsing by the receiver.
+            while ((not messenger.idle or
+                    senderHab.pre not in receiverHby.kevers) and
+                   doist.tyme < deadline):
+                doist.recur()
+                time.sleep(doist.tock)
+
+            assert senderHab.pre in receiverHby.kevers
+
+            # Consuming the completion cue must not make completed work non-idle.
+            assert messenger.sent.popleft() == msg
+            assert messenger.idle
+        finally:
+            doist.exit()
+
+
+def test_http_messenger_accounts_for_real_delivery():
+    with habbing.openHby(name="http-sender", temp=True) as senderHby, \
+            habbing.openHby(name="http-receiver", temp=True) as receiverHby:
+        senderHab = senderHby.makeHab(name="sender")
+        receiverHab = receiverHby.makeHab(name="receiver",
+                                          transferable=False)
+        endpoint = indirecting.HttpEnd(rxbs=receiverHab.psr.ims)
+        app = falcon.App()
+        app.add_route("/", endpoint)
+        servant = serving.Server(host="127.0.0.1", port=0)
+        server = http.Server(app=app, servant=servant)
+        assert server.reopen()
+        servant.eha = servant.ha
+
+        messenger = agenting.HTTPMessenger(
+            hab=senderHab,
+            wit=receiverHab.pre,
+            url=f"http://127.0.0.1:{servant.ha[1]}",
+        )
+        msg = bytearray(senderHab.makeOwnEvent(sn=0))
+
+        # The queued inception keeps the messenger active until its response arrives.
+        messenger.msgs.append(bytearray(msg))
+        assert not messenger.idle
+
+        doist = doing.Doist(tock=0.01,
+                            limit=1.0,
+                            doers=[http.ServerDoer(server=server), messenger])
+        doist.enter()
+        try:
+            deadline = doist.tyme + doist.limit
+
+            # Drive the real HTTP exchange until the pending response is accounted for.
+            while (not messenger.idle and doist.tyme < deadline):
+                doist.recur()
+                time.sleep(doist.tock)
+
+            # Verify transport success and application-layer delivery to the receiver.
+            response = messenger.sent.popleft()
+            assert response.status == 204
+            receiverHab.psr.parse()
+            assert senderHab.pre in receiverHby.kevers
+
+            # Removing the response cue does not erase completed lifecycle state.
+            assert messenger.idle
+        finally:
+            doist.exit()
 
 
 def test_receiptor_tocks_are_generator_local():


### PR DESCRIPTION
Fixes #1656.

## Summary
- Track queued and in-progress TCP work directly instead of comparing a cumulative counter with `sent`.
- Track outstanding HTTP responses with `pending`.
- Verify both TCP variants and HTTP behavior using real ephemeral endpoints, independent habitats, and real KERI messages.

## Rationale
`sent` is a consumable notification queue, not lifecycle state. The old accounting could report queued TCP work as idle, allowing premature messenger removal, and could report completed TCP or HTTP work as active after a caller consumed its cue.

## Validation
- `tests/app/test_agenting.py`: 10 passed
- `tests/app/test_forwarding.py`: 4 passed

## Scope
This is application-level accounting for v1.2.14. EOF/connection lifecycle, TLS, and timeout changes remain out of scope.
