### PR TITLE
fix(setup): allow Python 3.14 patch releases below 3.14.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='~=3.14.7',
+    python_requires='~=3.14.0',
     install_requires=[
                         'lmdb==2.3.0',
                         'pysodium==0.7.18',


### PR DESCRIPTION
`python_requires='~=3.14.7'` excludes Python 3.14.0 through 3.14.6. Read the Docs currently resolves `tools.python: "3.14"` to Python 3.14.6, so the documentation build fails before Sphinx runs.

This changes the specifier to `~=3.14.0`, which preserves the intended Python 3.14-only range (`>=3.14.0,<3.15.0`) while accepting any 3.14 patch release.

Validation:

- Python 3.14.0 accepted
- Python 3.14.6 accepted
- Python 3.14.7 accepted
- Python 3.15.0 rejected
- full suite: 711 passed, 3 skipped

Context: `cb34ef19` narrowed the range in the right direction but pinned the patch level too tightly. The intended change was to restrict support to Python 3.14, not to a single patch release of it.
