### PR TITLE
Cite the ACDC spec by section rather than by line number

### DIFF
--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -37,7 +37,9 @@ class Verifier:
     # operator to this verifier and is skipped when resolving a list-valued `o` (see
     # .verifyChain). DI2I and NOT are recognized but unimplemented: they are listed so
     # they fail closed diagnosably instead of being dropped and silently defaulting.
-    # E1E is a keripy extension not yet in the spec's normative operator table.
+    # E1E is normative on the spec's v1.1 branch (kswg-acdc-specification#197). It is
+    # absent from the 1.0 text currently under ToIP ratification, so a validator built
+    # against 1.0 alone will not recognize it.
     UnaryOps = ('I2I', 'NI2I', 'DI2I', 'E1E', 'NOT')
 
     # The delegative subset of .UnaryOps: each constrains the near ACDC's issuer
@@ -422,12 +424,13 @@ class Verifier:
         creder = self.reger.creds.get(keys=nodeSaid)  # far (node) credential
 
         # `o` is either a single unary operator or a list of them. Latest-wins applies
-        # only "among the conflicting Operators" (ACDC spec-body.md L1186), so the list
-        # is resolved in two parts: the delegative operators constrain the same thing
-        # (the near issuer relative to the far issuee) and therefore conflict, so the
-        # latest of those wins; E1E constrains the near issuee instead, so it does not
-        # conflict with them and composes (AND) rather than overriding or being
-        # overridden. Tokens this verifier does not recognize are skipped.
+        # only "among the conflicting Operators" (ACDC spec, Edge Section > Edge >
+        # Operator, `o` field), so the list is resolved in two parts: the delegative
+        # operators constrain the same thing (the near issuer relative to the far
+        # issuee) and therefore conflict, so the latest of those wins; E1E constrains
+        # the near issuee instead, so it does not conflict with them and composes
+        # (AND) rather than overriding or being overridden. Tokens this verifier does
+        # not recognize are skipped.
         ops = op if isinstance(op, (list, tuple)) else [op]
         ops = [cand for cand in ops if cand in self.UnaryOps]
         op = next((cand for cand in reversed(ops) if cand in self.DelegativeOps), None)

--- a/tests/acdc/test_bulk_issuance.py
+++ b/tests/acdc/test_bulk_issuance.py
@@ -68,9 +68,10 @@ this example does NOT close, beyond the shared registry/B (see the partition tes
 cross-verifier join key, removable only by the Merkle-INCLUSION variant (panel
 PRV-F3); (b) even with per-context AID strings, a real deployment that witnesses the
 M holder AIDs on a shared witness pool / endpoint / mailbox re-links them via KEL
-discovery metadata (spec L2891; panel PRV-F2). The independent-AID and
-independent-registry/herd variants (spec 15.4) raise the technical bar further and are
-a deliberate follow-on (tick 6sjz), not this example.
+discovery metadata (ACDC, Bulk-issued Private ACDCs > Independent AID Bulk Issued
+ACDCs; panel PRV-F2). The independent-AID and independent-registry/herd variants
+(same section) raise the technical bar further and are a deliberate follow-on
+(tick 6sjz), not this example.
 
 A note on altitude. Like the sibling examples, this one models the credential graph,
 the bulk derivation, the blinded aggregate, and the registry state at the
@@ -124,7 +125,8 @@ VERIFIERS = (ALCOVE, DISPENSARY, SPORTSBOOK)
 
 
 # ===========================================================================
-# Phase 1: the bulk-issuance derivation primitive (ACDC spec 15.4).
+# Phase 1: the bulk-issuance derivation primitive (ACDC, Bulk-issued Private
+# ACDCs > Basic Bulk Issuance Procedure).
 # ===========================================================================
 # The shared secret salt for Alice's bulk sets -- known to the Issuer (State) and the
 # Issuee (Alice), never handed to a verifier. In a real flow it is transported to Alice
@@ -137,7 +139,8 @@ BULK_SIZE = 5
 
 
 class _BulkNonces:
-    """Deterministic per-copy nonce derivation for a bulk-issued set (ACDC spec 15.4).
+    """Deterministic per-copy nonce derivation for a bulk-issued set (ACDC,
+    Bulk-issued Private ACDCs > Basic Bulk Issuance Procedure).
 
     Every nonce for every copy is derived from ONE shared secret salt by argon2id
     (Salter.stretch) at a hierarchical path keyed on the copy index k, then wrapped as a
@@ -166,36 +169,42 @@ class _BulkNonces:
     def v(self, k):
         """Copy k's blinding factor v_k, derived at the path "k.".
 
-        SPEC-FIDELITY / INTEROP NOTE (ACDC review panel SPC-F1, 2026-07-23). ACDC
-        spec 15.4 is self-contradictory on this path: L2799 derives the top-level u_k
-        at path "k", and L2811 says v_k "is not the top-level UUID ... but an entirely
-        different UUID" YET states its derivation path is also "k". Since Salter.stretch
-        is a pure function of (salt, path), a spec-literal reading yields v_k == u_k,
-        violating the spec's own "entirely different" requirement. This example resolves
-        the contradiction by deriving v_k at the DISTINCT path "k." so v_k != u_k as the
-        spec intends. A spec-literal implementation (path "k") would compute a different
-        v_k, hence a different b_k and aggregate B, and its bulk-membership proofs would
-        NOT cross-verify with this one -- so ACDC 15.4 must be corrected to pin v_k's
-        path unambiguously (proposed fix: "k."). Until then, this path is a keripy-local
-        convention, not a ratified interop invariant.
+        The specification pins this path. ACDC (Bulk-issued Private ACDCs > Basic
+        Bulk Issuance Procedure) requires v_k to be derived at a path distinct from
+        the top-level u_k's path "k", and names it: "The derivation path for v_k
+        from the shared secret salt is therefore `k.`". That section is still in the
+        Annex, so it is not yet normative; kswg-acdc-specification#207 proposes
+        moving it out.
+
+        HISTORY (ACDC review panel SPC-F1, 2026-07-23). The specification used to
+        give both u_k and v_k the path "k" while also requiring v_k to be "an
+        entirely different UUID". Since Salter.stretch is a pure function of
+        (salt, path), a literal reading yielded v_k == u_k and contradicted that
+        requirement. This example derived v_k at the distinct path "k." to resolve
+        it, and flagged the ambiguity as a cross-verification hazard; the spec was
+        then corrected to pin that same path, so what was a keripy-local convention
+        is now what the specification says.
         """
         return self._nonce(f"{k}.")
 
 
 def _blind_said(v, d):
-    """b_k = H(v_k + d_k): the blinded commitment to copy k's SAID (spec 15.4).
+    """b_k = H(v_k + d_k): the blinded commitment to copy k's SAID (ACDC,
+    Bulk-issued Private ACDCs > Basic Bulk Issuance Procedure).
 
     Concatenation (not XOR) because CESR crypto-agility means SAIDs and nonces are
     variable length. A commitment to b_k discloses nothing about d_k until v_k is
     revealed, so the list of b_k can be published while the SAIDs stay hidden.
 
-    SPEC-FIDELITY / INTEROP NOTE (panel SPC-F2). Spec 15.4 (L2813-2824) pins
+    SPEC-FIDELITY / INTEROP NOTE (panel SPC-F2). ACDC (Bulk-issued Private ACDCs >
+    Basic Bulk Issuance Procedure), where b_k and B are defined, pins
     concatenation-over-XOR and the ordered structure but does NOT pin (a) which digest
     code H uses nor (b) whether the concatenation "+" / C is over qb64 TEXT or raw
     bytes -- both change b_k and B. This example pins the concrete choice: concatenate
     the qb64 TEXT of v_k and d_k and digest with Blake3-256 (the Diger default). A
     signify-ts impl that concatenated raw bytes or used another digest code would not
-    cross-verify; ACDC 15.4 should pin H and the concatenation domain explicitly.
+    cross-verify. kswg-acdc-specification#204 proposes pinning both and is still open,
+    so this remains a keripy-local choice.
     """
     return Diger(ser=(v + d).encode()).qb64
 
@@ -213,7 +222,8 @@ def _bulk_aggregate(vs, ds):
 
 
 def _verify_membership(d, v, blist, B):
-    """The verifier's per-copy membership check (spec 15.4).
+    """The verifier's per-copy membership check (ACDC, Bulk-issued Private ACDCs >
+    Basic Bulk Issuance Procedure).
 
     Given the disclosed copy SAID d_k, its blinding factor v_k, the published blinded
     list [b_k], and the committed aggregate B, confirm (1) the list commits to B
@@ -440,7 +450,8 @@ def _sedi_id_set(kind, nonces=None):
     vs = [nonces.v(k) for k in range(BULK_SIZE)]
     ds = [c.said for c in copies]
     blist, B = _bulk_aggregate(vs, ds)
-    # The single issuance-proof commitment to B (spec 15.4): a blindable update whose
+    # The single issuance-proof commitment to B (ACDC, Bulk-issued Private ACDCs >
+    # Basic Bulk Issuance Procedure): a blindable update whose
     # blinded state binds "this set (identified by B) is issued". Reuses the existing
     # sn-keyed Blinder -- there is ONE shared registry per set, so no copy-index blinder
     # is needed. (A real Issuer also anchors the rip seal in its KEL; omitted at this

--- a/tests/acdc/test_examples.py
+++ b/tests/acdc/test_examples.py
@@ -682,8 +682,10 @@ def test_partial_disclosure_compaction_JSON():
     # the private attribute section withheld. This is the direction the spec's
     # Chain-Link Confidentiality flow uses: the terms are shown first so the
     # verifier (Disclosee) can agree to them, and the private attributes stay
-    # hidden until, and unless, that agreement is made (spec-body.md lines 256,
-    # 741). Hiding the terms while exposing the attributes would invert that.
+    # hidden until, and unless, that agreement is made (ACDC, Schema Section >
+    # Composable JSON Schema, and Aggregate Section > Inclusion proof via
+    # aggregated list digest (AGID)). Hiding the terms while exposing the
+    # attributes would invert that.
     disclosedRule = expanded.sad['r']                # the full rule block
     # Verifier recomputes the disclosed block's SAID and confirms it is the very
     # section the compact ACDC commits to under 'r'.
@@ -725,7 +727,8 @@ def test_partial_disclosure_compaction_JSON():
     # both a 'grades' block and an 'address' block, so the holder can reveal one
     # and withhold the other. The disclosable unit is the block, not the field:
     # street/number/zip inside 'address' are disclosed together; to hide just the
-    # zip it would have to be its own nested block (spec-body.md line 692).
+    # zip it would have to be its own nested block (ACDC, Aggregate Section >
+    # Selectively disclosable Aggregate of attribute blocks).
     multi = dict(d='', u=NONCES[7], i=BOB, name="Bob Student",
                  grades=dict(d='', u=NONCES[8], math=4, english=3),
                  address=dict(d='', u=NONCES[9], street="Main", number=5, zip="90210"))
@@ -982,7 +985,9 @@ def test_blindable_registry_correlation_minimizing_JSON():
     and that the updates belong to it (the 'rd', sequence number, and prior link
     are all in the clear) -- but what each update commits to (the state, and which
     ACDC it concerns) is blinded. The spec calls the resulting disclosure
-    "correlation-minimizing" (spec-body.md line 91).
+    "correlation-minimizing" (ACDC Structure, the `u`-field section -- titled
+    "Universally Unique Identifier (UUID) Fields" in 1.0 and "Unique Entropy (UE)
+    Fields" on the v1.1 branch).
 
     Each update's blinded state is protected by its own "blind": a nonce derived
     by a deterministic key-derivation over the secret salt and that event's
@@ -1006,7 +1011,8 @@ def test_blindable_registry_correlation_minimizing_JSON():
     sequence number => new blind) even without a state change, so a previously
     disclosed blind no longer matches the head and cannot be reused as a standing
     proof of current state. Re-blinding is issuer-provided and issuer-timed
-    (spec-body.md lines 2131, 2135): a holder cannot compel it, and it costs one
+    (ACDC, Registry Message Types and Fields > Blinded State Disclosure): a
+    holder cannot compel it, and it costs one
     registry event per presentation, so it MAY or MAY NOT be used. This test does
     not rely on it -- the guarantees above follow from per-event blind
     independence alone.

--- a/tests/acdc/test_regeventing.py
+++ b/tests/acdc/test_regeventing.py
@@ -47,9 +47,11 @@ STAMP3 = '2025-10-01T18:06:10.988921+00:00'
 # The verify path itself never sees it (that absence is row V23).
 SALT = Salter(raw=b'0123456789abcdef').qb64
 
-# The ACDC specification's BLID conformance vectors (spec-body.md ~:2166-2170
-# placeholder, ~:2209-2213 issued).  Lineage caveat: the spec's worked examples
-# were synced from keripy, so these defend against drift, not shared error.
+# The ACDC specification's BLID conformance vectors, from Blinded State Disclosure >
+# Blinded Attribute Block Placeholder Calculation Example (placeholder) and > Blinded
+# Attribute Block ACDC State Calculation Example (issued).  Lineage caveat: the spec's
+# worked examples were synced from keripy, so these defend against drift, not shared
+# error.
 SPEC_PLACEHOLDER_UUID = "aG1lSjdJSNl7TiroPl67Uqzd5eFvzmr6bPlL7Lh4ukv8"
 SPEC_PLACEHOLDER_BLID = "ECVr7QWEp_aqVQuz4yprRFXVxJ-9uWLx_d6oDinlHU6J"
 SPEC_ISSUED_UUID = "aLfCdNAnc-0P2SiruarZSajXiUWu5iU2VfQahvpNCyzB"

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -1048,11 +1048,11 @@ def setupOperatorFixture(ian, ianHby, ianreg, ianiss):
 def test_verifier_list_valued_operator(seeder):
     """A list-valued `o` is a spec-legal spelling and MUST NOT fall to the default.
 
-    ACDC spec-body.md L1186: "When more than one unary Operator is applied to a given
-    Edge, then the value of the Operator, `o`, field is a list of those unary
-    Operators. When multiple unary Operators appear in the list, and there is a
-    conflict between Operators, the latest Operator among the conflicting Operators
-    in the list takes precedence."
+    ACDC spec, Edge Section > Edge > Operator, `o` field: "When more than one unary
+    Operator is applied to a given Edge, then the value of the Operator, `o`, field
+    is a list of those unary Operators. When multiple unary Operators appear in the
+    list, and there is a conflict between Operators, the latest Operator among the
+    conflicting Operators in the list takes precedence."
 
     Previously ``op not in ['I2I','DI2I','NI2I','E1E']`` was tested against the list
     itself, which never matches, so every list form silently fell through to the
@@ -1173,10 +1173,10 @@ def test_verifier_list_valued_operator(seeder):
                                      saider=Diger(qb64=ian.kever.serder.said))
         assert "DI2I" in str(excinfo.value)
 
-        # NOT is normative (spec L1195: the far node's validity is inverted) and
-        # unimplemented here. It must fail closed like DI2I rather than being skipped
-        # as an unrecognized token -- otherwise an edge asserting "this node must be
-        # INVALID" would be accepted as valid.
+        # NOT is normative (the unary Operator table: the far node's validity is
+        # inverted) and unimplemented here. It must fail closed like DI2I rather than
+        # being skipped as an unrecognized token -- otherwise an edge asserting "this
+        # node must be INVALID" would be accepted as valid.
         chainSad = dict(d='', node=dict(n=far.said, o=["NOT"]))
         _, chain = Saider.saidify(sad=chainSad, code=MtrDex.Blake3_256, label=Saids.d)
         subject = dict(d="", i=han.pre, dt=helping.nowIso8601(), claim="not operator")
@@ -1203,10 +1203,11 @@ def test_verifier_list_valued_operator(seeder):
 def test_verifier_nonconflicting_operators_compose(seeder):
     """A non-delegative operator composes with the delegative winner, not overridden.
 
-    ACDC spec-body.md L1186 scopes latest-wins to "the conflicting Operators". I2I,
-    NI2I and DI2I all constrain the near ACDC's *issuer* relative to the far node's
-    issuee, so they conflict with one another. E1E constrains the near *issuee*, so it
-    conflicts with none of them and must be conjoined (AND).
+    ACDC spec, Edge Section > Edge > Operator, `o` field, scopes latest-wins to "the
+    conflicting Operators". I2I, NI2I and DI2I all constrain the near ACDC's *issuer*
+    relative to the far node's issuee, so they conflict with one another. E1E
+    constrains the near *issuee*, so it conflicts with none of them and must be
+    conjoined (AND).
 
     Collapsing the whole list to a single operator drops the constraint that loses,
     which is a silent weakening: ``["E1E", "I2I"]`` from a producer requiring both


### PR DESCRIPTION
Fourteen comments across the edge-operator code and the ACDC tests reference the specification. Two of them said things that are no longer true, and all fourteen were pinned positionally.

The E1E note said the operator was "a keripy extension not yet in the spec's normative operator table"; it has been normative on the spec's v1.1 branch since trustoverip/kswg-acdc-specification#197 merged, and what is actually true is narrower: E1E is absent from the 1.0 text under ToIP ratification, so a validator built against 1.0 alone will not know it.

The second is in `tests/acdc/test_bulk_issuance.py`, a SPEC-FIDELITY note arguing that ACDC's bulk-issuance section is self-contradictory about the derivation path for the blinding factor v<sub>k</sub>, that keripy resolves it by deriving at `k.`, and that "until [the spec is corrected], this path is a keripy-local convention, not a ratified interop invariant." The spec was corrected. It now reads "The derivation path for v<sub>k</sub> from the shared secret salt is therefore `k.`", on both branches. So the note told a reader that keripy was deviating where it in fact conforms.

The sibling note at `:192`, about the unpinned digest code and concatenation domain, is still accurate — trustoverip/kswg-acdc-specification#204 proposes pinning both and has not merged — so only its line range changed.

### Citing by position

The rest is one defect, manifested two different ways.

Four citations read `spec-body.md L1186` or `L1195`. Those are the 1.0 line numbers for a paragraph that sits at a different line on v1.1, so following one on the wrong branch lands in unrelated text rather than failing visibly, and it would drift again on the next spec edit either way. All four cite the same place, so they now name it: Edge Section > Edge > Operator, `o` field. A section name survives renumbering; a line number is stale the moment anything above it changes length.

The other manifestation is `spec 15.4`, used thirteen times in `tests/acdc/test_bulk_issuance.py`. All thirteen now name the section: the two module-docstring overview mentions cite Bulk-issued Private ACDCs, and the eleven that cite the derivation procedure name Bulk-issued Private ACDCs > Basic Bulk Issuance Procedure, which is also more precise, since the material they cite is in that subsection rather than in the parent.

#207 makes this concrete rather than hypothetical. Moving Bulk-issued Private ACDCs out of the Annex renumbers every section below it and shifts every line number in the file, while leaving heading text untouched. Every citation in this PR survives that move; none of the originals would have.

`tests/acdc/test_cp_disclosure.py` already cited by example name and is untouched.