### PR TITLE
KRAM: decide tsg currency against last establishment event, not last event

### DIFF
--- a/src/keri/core/kraming.py
+++ b/src/keri/core/kraming.py
@@ -455,8 +455,8 @@ class Kramer:
                 exist (``kramit`` ensures this before calling).
         """
         tsgs = kwa.get('tsgs', [])
-        cur_sn = kever.sner.num
-        cur_said = kever.serder.said
+        cur_sn = kever.lastEst.s
+        cur_said = kever.lastEst.d
         for prefixer, number, sdiger, sigers in tsgs:
             if prefixer.qb64 != senderId:
                 continue
@@ -552,8 +552,8 @@ class Kramer:
         if not tsgs:
             return stale_tsgs
 
-        cur_sn = kever.sner.num
-        cur_said = kever.serder.said
+        cur_sn = kever.lastEst.s
+        cur_said = kever.lastEst.d
         new_tsgs = []
         for quad in tsgs:
             prefixer, number, sdiger, sigers = quad
@@ -608,8 +608,8 @@ class Kramer:
             if not kwa['lsgs']:
                 kwa.pop('lsgs', None)
 
-        curSn = kever.sner.num
-        curSaid = kever.serder.said
+        curSn = kever.lastEst.s
+        curSaid = kever.lastEst.d
         if kwa.get('tsgs'):
             newTsgs = []
             for quad in kwa['tsgs']:
@@ -694,8 +694,8 @@ class Kramer:
         for prefixer, number, sdiger, sigers in kwa.get('tsgs', []):
             if prefixer.qb64 != senderId:
                 continue
-            if (number.sn != kever.sner.num or
-                    sdiger.qb64 != kever.serder.said):
+            if (number.sn != kever.lastEst.s or
+                    sdiger.qb64 != kever.lastEst.d):
                 continue
             for siger in sigers:
                 pool.add(siger.qb64)

--- a/tests/core/test_kraming.py
+++ b/tests/core/test_kraming.py
@@ -5766,3 +5766,92 @@ def test_invalid_signature_attachments_rejected(mockHelpingNowUTC):
             assert receiverHby.db.kramPMKM.get(keys=partialKey) is None
             assert receiverHby.db.kramPMKS.get(keys=partialKey) == []
             assert receiverHby.db.kramPMSK.get(keys=partialKey) is None
+
+
+def test_tsgs_current_when_latest_event_is_non_establishment(mockHelpingNowUTC):
+    """A tsg is current when it names the last establishment event, not the last event.
+
+    A TransIdxSigGroup references the establishment event that established the signing
+    keys, so currency is decided against ``kever.lastEst``. Both auth paths are here
+    because all four currency comparisons share that reference: assk accepts a
+    single-key sender whose latest event is an ixn, and asmk accumulates a multi-key
+    sender to threshold across two deliveries.
+    """
+    salt1 = Salter(raw=b'0123456789abcdej').qb64
+    salt2 = Salter(raw=b'0123456789abcdek').qb64
+    salt3 = Salter(raw=b'0123456789abcdel').qb64
+
+    with (openHby(name="ixnSender", base="test", salt=salt1) as senderHby,
+          openHby(name="ixnMulti", base="test", salt=salt2) as multiHby,
+          openHby(name="ixnReceiver", base="test", salt=salt3) as receiverHby):
+
+        senderHab = senderHby.makeHab(name="ixnSender", isith='1', icount=1,
+                                      transferable=True, version=V2, kind=Kinds.cesr)
+        multiHab = multiHby.makeHab(name="ixnMulti", isith='2', icount=3,
+                                    transferable=True, version=V2, kind=Kinds.cesr)
+        receiverHby.makeHab(name="ixnReceiver", isith='1', icount=1,
+                            transferable=True, version=V2, kind=Kinds.cesr)
+
+        crossKvy = Kevery(db=receiverHby.db, lax=False, local=False)
+
+        for hab in (senderHab, multiHab):
+            Parser(version=V2).parse(ims=bytearray(hab.msgOwnEvent(sn=0, framed=True,
+                                                                   gvrsn=V2)),
+                                     kvy=crossKvy)
+            assert hab.pre in crossKvy.kevers
+            # Anchor something, exactly as an issuer does. The KEL advances; the keys
+            # do not, so lastEst still names the inception.
+            Parser(version=V2).parse(
+                ims=bytearray(hab.interact(framed=True, version=V2, kind=Kinds.cesr,
+                                           gvrsn=V2)),
+                kvy=crossKvy)
+            kever = receiverHby.db.kevers[hab.pre]
+            assert kever.sner.num == 1 and kever.serder.ilk == Ilks.ixn
+            assert kever.lastEst.s == 0 and kever.lastEst.d != kever.serder.said
+
+        with openCF(name="ixnKram", base="test") as cf:
+            cf.put(KRAM_INTEGRATION_CONFIG)
+            kramer = Kramer(db=receiverHby.db, cf=cf)
+            assert kramer.enabled
+
+            stamp = helping.nowIso8601()
+
+            # assk: the single-key sender's signature names the inception, which is
+            # still its current establishment event.
+            skKever = receiverHby.db.kevers[senderHab.pre]
+            msg = query(pre=senderHab.pre, route="ksn",
+                        query=dict(i=senderHab.pre, src=senderHab.pre, n='ixn01'),
+                        stamp=stamp, pvrsn=Vrsn_2_0)
+            sigers = senderHab.mgr.sign(ser=msg.raw, verfers=skKever.verfers,
+                                        indexed=True)
+            kwa = dict(tsgs=[(Prefixer(qb64=senderHab.pre),
+                              Number(num=skKever.lastEst.s),
+                              Diger(qb64=skKever.lastEst.d), sigers)])
+            assert kramer.intake(msg, kwa) is not None, \
+                "an issuer that has anchored can still authenticate"
+            assert receiverHby.db.kramMSGC.get(keys=(senderHab.pre, msg.said)) is not None
+
+            # asmk: the multi-key sender accumulates across deliveries while its
+            # latest event is an ixn.
+            mkKever = receiverHby.db.kevers[multiHab.pre]
+            mkMsg = query(pre=multiHab.pre, route="ksn",
+                          query=dict(i=multiHab.pre, src=multiHab.pre, n='ixn02'),
+                          stamp=stamp, pvrsn=Vrsn_2_0)
+            allSigers = multiHab.mgr.sign(ser=mkMsg.raw, verfers=mkKever.verfers,
+                                          indexed=True)
+            partialKey = (multiHab.pre, mkMsg.said)
+
+            def delivered(chosen):
+                return dict(tsgs=[(Prefixer(qb64=multiHab.pre),
+                                   Number(num=mkKever.lastEst.s),
+                                   Diger(qb64=mkKever.lastEst.d), chosen)])
+
+            assert kramer.intake(mkMsg, delivered([allSigers[0]])) is None, \
+                "one of two is not a threshold, so it waits"
+            assert receiverHby.db.kramPMKM.get(keys=partialKey) is not None
+            assert [s.index for s in receiverHby.db.kramPMKS.get(keys=partialKey)] == [0]
+
+            assert kramer.intake(mkMsg, delivered([allSigers[1]])) is not None, \
+                "the second endorsement meets the threshold and releases the message"
+            assert sorted(s.index for s in
+                          receiverHby.db.kramPMKS.get(keys=partialKey)) == [0, 1]


### PR DESCRIPTION
I was trying to achieve KRAM support in a Bakobo tool I'm building, and I found what I believe to be a bug in the current KRAM impl.

`Kramer` decides whether an attached `TransIdxSigGroup` is current by comparing its `(number, sdiger)` against `kever.sner.num` and `kever.serder.said` — the sender's latest event of any kind. This doesn't seem right to me. A transferable indexed signature group references the establishment event that established the signing keys, which is `kever.lastEst`.

The docstring at `src/keri/core/kraming.py:440-445` already states the intended rule:

> Each tsgs entry is (prefixer, number, sdiger, sigers). When `prefixer.qb64 == senderId` and `(number, sdiger)` references the sender's **current establishment event**, those sigers are also added to `sigers` so `_hasSigs` and signature auth paths see them.

The code does not implement that. Four sites share the same wrong reference:

| Site | Purpose |
|---|---|
| `kraming.py:458-459` | fold current sender tsgs into `sigers` |
| `kraming.py:555-556` | classify non-current quads as stale |
| `kraming.py:611-612` | filter tsgs after verification |
| `kraming.py:697-698` | gate which quads enter the verification pool |

This matters because an interaction event advances the KEL without changing keys. So the moment a sender anchors anything, every correctly formed signature it sends starts failing the currency gate: the quad never enters the verification pool, `_verifyAttachedSigs` returns `verified=False`, and the message is dropped.

If I understand correctly, that is the case for every AID that has anchored a registry inception, a credential issuance or a revocation. Since KRAM's scope is exactly the non-key-event message set, and IPEX grants come from issuers, an enabled KRAM refuses essentially every real IPEX grant, on both the `assk` and `asmk` paths.

The multi-key case fails in a way that is easy to miss when reading the code: `kramit` returns at the "no sigs verified at all" guard (`kraming.py:1553-1556`) before writing any cache, so nothing is escrowed and nothing accumulates. A second delivery carrying the co-signer's endorsement behaves identically — `kramTMSC`, `kramPMKM` and `kramPMKS` all stay empty — so a multisig sender can never reach threshold.

There is a second-order effect, too: because site 555 falls through to the historical-lookup branch, the good signature *does* verify there — against the establishment event's own verfers, which are the correct keys — and is then filed in `stale_tsgs` as "not counted toward the current threshold". So the failure presents as a stale-key problem when the keys were never stale.

Here is how I manifested the bug. I built a 2-of-2 group that had issued a credential, driving its IPEX grant through a standalone `Kramer`:

```
kever.sner            = 2
kever.serder.said     = <the ixn at sn 2>
kever.serder.ilk      = ixn
kever.lastEst         = LastEstLoc(s=0, d='EMEMtQK6KvEfn29rhq-rGK-jzsr4sYgmT0JfQ0rRt_mM')
grant tsg names       = sn 0, EMEMtQK6KvEfn29rhq-rGK-jzsr4sYgmT0JfQ0rRt_mM   # correct
_verifyAttachedSigs() -> SigVerifyResult(verified=False, sigers=[], stale_tsgs=[<the one good quad>])
```

The fix I implemented is just to compare against `kever.lastEst.s` / `kever.lastEst.d` at all four sites. `lastEst` is set at inception and updated only on establishment events (`eventing.py:2404`, `2528`), which is the reference a tsg carries.

The PR includes `test_tsgs_current_when_latest_event_is_non_establishment`. This builds two senders — single-key and 2-of-3 — has each one `interact()` after inception so the latest event is an `ixn` while `lastEst` still names the inception, and asserts:       
- **assk**: the single-key sender is accepted and a cache row is written.
- **asmk**: the multi-key sender escrows on the first delivery (`kramPMKS` holds index 0), then meets threshold and releases on the second (`[0, 1]`).

This test fails on `main` and passes with the change. The existing `test_stale_tsgs` still passes, which is the guard that genuine staleness — a quad naming a *superseded establishment* event after a rotation — is still detected; a rotation advances `lastEst` too, so that path is unaffected.

## Related, deliberately not changed here
The key-state-change detection for partial multisig collection stores and compares `(kever.sner, Diger(qb64=kever.serder.said))` at `kraming.py:1097`, `1252` and `1330`. Keys change only at establishment events, so using the latest event there means any interaction event by the sender *during* signature collection drops the escrow with "key state changed" even though the keys did not change. That is fail-closed rather than unsafe, and it is a separate change with a separate test, so I have left it out of this PR to keep the diff to the one defect. I wrote up #1661 for this, and will raise a separate PR for it.