### PR TITLE
Correct KLI challenge file and mailbox request paths

### DIFF
--- a/src/keri/app/cli/commands/challenge/respond.py
+++ b/src/keri/app/cli/commands/challenge/respond.py
@@ -43,7 +43,7 @@ def respond(args):
     recp = args.recipient
 
     if args.words.startswith("@"):
-        f = open(args.data[1:], "r")
+        f = open(args.words[1:], "r")
         words = f.read()
     else:
         words = args.words

--- a/src/keri/app/cli/commands/mailbox/add.py
+++ b/src/keri/app/cli/commands/mailbox/add.py
@@ -112,7 +112,7 @@ class AddDoer(doing.DoDoer):
 
         client.request(
             method="POST",
-            path=f"{client.requester.path}/mailboxes",
+            path=f"{client.requester.path.rstrip('/')}/mailboxes",
             headers=headers,
             fargs=fargs
         )


### PR DESCRIPTION
## Summary

- read file-backed challenge words from the path supplied by the words argument
- remove a trailing slash from the mailbox requester base path before appending the endpoint

## Boundary

This extracts only the two KLI corrections from upstream PRs #1091 and #1344. It does not include tests or their unrelated import, SSH export, Exchanger cue, witness authentication, or Receiptor changes.

## Validation

- `git diff --check`
