### PR TITLE
Add disclosure path support to Compactor

### DIFF
--- a/src/keri/core/mapping.py
+++ b/src/keri/core/mapping.py
@@ -22,7 +22,7 @@ from ..kering import (Colds, Kinds, EmptyMaterialError, InvalidValueError,
 from ..help import isNonStringIterable
 
 from .counting import  Codens, Counter
-from .coring import (MtrDex, Matter, Labeler, LabelDex, DecDex, Decimer,
+from .coring import (MtrDex, Matter, Labeler, LabelDex, DecDex, Decimer, Pather,
                      DigDex, Diger)
 
 
@@ -789,9 +789,9 @@ class Compactor(Mapper):
         partials (dict[Compactor]|None): each compactor instance of partially
                                disclosable variants of with
                                fully computed saids for its leaves.
-                               keyed by tuple of leaf paths,
+                               keyed by tuple of disclosure paths,
                                value is Compactor instance.
-                               None means have yet to expand
+                               None means no partials have been built
         iscompact (bool|None): True means one leaf with path = '' i.e.
                                         leaf is at top level and has said
                                         but does not verify said
@@ -809,9 +809,11 @@ class Compactor(Mapper):
         ._saids (dict): default top-level said fields and codes
         ._saidive (bool): compute saids or not
         ._leaves (dict[Mapper]): mapper of each leaf indexed by path to leaf
+        ._eleaves (dict[tuple, Mapper]): mapper of each leaf indexed by exact
+                                         tuple of labels for internal traversal
         ._partials (dict[Compactor]|None): partially compacted mad with fully
                            computed saids
-                           indexd by tuple of leaf paths in mad
+                           indexed by tuple of disclosure paths in mad
 
     """
 
@@ -857,6 +859,7 @@ class Compactor(Mapper):
 
         """
         self._leaves = {}
+        self._eleaves = {}
         self._partials = None
         super(Compactor, self).__init__(saidive=saidive, makify=makify, **kwa)
         if makify and self.saidive and compactify:
@@ -896,7 +899,7 @@ class Compactor(Mapper):
         Returns:
             partials (dict[Compactor]): each compactor of partially disclosable
                                variant with fully computed saids for its leaves
-                               keyed by tuple of leaf paths,
+                               keyed by tuple of disclosure paths,
                                value is Compactor instance.
         """
         return self._partials
@@ -952,7 +955,8 @@ class Compactor(Mapper):
         return paths
 
 
-    def _trace(self, mad, paths=None, path='', *, saidify=False):
+    def _trace(self, mad, paths=None, path='', *, epath=(), epaths=None,
+               saidify=False):
         """Recursively trace paths to leaves in mad and populate .leaves
 
         Returns:
@@ -963,6 +967,8 @@ class Compactor(Mapper):
             paths(list|None): path strs of leafs in top down order
                                None means start at top
             path (str): current relative to top-level mad as dot '.' separated
+            epath (tuple): exact labels for current path
+            epaths (list|None): exact label paths for each leaf
             saidify (bool): True means compute and assign SAID at each leaf
                             False means do not assign SAID
 
@@ -984,22 +990,27 @@ class Compactor(Mapper):
                 if self._hassaid(mad=v):
                     isleaf = False
                     paths = self._trace(mad=v, paths=paths, path=path + "." + l,
+                                        epath=epath + (l,), epaths=epaths,
                                         saidify=saidify)
 
         if isleaf:
             paths.append(path)
+            if epaths is not None:
+                epaths.append(epath)
             if saidify:
                 # leafer Mapper makes deepcopy of input mad arg
-                leafer = Mapper(mad=mad, makify=True,
+                leafer = Mapper(mad=mad, makify=True, strict=self.strict,
                                 saids=self.saids, saidive=True, kind=self.kind)
                 for l in leafer.saids:  # assign computed saids to original mad
                     if l in mad:
                         mad[l] = leafer.mad[l]
             else:
                 # leafer Mapper makes deepcopy of input mad arg
-                leafer = Mapper(mad=mad, makify=True, kind=self.kind)
+                leafer = Mapper(mad=mad, makify=True, strict=self.strict,
+                                saids=self.saids, kind=self.kind)
 
             self.leaves[path] = leafer
+            self._eleaves[epath] = leafer
 
         return paths
 
@@ -1037,14 +1048,14 @@ class Compactor(Mapper):
             tail (dict|None):  tail of path into mad or None if not found
 
         Parameters:
-            path (str): dot "." separated path. Top-level is "" so ".x" is one
-                       level down.
+            path (str|tuple): dot "." separated path or exact label tuple.
+                              Top-level is "" or ().
            mad (dict|None): field map dict (MApping Dict). None uses default of
                             self.mad
 
         """
         tail = mad if mad is not None else self.mad
-        parts = path.split(".")[1:]  # split and strip off top level part
+        parts = path.split(".")[1:] if isinstance(path, str) else path
         for part in parts:
             if part not in tail:
                 return None
@@ -1062,13 +1073,27 @@ class Compactor(Mapper):
 
 
         Parameters:
-            path (str): dot "." separated path. Top-level is "" so ".x" is one
-                       level down.
+            path (str|tuple): dot "." separated path or exact label tuple.
+                              Top-level is "" or ().
            mad (dict|None): field map dict (MApping Dict). None uses default of
                             self.mad
 
         """
         mad = mad if mad is not None else self.mad
+        if not isinstance(path, str):
+            parts = list(path)
+            if not parts:
+                return (None, "")
+
+            tail = parts.pop()
+            for part in parts:
+                if part not in mad:
+                    return (None, tail)
+                mad = mad[part]
+            if tail not in mad:
+                return (None, None)
+            return (mad, tail)
+
         # split and then strip off bottom level part
         parts = path.split(".")  # split
         tail = parts[-1] if parts else None  # save tail
@@ -1086,7 +1111,7 @@ class Compactor(Mapper):
         return (mad, tail)
 
 
-    def compact(self):
+    def compact(self, paths=None, root=None):
         """Recursively apply most compact said algorithm to mad. Populates
         .leaves in the process
 
@@ -1095,17 +1120,135 @@ class Compactor(Mapper):
         compacting the leaves.
 
         Repeat above on newly compacted mad until reach fully compacted mad.
+        A targeted call consumes the expanded mapping. Use a new Compactor
+        instance to create another targeted partial.
+
+        Parameters:
+            paths (Iterable[str]|None): ACDC-relative SAD paths whose combined
+                closure remains expanded in one saved partial. A trailing path
+                separator keeps the whole node expanded. Numeric components
+                select mapping fields by ordinal. None means do not save a
+                targeted partial.
+            root (str|None): first path component for the section in self.mad.
+                No partial is saved when every path is outside root. None means
+                paths are relative to self.mad.
         """
+        dpaths = None
+        marks = set()
+        if paths is not None:
+            if not isNonStringIterable(paths):
+                raise InvalidValueError(f"Invalid disclosure {paths=}")
+            if root is not None and not isinstance(root, str):
+                raise InvalidValueError(f"Invalid disclosure {root=}")
+            if self.iscompact:
+                raise InvalidValueError("Cannot disclose from compact mapping")
+
+            dpaths = list(paths)
+            matched = False
+            # Resolve disclosure paths into exact mapping paths to preserve.
+            for path in dpaths:
+                if not isinstance(path, str):
+                    raise InvalidValueError(f"Invalid disclosure {path=}")
+
+                tail = self.mad
+                parts = list(Pather(path=path, relative=True).rparts)
+                isnode = not parts or not parts[-1]
+                if root is not None:
+                    if not parts or parts[0] != root:
+                        continue
+                    parts = parts[1:]
+
+                matched = True
+                marks.add(())
+                if isnode and parts and not parts[-1]:
+                    parts.pop()
+
+                mark = ()
+                for part in parts:
+                    if not isinstance(tail, Mapping):
+                        raise InvalidValueError(f"Invalid disclosure {path=}")
+
+                    if part.isdigit():
+                        index = int(part)
+                        labels = list(tail)
+                        if index >= len(labels):
+                            raise InvalidValueError(f"Invalid disclosure {path=}")
+                        label = labels[index]
+                    elif part in tail:
+                        label = part
+                    else:
+                        raise InvalidValueError(f"Invalid disclosure {path=}")
+
+                    tail = tail[label]
+                    mark += (label,)
+                    marks.add(mark)
+
+                if isnode:
+                    if not isinstance(tail, Mapping):
+                        raise InvalidValueError(f"Invalid disclosure {path=}")
+
+                    # Preserve every nested mapping for whole-node disclosure.
+                    nodes = [(mark, tail)]
+                    while nodes:
+                        parent, node = nodes.pop()
+                        for label, value in node.items():
+                            if isinstance(value, Mapping):
+                                child = parent + (label,)
+                                marks.add(child)
+                                nodes.append((child, value))
+
+            self._partials = {}
+            if not matched:
+                dpaths = None
+
+        pmad = None
+        pmarks = None
         while True:  # at least once so trace computes top-level said
-            paths = self._trace(mad=self.mad, paths=[], path='', saidify=True)
-            for path in paths:  # only check to compact new leaves
-                leafer = self.leaves[path]  # get leafer for new leaf path
+            epaths = []
+            cpaths = self._trace(mad=self.mad, paths=[], path='', epaths=epaths,
+                                 saidify=True)
+            compacted = False
+            for path in epaths:  # only check to compact new leaves
+                if path in marks:
+                    continue
+                leafer = self._eleaves[path]  # get leafer for new leaf path
                 mad, tail = self.getMad(path)
                 if mad is not None and tail is not None:
                     mad[tail] = leafer.said  # assign primary said to compact
+                    compacted = True
 
-            if not paths or self.iscompact:  # either no leaves or compact
+            # Save requested closure, then finish canonical compaction without marks.
+            if dpaths is not None and pmad is None and not compacted:
+                pmad = deepcopy(self.mad)
+                pmarks = marks
+                marks = set()
+                continue
+
+            if not cpaths or self.iscompact:  # either no leaves or compact
                 break
+            if not compacted:
+                raise InvalidValueError("Unable to compact mapping")
+
+        # Replace provisional SAIDs with values from the canonical compact tree.
+        if pmad is not None:
+            for path in pmarks:
+                if path not in self._eleaves:
+                    continue
+
+                tail = self.getTail(path=path, mad=pmad)
+                if not isinstance(tail, Mapping):
+                    continue
+
+                leafer = self._eleaves[path]
+                for label in leafer.saids:
+                    if label in tail:
+                        tail[label] = leafer.mad[label]
+
+            partial = Compactor(mad=pmad, strict=self.strict,
+                                saids=self.saids, saidive=self.saidive,
+                                verify=False, kind=self.kind)
+            partial.trace()
+            self.partials[tuple(dpaths)] = partial
 
 
     def expand(self, greedy=True):
@@ -1118,14 +1261,14 @@ class Compactor(Mapper):
                            False means do not use expand by reversing leaf order
         """
         self._partials = {}  # reset partials dict
-        paths = list(self.leaves.keys())
+        paths = list(self._eleaves.keys())
         if greedy:
             paths.reverse()
 
         used = []  # already expanded paths
-        if "" in paths:  # create partial of fully compacted leaf
-            path = ""
-            leafer = self.leaves[path]
+        if () in paths:  # create partial of fully compacted leaf
+            path = ()
+            leafer = self._eleaves[path]
             pmad = deepcopy(leafer.mad)  # expand pmad with copy of leafer
             used.append(path)
             # don't compute or verify top-level saids on partials makify=Fase verify=False
@@ -1140,7 +1283,7 @@ class Compactor(Mapper):
             for path in unused:
                 lmad, leaf = self.getMad(path=path, mad=pmad)
                 if lmad is not None and leaf is not None:
-                    leafer = self.leaves[path]
+                    leafer = self._eleaves[path]
                     lmad[leaf] = deepcopy(leafer.mad)  # expand pmad with copy of leafer
                     used.append(path)
                     created = True

--- a/src/keri/core/mapping.py
+++ b/src/keri/core/mapping.py
@@ -1120,6 +1120,8 @@ class Compactor(Mapper):
         compacting the leaves.
 
         Repeat above on newly compacted mad until reach fully compacted mad.
+        Then restore the requested disclosure from the cached canonical leaves
+        in one partial, with ancestors restored before their descendants.
         A targeted call consumes the expanded mapping. Use a new Compactor
         instance to create another targeted partial.
 
@@ -1201,48 +1203,32 @@ class Compactor(Mapper):
             if not matched:
                 dpaths = None
 
-        pmad = None
-        pmarks = None
         while True:  # at least once so trace computes top-level said
             epaths = []
             cpaths = self._trace(mad=self.mad, paths=[], path='', epaths=epaths,
                                  saidify=True)
             compacted = False
             for path in epaths:  # only check to compact new leaves
-                if path in marks:
-                    continue
                 leafer = self._eleaves[path]  # get leafer for new leaf path
                 mad, tail = self.getMad(path)
                 if mad is not None and tail is not None:
                     mad[tail] = leafer.said  # assign primary said to compact
                     compacted = True
 
-            # Save requested closure, then finish canonical compaction without marks.
-            if dpaths is not None and pmad is None and not compacted:
-                pmad = deepcopy(self.mad)
-                pmarks = marks
-                marks = set()
-                continue
-
             if not cpaths or self.iscompact:  # either no leaves or compact
                 break
             if not compacted:
                 raise InvalidValueError("Unable to compact mapping")
 
-        # Replace provisional SAIDs with values from the canonical compact tree.
-        if pmad is not None:
-            for path in pmarks:
-                if path not in self._eleaves:
+        if dpaths is not None:
+            # Restore marked ancestors before descendants from canonical leaves.
+            pmad = deepcopy(self.mad)
+            for path in sorted(marks.intersection(self._eleaves), key=len):
+                if not path:
                     continue
-
-                tail = self.getTail(path=path, mad=pmad)
-                if not isinstance(tail, Mapping):
-                    continue
-
-                leafer = self._eleaves[path]
-                for label in leafer.saids:
-                    if label in tail:
-                        tail[label] = leafer.mad[label]
+                mad, tail = self.getMad(path=path, mad=pmad)
+                if mad is not None and tail is not None:
+                    mad[tail] = deepcopy(self._eleaves[path].mad)
 
             partial = Compactor(mad=pmad, strict=self.strict,
                                 saids=self.saids, saidive=self.saidive,

--- a/tests/core/test_mapping.py
+++ b/tests/core/test_mapping.py
@@ -1951,7 +1951,7 @@ def test_compactor_compact_expand():
     assert compactor.mad == cmad
     assert compactor.said == csaid
 
-    # Disclose two non-adjacent blocks from single-layer credential attributes.
+    # Disclose non-adjacent leaves from credential attributes.
     attributes = dict(
         d="",
         u="",
@@ -1960,11 +1960,17 @@ def test_compactor_compact_expand():
         middle=dict(d="", u="", value="Henry Davis"),
         surname=dict(d="", u="", value="Smith"),
         dateOfBirth=dict(d="", u="", value="2020-08-22"),
+        grades=dict(
+            d="",
+            u="",
+            gpa="4.0",
+            transcript=dict(d="", u="", courses="Algebra"),
+        ),
     )
-    paths = [".given", ".surname"]
+    paths = ["i", "a/i", "a/given/value", "a/surname/value",
+             "a/grades/gpa"]
     compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
-    compactor.compact()
-    compactor.expand()
+    compactor.compact(paths=paths, root="a")
 
     assert tuple(paths) in compactor.partials
     partial = compactor.partials[tuple(paths)]
@@ -1972,11 +1978,99 @@ def test_compactor_compact_expand():
     assert partial.mad["surname"]["value"] == "Smith"
     assert isinstance(partial.mad["middle"], str)
     assert isinstance(partial.mad["dateOfBirth"], str)
+    assert partial.mad["grades"]["gpa"] == "4.0"
+    assert isinstance(partial.mad["grades"]["transcript"], str)
 
     recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
                             kind=Kinds.json)
     recompactor.compact()
     assert recompactor.said == compactor.said
+
+    # A trailing separator discloses the complete node and its descendants.
+    paths = ["a/grades/"]
+    compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+    compactor.compact(paths=paths, root="a")
+
+    partial = compactor.partials[tuple(paths)]
+    assert partial.mad["grades"]["gpa"] == "4.0"
+    assert partial.mad["grades"]["transcript"]["courses"] == "Algebra"
+    assert isinstance(partial.mad["given"], str)
+
+    recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
+                            kind=Kinds.json)
+    recompactor.compact()
+    assert recompactor.said == compactor.said
+
+    # Numeric path components resolve by field ordinal.
+    paths = ["a/given/value"]
+    compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+    compactor.compact(paths=paths, root="a")
+    named = compactor.partials[tuple(paths)]
+
+    paths = ["a/3/value"]
+    compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+    compactor.compact(paths=paths, root="a")
+    ordinal = compactor.partials[tuple(paths)]
+    assert ordinal.mad == named.mad
+
+    # Saved partials preserve the source Compactor configuration.
+    saids = dict(x=DigDex.Blake3_256)
+    custom = dict(
+        x="",
+        u="",
+        i="IssueeAID",
+        given=dict(x="", u="", value="John"),
+        surname=dict(x="", u="", value="Smith"),
+    )
+    paths = ["a/given/value"]
+    compactor = Compactor(mad=custom, makify=True, strict=False, saids=saids,
+                          kind=Kinds.json)
+    compactor.compact(paths=paths, root="a")
+
+    partial = compactor.partials[tuple(paths)]
+    assert partial.strict == compactor.strict
+    assert partial.saids == compactor.saids
+    assert partial.saidive == compactor.saidive
+    assert partial.said == compactor.said
+
+    # Paths outside this section do not create a disclosure partial.
+    canonical = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+    canonical.compact()
+    for paths in ([], ["i"]):
+        compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+        compactor.compact(paths=paths, root="a")
+        assert compactor.partials == {}
+        assert compactor.mad == canonical.mad
+
+    # Exact label paths support non-strict labels selected by ordinal.
+    for kind, label in ((Kinds.cesr, "contact-email"),
+                        (Kinds.json, "contact.email")):
+        custom = {
+            "d": "",
+            label: dict(d="", value="evan@example.com"),
+            "other": dict(d="", value="hidden"),
+        }
+        paths = ["a/1/value"]
+        compactor = Compactor(mad=custom, makify=True, strict=False, kind=kind)
+        compactor.compact(paths=paths, root="a")
+
+        partial = compactor.partials[tuple(paths)]
+        assert partial.mad[label]["value"] == "evan@example.com"
+        assert isinstance(partial.mad["other"], str)
+
+        recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
+                                strict=False, kind=kind)
+        recompactor.compact()
+        assert recompactor.said == compactor.said
+
+        # Targeted compaction consumes the expanded source mapping.
+        with pytest.raises(InvalidValueError):
+            compactor.compact(paths=paths, root="a")
+
+    for path in ("a/missing/value", "a/99/value", "a/i/"):
+        compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+        with pytest.raises(InvalidValueError):
+            compactor.compact(paths=[path], root="a")
 
     """Done Test"""
 

--- a/tests/core/test_mapping.py
+++ b/tests/core/test_mapping.py
@@ -9,6 +9,7 @@ import cbor2 as cbor
 import pytest
 
 from dataclasses import asdict
+from itertools import combinations
 
 from keri.kering import (Colds, Kinds, SerializeError,
                          DeserializeError, InvalidValueError)
@@ -1986,20 +1987,66 @@ def test_compactor_compact_expand():
     recompactor.compact()
     assert recompactor.said == compactor.said
 
-    # A trailing separator discloses the complete node and its descendants.
-    paths = ["a/grades/"]
-    compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
-    compactor.compact(paths=paths, root="a")
+    # Every combination of sibling leaves preserves the canonical commitment.
+    labels = ("given", "middle", "surname", "dateOfBirth")
+    for kind in (Kinds.json, Kinds.cesr):
+        canonical = Compactor(mad=attributes, makify=True, kind=kind)
+        canonical.compact()
+        for count in range(len(labels) + 1):
+            for selected in combinations(labels, count):
+                paths = ["a/i"] + [f"a/{label}/value" for label in selected]
+                compactor = Compactor(mad=attributes, makify=True, kind=kind)
+                compactor.compact(paths=paths, root="a")
+                assert compactor.mad == canonical.mad
+                assert list(compactor.partials) == [tuple(paths)]
+
+                partial = compactor.partials[tuple(paths)]
+                assert partial.said == canonical.said
+                assert partial.mad["grades"] == canonical.mad["grades"]
+                for label in labels:
+                    if label in selected:
+                        assert partial.mad[label]["value"] == attributes[label]["value"]
+                        assert partial.mad[label]["d"] == canonical.mad[label]
+                    else:
+                        assert partial.mad[label] == canonical.mad[label]
+
+                recompactor = Compactor(mad=partial.mad, verify=False, kind=kind)
+                recompactor.compact()
+                assert recompactor.mad == canonical.mad
+
+    # A trailing separator discloses descendants even with overlapping paths.
+    for paths in (["a/grades/"],
+                  ["a/grades/transcript/courses", "a/grades/",
+                   "a/grades/transcript/courses"]):
+        compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+        compactor.compact(paths=paths, root="a")
+
+        partial = compactor.partials[tuple(paths)]
+        assert partial.mad["grades"]["gpa"] == "4.0"
+        assert partial.mad["grades"]["transcript"]["courses"] == "Algebra"
+        assert isinstance(partial.mad["given"], str)
+
+        recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
+                                kind=Kinds.json)
+        recompactor.compact()
+        assert recompactor.said == compactor.said
+
+    # A disclosed leaf may have enclosing mappings without their own SAIDs.
+    plain = dict(z=imad["z"], y=imad["y"])
+    canonical = Compactor(mad=plain, makify=True)
+    canonical.compact()
+    paths = ["z/x/w"]
+    compactor = Compactor(mad=plain, makify=True)
+    compactor.compact(paths=paths)
 
     partial = compactor.partials[tuple(paths)]
-    assert partial.mad["grades"]["gpa"] == "4.0"
-    assert partial.mad["grades"]["transcript"]["courses"] == "Algebra"
-    assert isinstance(partial.mad["given"], str)
-
-    recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
-                            kind=Kinds.json)
+    assert partial.said is None
+    assert partial.mad["z"]["x"] == xmad
+    assert partial.mad["z"]["u"] == "under"
+    assert partial.mad["y"] == ysaid
+    recompactor = Compactor(mad=partial.mad, verify=False)
     recompactor.compact()
-    assert recompactor.said == compactor.said
+    assert recompactor.mad == canonical.mad == compactor.mad
 
     # Numeric path components resolve by field ordinal.
     paths = ["a/given/value"]

--- a/tests/core/test_mapping.py
+++ b/tests/core/test_mapping.py
@@ -1951,6 +1951,33 @@ def test_compactor_compact_expand():
     assert compactor.mad == cmad
     assert compactor.said == csaid
 
+    # Disclose two non-adjacent blocks from single-layer credential attributes.
+    attributes = dict(
+        d="",
+        u="",
+        i="IssueeAID",
+        given=dict(d="", u="", value="John"),
+        middle=dict(d="", u="", value="Henry Davis"),
+        surname=dict(d="", u="", value="Smith"),
+        dateOfBirth=dict(d="", u="", value="2020-08-22"),
+    )
+    paths = [".given", ".surname"]
+    compactor = Compactor(mad=attributes, makify=True, kind=Kinds.json)
+    compactor.compact()
+    compactor.expand()
+
+    assert tuple(paths) in compactor.partials
+    partial = compactor.partials[tuple(paths)]
+    assert partial.mad["given"]["value"] == "John"
+    assert partial.mad["surname"]["value"] == "Smith"
+    assert isinstance(partial.mad["middle"], str)
+    assert isinstance(partial.mad["dateOfBirth"], str)
+
+    recompactor = Compactor(mad=dict(partial.mad, d=""), makify=True,
+                            kind=Kinds.json)
+    recompactor.compact()
+    assert recompactor.said == compactor.said
+
     """Done Test"""
 
 
@@ -2395,4 +2422,3 @@ if __name__ == "__main__":
     test_compactor_basic()
     test_compactor_compact_expand()
     test_aggor_basic()
-


### PR DESCRIPTION
This PR started by adding a failing section to `test_compactor_compact_expand()`.

The test requests non-adjacent blocks from a sample attribute section based on one of the credentials in `test_sedi.py`. The current Compactor does not create the requested disclosure shape.

This proved the need for the Compactor upgrade.

## Update

The implementation now lets Compactor create one partial for any requested combination of disclosure paths.

This change:

- Resolves disclosure paths and their required ancestors
- Includes all descendants when a trailing separator requests a complete node
- Computes the canonical compact form, then restores the requested branches from cached leaves into one partial
- Preserves numeric path selection and non-strict labels, and creates no partial when no path applies to the section
- Extends the existing tests for sibling combinations, overlapping paths, canonical SAIDs, and mappings without their own SAIDs

Calling compact() without disclosure paths keeps the existing behavior.

